### PR TITLE
Redesign Woof around the Adventure System and trusted Bond XP

### DIFF
--- a/.github/workflows/adventure-system-ci.yml
+++ b/.github/workflows/adventure-system-ci.yml
@@ -5,53 +5,27 @@ on:
     branches: [agent/woof-adventure-system-v1]
   pull_request:
     paths:
-      - 'apps/api/.env.example'
       - 'apps/api/src/adventure/**'
       - 'apps/api/src/care-events/**'
       - 'apps/api/src/activities/**'
       - 'apps/api/src/coaching/**'
-      - 'apps/api/src/auth/authenticated-request.ts'
       - 'apps/api/src/config/env.validation.ts'
-      - 'apps/api/src/common/filters/all-exceptions.filter.ts'
-      - 'apps/api/src/common/filters/all-exceptions.filter.spec.ts'
       - 'apps/api/src/gamification/gamification.controller.ts'
-      - 'apps/api/src/behavior-vision/behavior-profile.spec.ts'
-      - 'apps/api/src/behavior-vision/behavior-vision.service.ts'
-      - 'apps/api/src/chat/chat.gateway.ts'
-      - 'apps/api/src/goals/goals.controller.ts'
-      - 'apps/api/src/quiz/dto/save-quiz-response.dto.ts'
-      - 'apps/api/src/media-library/media-library.service.spec.ts'
-      - 'apps/api/src/app.controller.ts'
-      - 'apps/api/src/app.service.ts'
-      - 'apps/api/src/app.service.spec.ts'
       - 'apps/api/src/app.module.ts'
-      - 'apps/api/src/main.ts'
-      - 'apps/web/.eslintrc.js'
-      - 'apps/web/next.config.ts'
-      - 'apps/web/tailwind.config.ts'
-      - 'apps/web/vitest.config.ts'
-      - 'apps/web/src/app/**'
-      - 'apps/web/src/components/activity/activity-history.tsx'
+      - 'apps/web/src/app/page.tsx'
+      - 'apps/web/src/app/compass/**'
+      - 'apps/web/src/app/journey/**'
+      - 'apps/web/src/app/pack/**'
       - 'apps/web/src/components/bottom-nav.tsx'
-      - 'apps/web/src/components/events/EventDetailsDialog.tsx'
-      - 'apps/web/src/components/matches/MatchDiscoveryScreen.tsx'
-      - 'apps/web/src/components/onboarding/**'
-      - 'apps/web/src/components/quiz/**'
-      - 'apps/web/src/data/quizQuestions.ts'
-      - 'apps/web/src/hooks/use-push-notifications.ts'
-      - 'apps/web/src/lib/api.ts'
-      - 'apps/web/src/lib/api/**'
-      - 'apps/web/src/lib/analytics.ts'
-      - 'apps/web/src/lib/push-notifications.ts'
-      - 'apps/web/src/lib/types.ts'
-      - 'apps/web/src/store/session.ts'
-      - 'apps/web/src/types/quiz.ts'
+      - 'apps/web/src/lib/api/adventure.ts'
+      - 'apps/web/src/lib/api/adventure.spec.ts'
+      - 'apps/web/src/lib/api/pack.ts'
       - 'packages/database/prisma/schema.prisma'
       - 'packages/database/prisma/migrations/**'
       - '.github/workflows/adventure-system-ci.yml'
-      - 'DEPLOYMENT_GUIDE.md'
       - 'docs/ADVENTURE_QUALIFICATION.md'
-      - 'docker-compose.yml'
+      - 'docs/ADVENTURE_ROLLOUT.md'
+      - 'docs/WOOF_ADVENTURE_SYSTEM.md'
 
 permissions:
   contents: read
@@ -135,115 +109,32 @@ jobs:
           --to-schema-datamodel prisma/schema.prisma
           --exit-code
 
-      - name: Check redesign formatting
+      - name: Check Adventure release formatting
         run: >-
           pnpm exec prettier --check
-          docker-compose.yml
-          apps/web/.eslintrc.js
-          apps/web/next.config.ts
-          apps/web/tailwind.config.ts
-          apps/web/vitest.config.ts
           apps/api/src/adventure
           apps/api/src/care-events
-          apps/api/src/auth/authenticated-request.ts
           apps/api/src/config/env.validation.ts
-          apps/api/src/common/filters/all-exceptions.filter.ts
-          apps/api/src/common/filters/all-exceptions.filter.spec.ts
           apps/api/src/activities/activities.module.ts
           apps/api/src/activities/activities.service.ts
           apps/api/src/coaching/coaching.controller.ts
           apps/api/src/coaching/coaching.module.ts
           apps/api/src/gamification/gamification.controller.ts
-          apps/api/src/behavior-vision/behavior-profile.spec.ts
-          apps/api/src/goals/goals.controller.ts
-          apps/api/src/quiz/dto/save-quiz-response.dto.ts
-          apps/api/src/media-library/media-library.service.spec.ts
-          apps/api/src/app.controller.ts
-          apps/api/src/app.service.ts
-          apps/api/src/app.service.spec.ts
           apps/api/src/app.module.ts
-          apps/api/src/main.ts
           apps/web/src/app/page.tsx
           apps/web/src/app/compass
-          apps/web/src/app/health/page.tsx
           apps/web/src/app/journey
-          apps/web/src/app/notifications/page.tsx
           apps/web/src/app/pack
-          apps/web/src/components/activity/activity-history.tsx
           apps/web/src/components/bottom-nav.tsx
-          apps/web/src/components/events/EventDetailsDialog.tsx
-          apps/web/src/components/matches/MatchDiscoveryScreen.tsx
-          apps/web/src/components/onboarding
-          apps/web/src/components/quiz
-          apps/web/src/data/quizQuestions.ts
-          apps/web/src/hooks/use-push-notifications.ts
-          apps/web/src/lib/api.ts
-          apps/web/src/lib/api
-          apps/web/src/lib/analytics.ts
-          apps/web/src/lib/push-notifications.ts
-          apps/web/src/lib/types.ts
-          apps/web/src/store/session.ts
-          apps/web/src/types/quiz.ts
+          apps/web/src/lib/api/adventure.ts
+          apps/web/src/lib/api/adventure.spec.ts
+          apps/web/src/lib/api/pack.ts
 
-      - name: Lint Adventure API changes
-        run: >-
-          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
-          'src/adventure/**/*.ts'
-          'src/care-events/**/*.ts'
-          src/auth/authenticated-request.ts
-          src/config/env.validation.ts
-          src/common/filters/all-exceptions.filter.ts
-          src/common/filters/all-exceptions.filter.spec.ts
-          src/activities/activities.module.ts
-          src/activities/activities.service.ts
-          src/coaching/coaching.controller.ts
-          src/coaching/coaching.module.ts
-          src/gamification/gamification.controller.ts
-          src/behavior-vision/behavior-profile.spec.ts
-          src/behavior-vision/behavior-vision.service.ts
-          src/chat/chat.gateway.ts
-          src/goals/goals.controller.ts
-          src/quiz/dto/save-quiz-response.dto.ts
-          src/media-library/media-library.service.spec.ts
-          src/app.controller.ts
-          src/app.service.ts
-          src/app.service.spec.ts
-          src/app.module.ts
-          src/main.ts
+      - name: Lint monorepo
+        run: pnpm lint
 
-      - name: Lint Adventure web changes
-        run: >-
-          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
-          next.config.ts
-          tailwind.config.ts
-          vitest.config.ts
-          src/app/page.tsx
-          src/app/compass/page.tsx
-          src/app/health/page.tsx
-          src/app/journey/page.tsx
-          src/app/notifications/page.tsx
-          src/app/pack/page.tsx
-          src/components/activity/activity-history.tsx
-          src/components/bottom-nav.tsx
-          src/components/events/EventDetailsDialog.tsx
-          src/components/matches/MatchDiscoveryScreen.tsx
-          'src/components/onboarding/**/*.tsx'
-          'src/components/quiz/**/*.tsx'
-          src/data/quizQuestions.ts
-          src/hooks/use-push-notifications.ts
-          src/lib/api.ts
-          'src/lib/api/**/*.ts'
-          src/lib/analytics.ts
-          src/lib/push-notifications.ts
-          src/lib/types.ts
-          src/store/session.ts
-          src/types/quiz.ts
-
-      - name: Type-check API
-        run: pnpm --filter @woof/api type-check
-
-      - name: Type-check web app
-        run: pnpm --filter @woof/web type-check
+      - name: Type-check monorepo
+        run: pnpm type-check
 
       - name: Run Adventure web contract tests
         run: pnpm --filter @woof/web test

--- a/.github/workflows/adventure-system-ci.yml
+++ b/.github/workflows/adventure-system-ci.yml
@@ -1,0 +1,269 @@
+name: Adventure System CI
+
+on:
+  push:
+    branches: [agent/woof-adventure-system-v1]
+  pull_request:
+    paths:
+      - 'apps/api/.env.example'
+      - 'apps/api/src/adventure/**'
+      - 'apps/api/src/care-events/**'
+      - 'apps/api/src/activities/**'
+      - 'apps/api/src/coaching/**'
+      - 'apps/api/src/auth/authenticated-request.ts'
+      - 'apps/api/src/config/env.validation.ts'
+      - 'apps/api/src/common/filters/all-exceptions.filter.ts'
+      - 'apps/api/src/common/filters/all-exceptions.filter.spec.ts'
+      - 'apps/api/src/gamification/gamification.controller.ts'
+      - 'apps/api/src/behavior-vision/behavior-profile.spec.ts'
+      - 'apps/api/src/behavior-vision/behavior-vision.service.ts'
+      - 'apps/api/src/chat/chat.gateway.ts'
+      - 'apps/api/src/goals/goals.controller.ts'
+      - 'apps/api/src/quiz/dto/save-quiz-response.dto.ts'
+      - 'apps/api/src/media-library/media-library.service.spec.ts'
+      - 'apps/api/src/app.controller.ts'
+      - 'apps/api/src/app.service.ts'
+      - 'apps/api/src/app.service.spec.ts'
+      - 'apps/api/src/app.module.ts'
+      - 'apps/api/src/main.ts'
+      - 'apps/web/.eslintrc.js'
+      - 'apps/web/next.config.ts'
+      - 'apps/web/tailwind.config.ts'
+      - 'apps/web/vitest.config.ts'
+      - 'apps/web/src/app/**'
+      - 'apps/web/src/components/activity/activity-history.tsx'
+      - 'apps/web/src/components/bottom-nav.tsx'
+      - 'apps/web/src/components/events/EventDetailsDialog.tsx'
+      - 'apps/web/src/components/matches/MatchDiscoveryScreen.tsx'
+      - 'apps/web/src/components/onboarding/**'
+      - 'apps/web/src/components/quiz/**'
+      - 'apps/web/src/data/quizQuestions.ts'
+      - 'apps/web/src/hooks/use-push-notifications.ts'
+      - 'apps/web/src/lib/api.ts'
+      - 'apps/web/src/lib/api/**'
+      - 'apps/web/src/lib/analytics.ts'
+      - 'apps/web/src/lib/push-notifications.ts'
+      - 'apps/web/src/lib/types.ts'
+      - 'apps/web/src/store/session.ts'
+      - 'apps/web/src/types/quiz.ts'
+      - 'packages/database/prisma/schema.prisma'
+      - 'packages/database/prisma/migrations/**'
+      - '.github/workflows/adventure-system-ci.yml'
+      - 'DEPLOYMENT_GUIDE.md'
+      - 'docs/ADVENTURE_QUALIFICATION.md'
+      - 'docker-compose.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: adventure-system-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  NEXT_PUBLIC_API_URL: http://127.0.0.1:59999/api/v1
+
+jobs:
+  qualify:
+    name: Adventure redesign qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+      SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_shadow
+      JWT_SECRET: ci-only-adventure-secret
+      NODE_ENV: test
+      ML_SERVICE_ENABLED: 'false'
+      ENABLE_ADVENTURE_SYSTEM: 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate Prisma schema
+        run: pnpm --filter @woof/database exec prisma validate
+
+      - name: Check Prisma schema formatting
+        run: |
+          pnpm --filter @woof/database exec prisma format
+          git diff --exit-code -- packages/database/prisma/schema.prisma
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject destructive Adventure migration operations
+        run: |
+          migration="packages/database/prisma/migrations/20260821223000_add_woof_adventure_system/migration.sql"
+          if grep -Ein '\b(DROP[[:space:]]+(TABLE|COLUMN|INDEX|CONSTRAINT)|TRUNCATE|DELETE[[:space:]]+FROM)\b' "$migration"; then
+            echo "Adventure migration must remain additive; destructive SQL was detected."
+            exit 1
+          fi
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Verify migrated database matches Prisma datamodel
+        run: >-
+          pnpm --filter @woof/database exec prisma migrate diff
+          --from-url "$DATABASE_URL"
+          --to-schema-datamodel prisma/schema.prisma
+          --exit-code
+
+      - name: Check redesign formatting
+        run: >-
+          pnpm exec prettier --check
+          docker-compose.yml
+          apps/web/.eslintrc.js
+          apps/web/next.config.ts
+          apps/web/tailwind.config.ts
+          apps/web/vitest.config.ts
+          apps/api/src/adventure
+          apps/api/src/care-events
+          apps/api/src/auth/authenticated-request.ts
+          apps/api/src/config/env.validation.ts
+          apps/api/src/common/filters/all-exceptions.filter.ts
+          apps/api/src/common/filters/all-exceptions.filter.spec.ts
+          apps/api/src/activities/activities.module.ts
+          apps/api/src/activities/activities.service.ts
+          apps/api/src/coaching/coaching.controller.ts
+          apps/api/src/coaching/coaching.module.ts
+          apps/api/src/gamification/gamification.controller.ts
+          apps/api/src/behavior-vision/behavior-profile.spec.ts
+          apps/api/src/goals/goals.controller.ts
+          apps/api/src/quiz/dto/save-quiz-response.dto.ts
+          apps/api/src/media-library/media-library.service.spec.ts
+          apps/api/src/app.controller.ts
+          apps/api/src/app.service.ts
+          apps/api/src/app.service.spec.ts
+          apps/api/src/app.module.ts
+          apps/api/src/main.ts
+          apps/web/src/app/page.tsx
+          apps/web/src/app/compass
+          apps/web/src/app/health/page.tsx
+          apps/web/src/app/journey
+          apps/web/src/app/notifications/page.tsx
+          apps/web/src/app/pack
+          apps/web/src/components/activity/activity-history.tsx
+          apps/web/src/components/bottom-nav.tsx
+          apps/web/src/components/events/EventDetailsDialog.tsx
+          apps/web/src/components/matches/MatchDiscoveryScreen.tsx
+          apps/web/src/components/onboarding
+          apps/web/src/components/quiz
+          apps/web/src/data/quizQuestions.ts
+          apps/web/src/hooks/use-push-notifications.ts
+          apps/web/src/lib/api.ts
+          apps/web/src/lib/api
+          apps/web/src/lib/analytics.ts
+          apps/web/src/lib/push-notifications.ts
+          apps/web/src/lib/types.ts
+          apps/web/src/store/session.ts
+          apps/web/src/types/quiz.ts
+
+      - name: Lint Adventure API changes
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          'src/adventure/**/*.ts'
+          'src/care-events/**/*.ts'
+          src/auth/authenticated-request.ts
+          src/config/env.validation.ts
+          src/common/filters/all-exceptions.filter.ts
+          src/common/filters/all-exceptions.filter.spec.ts
+          src/activities/activities.module.ts
+          src/activities/activities.service.ts
+          src/coaching/coaching.controller.ts
+          src/coaching/coaching.module.ts
+          src/gamification/gamification.controller.ts
+          src/behavior-vision/behavior-profile.spec.ts
+          src/behavior-vision/behavior-vision.service.ts
+          src/chat/chat.gateway.ts
+          src/goals/goals.controller.ts
+          src/quiz/dto/save-quiz-response.dto.ts
+          src/media-library/media-library.service.spec.ts
+          src/app.controller.ts
+          src/app.service.ts
+          src/app.service.spec.ts
+          src/app.module.ts
+          src/main.ts
+
+      - name: Lint Adventure web changes
+        run: >-
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          next.config.ts
+          tailwind.config.ts
+          vitest.config.ts
+          src/app/page.tsx
+          src/app/compass/page.tsx
+          src/app/health/page.tsx
+          src/app/journey/page.tsx
+          src/app/notifications/page.tsx
+          src/app/pack/page.tsx
+          src/components/activity/activity-history.tsx
+          src/components/bottom-nav.tsx
+          src/components/events/EventDetailsDialog.tsx
+          src/components/matches/MatchDiscoveryScreen.tsx
+          'src/components/onboarding/**/*.tsx'
+          'src/components/quiz/**/*.tsx'
+          src/data/quizQuestions.ts
+          src/hooks/use-push-notifications.ts
+          src/lib/api.ts
+          'src/lib/api/**/*.ts'
+          src/lib/analytics.ts
+          src/lib/push-notifications.ts
+          src/lib/types.ts
+          src/store/session.ts
+          src/types/quiz.ts
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Type-check web app
+        run: pnpm --filter @woof/web type-check
+
+      - name: Run Adventure web contract tests
+        run: pnpm --filter @woof/web test
+
+      - name: Run reward policy contract tests
+        run: pnpm --filter @woof/api exec jest src/care-events/reward-policy.spec.ts --runInBand
+
+      - name: Run reward ledger integrity tests
+        run: pnpm --filter @woof/api exec jest src/care-events/care-events.integration.spec.ts --runInBand
+
+      - name: Run quest engine contract tests
+        run: pnpm --filter @woof/api exec jest src/adventure/adventure.service.spec.ts --runInBand
+
+      - name: Run API tests
+        run: pnpm --filter @woof/api exec jest --runInBand
+
+      - name: Build API
+        run: pnpm --filter @woof/api build
+
+      - name: Build web app
+        env:
+          NEXT_PUBLIC_API_URL: https://api.example.com/api/v1
+        run: pnpm --filter @woof/web build

--- a/apps/api/src/activities/activities.module.ts
+++ b/apps/api/src/activities/activities.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
-import { ActivitiesService } from './activities.service';
+import { CareEventsModule } from '../care-events/care-events.module';
 import { ActivitiesController } from './activities.controller';
+import { ActivitiesService } from './activities.service';
 
 @Module({
+  imports: [CareEventsModule],
   providers: [ActivitiesService],
   controllers: [ActivitiesController],
   exports: [ActivitiesService],

--- a/apps/api/src/activities/activities.service.ts
+++ b/apps/api/src/activities/activities.service.ts
@@ -1,15 +1,18 @@
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@woof/database';
+import { CareEventsService } from '../care-events/care-events.service';
+import type { WellbeingPathway } from '../care-events/care-event.types';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateActivityDto, UpdateActivityDto } from './dto/activity.dto';
 
 @Injectable()
 export class ActivitiesService {
-  constructor(private readonly prisma: PrismaService) {}
+  private readonly logger = new Logger(ActivitiesService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly careEvents: CareEventsService
+  ) {}
 
   async create(userId: string, dto: CreateActivityDto) {
     if (dto.petId) {
@@ -20,7 +23,7 @@ export class ActivitiesService {
     const endedAt = dto.endedAt ? new Date(dto.endedAt) : null;
     this.assertChronology(startedAt, endedAt);
 
-    return this.prisma.activity.create({
+    const activity = await this.prisma.activity.create({
       data: {
         userId,
         petId: dto.petId,
@@ -34,6 +37,12 @@ export class ActivitiesService {
       },
       include: this.activityInclude(),
     });
+
+    if (activity.endedAt && activity.petId) {
+      await this.emitActivityCareEvent(userId, activity);
+    }
+
+    return activity;
   }
 
   async findAll(userId: string, skip = 0, take = 20, petId?: string) {
@@ -98,12 +107,10 @@ export class ActivitiesService {
     }
 
     const startedAt = dto.startedAt ? new Date(dto.startedAt) : existing.startedAt;
-    const endedAt = dto.endedAt
-      ? new Date(dto.endedAt)
-      : existing.endedAt;
+    const endedAt = dto.endedAt ? new Date(dto.endedAt) : existing.endedAt;
     this.assertChronology(startedAt, endedAt);
 
-    return this.prisma.activity.update({
+    const activity = await this.prisma.activity.update({
       where: { id },
       data: {
         ...(dto.petId !== undefined ? { petId: dto.petId } : {}),
@@ -111,23 +118,105 @@ export class ActivitiesService {
         ...(dto.endedAt !== undefined ? { endedAt } : {}),
         ...(dto.type !== undefined ? { type: dto.type } : {}),
         ...(dto.route !== undefined ? { route: this.json(dto.route) } : {}),
-        ...(dto.humanMetrics !== undefined
-          ? { humanMetrics: this.json(dto.humanMetrics) }
-          : {}),
-        ...(dto.petMetrics !== undefined
-          ? { petMetrics: this.json(dto.petMetrics) }
-          : {}),
-        ...(dto.jointMetrics !== undefined
-          ? { jointMetrics: this.json(dto.jointMetrics) }
-          : {}),
+        ...(dto.humanMetrics !== undefined ? { humanMetrics: this.json(dto.humanMetrics) } : {}),
+        ...(dto.petMetrics !== undefined ? { petMetrics: this.json(dto.petMetrics) } : {}),
+        ...(dto.jointMetrics !== undefined ? { jointMetrics: this.json(dto.jointMetrics) } : {}),
       },
       include: this.activityInclude(),
     });
+
+    if (activity.endedAt && activity.petId) {
+      await this.emitActivityCareEvent(userId, activity);
+    }
+
+    return activity;
   }
 
   async delete(userId: string, id: string) {
     await this.assertOwnedActivity(userId, id);
     return this.prisma.activity.delete({ where: { id } });
+  }
+
+  private async emitActivityCareEvent(
+    userId: string,
+    activity: {
+      id: string;
+      petId: string | null;
+      type: string;
+      startedAt: Date;
+      endedAt: Date | null;
+      route: unknown;
+    }
+  ) {
+    if (!activity.petId || !activity.endedAt) return;
+    const semantic = this.activitySemantic(activity.type);
+    if (!semantic) return;
+
+    const durationMinutes = Math.max(
+      0,
+      Math.round((activity.endedAt.getTime() - activity.startedAt.getTime()) / 60000)
+    );
+
+    try {
+      await this.careEvents.record({
+        userId,
+        petId: activity.petId,
+        eventType: semantic.eventType,
+        pathway: semantic.pathway,
+        occurredAt: activity.endedAt,
+        source: 'ACTIVITIES',
+        evidenceType: 'ACTIVITY',
+        evidenceConfidence: 0.78,
+        dedupeKey: `activity:${activity.id}:completed`,
+        context: {
+          activityId: activity.id,
+          activityType: activity.type.toUpperCase(),
+          durationMinutes,
+          routePresent: Boolean(activity.route),
+        },
+      });
+    } catch (error) {
+      // Rewards are additive product infrastructure. Logging an activity must remain
+      // reliable during a rolling deployment even if the new ledger migration has
+      // not reached this API instance yet.
+      this.logger.warn(
+        `Activity ${activity.id} saved, but Adventure reward emission failed: ${
+          error instanceof Error ? error.message : 'unknown error'
+        }`
+      );
+    }
+  }
+
+  private activitySemantic(type: string): {
+    eventType: string;
+    pathway: WellbeingPathway;
+  } | null {
+    switch (type.toUpperCase()) {
+      case 'WALK':
+        return { eventType: 'ACTIVITY_WALK', pathway: 'MOVE' };
+      case 'RUN':
+        return { eventType: 'ACTIVITY_RUN', pathway: 'MOVE' };
+      case 'HIKE':
+        return { eventType: 'ACTIVITY_HIKE', pathway: 'EXPLORE' };
+      case 'PLAY':
+      case 'ENRICHMENT':
+      case 'SCENT':
+      case 'PUZZLE':
+        return { eventType: 'ENRICHMENT_SESSION', pathway: 'ENRICH' };
+      case 'TRAINING':
+        return { eventType: 'TRAINING_SESSION', pathway: 'LEARN' };
+      case 'SOCIAL':
+      case 'MEETUP':
+        return { eventType: 'SOCIAL_OUTING', pathway: 'CONNECT' };
+      case 'PARALLEL_WALK':
+        return { eventType: 'PARALLEL_WALK', pathway: 'CONNECT' };
+      case 'RECOVERY':
+      case 'REST':
+      case 'DECOMPRESSION':
+        return { eventType: 'RECOVERY_SESSION', pathway: 'RECOVER' };
+      default:
+        return null;
+    }
   }
 
   private async assertOwnedPet(userId: string, petId: string) {
@@ -159,9 +248,7 @@ export class ActivitiesService {
   }
 
   private json(value?: Record<string, unknown>) {
-    return value === undefined
-      ? undefined
-      : (value as Prisma.InputJsonValue);
+    return value === undefined ? undefined : (value as Prisma.InputJsonValue);
   }
 
   private activityInclude() {

--- a/apps/api/src/adventure/adventure-enabled.guard.ts
+++ b/apps/api/src/adventure/adventure-enabled.guard.ts
@@ -1,0 +1,22 @@
+import { CanActivate, Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class AdventureEnabledGuard implements CanActivate {
+  constructor(private readonly config: ConfigService) {}
+
+  canActivate(): boolean {
+    const configured = this.config.get<string>('ENABLE_ADVENTURE_SYSTEM');
+    const enabled =
+      configured === 'true' ||
+      (configured !== 'false' && this.config.get<string>('NODE_ENV') !== 'production');
+
+    if (!enabled) {
+      // A disabled experimental surface should disappear rather than advertise
+      // configuration or rollout state to clients.
+      throw new NotFoundException();
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/adventure/adventure.controller.ts
+++ b/apps/api/src/adventure/adventure.controller.ts
@@ -1,0 +1,53 @@
+import { Body, Controller, Get, Param, Post, Query, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { AuthenticatedRequest } from '../auth/authenticated-request';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdventureEnabledGuard } from './adventure-enabled.guard';
+import { AdventureService } from './adventure.service';
+import { CompleteQuestDto, QuestInteractionDto } from './dto/adventure.dto';
+
+@ApiTags('adventure')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, AdventureEnabledGuard)
+@Controller('adventure')
+export class AdventureController {
+  constructor(private readonly adventureService: AdventureService) {}
+
+  @Get('me')
+  @ApiOperation({ summary: 'Get the personalized Woof Adventure dashboard and daily quest deck' })
+  getMine(@Request() req: AuthenticatedRequest, @Query('petId') petId?: string) {
+    return this.adventureService.getDashboard(req.user.sub, petId);
+  }
+
+  @Post('quests/:questId/select')
+  @ApiOperation({ summary: 'Record that the owner selected a generated quest' })
+  selectQuest(
+    @Request() req: AuthenticatedRequest,
+    @Param('questId') questId: string,
+    @Body() dto: QuestInteractionDto
+  ) {
+    return this.adventureService.recordInteraction(req.user.sub, dto.petId, questId, 'SELECTED');
+  }
+
+  @Post('quests/:questId/dismiss')
+  @ApiOperation({ summary: 'Record that a generated quest did not fit today' })
+  dismissQuest(
+    @Request() req: AuthenticatedRequest,
+    @Param('questId') questId: string,
+    @Body() dto: QuestInteractionDto
+  ) {
+    return this.adventureService.recordInteraction(req.user.sub, dto.petId, questId, 'DISMISSED');
+  }
+
+  @Post('quests/:questId/complete')
+  @ApiOperation({
+    summary: 'Close the five-second outcome loop and issue server-calculated Bond XP',
+  })
+  completeQuest(
+    @Request() req: AuthenticatedRequest,
+    @Param('questId') questId: string,
+    @Body() dto: CompleteQuestDto
+  ) {
+    return this.adventureService.completeQuest(req.user.sub, questId, dto);
+  }
+}

--- a/apps/api/src/adventure/adventure.module.ts
+++ b/apps/api/src/adventure/adventure.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { CareEventsModule } from '../care-events/care-events.module';
+import { InsightsModule } from '../insights/insights.module';
+import { AdventureEnabledGuard } from './adventure-enabled.guard';
+import { AdventureController } from './adventure.controller';
+import { AdventureService } from './adventure.service';
+import { PackChallengesController } from './pack-challenges.controller';
+import { PackChallengesService } from './pack-challenges.service';
+
+@Module({
+  imports: [InsightsModule, CareEventsModule],
+  controllers: [AdventureController, PackChallengesController],
+  providers: [AdventureEnabledGuard, AdventureService, PackChallengesService],
+  exports: [AdventureService],
+})
+export class AdventureModule {}

--- a/apps/api/src/adventure/adventure.service.spec.ts
+++ b/apps/api/src/adventure/adventure.service.spec.ts
@@ -1,0 +1,256 @@
+import { NotFoundException } from '@nestjs/common';
+import { CareEventsService } from '../care-events/care-events.service';
+import type { RewardReceipt } from '../care-events/care-event.types';
+import { InsightsService } from '../insights/insights.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AdventureService } from './adventure.service';
+import type { CompleteQuestDto } from './dto/adventure.dto';
+
+const quest = {
+  id: 'quest-1',
+  key: 'skill-spark',
+  title: 'Five-minute skill spark',
+  description: 'Practice one easy skill.',
+  why: 'Short comfortable repetitions build communication.',
+  primaryPathway: 'LEARN' as const,
+  pathways: ['LEARN', 'BOND'] as const,
+  xp: 15,
+  confidence: 0.82,
+  href: '/coach',
+  actionLabel: 'Open Coach',
+  variant: 'recommended' as const,
+  safeStopEligible: true,
+  personalRelevance: 1.02,
+  expiresAt: '2026-08-22T00:00:00.000Z',
+};
+
+const dashboard = {
+  pet: { id: 'pet-1', name: 'Shasta', species: 'DOG', avatarUrl: null },
+  generatedAt: '2026-08-21T12:00:00.000Z',
+  bondXp: 12,
+  rhythm: { activeWeeks: 2, windowWeeks: 5, label: 'A steady rhythm is growing' },
+  compass: [],
+  quests: [{ ...quest, pathways: [...quest.pathways] }],
+  learningSummary: [],
+  principles: [],
+  disclaimer: 'Opportunity coverage only.',
+};
+
+const dto = (overrides: Partial<CompleteQuestDto> = {}): CompleteQuestDto => ({
+  petId: 'pet-1',
+  dogExperience: 'comfortable',
+  ownerExperience: 'fine',
+  ...overrides,
+});
+
+const receipt = (overrides: Partial<RewardReceipt> = {}): RewardReceipt => ({
+  careEventId: 'care-1',
+  ledgerId: 'ledger-1',
+  bondXp: 17,
+  pathway: 'LEARN',
+  policyVersion: 'bond-xp-v1',
+  explanation: 'trusted reward',
+  duplicate: false,
+  ...overrides,
+});
+
+type PrismaHarness = {
+  mediaAsset: { findFirst: jest.Mock };
+  telemetry: { create: jest.Mock };
+};
+
+type CareEventsHarness = {
+  record: jest.Mock;
+  recordQuestInteraction: jest.Mock;
+  getRecentSelectedQuestContext: jest.Mock;
+};
+
+describe('AdventureService', () => {
+  let prismaHarness: PrismaHarness;
+  let careHarness: CareEventsHarness;
+  let service: AdventureService;
+
+  beforeEach(() => {
+    prismaHarness = {
+      mediaAsset: { findFirst: jest.fn().mockResolvedValue(null) },
+      telemetry: { create: jest.fn().mockResolvedValue({ id: 'telemetry-1' }) },
+    };
+    careHarness = {
+      record: jest.fn().mockResolvedValue(receipt()),
+      recordQuestInteraction: jest.fn().mockResolvedValue({ id: 'interaction-1' }),
+      getRecentSelectedQuestContext: jest.fn().mockResolvedValue(null),
+    };
+
+    service = new AdventureService(
+      prismaHarness as unknown as PrismaService,
+      {} as InsightsService,
+      careHarness as unknown as CareEventsService
+    );
+    jest.spyOn(service, 'getDashboard').mockResolvedValue(dashboard);
+  });
+
+  it('stores only completion semantics when a quest is selected', async () => {
+    await service.recordInteraction('user-1', 'pet-1', quest.id, 'SELECTED');
+
+    expect(careHarness.recordQuestInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interaction: 'SELECTED',
+        pathway: 'LEARN',
+        context: expect.objectContaining({
+          questSnapshot: {
+            id: quest.id,
+            key: quest.key,
+            title: quest.title,
+            primaryPathway: 'LEARN',
+            safeStopEligible: true,
+            personalRelevance: quest.personalRelevance,
+          },
+        }),
+      })
+    );
+
+    const call = careHarness.recordQuestInteraction.mock.calls[0]?.[0] as {
+      context: { questSnapshot: Record<string, unknown> };
+    };
+    expect(call.context.questSnapshot).not.toHaveProperty('xp');
+    expect(call.context.questSnapshot).not.toHaveProperty('href');
+  });
+
+  it('turns an eligible safe opt-out into Bond rather than Learn credit', async () => {
+    careHarness.record.mockResolvedValue(receipt({ pathway: 'BOND', bondXp: 18 }));
+
+    await service.completeQuest(
+      'user-1',
+      quest.id,
+      dto({ dogExperience: 'not_their_thing', ownerExperience: 'a_lot_today', safeOptOut: true })
+    );
+
+    expect(careHarness.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'SAFE_OPT_OUT',
+        pathway: 'BOND',
+        safetyEligible: true,
+      })
+    );
+  });
+
+  it('treats not-their-thing as Bond learning instead of inflating the attempted pathway', async () => {
+    careHarness.record.mockResolvedValue(receipt({ pathway: 'BOND', bondXp: 12 }));
+
+    await service.completeQuest(
+      'user-1',
+      quest.id,
+      dto({ dogExperience: 'not_their_thing', safeOptOut: false })
+    );
+
+    expect(careHarness.record).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'QUEST_BOND', pathway: 'BOND' })
+    );
+  });
+
+  it('does not grant a memory modifier for an unverified media id', async () => {
+    await service.completeQuest('user-1', quest.id, dto({ memoryAssetId: 'unowned-asset' }));
+
+    expect(prismaHarness.mediaAsset.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'unowned-asset',
+        ownerId: 'user-1',
+        petId: 'pet-1',
+        status: 'READY',
+      },
+      select: { id: true },
+    });
+    expect(careHarness.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({ memoryAdded: false, memoryAssetId: null }),
+      })
+    );
+  });
+
+  it('allows the small memory modifier only for READY media owned by the same dog-owner pair', async () => {
+    prismaHarness.mediaAsset.findFirst.mockResolvedValue({ id: 'owned-asset' });
+
+    await service.completeQuest('user-1', quest.id, dto({ memoryAssetId: 'owned-asset' }));
+
+    expect(careHarness.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({ memoryAdded: true, memoryAssetId: 'owned-asset' }),
+      })
+    );
+  });
+
+  it('completes a recently selected quest after it reshuffles out of the current deck', async () => {
+    jest.spyOn(service, 'getDashboard').mockResolvedValue({ ...dashboard, quests: [] });
+    careHarness.getRecentSelectedQuestContext.mockResolvedValue({
+      created_at: new Date(),
+      context: {
+        questSnapshot: {
+          id: quest.id,
+          key: quest.key,
+          title: quest.title,
+          primaryPathway: quest.primaryPathway,
+          safeStopEligible: quest.safeStopEligible,
+          personalRelevance: quest.personalRelevance,
+        },
+      },
+    });
+
+    await service.completeQuest('user-1', quest.id, dto());
+
+    expect(careHarness.getRecentSelectedQuestContext).toHaveBeenCalledWith(
+      'user-1',
+      'pet-1',
+      quest.id
+    );
+    expect(careHarness.record).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'QUEST_LEARN', pathway: 'LEARN' })
+    );
+  });
+
+  it('rejects a malformed selected snapshot instead of trusting persisted JSON blindly', async () => {
+    jest.spyOn(service, 'getDashboard').mockResolvedValue({ ...dashboard, quests: [] });
+    careHarness.getRecentSelectedQuestContext.mockResolvedValue({
+      created_at: new Date(),
+      context: {
+        questSnapshot: {
+          id: quest.id,
+          key: quest.key,
+          title: quest.title,
+          primaryPathway: 'NOT_A_PATHWAY',
+          safeStopEligible: true,
+          personalRelevance: 99,
+        },
+      },
+    });
+
+    await expect(service.completeQuest('user-1', quest.id, dto())).rejects.toBeInstanceOf(
+      NotFoundException
+    );
+    expect(careHarness.record).not.toHaveBeenCalled();
+  });
+
+  it('does not report failure after the authoritative reward commits if telemetry fails', async () => {
+    careHarness.recordQuestInteraction.mockRejectedValue(new Error('interaction store offline'));
+    prismaHarness.telemetry.create.mockRejectedValue(new Error('telemetry store offline'));
+
+    await expect(service.completeQuest('user-1', quest.id, dto())).resolves.toEqual(
+      expect.objectContaining({ reward: expect.objectContaining({ careEventId: 'care-1' }) })
+    );
+  });
+
+  it('uses an idempotent retry to repair interaction telemetry without implying new XP', async () => {
+    careHarness.record.mockResolvedValue(receipt({ duplicate: true, bondXp: 17 }));
+
+    const result = await service.completeQuest('user-1', quest.id, dto());
+
+    expect(result.reward.duplicate).toBe(true);
+    expect(careHarness.recordQuestInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({ interaction: 'COMPLETED' })
+    );
+    expect(prismaHarness.telemetry.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ data: expect.objectContaining({ duplicate: true }) }),
+      })
+    );
+  });
+});

--- a/apps/api/src/adventure/adventure.service.ts
+++ b/apps/api/src/adventure/adventure.service.ts
@@ -1,0 +1,469 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import { CareEventsService } from '../care-events/care-events.service';
+import {
+  QUEST_EVENT_TYPES,
+  WELLBEING_PATHWAYS,
+  type CareSummary,
+  type WellbeingPathway,
+} from '../care-events/care-event.types';
+import { baseXpForEvent } from '../care-events/reward-policy';
+import { InsightsService } from '../insights/insights.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { CompleteQuestDto } from './dto/adventure.dto';
+
+type Quest = {
+  id: string;
+  key: string;
+  title: string;
+  description: string;
+  why: string;
+  primaryPathway: WellbeingPathway;
+  pathways: WellbeingPathway[];
+  xp: number;
+  confidence: number;
+  href: string;
+  actionLabel: string;
+  variant: 'recommended' | 'alternative' | 'wildcard';
+  safeStopEligible: boolean;
+  personalRelevance: number;
+  expiresAt: string;
+};
+
+type Candidate = Omit<Quest, 'id' | 'variant' | 'expiresAt'> & { score: number };
+
+type QuestCompletionContext = Pick<
+  Quest,
+  'id' | 'key' | 'title' | 'primaryPathway' | 'safeStopEligible' | 'personalRelevance'
+>;
+
+type SelectedQuestSnapshot = QuestCompletionContext;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const CATEGORY_PATHWAYS: Record<string, WellbeingPathway> = {
+  activity: 'MOVE',
+  enrichment: 'ENRICH',
+  social: 'CONNECT',
+  recovery: 'RECOVER',
+  reflection: 'BOND',
+  goal: 'BOND',
+};
+
+@Injectable()
+export class AdventureService {
+  private readonly logger = new Logger(AdventureService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly insights: InsightsService,
+    private readonly careEvents: CareEventsService
+  ) {}
+
+  async getDashboard(userId: string, requestedPetId?: string) {
+    const insights = await this.insights.getForUser(userId, requestedPetId);
+    const summary = await this.careEvents.getSummary(userId, insights.pet.id);
+    const quests = this.buildQuests(userId, insights, summary);
+
+    return {
+      pet: insights.pet,
+      generatedAt: new Date().toISOString(),
+      bondXp: summary.bondXp,
+      rhythm: summary.rhythm,
+      compass: summary.pathways,
+      quests,
+      learningSummary: insights.learningSummary,
+      principles: [
+        'individual-fit-over-volume',
+        'choice-over-coercion',
+        'recovery-counts',
+        'safe-opt-outs-succeed',
+        'reward-based-learning',
+      ],
+      disclaimer:
+        'The Pawprint Compass shows recent opportunity coverage, not a health score or veterinary assessment.',
+    };
+  }
+
+  async recordInteraction(
+    userId: string,
+    petId: string,
+    questId: string,
+    interaction: 'SELECTED' | 'DISMISSED'
+  ) {
+    const dashboard = await this.getDashboard(userId, petId);
+    const quest = dashboard.quests.find((candidate) => candidate.id === questId);
+    if (!quest) throw new NotFoundException('This quest is no longer available');
+
+    await this.careEvents.recordQuestInteraction({
+      userId,
+      petId,
+      questId,
+      interaction,
+      pathway: quest.primaryPathway,
+      context: {
+        questKey: quest.key,
+        confidence: quest.confidence,
+        ...(interaction === 'SELECTED' ? { questSnapshot: this.questSnapshot(quest) } : {}),
+      },
+    });
+    return { ok: true };
+  }
+
+  async completeQuest(userId: string, questId: string, dto: CompleteQuestDto) {
+    const dashboard = await this.getDashboard(userId, dto.petId);
+    const currentQuest = dashboard.quests.find((candidate) => candidate.id === questId);
+    const selected = currentQuest
+      ? null
+      : await this.careEvents.getRecentSelectedQuestContext(userId, dto.petId, questId);
+    const quest: QuestCompletionContext | null =
+      currentQuest ?? this.questFromSnapshot(selected?.context?.questSnapshot, questId);
+
+    if (!quest) throw new NotFoundException('This quest is no longer available');
+
+    const safeOptOut = Boolean(dto.safeOptOut && quest.safeStopEligible);
+    const learnedMismatch = dto.dogExperience === 'not_their_thing' && !safeOptOut;
+    const eventType = safeOptOut
+      ? 'SAFE_OPT_OUT'
+      : learnedMismatch
+        ? QUEST_EVENT_TYPES.BOND
+        : QUEST_EVENT_TYPES[quest.primaryPathway];
+    const rewardPathway: WellbeingPathway =
+      safeOptOut || learnedMismatch ? 'BOND' : quest.primaryPathway;
+
+    // Memory bonuses require a real, completed private asset owned by this exact
+    // dog-owner pair. A random client-supplied asset ID never changes rewards.
+    const verifiedMemory = dto.memoryAssetId
+      ? await this.prisma.mediaAsset.findFirst({
+          where: {
+            id: dto.memoryAssetId,
+            ownerId: userId,
+            petId: dto.petId,
+            status: 'READY',
+          },
+          select: { id: true },
+        })
+      : null;
+
+    const receipt = await this.careEvents.record({
+      userId,
+      petId: dto.petId,
+      eventType,
+      pathway: rewardPathway,
+      source: 'QUEST_ENGINE',
+      evidenceType: 'SELF_REPORT',
+      evidenceConfidence: 0.68,
+      dedupeKey: `quest:${quest.id}`,
+      safetyEligible: true,
+      context: {
+        questId: quest.id,
+        questKey: quest.key,
+        questTitle: quest.title,
+        originalPathway: quest.primaryPathway,
+        personalRelevance: quest.personalRelevance,
+        memoryAdded: Boolean(verifiedMemory),
+        memoryAssetId: verifiedMemory?.id ?? null,
+      },
+      outcome: {
+        dogExperience: dto.dogExperience,
+        ownerExperience: dto.ownerExperience,
+        safeOptOut,
+        note: dto.note ?? null,
+      },
+    });
+
+    // These records are useful for analytics and continuity, but the CareEvent +
+    // RewardLedger transaction above is authoritative. A telemetry outage must never
+    // turn a successful reward into an apparent client failure. The upsert also lets
+    // a retry repair a previously failed interaction write without issuing XP twice.
+    try {
+      await this.careEvents.recordQuestInteraction({
+        userId,
+        petId: dto.petId,
+        questId,
+        interaction: 'COMPLETED',
+        pathway: rewardPathway,
+        context: {
+          questKey: quest.key,
+          dogExperience: dto.dogExperience,
+          ownerExperience: dto.ownerExperience,
+          safeOptOut,
+          bondXp: receipt.bondXp,
+        },
+      });
+    } catch (error) {
+      this.logger.warn(
+        `Quest ${questId} reward committed but interaction telemetry failed: ${
+          error instanceof Error ? error.message : 'unknown error'
+        }`
+      );
+    }
+
+    try {
+      await this.prisma.telemetry.create({
+        data: {
+          source: 'ADVENTURE',
+          event: safeOptOut
+            ? 'QUEST_SAFE_OPT_OUT'
+            : learnedMismatch
+              ? 'QUEST_LEARNED_MISMATCH'
+              : 'QUEST_COMPLETED',
+          userId,
+          petId: dto.petId,
+          data: {
+            questId,
+            pathway: rewardPathway,
+            bondXp: receipt.bondXp,
+            duplicate: receipt.duplicate,
+            dogExperience: dto.dogExperience,
+            ownerExperience: dto.ownerExperience,
+          },
+        },
+      });
+    } catch (error) {
+      this.logger.warn(
+        `Quest ${questId} reward committed but Adventure telemetry failed: ${
+          error instanceof Error ? error.message : 'unknown error'
+        }`
+      );
+    }
+
+    return {
+      reward: receipt,
+      message: safeOptOut
+        ? 'You listened. Giving space was the right play.'
+        : learnedMismatch
+          ? 'Useful discovery. Woof will treat this as preference evidence, not a failure.'
+          : dto.dogExperience === 'loved_it'
+            ? 'That one is worth remembering.'
+            : 'Nice read. Another useful piece of your shared pattern.',
+    };
+  }
+
+  private questSnapshot(quest: Quest): SelectedQuestSnapshot {
+    return {
+      id: quest.id,
+      key: quest.key,
+      title: quest.title,
+      primaryPathway: quest.primaryPathway,
+      safeStopEligible: quest.safeStopEligible,
+      personalRelevance: quest.personalRelevance,
+    };
+  }
+
+  private questFromSnapshot(value: unknown, questId: string): SelectedQuestSnapshot | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+
+    const candidate = value as Record<string, unknown>;
+    const personalRelevance = candidate.personalRelevance;
+    if (
+      candidate.id !== questId ||
+      typeof candidate.key !== 'string' ||
+      candidate.key.length === 0 ||
+      typeof candidate.title !== 'string' ||
+      candidate.title.length === 0 ||
+      !this.isWellbeingPathway(candidate.primaryPathway) ||
+      typeof candidate.safeStopEligible !== 'boolean' ||
+      typeof personalRelevance !== 'number' ||
+      !Number.isFinite(personalRelevance) ||
+      personalRelevance < 0.9 ||
+      personalRelevance > 1.08
+    ) {
+      return null;
+    }
+
+    return {
+      id: questId,
+      key: candidate.key,
+      title: candidate.title,
+      primaryPathway: candidate.primaryPathway,
+      safeStopEligible: candidate.safeStopEligible,
+      personalRelevance,
+    };
+  }
+
+  private isWellbeingPathway(value: unknown): value is WellbeingPathway {
+    return (
+      typeof value === 'string' &&
+      WELLBEING_PATHWAYS.includes(value as (typeof WELLBEING_PATHWAYS)[number])
+    );
+  }
+
+  private buildQuests(
+    userId: string,
+    insights: Awaited<ReturnType<InsightsService['getForUser']>>,
+    summary: CareSummary
+  ): Quest[] {
+    const dateKey = new Date().toISOString().slice(0, 10);
+    const coverage = new Map(summary.pathways.map((item) => [item.pathway, item.coverage]));
+    const preference = this.preferenceSignals(summary);
+
+    const candidates: Candidate[] = insights.recommendations.map((recommendation) => {
+      const pathway = CATEGORY_PATHWAYS[recommendation.category] ?? 'BOND';
+      const eventType = QUEST_EVENT_TYPES[pathway];
+      const gap = 1 - (coverage.get(pathway) ?? 0) / 100;
+      const personalRelevance = this.clamp(1 + (preference[pathway] ?? 0), 0.9, 1.08);
+      return {
+        key: `insight-${recommendation.id}`,
+        title: recommendation.title,
+        description: this.questDescription(pathway, insights.pet.name),
+        why: recommendation.reason,
+        primaryPathway: pathway,
+        pathways: this.secondaryPathways(pathway),
+        xp: baseXpForEvent(eventType),
+        confidence: recommendation.confidence,
+        href: recommendation.href,
+        actionLabel: recommendation.actionLabel,
+        safeStopEligible: pathway === 'CONNECT' || pathway === 'LEARN',
+        personalRelevance,
+        score: recommendation.score * 0.68 + gap * 0.24 + (personalRelevance - 0.9) * 0.5,
+      };
+    });
+
+    const templates: Candidate[] = [
+      {
+        key: 'sniffari',
+        title: 'Take a Sniffari',
+        description: `Give ${insights.pet.name} an easy exploration where sniffing, pausing, and choosing the pace are part of the point.`,
+        why: 'Novel sensory exploration can add variety without turning distance into the objective.',
+        primaryPathway: 'EXPLORE',
+        pathways: ['EXPLORE', 'ENRICH', 'BOND'],
+        xp: baseXpForEvent('QUEST_EXPLORE'),
+        confidence: Math.max(0.55, insights.algorithm.confidence),
+        href: '/activity',
+        actionLabel: 'Start an exploration',
+        safeStopEligible: false,
+        personalRelevance: this.clamp(1 + (preference.EXPLORE ?? 0), 0.9, 1.08),
+        score: 0.62 + (1 - (coverage.get('EXPLORE') ?? 0) / 100) * 0.28,
+      },
+      {
+        key: 'skill-spark',
+        title: 'Five-minute skill spark',
+        description:
+          'Choose one tiny reward-based skill and stop while the session still feels easy.',
+        why: 'Short comfortable repetitions build communication without making training a grind.',
+        primaryPathway: 'LEARN',
+        pathways: ['LEARN', 'BOND'],
+        xp: baseXpForEvent('QUEST_LEARN'),
+        confidence: 0.82,
+        href: '/coach',
+        actionLabel: 'Open Coach',
+        safeStopEligible: true,
+        personalRelevance: this.clamp(1 + (preference.LEARN ?? 0), 0.9, 1.08),
+        score: 0.58 + (1 - (coverage.get('LEARN') ?? 0) / 100) * 0.3,
+      },
+      {
+        key: 'easy-day',
+        title: 'Choose an easy day',
+        description:
+          'Keep the outing simple, add calm sniffing or enrichment, and leave room for decompression.',
+        why: 'Recovery is a valid wellbeing action. Woof does not treat more miles as automatically better.',
+        primaryPathway: 'RECOVER',
+        pathways: ['RECOVER', 'BOND'],
+        xp: baseXpForEvent('QUEST_RECOVER'),
+        confidence: 0.78,
+        href: '/activity',
+        actionLabel: 'Log an easy session',
+        safeStopEligible: false,
+        personalRelevance: this.clamp(1 + (preference.RECOVER ?? 0), 0.9, 1.08),
+        score: 0.48 + (1 - (coverage.get('RECOVER') ?? 0) / 100) * 0.24,
+      },
+      {
+        key: 'favorite-ritual',
+        title: 'Do one favorite thing together',
+        description:
+          'Pick a small ritual you both genuinely enjoy. Familiar can be as valuable as novel.',
+        why: 'The Bond pathway is about shared fit, not performance.',
+        primaryPathway: 'BOND',
+        pathways: ['BOND'],
+        xp: baseXpForEvent('QUEST_BOND'),
+        confidence: 0.72,
+        href: '/activity',
+        actionLabel: 'Log the moment',
+        safeStopEligible: false,
+        personalRelevance: this.clamp(1 + (preference.BOND ?? 0), 0.9, 1.08),
+        score: 0.5 + (1 - (coverage.get('BOND') ?? 0) / 100) * 0.22,
+      },
+    ];
+
+    const pool = [...candidates, ...templates]
+      .filter(
+        (candidate, index, items) => items.findIndex((item) => item.key === candidate.key) === index
+      )
+      .sort((a, b) => b.score - a.score);
+
+    const selected: Candidate[] = [];
+    for (const candidate of pool) {
+      if (selected.length >= 3) break;
+      if (selected.some((item) => item.primaryPathway === candidate.primaryPathway)) continue;
+      selected.push(candidate);
+    }
+    for (const candidate of pool) {
+      if (selected.length >= 3) break;
+      if (!selected.includes(candidate)) selected.push(candidate);
+    }
+
+    const expiresAt = new Date(
+      new Date(`${dateKey}T00:00:00.000Z`).getTime() + DAY_MS
+    ).toISOString();
+    return selected.slice(0, 3).map((candidate, index) => ({
+      ...candidate,
+      id: this.questId(userId, insights.pet.id, dateKey, candidate.key),
+      variant: index === 0 ? 'recommended' : index === 2 ? 'wildcard' : 'alternative',
+      expiresAt,
+    }));
+  }
+
+  private preferenceSignals(summary: CareSummary) {
+    const signals: Partial<Record<WellbeingPathway, number>> = {};
+    for (const event of summary.recentEvents.slice(0, 10)) {
+      const dog = event.outcome?.dogExperience;
+      const owner = event.outcome?.ownerExperience;
+      const positiveDog = dog === 'loved_it' || dog === 'comfortable';
+      const positiveOwner = owner === 'great' || owner === 'fine';
+      const negative = dog === 'not_their_thing' || owner === 'a_lot_today';
+      const delta = negative ? -0.025 : positiveDog && positiveOwner ? 0.018 : 0;
+      signals[event.pathway] = this.clamp((signals[event.pathway] ?? 0) + delta, -0.1, 0.08);
+    }
+    return signals;
+  }
+
+  private secondaryPathways(primary: WellbeingPathway): WellbeingPathway[] {
+    const map: Record<WellbeingPathway, WellbeingPathway[]> = {
+      MOVE: ['MOVE', 'BOND'],
+      EXPLORE: ['EXPLORE', 'ENRICH', 'BOND'],
+      ENRICH: ['ENRICH', 'BOND'],
+      LEARN: ['LEARN', 'BOND'],
+      CONNECT: ['CONNECT', 'BOND'],
+      CARE: ['CARE', 'BOND'],
+      RECOVER: ['RECOVER', 'BOND'],
+      BOND: ['BOND'],
+    };
+    return map[primary];
+  }
+
+  private questDescription(pathway: WellbeingPathway, petName: string) {
+    const copy: Record<WellbeingPathway, string> = {
+      MOVE: `Choose movement that fits ${petName}'s current rhythm rather than chasing a distance target.`,
+      EXPLORE: `Let ${petName} investigate the world at a comfortable pace.`,
+      ENRICH: 'Add a short search, scent, puzzle, or foraging experience.',
+      LEARN: 'Practice one reward-based skill with easy repetitions and clear exits.',
+      CONNECT: 'Choose a social context with enough space, easy exits, and no pressure to finish.',
+      CARE: 'Take one small preventive-care action that fits your existing care plan.',
+      RECOVER: 'Choose calm movement, decompression, or rest and count it as real progress.',
+      BOND: 'Do something that feels good for both halves of the team.',
+    };
+    return copy[pathway];
+  }
+
+  private questId(userId: string, petId: string, dateKey: string, key: string) {
+    return createHash('sha256')
+      .update(`${userId}:${petId}:${dateKey}:${key}`)
+      .digest('hex')
+      .slice(0, 24);
+  }
+
+  private clamp(value: number, min: number, max: number) {
+    return Math.max(min, Math.min(max, value));
+  }
+}

--- a/apps/api/src/adventure/dto/adventure.dto.ts
+++ b/apps/api/src/adventure/dto/adventure.dto.ts
@@ -1,0 +1,30 @@
+import { IsBoolean, IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class QuestInteractionDto {
+  @IsString()
+  petId!: string;
+}
+
+export class CompleteQuestDto {
+  @IsString()
+  petId!: string;
+
+  @IsIn(['loved_it', 'comfortable', 'not_their_thing'])
+  dogExperience!: 'loved_it' | 'comfortable' | 'not_their_thing';
+
+  @IsIn(['great', 'fine', 'a_lot_today'])
+  ownerExperience!: 'great' | 'fine' | 'a_lot_today';
+
+  @IsOptional()
+  @IsBoolean()
+  safeOptOut?: boolean;
+
+  @IsOptional()
+  @IsString()
+  memoryAssetId?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(280)
+  note?: string;
+}

--- a/apps/api/src/adventure/pack-challenges.controller.ts
+++ b/apps/api/src/adventure/pack-challenges.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { AuthenticatedRequest } from '../auth/authenticated-request';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdventureEnabledGuard } from './adventure-enabled.guard';
+import { PackChallengesService } from './pack-challenges.service';
+
+@ApiTags('pack')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, AdventureEnabledGuard)
+@Controller('pack')
+export class PackChallengesController {
+  constructor(private readonly packChallenges: PackChallengesService) {}
+
+  @Get('challenges')
+  @ApiOperation({ summary: 'Get cooperative, non-ranking Pack challenges' })
+  getChallenges(@Request() req: AuthenticatedRequest) {
+    return this.packChallenges.getChallenges(req.user.sub);
+  }
+}

--- a/apps/api/src/adventure/pack-challenges.service.ts
+++ b/apps/api/src/adventure/pack-challenges.service.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+
+type AggregateRow = {
+  total: number;
+  contributors: number;
+  mine: number;
+};
+
+type ChallengeDefinition = {
+  id: string;
+  title: string;
+  description: string;
+  pathways: string[];
+  target: number;
+  unit: string;
+};
+
+const CHALLENGES: ChallengeDefinition[] = [
+  {
+    id: 'sniff-explore-week',
+    title: 'Sniff & Explore Week',
+    description:
+      'Together, make room for exploration and enrichment. Every useful session contributes once.',
+    pathways: ['EXPLORE', 'ENRICH'],
+    target: 250,
+    unit: 'shared adventures',
+  },
+  {
+    id: 'recovery-counts-week',
+    title: 'Recovery Counts',
+    description: 'Make rest and decompression visible as legitimate care, not a broken streak.',
+    pathways: ['RECOVER'],
+    target: 100,
+    unit: 'recovery moments',
+  },
+];
+
+@Injectable()
+export class PackChallengesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getChallenges(userId: string) {
+    const challenges = await Promise.all(
+      CHALLENGES.map(async (challenge) => {
+        const rows = await this.prisma.$queryRaw<AggregateRow[]>(Prisma.sql`
+          SELECT
+            COUNT(*)::int AS total,
+            COUNT(DISTINCT user_id)::int AS contributors,
+            COUNT(*) FILTER (WHERE user_id = ${userId})::int AS mine
+          FROM care_events
+          WHERE occurred_at >= NOW() - INTERVAL '7 days'
+            AND pathway = ANY(${challenge.pathways}::text[])
+        `);
+        const aggregate = rows[0] ?? { total: 0, contributors: 0, mine: 0 };
+        return {
+          ...challenge,
+          total: aggregate.total,
+          contributors: aggregate.contributors,
+          myContribution: aggregate.mine,
+          progress: Math.min(1, aggregate.total / challenge.target),
+          completed: aggregate.total >= challenge.target,
+        };
+      })
+    );
+
+    return {
+      generatedAt: new Date().toISOString(),
+      windowDays: 7,
+      challenges,
+      principles: [
+        'everyone-contributes',
+        'nobody-loses',
+        'no-raw-distance-ranking',
+        'no-medical-competition',
+      ],
+    };
+  }
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { ThrottlerGuard, ThrottlerModule, type ThrottlerModuleOptions } from '@nestjs/throttler';
 import { ABTestModule } from './ab-testing/ab-test.module';
 import { ActivitiesModule } from './activities/activities.module';
+import { AdventureModule } from './adventure/adventure.module';
 import { AnalyticsModule } from './analytics/analytics.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -62,6 +63,7 @@ export const throttlerOptions: ThrottlerModuleOptions = {
     UsersModule,
     PetsModule,
     ActivitiesModule,
+    AdventureModule,
     SocialModule,
     MeetupsModule,
     CompatibilityModule,

--- a/apps/api/src/care-events/care-event.types.ts
+++ b/apps/api/src/care-events/care-event.types.ts
@@ -1,0 +1,79 @@
+export const WELLBEING_PATHWAYS = [
+  'MOVE',
+  'EXPLORE',
+  'ENRICH',
+  'LEARN',
+  'CONNECT',
+  'CARE',
+  'RECOVER',
+  'BOND',
+] as const;
+
+export type WellbeingPathway = (typeof WELLBEING_PATHWAYS)[number];
+
+export const QUEST_EVENT_TYPES = {
+  MOVE: 'QUEST_MOVE',
+  EXPLORE: 'QUEST_EXPLORE',
+  ENRICH: 'QUEST_ENRICH',
+  LEARN: 'QUEST_LEARN',
+  CONNECT: 'QUEST_CONNECT',
+  CARE: 'QUEST_CARE',
+  RECOVER: 'QUEST_RECOVER',
+  BOND: 'QUEST_BOND',
+} as const satisfies Record<WellbeingPathway, string>;
+
+export type EvidenceType =
+  'SELF_REPORT' | 'ACTIVITY' | 'COACH' | 'BEHAVIOR_VISION' | 'LOCATION' | 'MEDIA' | 'CLINIC';
+
+export type CareEventInput = {
+  userId: string;
+  petId?: string | null;
+  eventType: string;
+  pathway: WellbeingPathway;
+  occurredAt?: Date;
+  source: string;
+  evidenceType?: EvidenceType;
+  evidenceConfidence?: number;
+  context?: Record<string, unknown>;
+  outcome?: Record<string, unknown>;
+  dedupeKey: string;
+  visibility?: 'PRIVATE' | 'HOUSEHOLD' | 'FRIENDS';
+  safetyEligible?: boolean;
+};
+
+export type RewardReceipt = {
+  careEventId: string;
+  ledgerId: string | null;
+  bondXp: number;
+  pathway: WellbeingPathway;
+  policyVersion: string;
+  explanation: string;
+  duplicate: boolean;
+};
+
+export type PathwayProgress = {
+  pathway: WellbeingPathway;
+  label: string;
+  recentDays: number;
+  coverage: number;
+  xp: number;
+  lastEventAt: string | null;
+};
+
+export type CareSummary = {
+  bondXp: number;
+  rhythm: {
+    activeWeeks: number;
+    windowWeeks: number;
+    label: string;
+  };
+  pathways: PathwayProgress[];
+  recentEvents: Array<{
+    id: string;
+    eventType: string;
+    pathway: WellbeingPathway;
+    occurredAt: string;
+    outcome: Record<string, unknown> | null;
+    bondXp: number;
+  }>;
+};

--- a/apps/api/src/care-events/care-events.integration.spec.ts
+++ b/apps/api/src/care-events/care-events.integration.spec.ts
@@ -1,0 +1,220 @@
+import { randomUUID } from 'node:crypto';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+import { CareEventsService } from './care-events.service';
+import { rewardCareEvent } from './reward-policy';
+
+const emptyPolicyContext = {
+  totalXpToday: 0,
+  pathwayXpToday: 0,
+  samePathwayEventsToday: 0,
+  repeatedEventCount7d: 0,
+};
+
+type Fixture = {
+  userId: string;
+  petId: string;
+};
+
+describe('CareEventsService integration', () => {
+  const prisma = new PrismaService();
+  const service = new CareEventsService(prisma);
+  const usersToDelete: string[] = [];
+
+  beforeAll(async () => {
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    if (usersToDelete.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: usersToDelete } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  async function fixture(label: string): Promise<Fixture> {
+    const suffix = randomUUID().slice(0, 8);
+    const user = await prisma.user.create({
+      data: {
+        handle: `adventure-${label}-${suffix}`,
+        email: `adventure-${label}-${suffix}@example.test`,
+      },
+      select: { id: true },
+    });
+    usersToDelete.push(user.id);
+
+    const pet = await prisma.pet.create({
+      data: {
+        ownerId: user.id,
+        name: `Test ${label}`,
+        species: 'DOG',
+      },
+      select: { id: true },
+    });
+
+    return { userId: user.id, petId: pet.id };
+  }
+
+  it('issues exactly one reward for simultaneous requests with the same dedupe key', async () => {
+    const { userId, petId } = await fixture('dedupe');
+    const input = {
+      userId,
+      petId,
+      eventType: 'QUEST_EXPLORE',
+      pathway: 'EXPLORE' as const,
+      source: 'INTEGRATION_TEST',
+      evidenceType: 'SELF_REPORT' as const,
+      evidenceConfidence: 0.65,
+      dedupeKey: `race:${randomUUID()}`,
+    };
+
+    const receipts = await Promise.all(Array.from({ length: 10 }, () => service.record(input)));
+    const newlyIssued = receipts.filter((receipt) => !receipt.duplicate);
+    const duplicates = receipts.filter((receipt) => receipt.duplicate);
+
+    expect(newlyIssued).toHaveLength(1);
+    expect(duplicates).toHaveLength(9);
+    expect(new Set(receipts.map((receipt) => receipt.careEventId)).size).toBe(1);
+    expect(new Set(receipts.map((receipt) => receipt.ledgerId)).size).toBe(1);
+
+    const eventRows = await prisma.$queryRaw<Array<{ count: number }>>(Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM care_events
+      WHERE user_id = ${userId} AND dedupe_key = ${input.dedupeKey}
+    `);
+    const ledgerRows = await prisma.$queryRaw<Array<{ count: number }>>(Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM reward_ledger
+      WHERE user_id = ${userId}
+    `);
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { id: userId },
+      select: { totalPoints: true },
+    });
+
+    expect(eventRows[0]?.count).toBe(1);
+    expect(ledgerRows[0]?.count).toBe(1);
+    expect(user.totalPoints).toBe(newlyIssued[0]?.bondXp);
+  });
+
+  it('serializes distinct simultaneous rewards so a pathway cap cannot be raced', async () => {
+    const { userId, petId } = await fixture('cap-race');
+
+    const receipts = await Promise.all(
+      Array.from({ length: 12 }, (_, index) =>
+        service.record({
+          userId,
+          petId,
+          eventType: 'ACTIVITY_HIKE',
+          pathway: 'MOVE',
+          source: 'INTEGRATION_TEST',
+          evidenceType: 'ACTIVITY',
+          evidenceConfidence: 0.9,
+          dedupeKey: `cap-race:${index}:${randomUUID()}`,
+        })
+      )
+    );
+
+    const issuedXp = receipts.reduce((sum, receipt) => sum + receipt.bondXp, 0);
+    const ledgerRows = await prisma.$queryRaw<Array<{ xp: number }>>(Prisma.sql`
+      SELECT COALESCE(SUM(bond_xp), 0)::int AS xp
+      FROM reward_ledger
+      WHERE user_id = ${userId}
+    `);
+
+    expect(receipts.every((receipt) => !receipt.duplicate)).toBe(true);
+    expect(issuedXp).toBeLessThanOrEqual(60);
+    expect(ledgerRows[0]?.xp).toBe(issuedXp);
+  });
+
+  it('does not let a future occurrence timestamp bypass caps or skew recent summaries', async () => {
+    const { userId, petId } = await fixture('future-time');
+
+    for (let index = 0; index < 12; index += 1) {
+      await service.record({
+        userId,
+        petId,
+        eventType: 'ACTIVITY_HIKE',
+        pathway: 'MOVE',
+        source: 'INTEGRATION_TEST',
+        evidenceType: 'ACTIVITY',
+        evidenceConfidence: 0.9,
+        dedupeKey: `future-fill:${index}:${randomUUID()}`,
+      });
+    }
+
+    const before = await prisma.$queryRaw<Array<{ xp: number }>>(Prisma.sql`
+      SELECT COALESCE(SUM(bond_xp), 0)::int AS xp
+      FROM reward_ledger
+      WHERE user_id = ${userId}
+    `);
+    expect(before[0]?.xp).toBe(60);
+
+    const beforeAttemptMs = Date.now();
+    const futureReceipt = await service.record({
+      userId,
+      petId,
+      eventType: 'ACTIVITY_HIKE',
+      pathway: 'MOVE',
+      occurredAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      source: 'INTEGRATION_TEST',
+      evidenceType: 'ACTIVITY',
+      evidenceConfidence: 0.9,
+      dedupeKey: `future-attempt:${randomUUID()}`,
+    });
+
+    expect(futureReceipt.bondXp).toBe(0);
+
+    const futureEventRows = await prisma.$queryRaw<Array<{ occurred_at: Date }>>(Prisma.sql`
+      SELECT occurred_at
+      FROM care_events
+      WHERE id = ${futureReceipt.careEventId}
+      LIMIT 1
+    `);
+    const storedOccurrenceMs = futureEventRows[0]?.occurred_at.getTime();
+    expect(storedOccurrenceMs).toBeDefined();
+    expect(storedOccurrenceMs).toBeGreaterThanOrEqual(beforeAttemptMs - 1000);
+    expect(storedOccurrenceMs).toBeLessThanOrEqual(Date.now() + 1000);
+
+    const summary = await service.getSummary(userId, petId);
+    const moveSummary = summary.pathways.find((pathway) => pathway.pathway === 'MOVE');
+    expect(moveSummary?.lastEventAt).not.toBeNull();
+    expect(new Date(moveSummary!.lastEventAt!).getTime()).toBeLessThanOrEqual(Date.now() + 1000);
+  });
+
+  it('does not let a zero-XP safety event decay the next legitimate reward', async () => {
+    const { userId, petId } = await fixture('safety-zero');
+    const common = {
+      userId,
+      petId,
+      eventType: 'QUEST_EXPLORE',
+      pathway: 'EXPLORE' as const,
+      source: 'INTEGRATION_TEST',
+      evidenceType: 'SELF_REPORT' as const,
+      evidenceConfidence: 0.65,
+    };
+
+    const blocked = await service.record({
+      ...common,
+      dedupeKey: `blocked:${randomUUID()}`,
+      safetyEligible: false,
+    });
+    expect(blocked.bondXp).toBe(0);
+
+    const legitimate = await service.record({
+      ...common,
+      dedupeKey: `legitimate:${randomUUID()}`,
+      safetyEligible: true,
+    });
+    const baseline = rewardCareEvent(
+      {
+        ...common,
+        dedupeKey: 'pure-baseline',
+        safetyEligible: true,
+      },
+      emptyPolicyContext
+    );
+
+    expect(legitimate.bondXp).toBe(baseline.bondXp);
+  });
+});

--- a/apps/api/src/care-events/care-events.module.ts
+++ b/apps/api/src/care-events/care-events.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { CareEventsService } from './care-events.service';
+
+@Module({
+  providers: [CareEventsService],
+  exports: [CareEventsService],
+})
+export class CareEventsModule {}

--- a/apps/api/src/care-events/care-events.service.ts
+++ b/apps/api/src/care-events/care-events.service.ts
@@ -1,0 +1,346 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { randomUUID } from 'node:crypto';
+import { PrismaService } from '../prisma/prisma.service';
+import {
+  WELLBEING_PATHWAYS,
+  type CareEventInput,
+  type CareSummary,
+  type RewardReceipt,
+  type WellbeingPathway,
+} from './care-event.types';
+import { rewardCareEvent } from './reward-policy';
+
+type EventRow = {
+  id: string;
+  event_type: string;
+  pathway: WellbeingPathway;
+  occurred_at: Date;
+  outcome: Record<string, unknown> | null;
+};
+
+type LedgerRow = {
+  id: string;
+  bond_xp: number;
+  policy_version: string;
+  explanation: string;
+};
+
+type RewardStatsRow = {
+  total_xp_today: number;
+  pathway_xp_today: number;
+  same_pathway_events_today: number;
+  repeated_event_count_7d: number;
+};
+
+type PathwaySummaryRow = {
+  pathway: WellbeingPathway;
+  recent_days: number;
+  xp: number;
+  last_event_at: Date | null;
+};
+
+type SelectedQuestContextRow = {
+  context: Record<string, unknown> | null;
+  created_at: Date;
+};
+
+const PATHWAY_LABELS: Record<WellbeingPathway, string> = {
+  MOVE: 'Move',
+  EXPLORE: 'Explore',
+  ENRICH: 'Enrich',
+  LEARN: 'Learn',
+  CONNECT: 'Connect',
+  CARE: 'Care',
+  RECOVER: 'Recover',
+  BOND: 'Bond',
+};
+
+@Injectable()
+export class CareEventsService {
+  private readonly logger = new Logger(CareEventsService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async record(input: CareEventInput): Promise<RewardReceipt> {
+    if (input.petId) await this.assertOwnedPet(input.userId, input.petId);
+
+    const now = new Date();
+    const requestedOccurrenceMs = input.occurredAt?.getTime();
+    const occurrenceTimestampNormalized =
+      input.occurredAt !== undefined &&
+      (!Number.isFinite(requestedOccurrenceMs) || (requestedOccurrenceMs ?? 0) > now.getTime());
+    // Offline/historical events retain their original chronology, but an upstream
+    // device clock can never place a trusted CareEvent in the future. That prevents
+    // future timestamps from inflating Compass/Rhythm recency or ordering.
+    const occurredAt = occurrenceTimestampNormalized ? now : (input.occurredAt ?? now);
+    const evidenceConfidence = Math.max(0, Math.min(1, input.evidenceConfidence ?? 0.65));
+    const visibility = input.visibility ?? 'PRIVATE';
+
+    const receipt = await this.prisma.$transaction(async (tx) => {
+      // Serialize reward issuance for one user so concurrent legitimate requests cannot
+      // race daily/pathway caps or a shared dedupe key. pg_advisory_xact_lock returns
+      // PostgreSQL's `void` pseudo-type, which Prisma cannot deserialize directly, so
+      // materialize the lock call and expose only a supported integer scalar.
+      await tx.$queryRaw<Array<{ acquired: number }>>(Prisma.sql`
+        WITH lock_row AS MATERIALIZED (
+          SELECT pg_advisory_xact_lock(hashtextextended(${input.userId}, 0))
+        )
+        SELECT 1::int AS acquired FROM lock_row
+      `);
+
+      const existing = await tx.$queryRaw<EventRow[]>(Prisma.sql`
+        SELECT id, event_type, pathway, occurred_at, outcome
+        FROM care_events
+        WHERE user_id = ${input.userId} AND dedupe_key = ${input.dedupeKey}
+        LIMIT 1
+      `);
+
+      if (existing[0]) {
+        const ledger = await tx.$queryRaw<LedgerRow[]>(Prisma.sql`
+          SELECT id, bond_xp, policy_version, explanation
+          FROM reward_ledger
+          WHERE care_event_id = ${existing[0].id}
+          LIMIT 1
+        `);
+        const prior = ledger[0];
+        return {
+          careEventId: existing[0].id,
+          ledgerId: prior?.id ?? null,
+          bondXp: prior?.bond_xp ?? 0,
+          pathway: existing[0].pathway,
+          policyVersion: prior?.policy_version ?? 'bond-xp-v1',
+          explanation: prior?.explanation ?? 'This trusted event was already recorded.',
+          duplicate: true,
+        };
+      }
+
+      // Anti-farming windows are based on trusted server issuance time, not the
+      // client-influenced occurrence timestamp. This prevents backdating or future
+      // timestamps from manufacturing fresh cap windows. Zero-reward events do not
+      // decay later legitimate actions.
+      const stats = await tx.$queryRaw<RewardStatsRow[]>(Prisma.sql`
+        SELECT
+          COALESCE(SUM(CASE WHEN rl.created_at >= date_trunc('day', NOW()) THEN rl.bond_xp ELSE 0 END), 0)::int AS total_xp_today,
+          COALESCE(SUM(CASE WHEN rl.created_at >= date_trunc('day', NOW()) AND ce.pathway = ${input.pathway} THEN rl.bond_xp ELSE 0 END), 0)::int AS pathway_xp_today,
+          COUNT(*) FILTER (
+            WHERE rl.created_at >= date_trunc('day', NOW())
+              AND ce.pathway = ${input.pathway}
+              AND rl.bond_xp > 0
+          )::int AS same_pathway_events_today,
+          COUNT(*) FILTER (
+            WHERE rl.created_at >= NOW() - INTERVAL '7 days'
+              AND ce.event_type = ${input.eventType}
+              AND rl.bond_xp > 0
+          )::int AS repeated_event_count_7d
+        FROM care_events ce
+        LEFT JOIN reward_ledger rl ON rl.care_event_id = ce.id
+        WHERE ce.user_id = ${input.userId}
+      `);
+
+      const reward = rewardCareEvent(input, {
+        totalXpToday: stats[0]?.total_xp_today ?? 0,
+        pathwayXpToday: stats[0]?.pathway_xp_today ?? 0,
+        samePathwayEventsToday: stats[0]?.same_pathway_events_today ?? 0,
+        repeatedEventCount7d: stats[0]?.repeated_event_count_7d ?? 0,
+      });
+
+      const eventId = randomUUID();
+      const ledgerId = randomUUID();
+      const contextJson = JSON.stringify(input.context ?? {});
+      const outcomeJson = JSON.stringify(input.outcome ?? {});
+      const pathwayXpJson = JSON.stringify(reward.pathwayXp);
+
+      await tx.$executeRaw(Prisma.sql`
+        INSERT INTO care_events (
+          id, user_id, pet_id, event_type, pathway, occurred_at, source,
+          evidence_type, evidence_confidence, context, outcome, dedupe_key,
+          visibility, created_at
+        ) VALUES (
+          ${eventId}, ${input.userId}, ${input.petId ?? null}, ${input.eventType},
+          ${input.pathway}, ${occurredAt}, ${input.source}, ${input.evidenceType ?? null},
+          ${evidenceConfidence}, CAST(${contextJson} AS JSONB), CAST(${outcomeJson} AS JSONB),
+          ${input.dedupeKey}, ${visibility}, NOW()
+        )
+      `);
+
+      await tx.$executeRaw(Prisma.sql`
+        INSERT INTO reward_ledger (
+          id, care_event_id, user_id, pet_id, bond_xp, pathway_xp,
+          policy_version, explanation, created_at
+        ) VALUES (
+          ${ledgerId}, ${eventId}, ${input.userId}, ${input.petId ?? null},
+          ${reward.bondXp}, CAST(${pathwayXpJson} AS JSONB), ${reward.policyVersion},
+          ${reward.explanation}, NOW()
+        )
+      `);
+
+      if (reward.bondXp > 0) {
+        // Keep the legacy aggregate synchronized for older surfaces while all new
+        // reward reads come from the immutable ledger.
+        await tx.user.update({
+          where: { id: input.userId },
+          data: { totalPoints: { increment: reward.bondXp } },
+        });
+      }
+
+      return {
+        careEventId: eventId,
+        ledgerId,
+        bondXp: reward.bondXp,
+        pathway: input.pathway,
+        policyVersion: reward.policyVersion,
+        explanation: reward.explanation,
+        duplicate: false,
+      };
+    });
+
+    // Keep reward observability useful without placing user/pet identifiers in logs.
+    this.logger.log(
+      JSON.stringify({
+        event: 'adventure_reward_decision',
+        careEventId: receipt.careEventId,
+        eventType: input.eventType,
+        pathway: receipt.pathway,
+        bondXp: receipt.bondXp,
+        duplicate: receipt.duplicate,
+        policyVersion: receipt.policyVersion,
+        occurrenceTimestampNormalized,
+      })
+    );
+
+    return receipt;
+  }
+
+  async recordQuestInteraction(input: {
+    userId: string;
+    petId: string;
+    questId: string;
+    interaction: 'SHOWN' | 'SELECTED' | 'DISMISSED' | 'COMPLETED';
+    pathway: WellbeingPathway;
+    context?: Record<string, unknown>;
+  }) {
+    await this.assertOwnedPet(input.userId, input.petId);
+    const id = randomUUID();
+    const rows = await this.prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+      INSERT INTO quest_interactions (
+        id, user_id, pet_id, quest_id, interaction, pathway, context, created_at
+      ) VALUES (
+        ${id}, ${input.userId}, ${input.petId}, ${input.questId}, ${input.interaction},
+        ${input.pathway}, CAST(${JSON.stringify(input.context ?? {})} AS JSONB), NOW()
+      )
+      ON CONFLICT (user_id, pet_id, quest_id, interaction)
+      DO UPDATE SET
+        pathway = EXCLUDED.pathway,
+        context = EXCLUDED.context,
+        created_at = EXCLUDED.created_at
+      RETURNING id
+    `);
+    return { id: rows[0]?.id ?? id };
+  }
+
+  async getRecentSelectedQuestContext(userId: string, petId: string, questId: string) {
+    await this.assertOwnedPet(userId, petId);
+    const rows = await this.prisma.$queryRaw<SelectedQuestContextRow[]>(Prisma.sql`
+      SELECT context, created_at
+      FROM quest_interactions
+      WHERE user_id = ${userId}
+        AND pet_id = ${petId}
+        AND quest_id = ${questId}
+        AND interaction = 'SELECTED'
+        AND created_at >= NOW() - INTERVAL '72 hours'
+      ORDER BY created_at DESC
+      LIMIT 1
+    `);
+    return rows[0] ?? null;
+  }
+
+  async getSummary(userId: string, petId?: string): Promise<CareSummary> {
+    if (petId) await this.assertOwnedPet(userId, petId);
+
+    const petFilter = petId ? Prisma.sql`AND ce.pet_id = ${petId}` : Prisma.empty;
+    const [totalRows, pathwayRows, recentRows, rhythmRows] = await Promise.all([
+      this.prisma.$queryRaw<Array<{ bond_xp: number }>>(Prisma.sql`
+        SELECT COALESCE(SUM(rl.bond_xp), 0)::int AS bond_xp
+        FROM reward_ledger rl
+        JOIN care_events ce ON ce.id = rl.care_event_id
+        WHERE ce.user_id = ${userId} ${petFilter}
+      `),
+      this.prisma.$queryRaw<PathwaySummaryRow[]>(Prisma.sql`
+        SELECT
+          ce.pathway,
+          COUNT(DISTINCT DATE(ce.occurred_at)) FILTER (WHERE ce.occurred_at >= NOW() - INTERVAL '28 days')::int AS recent_days,
+          COALESCE(SUM(rl.bond_xp), 0)::int AS xp,
+          MAX(ce.occurred_at) AS last_event_at
+        FROM care_events ce
+        LEFT JOIN reward_ledger rl ON rl.care_event_id = ce.id
+        WHERE ce.user_id = ${userId} ${petFilter}
+        GROUP BY ce.pathway
+      `),
+      this.prisma.$queryRaw<Array<EventRow & { bond_xp: number }>>(Prisma.sql`
+        SELECT ce.id, ce.event_type, ce.pathway, ce.occurred_at, ce.outcome,
+               COALESCE(rl.bond_xp, 0)::int AS bond_xp
+        FROM care_events ce
+        LEFT JOIN reward_ledger rl ON rl.care_event_id = ce.id
+        WHERE ce.user_id = ${userId} ${petFilter}
+        ORDER BY ce.occurred_at DESC
+        LIMIT 12
+      `),
+      this.prisma.$queryRaw<Array<{ active_weeks: number }>>(Prisma.sql`
+        SELECT COUNT(DISTINCT date_trunc('week', ce.occurred_at))::int AS active_weeks
+        FROM care_events ce
+        WHERE ce.user_id = ${userId}
+          AND ce.occurred_at >= NOW() - INTERVAL '35 days'
+          ${petFilter}
+      `),
+    ]);
+
+    const byPathway = new Map(pathwayRows.map((row) => [row.pathway, row]));
+    const activeWeeks = Math.min(5, rhythmRows[0]?.active_weeks ?? 0);
+
+    return {
+      bondXp: totalRows[0]?.bond_xp ?? 0,
+      rhythm: {
+        activeWeeks,
+        windowWeeks: 5,
+        label:
+          activeWeeks >= 4
+            ? 'Great rhythm this month'
+            : activeWeeks >= 2
+              ? 'A steady rhythm is growing'
+              : 'Every useful moment can start a rhythm',
+      },
+      pathways: WELLBEING_PATHWAYS.map((pathway) => {
+        const row = byPathway.get(pathway);
+        const recentDays = row?.recent_days ?? 0;
+        return {
+          pathway,
+          label: PATHWAY_LABELS[pathway],
+          recentDays,
+          // This is opportunity coverage, not a health score. Four distinct recent
+          // days fills the visual treatment without implying a universal prescription.
+          coverage: Math.min(100, recentDays * 25),
+          xp: row?.xp ?? 0,
+          lastEventAt: row?.last_event_at?.toISOString() ?? null,
+        };
+      }),
+      recentEvents: recentRows.map((row) => ({
+        id: row.id,
+        eventType: row.event_type,
+        pathway: row.pathway,
+        occurredAt: row.occurred_at.toISOString(),
+        outcome: row.outcome,
+        bondXp: row.bond_xp,
+      })),
+    };
+  }
+
+  private async assertOwnedPet(userId: string, petId: string) {
+    const pet = await this.prisma.pet.findFirst({
+      where: { id: petId, ownerId: userId },
+      select: { id: true },
+    });
+    if (!pet) throw new NotFoundException('Pet not found');
+    return pet;
+  }
+}

--- a/apps/api/src/care-events/reward-policy.spec.ts
+++ b/apps/api/src/care-events/reward-policy.spec.ts
@@ -1,0 +1,83 @@
+import { DAILY_BOND_XP_CAP, rewardCareEvent } from './reward-policy';
+import type { CareEventInput } from './care-event.types';
+
+const baseEvent: CareEventInput = {
+  userId: 'user-1',
+  petId: 'pet-1',
+  eventType: 'QUEST_EXPLORE',
+  pathway: 'EXPLORE',
+  source: 'QUEST_ENGINE',
+  evidenceType: 'SELF_REPORT',
+  evidenceConfidence: 0.65,
+  dedupeKey: 'quest:one',
+};
+
+const emptyContext = {
+  totalXpToday: 0,
+  pathwayXpToday: 0,
+  samePathwayEventsToday: 0,
+  repeatedEventCount7d: 0,
+};
+
+describe('rewardCareEvent', () => {
+  it('rewards recovery rather than treating rest as failure', () => {
+    const decision = rewardCareEvent(
+      { ...baseEvent, eventType: 'QUEST_RECOVER', pathway: 'RECOVER' },
+      emptyContext
+    );
+
+    expect(decision.bondXp).toBeGreaterThan(0);
+    expect(decision.pathwayXp.RECOVER).toBe(decision.bondXp);
+  });
+
+  it('rewards a welfare-aware safe opt-out', () => {
+    const decision = rewardCareEvent(
+      {
+        ...baseEvent,
+        eventType: 'SAFE_OPT_OUT',
+        pathway: 'BOND',
+        outcome: { safeOptOut: true, dogExperience: 'not_their_thing' },
+      },
+      emptyContext
+    );
+
+    expect(decision.bondXp).toBeGreaterThanOrEqual(18);
+  });
+
+  it('does not let optional media dominate the underlying action', () => {
+    const withoutMemory = rewardCareEvent(baseEvent, emptyContext);
+    const withMemory = rewardCareEvent(
+      { ...baseEvent, context: { memoryAdded: true } },
+      emptyContext
+    );
+
+    expect(withMemory.bondXp - withoutMemory.bondXp).toBeLessThanOrEqual(2);
+  });
+
+  it('reduces farming value for repeated same-pathway events', () => {
+    const first = rewardCareEvent(baseEvent, emptyContext);
+    const repeated = rewardCareEvent(baseEvent, {
+      ...emptyContext,
+      samePathwayEventsToday: 4,
+      repeatedEventCount7d: 8,
+    });
+
+    expect(repeated.bondXp).toBeLessThan(first.bondXp);
+  });
+
+  it('enforces the global daily cap', () => {
+    const decision = rewardCareEvent(baseEvent, {
+      ...emptyContext,
+      totalXpToday: DAILY_BOND_XP_CAP,
+    });
+
+    expect(decision.bondXp).toBe(0);
+  });
+
+  it('fails closed for a safety-ineligible event', () => {
+    const decision = rewardCareEvent({ ...baseEvent, safetyEligible: false }, emptyContext);
+
+    expect(decision.bondXp).toBe(0);
+    expect(decision.explanation).toContain('not safety-eligible');
+  });
+});

--- a/apps/api/src/care-events/reward-policy.ts
+++ b/apps/api/src/care-events/reward-policy.ts
@@ -1,0 +1,132 @@
+import type { CareEventInput, WellbeingPathway } from './care-event.types';
+
+export const REWARD_POLICY_VERSION = 'bond-xp-v1';
+export const DAILY_BOND_XP_CAP = 120;
+export const DAILY_PATHWAY_XP_CAP = 60;
+
+const BASE_XP: Record<string, number> = {
+  QUEST_MOVE: 15,
+  QUEST_EXPLORE: 20,
+  QUEST_ENRICH: 15,
+  QUEST_LEARN: 15,
+  QUEST_CONNECT: 20,
+  QUEST_CARE: 18,
+  QUEST_RECOVER: 12,
+  QUEST_BOND: 12,
+  ACTIVITY_WALK: 15,
+  ACTIVITY_RUN: 22,
+  ACTIVITY_HIKE: 30,
+  ACTIVITY_PLAY: 15,
+  ACTIVITY_SNIFF: 20,
+  TRAINING_SESSION: 15,
+  ENRICHMENT_SESSION: 15,
+  SOCIAL_OUTING: 20,
+  PARALLEL_WALK: 20,
+  WELLNESS_VISIT: 40,
+  DENTAL_CARE: 8,
+  COOPERATIVE_CARE: 15,
+  RECOVERY_SESSION: 12,
+  QUEST_REFLECTION: 5,
+  SAFE_OPT_OUT: 18,
+  MEMORY_ADDED: 2,
+};
+
+export type RewardPolicyContext = {
+  totalXpToday: number;
+  pathwayXpToday: number;
+  samePathwayEventsToday: number;
+  repeatedEventCount7d: number;
+};
+
+export type RewardDecision = {
+  bondXp: number;
+  pathwayXp: Partial<Record<WellbeingPathway, number>>;
+  policyVersion: string;
+  explanation: string;
+};
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function booleanContext(input: CareEventInput, key: string) {
+  return input.context?.[key] === true || input.outcome?.[key] === true;
+}
+
+export function rewardCareEvent(
+  input: CareEventInput,
+  context: RewardPolicyContext
+): RewardDecision {
+  if (input.safetyEligible === false) {
+    return {
+      bondXp: 0,
+      pathwayXp: {},
+      policyVersion: REWARD_POLICY_VERSION,
+      explanation: 'No reward was issued because the event was not safety-eligible.',
+    };
+  }
+
+  const base = BASE_XP[input.eventType] ?? 0;
+  if (base <= 0) {
+    return {
+      bondXp: 0,
+      pathwayXp: {},
+      policyVersion: REWARD_POLICY_VERSION,
+      explanation: 'This event is useful context but is not eligible for Bond XP.',
+    };
+  }
+
+  // Evidence changes confidence, not the moral value of the action. The multiplier
+  // deliberately stays in a narrow range so photos, wearables, or location never
+  // dominate self-report.
+  const evidenceConfidence = clamp(input.evidenceConfidence ?? 0.65, 0, 1);
+  const evidenceMultiplier = 0.96 + evidenceConfidence * 0.04;
+
+  // Repeating the same pathway remains useful, but the game does not reward farming.
+  const diversityMultiplier =
+    context.samePathwayEventsToday <= 1 ? 1 : context.samePathwayEventsToday === 2 ? 0.82 : 0.58;
+  const repetitionMultiplier =
+    context.repeatedEventCount7d <= 2 ? 1 : context.repeatedEventCount7d <= 5 ? 0.88 : 0.72;
+
+  // Quest ranking may contribute a server-generated relevance value. It is tightly
+  // capped and never accepted as an arbitrary XP amount.
+  const relevance = Number(input.context?.personalRelevance ?? 1);
+  const relevanceMultiplier = clamp(Number.isFinite(relevance) ? relevance : 1, 0.9, 1.08);
+
+  let raw =
+    base * evidenceMultiplier * diversityMultiplier * repetitionMultiplier * relevanceMultiplier;
+
+  const reflected =
+    typeof input.outcome?.dogExperience === 'string' &&
+    typeof input.outcome?.ownerExperience === 'string';
+  if (reflected && input.eventType !== 'QUEST_REFLECTION') raw += 5;
+
+  if (booleanContext(input, 'newPlace')) raw += 5;
+  if (booleanContext(input, 'memoryAdded')) raw += 2;
+
+  // Respecting a stress/opt-out signal is a successful welfare decision. SAFE_OPT_OUT
+  // has its own full-value base reward rather than requiring task completion.
+  if (input.eventType === 'SAFE_OPT_OUT') raw = Math.max(raw, BASE_XP.SAFE_OPT_OUT);
+
+  const totalRemaining = Math.max(0, DAILY_BOND_XP_CAP - context.totalXpToday);
+  const pathwayRemaining = Math.max(0, DAILY_PATHWAY_XP_CAP - context.pathwayXpToday);
+  const bondXp = Math.max(0, Math.floor(Math.min(raw, totalRemaining, pathwayRemaining)));
+
+  const capReason =
+    bondXp === 0 && (totalRemaining === 0 || pathwayRemaining === 0)
+      ? ' Daily reward coverage is already complete for this window.'
+      : bondXp < Math.floor(raw)
+        ? ' Reward was capped to keep volume from overpowering balance.'
+        : '';
+
+  return {
+    bondXp,
+    pathwayXp: bondXp > 0 ? { [input.pathway]: bondXp } : {},
+    policyVersion: REWARD_POLICY_VERSION,
+    explanation: `Bond XP reflects a trusted ${input.pathway.toLowerCase()} experience, with diminishing returns for repetition.${capReason}`,
+  };
+}
+
+export function baseXpForEvent(eventType: string) {
+  return BASE_XP[eventType] ?? 0;
+}

--- a/apps/api/src/coaching/coaching.controller.ts
+++ b/apps/api/src/coaching/coaching.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Get,
+  Logger,
   Param,
   Patch,
   Post,
@@ -12,6 +13,7 @@ import {
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import type { AuthenticatedRequest } from '../auth/authenticated-request';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CareEventsService } from '../care-events/care-events.service';
 import { CoachingService } from './coaching.service';
 import {
   CreateTrainingPlanDto,
@@ -24,7 +26,12 @@ import {
 @UseGuards(JwtAuthGuard)
 @Controller('coaching')
 export class CoachingController {
-  constructor(private readonly coachingService: CoachingService) {}
+  private readonly logger = new Logger(CoachingController.name);
+
+  constructor(
+    private readonly coachingService: CoachingService,
+    private readonly careEvents: CareEventsService
+  ) {}
 
   @Get('me')
   @ApiOperation({ summary: 'Get the current reward-based coaching plan and practice context' })
@@ -50,11 +57,51 @@ export class CoachingController {
 
   @Post('plans/:planId/sessions')
   @ApiOperation({ summary: 'Record an observable practice session and adapt the next difficulty' })
-  recordSession(
+  async recordSession(
     @Request() req: AuthenticatedRequest,
     @Param('planId') planId: string,
     @Body() dto: RecordTrainingSessionDto
   ) {
-    return this.coachingService.recordSession(req.user.sub, planId, dto);
+    const result = await this.coachingService.recordSession(req.user.sub, planId, dto);
+    const petId = result.plan?.petId;
+
+    if (petId) {
+      const concernSignals = dto.stressSignals ?? [];
+      const listenedAndStopped = Boolean(dto.stoppedEarly && concernSignals.length > 0);
+
+      try {
+        await this.careEvents.record({
+          userId: req.user.sub,
+          petId,
+          eventType: listenedAndStopped ? 'SAFE_OPT_OUT' : 'TRAINING_SESSION',
+          pathway: listenedAndStopped ? 'BOND' : 'LEARN',
+          source: 'WOOF_COACH',
+          evidenceType: 'COACH',
+          evidenceConfidence: 0.86,
+          dedupeKey: `coach:${result.activityId}`,
+          safetyEligible: listenedAndStopped || concernSignals.length === 0,
+          context: {
+            planId,
+            activityId: result.activityId,
+            attempts: dto.attempts,
+            successes: dto.successes,
+            durationSeconds: dto.durationSeconds,
+          },
+          outcome: {
+            stressSignals: concernSignals,
+            stoppedEarly: dto.stoppedEarly ?? false,
+            safeOptOut: listenedAndStopped,
+          },
+        });
+      } catch (error) {
+        this.logger.warn(
+          `Coach session ${result.activityId} was saved, but Adventure reward emission failed: ${
+            error instanceof Error ? error.message : 'unknown error'
+          }`
+        );
+      }
+    }
+
+    return result;
   }
 }

--- a/apps/api/src/coaching/coaching.module.ts
+++ b/apps/api/src/coaching/coaching.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
+import { CareEventsModule } from '../care-events/care-events.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { CoachingController } from './coaching.controller';
 import { CoachingService } from './coaching.service';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, CareEventsModule],
   controllers: [CoachingController],
   providers: [CoachingService],
   exports: [CoachingService],

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -4,6 +4,7 @@ const envSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   PORT: z.coerce.number().int().positive().default(4000),
   API_PREFIX: z.string().default('api/v1'),
+  API_DOCS_ENABLED: z.enum(['true', 'false']).default('false'),
   DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
   SHADOW_DATABASE_URL: z.string().optional(),
   JWT_SECRET: z.string().min(16, 'JWT_SECRET must be at least 16 characters'),
@@ -16,6 +17,7 @@ const envSchema = z.object({
   S3_SECRET_ACCESS_KEY: z.string().optional(),
   S3_PUBLIC_URL: z.string().optional(),
   AWS_REGION: z.string().optional(),
+  ENABLE_ADVENTURE_SYSTEM: z.enum(['true', 'false']).optional(),
   MEDIA_LIBRARY_IMAGE_MAX_BYTES: z.coerce
     .number()
     .int()
@@ -64,7 +66,7 @@ export function validateEnvironment(config: Record<string, unknown>) {
     const knownDevelopmentSecret = /^(dev-|change-this|your-)/i;
     if (env.JWT_SECRET.length < 32 || knownDevelopmentSecret.test(env.JWT_SECRET)) {
       throw new Error(
-        'JWT_SECRET must be a non-development secret of at least 32 characters in production',
+        'JWT_SECRET must be a non-development secret of at least 32 characters in production'
       );
     }
 
@@ -74,7 +76,7 @@ export function validateEnvironment(config: Record<string, unknown>) {
 
     if (env.BEHAVIOR_VISION_SERVICE_URL && !env.BEHAVIOR_VISION_SERVICE_TOKEN) {
       throw new Error(
-        'BEHAVIOR_VISION_SERVICE_TOKEN is required when the behavior vision service is enabled in production',
+        'BEHAVIOR_VISION_SERVICE_TOKEN is required when the behavior vision service is enabled in production'
       );
     }
 
@@ -88,7 +90,7 @@ export function validateEnvironment(config: Record<string, unknown>) {
       !(env.S3_ACCESS_KEY_ID && env.S3_SECRET_ACCESS_KEY && env.S3_BUCKET)
     ) {
       throw new Error(
-        'Private object storage must be configured when MEDIA_DERIVATIVES_ENABLED=true',
+        'Private object storage must be configured when MEDIA_DERIVATIVES_ENABLED=true'
       );
     }
   }

--- a/apps/api/src/gamification/gamification.controller.ts
+++ b/apps/api/src/gamification/gamification.controller.ts
@@ -1,83 +1,24 @@
-import { Body, Controller, Get, Param, Post, Query, Request, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import type { AuthenticatedRequest } from '../auth/authenticated-request';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { AwardBadgeDto } from './dto/award-badge.dto';
-import { AwardPointsDto } from './dto/award-points.dto';
-import { UpdateStreakDto } from './dto/update-streak.dto';
 import { GamificationService } from './gamification.service';
 
 @ApiTags('gamification')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @Controller('gamification')
 export class GamificationController {
   constructor(private readonly gamificationService: GamificationService) {}
 
-  @Post('points')
-  @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
-  @ApiOperation({ summary: 'Award points to a user' })
-  @ApiResponse({ status: 201, description: 'Points awarded successfully' })
-  async awardPoints(@Body() awardPointsDto: AwardPointsDto) {
-    return this.gamificationService.awardPoints(awardPointsDto);
-  }
-
-  @Get('points/:userId')
-  @ApiOperation({ summary: 'Get total points for a user' })
-  @ApiResponse({ status: 200, description: 'User points retrieved' })
-  async getUserPoints(@Param('userId') userId: string) {
-    return this.gamificationService.getUserPoints(userId);
-  }
-
-  @Get('points/:userId/transactions')
-  @ApiOperation({ summary: 'Get point transaction history for a user' })
-  async getPointTransactions(@Param('userId') userId: string) {
-    return this.gamificationService.getPointTransactions(userId);
-  }
-
-  @Post('badges')
-  @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
-  @ApiOperation({ summary: 'Award a badge to a user' })
-  async awardBadge(@Body() awardBadgeDto: AwardBadgeDto) {
-    return this.gamificationService.awardBadge(awardBadgeDto);
-  }
-
-  @Get('badges/:userId')
-  @ApiOperation({ summary: 'Get all badges for a user' })
-  async getUserBadges(@Param('userId') userId: string) {
-    return this.gamificationService.getUserBadges(userId);
-  }
-
-  @Post('streaks')
-  @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
-  @ApiOperation({ summary: 'Update user activity streak' })
-  async updateStreak(@Body() updateStreakDto: UpdateStreakDto) {
-    return this.gamificationService.updateStreak(updateStreakDto);
-  }
-
-  @Get('streaks/:userId')
-  @ApiOperation({ summary: 'Get current streak for a user' })
-  async getUserStreak(@Param('userId') userId: string) {
-    return this.gamificationService.getUserStreak(userId);
-  }
-
-  @Get('leaderboard')
-  @ApiOperation({ summary: 'Get points leaderboard' })
-  @ApiQuery({ name: 'limit', required: false, description: 'Number of top users to return', example: 20 })
-  async getLeaderboard(@Query('limit') limit?: string) {
-    const parsed = limit ? Number.parseInt(limit, 10) : 20;
-    const safeLimit = Number.isFinite(parsed) ? Math.max(1, Math.min(parsed, 100)) : 20;
-    return this.gamificationService.getLeaderboard(safeLimit);
-  }
-
   @Get('me/summary')
-  @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
-  @ApiOperation({ summary: 'Get gamification summary for current user' })
+  @ApiOperation({
+    summary: 'Get the legacy reward summary for the current user',
+    description:
+      'Read-only compatibility endpoint. All new rewards are issued by trusted domain events through the Adventure System.',
+  })
   async getMySummary(@Request() req: AuthenticatedRequest) {
     const userId = req.user.sub;
-
     const [points, badges, streak] = await Promise.all([
       this.gamificationService.getUserPoints(userId),
       this.gamificationService.getUserBadges(userId),
@@ -90,6 +31,8 @@ export class GamificationController {
       badgeCount: badges.length,
       streak: streak.currentWeek,
       lastActivity: streak.lastActivityAt,
+      deprecated: true,
+      replacement: '/adventure/me',
     };
   }
 }

--- a/apps/web/src/app/compass/page.tsx
+++ b/apps/web/src/app/compass/page.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import {
+  Brain,
+  Footprints,
+  Heart,
+  HeartHandshake,
+  HeartPulse,
+  Loader2,
+  MoonStar,
+  PawPrint,
+  ShieldCheck,
+  Sparkles,
+  TreePine,
+} from 'lucide-react';
+import Link from 'next/link';
+import { BottomNav } from '@/components/bottom-nav';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { adventureApi, type WellbeingPathway } from '@/lib/api/adventure';
+
+const pathwayMeta: Record<
+  WellbeingPathway,
+  { icon: typeof PawPrint; description: string; href: string; action: string }
+> = {
+  MOVE: {
+    icon: Footprints,
+    description: 'Movement and conditioning that fit the individual dog and the current day.',
+    href: '/activity',
+    action: 'Activity',
+  },
+  EXPLORE: {
+    icon: TreePine,
+    description:
+      'Nature, novelty, sniffing, and sensory exploration without turning miles into the goal.',
+    href: '/journey',
+    action: 'Journey',
+  },
+  ENRICH: {
+    icon: Sparkles,
+    description:
+      'Searching, scent work, puzzles, foraging, and other species-appropriate enrichment.',
+    href: '/',
+    action: 'Quest deck',
+  },
+  LEARN: {
+    icon: Brain,
+    description: 'Reward-based communication, life skills, and cooperative-care practice.',
+    href: '/coach',
+    action: 'Coach',
+  },
+  CONNECT: {
+    icon: HeartHandshake,
+    description:
+      'Comfortable social experiences where space, choice, and good matches matter more than volume.',
+    href: '/pack',
+    action: 'Pack',
+  },
+  CARE: {
+    icon: ShieldCheck,
+    description: 'Private preventive-care support. Medical severity is never a game score.',
+    href: '/health',
+    action: 'Health & care',
+  },
+  RECOVER: {
+    icon: MoonStar,
+    description: 'Rest, decompression, and easier days that count as real progress.',
+    href: '/',
+    action: 'Recovery quests',
+  },
+  BOND: {
+    icon: Heart,
+    description: 'Shared rituals and experiences that both halves of the team actually enjoy.',
+    href: '/journey',
+    action: 'Memories',
+  },
+};
+
+export default function CompassPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['adventure', 'me'],
+    queryFn: () => adventureApi.getMine(),
+    retry: false,
+  });
+
+  return (
+    <div className="min-h-screen pb-24">
+      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/88 backdrop-blur-2xl">
+        <div className="mx-auto flex h-16 max-w-xl items-center gap-3 px-4">
+          <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <PawPrint className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Eight pathways
+            </p>
+            <h1 className="text-lg font-bold tracking-tight">Pawprint Compass</h1>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-xl px-4 pb-8 pt-5">
+        <section className="rounded-3xl border border-primary/15 bg-gradient-to-br from-primary/[0.09] via-card/85 to-secondary/[0.06] p-5">
+          <p className="eyebrow">A map, not a grade</p>
+          <h2 className="mt-1 text-2xl font-bold tracking-tight">
+            Notice what has had room lately.
+          </h2>
+          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+            The Compass shows recent opportunity coverage. A full ring does not mean “healthy,” and
+            an empty one does not mean “bad owner.” Different dogs, seasons, restrictions, and life
+            stages should produce different shapes.
+          </p>
+        </section>
+
+        {isLoading ? (
+          <div className="flex min-h-64 items-center justify-center" role="status">
+            <Loader2 className="h-6 w-6 animate-spin text-primary" aria-hidden="true" />
+          </div>
+        ) : error || !data ? (
+          <div className="surface-soft mt-4 rounded-2xl p-5 text-center">
+            <p className="font-semibold">Compass data is unavailable.</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              The Adventure migration may still need to be applied.
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              {data.compass.map((item) => {
+                const meta = pathwayMeta[item.pathway];
+                const Icon = meta.icon;
+                return (
+                  <article key={item.pathway} className="surface-soft rounded-3xl p-5">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex items-center gap-3">
+                        <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                          <Icon className="h-5 w-5" aria-hidden="true" />
+                        </span>
+                        <div>
+                          <h3 className="font-bold">{item.label}</h3>
+                          <p className="text-xs text-muted-foreground">{item.xp} pathway XP</p>
+                        </div>
+                      </div>
+                      <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-bold text-primary">
+                        {item.recentDays}d
+                      </span>
+                    </div>
+                    <Progress className="mt-4 h-2" value={item.coverage} />
+                    <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                      {meta.description}
+                    </p>
+                    <Button variant="ghost" size="sm" asChild className="mt-3 px-0 text-primary">
+                      <Link href={meta.href}>{meta.action} →</Link>
+                    </Button>
+                  </article>
+                );
+              })}
+            </div>
+
+            <section className="mt-5 rounded-3xl border border-border/60 bg-card/55 p-5">
+              <div className="flex items-center gap-3">
+                <HeartPulse className="h-5 w-5 text-primary" aria-hidden="true" />
+                <div>
+                  <p className="font-semibold">Care has a hard boundary</p>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                    Preventive routines can appear on the Compass. Emergency or illness flows do not
+                    award XP, show confetti, or become social competition.
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <p className="mt-5 text-center text-xs leading-relaxed text-muted-foreground">
+              {data.disclaimer}
+            </p>
+          </>
+        )}
+      </main>
+      <BottomNav />
+    </div>
+  );
+}

--- a/apps/web/src/app/journey/page.tsx
+++ b/apps/web/src/app/journey/page.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import {
+  Camera,
+  Image as ImageIcon,
+  Loader2,
+  Map,
+  PawPrint,
+  Sparkles,
+  Star,
+  Video,
+} from 'lucide-react';
+import Link from 'next/link';
+import { BottomNav } from '@/components/bottom-nav';
+import { Button } from '@/components/ui/button';
+import { adventureApi } from '@/lib/api/adventure';
+import { mediaLibraryApi } from '@/lib/api/media-library';
+
+export default function JourneyPage() {
+  const adventure = useQuery({
+    queryKey: ['adventure', 'me'],
+    queryFn: () => adventureApi.getMine(),
+    retry: false,
+  });
+
+  const library = useQuery({
+    queryKey: ['media-library', 'journey', adventure.data?.pet.id],
+    queryFn: () => mediaLibraryApi.library(adventure.data!.pet.id, { limit: 18 }),
+    enabled: Boolean(adventure.data?.pet.id),
+    retry: false,
+  });
+
+  const pet = adventure.data?.pet;
+  const assets = library.data?.assets ?? [];
+  const albums = library.data?.albums ?? [];
+
+  return (
+    <div className="min-h-screen pb-24">
+      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/88 backdrop-blur-2xl">
+        <div className="mx-auto flex h-16 max-w-xl items-center gap-3 px-4">
+          <span className="brand-mark flex h-9 w-9 items-center justify-center rounded-xl">
+            <Map className="h-5 w-5 text-primary-foreground" aria-hidden="true" />
+          </span>
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Real world → game world
+            </p>
+            <h1 className="text-lg font-bold tracking-tight">Journey</h1>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-xl px-4 pb-8 pt-5">
+        <section className="rounded-3xl border border-primary/15 bg-gradient-to-br from-primary/[0.1] via-card/90 to-secondary/[0.07] p-5">
+          <p className="eyebrow">Adventure Book</p>
+          <h2 className="mt-1 text-2xl font-bold tracking-tight">
+            {pet
+              ? `${pet.name}'s world is becoming a story.`
+              : 'Shared experiences become a story.'}
+          </h2>
+          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+            Memories are the evidence trail and the scrapbook, not the objective. The real reward
+            comes from the experience itself.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Button asChild>
+              <Link href="/activity">Start an adventure</Link>
+            </Button>
+            <Button variant="outline" asChild className="bg-transparent">
+              <Link href="/library">
+                <Camera className="mr-2 h-4 w-4" aria-hidden="true" />
+                Open full library
+              </Link>
+            </Button>
+          </div>
+        </section>
+
+        {adventure.isLoading || library.isLoading ? (
+          <div className="flex min-h-56 items-center justify-center" role="status">
+            <Loader2 className="h-6 w-6 animate-spin text-primary" aria-hidden="true" />
+          </div>
+        ) : (
+          <>
+            <section className="mt-6">
+              <div className="flex items-end justify-between gap-3">
+                <div>
+                  <p className="eyebrow">Collections</p>
+                  <h2 className="mt-1 text-xl font-bold tracking-tight">
+                    Stamps from your actual life
+                  </h2>
+                </div>
+                <span className="text-xs text-muted-foreground">{albums.length} collections</span>
+              </div>
+
+              {albums.length > 0 ? (
+                <div className="mt-3 flex gap-3 overflow-x-auto pb-2">
+                  {albums.slice(0, 10).map((album) => (
+                    <Link
+                      key={album.id}
+                      href="/library"
+                      className="surface-soft min-w-[148px] rounded-2xl p-4 transition-colors hover:border-primary/30"
+                    >
+                      <span
+                        className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-lg"
+                        aria-hidden="true"
+                      >
+                        {album.icon || '🐾'}
+                      </span>
+                      <p className="mt-4 text-sm font-semibold">{album.name}</p>
+                      <p className="mt-1 text-xs text-muted-foreground">{album.count} memories</p>
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <div className="surface-soft mt-3 rounded-2xl p-5">
+                  <p className="font-semibold">Your Adventure Book has room to grow.</p>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                    Keep a favorite walk, training win, first beach trip, or quiet recovery day when
+                    it is worth remembering.
+                  </p>
+                </div>
+              )}
+            </section>
+
+            <section className="mt-6">
+              <div className="flex items-end justify-between gap-3">
+                <div>
+                  <p className="eyebrow">Recent pages</p>
+                  <h2 className="mt-1 text-xl font-bold tracking-tight">
+                    Memories, not proof chores
+                  </h2>
+                </div>
+                <Button variant="ghost" size="sm" asChild className="text-primary">
+                  <Link href="/library">See all →</Link>
+                </Button>
+              </div>
+
+              {assets.length > 0 ? (
+                <div className="mt-3 grid grid-cols-3 gap-2">
+                  {assets.slice(0, 9).map((asset) => (
+                    <Link
+                      key={asset.id}
+                      href="/library"
+                      className="group relative aspect-square overflow-hidden rounded-2xl border border-border/60 bg-muted"
+                    >
+                      {asset.url && asset.mediaType === 'image' ? (
+                        <>
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
+                          <img
+                            src={asset.url}
+                            alt={asset.filename}
+                            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                          />
+                        </>
+                      ) : (
+                        <div className="flex h-full items-center justify-center text-muted-foreground">
+                          {asset.mediaType === 'video' ? (
+                            <Video className="h-6 w-6" aria-hidden="true" />
+                          ) : (
+                            <ImageIcon className="h-6 w-6" aria-hidden="true" />
+                          )}
+                        </div>
+                      )}
+                      {asset.favorite && (
+                        <span className="absolute right-2 top-2 rounded-full bg-background/80 p-1 text-primary backdrop-blur-sm">
+                          <Star className="h-3.5 w-3.5 fill-current" aria-hidden="true" />
+                        </span>
+                      )}
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <div className="surface-soft mt-3 flex min-h-40 flex-col items-center justify-center rounded-2xl p-6 text-center">
+                  <PawPrint className="h-7 w-7 text-primary" aria-hidden="true" />
+                  <p className="mt-3 font-semibold">No kept memories yet</p>
+                  <p className="mt-1 max-w-xs text-sm leading-relaxed text-muted-foreground">
+                    Photos stay optional. A completed quest is valuable even when the phone never
+                    leaves your pocket.
+                  </p>
+                </div>
+              )}
+            </section>
+
+            <section className="mt-6 rounded-3xl border border-secondary/20 bg-secondary/[0.05] p-5">
+              <div className="flex items-start gap-3">
+                <Sparkles className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+                <div>
+                  <p className="font-semibold">What Journey will learn next</p>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                    Route semantics, favorite places, first-time locations, terrain, season, and
+                    paired outcome history can turn future outings into real map stamps without
+                    making location sharing mandatory.
+                  </p>
+                </div>
+              </div>
+            </section>
+          </>
+        )}
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+}

--- a/apps/web/src/app/pack/page.tsx
+++ b/apps/web/src/app/pack/page.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import {
+  CalendarHeart,
+  Compass,
+  HeartHandshake,
+  Loader2,
+  PawPrint,
+  Sparkles,
+  Users,
+} from 'lucide-react';
+import Link from 'next/link';
+import { BottomNav } from '@/components/bottom-nav';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { packApi } from '@/lib/api/pack';
+
+export default function PackPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['pack', 'challenges'],
+    queryFn: packApi.challenges,
+    retry: false,
+  });
+
+  return (
+    <div className="min-h-screen pb-24">
+      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/88 backdrop-blur-2xl">
+        <div className="mx-auto flex h-16 max-w-xl items-center gap-3 px-4">
+          <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <Users className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Together, without a podium
+            </p>
+            <h1 className="text-lg font-bold tracking-tight">Pack</h1>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-xl px-4 pb-8 pt-5">
+        <section className="rounded-3xl border border-primary/15 bg-gradient-to-br from-primary/[0.1] via-card/90 to-secondary/[0.07] p-5">
+          <p className="eyebrow">Cooperative play</p>
+          <h2 className="mt-1 text-2xl font-bold tracking-tight">
+            Everybody can move the pack forward.
+          </h2>
+          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+            Pack challenges count appropriate shared actions, not raw distance. A senior dog, a
+            cautious dog, and an adolescent trail rocket can all contribute without pretending their
+            ideal weeks should look alike.
+          </p>
+          <div className="mt-4 grid grid-cols-2 gap-2">
+            <Button asChild>
+              <Link href="/discover">
+                <Compass className="mr-2 h-4 w-4" aria-hidden="true" />
+                Find a good match
+              </Link>
+            </Button>
+            <Button variant="outline" asChild className="bg-transparent">
+              <Link href="/events">
+                <CalendarHeart className="mr-2 h-4 w-4" aria-hidden="true" />
+                Plan together
+              </Link>
+            </Button>
+          </div>
+        </section>
+
+        <section className="mt-6">
+          <div>
+            <p className="eyebrow">This week</p>
+            <h2 className="mt-1 text-xl font-bold tracking-tight">Community quests</h2>
+          </div>
+
+          {isLoading ? (
+            <div className="flex min-h-48 items-center justify-center" role="status">
+              <Loader2 className="h-6 w-6 animate-spin text-primary" aria-hidden="true" />
+            </div>
+          ) : error || !data ? (
+            <div className="surface-soft mt-3 rounded-2xl p-5 text-center">
+              <PawPrint className="mx-auto h-6 w-6 text-primary" aria-hidden="true" />
+              <p className="mt-2 font-semibold">Pack totals are unavailable.</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Your individual Adventure system still works normally.
+              </p>
+            </div>
+          ) : (
+            <div className="mt-3 space-y-3">
+              {data.challenges.map((challenge) => (
+                <article key={challenge.id} className="surface-soft rounded-3xl p-5">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <Sparkles className="h-4 w-4 text-primary" aria-hidden="true" />
+                        <h3 className="font-bold">{challenge.title}</h3>
+                      </div>
+                      <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                        {challenge.description}
+                      </p>
+                    </div>
+                    {challenge.completed && (
+                      <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-bold text-primary">
+                        Done
+                      </span>
+                    )}
+                  </div>
+
+                  <Progress className="mt-4 h-2" value={challenge.progress * 100} />
+                  <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                    <span>
+                      {challenge.total} / {challenge.target} {challenge.unit}
+                    </span>
+                    <span>{challenge.contributors} contributors</span>
+                  </div>
+                  <div className="mt-3 rounded-2xl bg-primary/[0.06] px-3 py-2 text-sm">
+                    <span className="font-semibold text-primary">Your contribution:</span>{' '}
+                    {challenge.myContribution} meaningful{' '}
+                    {challenge.myContribution === 1 ? 'action' : 'actions'}
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="mt-6 rounded-3xl border border-border/60 bg-card/55 p-5">
+          <div className="flex items-start gap-3">
+            <HeartHandshake className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+            <div>
+              <h2 className="font-bold">Social fit still comes first</h2>
+              <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                Pack does not reward forcing interactions. Parallel walks, extra distance, ending
+                early, or skipping a crowded event can all be better choices for a particular dog.
+              </p>
+              <Button variant="ghost" size="sm" asChild className="mt-2 px-0 text-primary">
+                <Link href="/discover">Explore compatibility-first discovery →</Link>
+              </Button>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,424 +2,463 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
-  Bell,
   Brain,
-  CalendarHeart,
-  Compass,
+  Check,
   Footprints,
+  Heart,
   HeartHandshake,
   Loader2,
   MoonStar,
   PawPrint,
+  ShieldCheck,
   Sparkles,
-  Target,
+  TreePine,
+  X,
 } from 'lucide-react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { BottomNav } from '@/components/bottom-nav';
-import { FullScreenPostView } from '@/components/feed/full-screen-post-view';
-import { PostCard } from '@/components/feed/post-card';
-import { PWAInstallPrompt } from '@/components/pwa-install-prompt';
 import { Button } from '@/components/ui/button';
-import {
-  type InsightRecommendation,
-  insightsApi,
-} from '@/lib/api/insights';
-import { webSocialApi } from '@/lib/api/social';
+import { Progress } from '@/components/ui/progress';
+import { adventureApi, type AdventureQuest, type WellbeingPathway } from '@/lib/api/adventure';
 
-const fallbackActions = [
-  {
-    href: '/discover',
-    label: 'Find a match',
-    description: 'Compatibility-first discovery',
-    icon: Compass,
-  },
-  {
-    href: '/events',
-    label: 'Plan a meetup',
-    description: 'Choose a comfortable shared setting',
-    icon: CalendarHeart,
-  },
-  {
-    href: '/activity',
-    label: 'Log activity',
-    description: 'Teach Woof about your shared routine',
-    icon: Footprints,
-  },
-  {
-    href: '/profile',
-    label: 'Update preferences',
-    description: 'Tell Woof what you are noticing',
-    icon: Brain,
-  },
+const pathwayIcons: Record<WellbeingPathway, typeof PawPrint> = {
+  MOVE: Footprints,
+  EXPLORE: TreePine,
+  ENRICH: Sparkles,
+  LEARN: Brain,
+  CONNECT: HeartHandshake,
+  CARE: ShieldCheck,
+  RECOVER: MoonStar,
+  BOND: Heart,
+};
+
+const dogChoices = [
+  { value: 'loved_it' as const, emoji: '😄', label: 'Loved it' },
+  { value: 'comfortable' as const, emoji: '😌', label: 'Comfortable' },
+  { value: 'not_their_thing' as const, emoji: '😕', label: 'Not their thing' },
 ];
 
-const recommendationIcons = {
-  activity: Footprints,
-  enrichment: Sparkles,
-  social: HeartHandshake,
-  recovery: MoonStar,
-  reflection: Brain,
-  goal: Target,
-} satisfies Record<InsightRecommendation['category'], typeof Footprints>;
+const ownerChoices = [
+  { value: 'great' as const, emoji: '✨', label: 'Great' },
+  { value: 'fine' as const, emoji: '🙂', label: 'Fine' },
+  { value: 'a_lot_today' as const, emoji: '😮‍💨', label: 'A lot today' },
+];
 
 export default function HomePage() {
   const queryClient = useQueryClient();
-  const [fullScreenIndex, setFullScreenIndex] = useState<number | null>(null);
+  const router = useRouter();
+  const [closingQuest, setClosingQuest] = useState<AdventureQuest | null>(null);
+  const [startingQuestId, setStartingQuestId] = useState<string | null>(null);
+  const [dogExperience, setDogExperience] = useState<
+    'loved_it' | 'comfortable' | 'not_their_thing' | null
+  >(null);
+  const [safeOptOut, setSafeOptOut] = useState(false);
+  const [completionMessage, setCompletionMessage] = useState<string | null>(null);
 
-  const {
-    data: insights,
-    isLoading: insightsLoading,
-    error: insightsError,
-  } = useQuery({
-    queryKey: ['insights', 'me'],
-    queryFn: () => insightsApi.getMine(),
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['adventure', 'me'],
+    queryFn: () => adventureApi.getMine(),
     retry: false,
   });
 
-  const {
-    data: posts = [],
-    isLoading: feedLoading,
-    error: feedError,
-  } = useQuery({
-    queryKey: ['feed'],
-    queryFn: webSocialApi.getFeed,
-  });
-
-  const likeMutation = useMutation({
-    mutationFn: ({ postId, isLiked }: { postId: string; isLiked: boolean }) =>
-      isLiked ? webSocialApi.unlikePost(postId) : webSocialApi.likePost(postId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['feed'] });
+  const completeMutation = useMutation({
+    mutationFn: ({
+      quest,
+      ownerExperience,
+    }: {
+      quest: AdventureQuest;
+      ownerExperience: 'great' | 'fine' | 'a_lot_today';
+    }) => {
+      if (!data || !dogExperience) throw new Error('Outcome is incomplete');
+      return adventureApi.completeQuest(quest.id, {
+        petId: data.pet.id,
+        dogExperience,
+        ownerExperience,
+        safeOptOut,
+      });
+    },
+    onSuccess: async (result) => {
+      const rewardCopy = result.reward.duplicate
+        ? 'Already saved. No extra Bond XP was issued.'
+        : result.reward.bondXp > 0
+          ? `+${result.reward.bondXp} Bond XP`
+          : '';
+      setCompletionMessage(`${result.message} ${rewardCopy}`.trim());
+      await queryClient.invalidateQueries({ queryKey: ['adventure', 'me'] });
     },
   });
 
-  const handleLike = (postId: string) => {
-    const post = posts.find((candidate) => candidate.id === postId);
-    if (!post) return;
-    likeMutation.mutate({ postId, isLiked: post.isLiked });
+  const startQuest = async (quest: AdventureQuest) => {
+    if (!data || startingQuestId) return;
+
+    setStartingQuestId(quest.id);
+    try {
+      await adventureApi.selectQuest(quest.id, data.pet.id);
+    } finally {
+      // Selection persistence improves continuity, but a transient analytics/network
+      // failure must never trap the user on Today instead of letting them do the activity.
+      setStartingQuestId(null);
+      router.push(quest.href);
+    }
   };
 
-  const handleRecommendationAccepted = (recommendation: InsightRecommendation) => {
-    if (!insights) return;
-    void insightsApi.feedback(insights.pet.id, recommendation, 'accepted');
+  const closeOutcome = () => {
+    setClosingQuest(null);
+    setDogExperience(null);
+    setSafeOptOut(false);
+    setCompletionMessage(null);
+    completeMutation.reset();
+  };
+
+  const openCompletion = (quest: AdventureQuest, optOut = false) => {
+    setClosingQuest(quest);
+    setCompletionMessage(null);
+    setSafeOptOut(optOut);
+    setDogExperience(optOut ? 'not_their_thing' : null);
   };
 
   return (
     <div className="min-h-screen pb-24">
       <header className="sticky top-0 z-40 border-b border-border/60 bg-background/88 backdrop-blur-2xl">
         <div className="mx-auto flex h-16 max-w-xl items-center justify-between px-4">
-          <Link
-            href="/"
-            className="flex min-h-0 min-w-0 items-center gap-3"
-            aria-label="Woof home"
-          >
+          <Link href="/" className="flex items-center gap-3" aria-label="Woof Today">
             <span className="brand-mark flex h-9 w-9 items-center justify-center rounded-xl">
-              <PawPrint
-                className="h-5 w-5 text-primary-foreground"
-                aria-hidden="true"
-              />
+              <PawPrint className="h-5 w-5 text-primary-foreground" aria-hidden="true" />
             </span>
             <span>
               <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                Learn together
+                Dog + human
               </span>
-              <span className="block text-lg font-bold tracking-tight">Woof</span>
+              <span className="block text-lg font-bold tracking-tight">Woof Adventure</span>
             </span>
           </Link>
-
-          <Button variant="ghost" size="icon" asChild className="relative rounded-xl">
-            <Link href="/notifications" aria-label="Open notifications">
-              <Bell className="h-5 w-5" aria-hidden="true" />
-            </Link>
-          </Button>
+          {data && (
+            <div className="rounded-2xl border border-border/60 bg-card/70 px-3 py-1.5 text-right">
+              <p className="text-[9px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                Bond XP
+              </p>
+              <p className="text-base font-bold text-primary">{data.bondXp}</p>
+            </div>
+          )}
         </div>
       </header>
 
-      <main id="main-content" className="mx-auto max-w-xl px-4 pb-6 pt-5">
-        <section aria-labelledby="today-heading" className="animate-in">
-          <div className="rounded-3xl border border-primary/15 bg-gradient-to-br from-primary/[0.09] via-card/80 to-secondary/[0.07] p-5 shadow-sm">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <p className="eyebrow">Today&apos;s learning loop</p>
-                <h1
-                  id="today-heading"
-                  className="mt-1 text-2xl font-bold tracking-tight sm:text-3xl"
-                >
-                  {insights
-                    ? `What might help ${insights.pet.name} today?`
-                    : 'What does your pet need today?'}
-                </h1>
-                <p className="mt-2 max-w-md text-sm leading-relaxed text-muted-foreground">
-                  Woof combines the routines you record, the preferences you share, and
-                  outcomes from real experiences to suggest useful next steps without
-                  pretending certainty.
-                </p>
-              </div>
-              {insights && (
-                <div className="shrink-0 rounded-2xl border border-border/60 bg-background/60 px-3 py-2 text-right">
-                  <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                    Context confidence
-                  </p>
-                  <p className="mt-0.5 text-lg font-bold text-primary">
-                    {Math.round(insights.algorithm.confidence * 100)}%
-                  </p>
-                </div>
-              )}
+      <main id="main-content" className="mx-auto max-w-xl px-4 pb-8 pt-5">
+        {isLoading ? (
+          <div className="flex min-h-[60vh] items-center justify-center" role="status">
+            <div className="text-center">
+              <Loader2 className="mx-auto h-7 w-7 animate-spin text-primary" aria-hidden="true" />
+              <p className="mt-3 text-sm text-muted-foreground">
+                Building today&apos;s quest deck…
+              </p>
             </div>
           </div>
+        ) : error || !data ? (
+          <section className="surface-soft rounded-3xl p-6 text-center">
+            <PawPrint className="mx-auto h-8 w-8 text-primary" aria-hidden="true" />
+            <h1 className="mt-3 text-xl font-bold">Adventure mode is unavailable</h1>
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+              Adventure may be paused or temporarily unavailable. Your existing Coach, Health,
+              Library, and social tools are still available.
+            </p>
+            <Button
+              className="mt-5"
+              onClick={() => queryClient.invalidateQueries({ queryKey: ['adventure'] })}
+            >
+              Try again
+            </Button>
+          </section>
+        ) : (
+          <>
+            <section className="rounded-3xl border border-primary/15 bg-gradient-to-br from-primary/[0.11] via-card/90 to-secondary/[0.08] p-5 shadow-sm">
+              <p className="eyebrow">Today&apos;s party quest</p>
+              <h1 className="mt-1 text-3xl font-bold tracking-tight">
+                {data.pet.name} has {data.quests.length} adventures available.
+              </h1>
+              <p className="mt-2 max-w-lg text-sm leading-relaxed text-muted-foreground">
+                Woof recommends. You choose. Rest, changing your mind, or listening when your dog
+                says “not today” can all be the right play.
+              </p>
 
-          <div className="mt-4">
-            {insightsLoading ? (
-              <div
-                className="surface-soft flex min-h-40 items-center justify-center rounded-2xl"
-                role="status"
-              >
-                <div className="text-center">
-                  <Loader2
-                    className="mx-auto h-6 w-6 animate-spin text-primary"
-                    aria-hidden="true"
+              <div className="mt-5 flex items-center gap-3 rounded-2xl border border-border/60 bg-background/55 p-3">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                  <Heart className="h-5 w-5" aria-hidden="true" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-sm font-semibold">{data.rhythm.label}</p>
+                    <span className="text-xs font-semibold text-primary">
+                      {data.rhythm.activeWeeks}/{data.rhythm.windowWeeks} weeks
+                    </span>
+                  </div>
+                  <Progress
+                    className="mt-2 h-1.5"
+                    value={(data.rhythm.activeWeeks / data.rhythm.windowWeeks) * 100}
                   />
-                  <p className="mt-2 text-sm text-muted-foreground">
-                    Reading the recent routine…
-                  </p>
                 </div>
               </div>
-            ) : insights && insights.recommendations.length > 0 ? (
-              <div className="space-y-3">
-                {insights.recommendations.slice(0, 3).map((recommendation, index) => {
-                  const Icon = recommendationIcons[recommendation.category];
-                  return (
-                    <Link
-                      key={recommendation.id}
-                      href={recommendation.href}
-                      onClick={() => handleRecommendationAccepted(recommendation)}
-                      className="group surface-soft flex gap-4 rounded-2xl p-4 transition-colors hover:border-primary/30 hover:bg-primary/[0.045]"
-                    >
-                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            </section>
+
+            <section className="mt-5 space-y-3" aria-label="Today's quests">
+              {data.quests.map((quest, index) => {
+                const Icon = pathwayIcons[quest.primaryPathway];
+                return (
+                  <article
+                    key={quest.id}
+                    className={`surface-soft rounded-3xl p-5 ${index === 0 ? 'border-primary/30 bg-primary/[0.035]' : ''}`}
+                  >
+                    <div className="flex items-start gap-4">
+                      <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
                         <Icon className="h-5 w-5" aria-hidden="true" />
                       </div>
                       <div className="min-w-0 flex-1">
                         <div className="flex items-start justify-between gap-3">
                           <div>
-                            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                              {index === 0 ? 'Best next step' : recommendation.category}
+                            <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+                              {index === 0
+                                ? 'Best quest'
+                                : quest.variant === 'wildcard'
+                                  ? 'Wildcard'
+                                  : 'Alternative'}{' '}
+                              · {quest.primaryPathway.toLowerCase()}
                             </p>
-                            <h2 className="mt-1 font-semibold tracking-tight">
-                              {recommendation.title}
-                            </h2>
+                            <h2 className="mt-1 text-lg font-bold tracking-tight">{quest.title}</h2>
                           </div>
-                          <span className="shrink-0 text-xs font-semibold text-primary">
-                            {Math.round(recommendation.confidence * 100)}% context
+                          <span className="shrink-0 rounded-full bg-primary/10 px-2.5 py-1 text-xs font-bold text-primary">
+                            Base {quest.xp} XP
                           </span>
                         </div>
-                        <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
-                          {recommendation.reason}
+                        <p className="mt-2 text-sm leading-relaxed">{quest.description}</p>
+                        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                          {quest.why}
                         </p>
-                        <span className="mt-3 inline-flex text-sm font-semibold text-primary group-hover:text-primary/80">
-                          {recommendation.actionLabel} →
-                        </span>
-                      </div>
-                    </Link>
-                  );
-                })}
-              </div>
-            ) : (
-              <div className="grid grid-cols-2 gap-3">
-                {fallbackActions.map((action) => {
-                  const Icon = action.icon;
-                  return (
-                    <Link
-                      key={action.href}
-                      href={action.href}
-                      className="group surface-soft flex min-h-[122px] flex-col justify-between rounded-2xl p-4 transition-colors hover:border-primary/30 hover:bg-primary/[0.045]"
-                    >
-                      <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary transition-transform group-hover:-translate-y-0.5">
-                        <Icon className="h-5 w-5" aria-hidden="true" />
-                      </span>
-                      <span className="mt-5">
-                        <span className="block text-sm font-semibold">{action.label}</span>
-                        <span className="mt-1 block text-xs leading-relaxed text-muted-foreground">
-                          {action.description}
-                        </span>
-                      </span>
-                    </Link>
-                  );
-                })}
-              </div>
-            )}
-          </div>
 
-          {insights && (
-            <div className="mt-6">
-              <div className="mb-3 flex items-end justify-between gap-4">
+                        <div className="mt-4 flex flex-wrap gap-1.5">
+                          {quest.pathways.map((pathway) => (
+                            <span
+                              key={pathway}
+                              className="rounded-full border border-border/70 bg-background/60 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+                            >
+                              {pathway}
+                            </span>
+                          ))}
+                        </div>
+
+                        <div className="mt-4 flex flex-wrap gap-2">
+                          <Button
+                            size="sm"
+                            disabled={startingQuestId !== null}
+                            onClick={() => void startQuest(quest)}
+                          >
+                            {startingQuestId === quest.id && (
+                              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" aria-hidden="true" />
+                            )}
+                            {quest.actionLabel}
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="bg-transparent"
+                            onClick={() => openCompletion(quest)}
+                          >
+                            <Check className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                            Close the loop
+                          </Button>
+                          {quest.safeStopEligible && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => openCompletion(quest, true)}
+                            >
+                              I listened and stopped
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </article>
+                );
+              })}
+            </section>
+
+            <section className="mt-7">
+              <div className="flex items-end justify-between gap-3">
                 <div>
-                  <p className="eyebrow">What Woof is learning</p>
+                  <p className="eyebrow">Pawprint Compass</p>
                   <h2 className="mt-1 text-xl font-bold tracking-tight">
-                    Your relationship, in signals
+                    Recent opportunities, not a score
                   </h2>
                 </div>
-                <span className="text-[10px] text-muted-foreground">
-                  Not a medical or bond score
-                </span>
+                <Link href="/compass" className="text-sm font-semibold text-primary">
+                  Full compass →
+                </Link>
               </div>
-
-              <div className="grid grid-cols-2 gap-3">
-                {insights.relationshipSignals.map((signal) => (
-                  <div key={signal.key} className="surface-soft rounded-2xl p-4">
-                    <div className="flex items-baseline justify-between gap-2">
-                      <p className="text-sm font-semibold">{signal.label}</p>
-                      <span className="text-sm font-bold text-primary">{signal.value}</span>
-                    </div>
-                    <div
-                      className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted"
-                      aria-hidden="true"
-                    >
-                      <div
-                        className="h-full rounded-full bg-primary"
-                        style={{ width: `${signal.value}%` }}
-                      />
-                    </div>
-                    <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-                      {signal.explanation}
-                    </p>
-                  </div>
-                ))}
-              </div>
-
-              {insights.learningSummary.length > 0 && (
-                <div className="mt-3 rounded-2xl border border-secondary/20 bg-secondary/[0.05] p-4">
-                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-secondary-foreground">
-                    Recent observations
-                  </p>
-                  <ul className="mt-2 space-y-1.5 text-sm leading-relaxed text-muted-foreground">
-                    {insights.learningSummary.map((observation) => (
-                      <li key={observation} className="flex gap-2">
-                        <span className="text-primary" aria-hidden="true">
-                          •
+              <div className="mt-3 grid grid-cols-2 gap-3">
+                {data.compass.slice(0, 4).map((item) => {
+                  const Icon = pathwayIcons[item.pathway];
+                  return (
+                    <div key={item.pathway} className="surface-soft rounded-2xl p-4">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="flex items-center gap-2 text-sm font-semibold">
+                          <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
+                          {item.label}
                         </span>
-                        <span>{observation}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-            </div>
-          )}
+                        <span className="text-xs font-bold text-primary">{item.recentDays}d</span>
+                      </div>
+                      <Progress className="mt-3 h-1.5" value={item.coverage} />
+                      <p className="mt-2 text-[11px] text-muted-foreground">
+                        {item.xp} pathway XP · 28-day window
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
 
-          {insightsError && !insights && (
-            <p className="mt-3 text-xs leading-relaxed text-muted-foreground">
-              Personalized guidance is unavailable right now, so Woof is showing the
-              core actions instead. Your feed and account still work normally.
+            {data.learningSummary.length > 0 && (
+              <section className="mt-6 rounded-3xl border border-secondary/20 bg-secondary/[0.05] p-5">
+                <p className="eyebrow">What Woof is learning</p>
+                <ul className="mt-3 space-y-2 text-sm leading-relaxed text-muted-foreground">
+                  {data.learningSummary.slice(0, 3).map((line) => (
+                    <li key={line} className="flex gap-2">
+                      <Sparkles
+                        className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+                        aria-hidden="true"
+                      />
+                      <span>{line}</span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            <p className="mt-5 text-center text-xs leading-relaxed text-muted-foreground">
+              {data.disclaimer}
             </p>
-          )}
-        </section>
+          </>
+        )}
+      </main>
 
-        <section aria-labelledby="feed-heading" className="mt-8">
-          <div className="mb-3 flex items-center justify-between gap-3">
-            <div>
-              <p className="eyebrow">Community, not the finish line</p>
-              <h2 id="feed-heading" className="mt-1 text-xl font-bold tracking-tight">
-                Learn from your pack
-              </h2>
-            </div>
-            <Link
-              href="/discover"
-              className="flex min-h-0 min-w-0 items-center gap-1 text-sm font-semibold text-primary hover:text-primary/80"
-            >
-              Discover
-              <span aria-hidden="true">→</span>
-            </Link>
-          </div>
-
-          <div className="overflow-hidden rounded-2xl border border-border/60 bg-card/55">
-            {feedLoading ? (
-              <div
-                className="flex min-h-52 flex-col items-center justify-center gap-3 px-5 py-12"
-                role="status"
+      {closingQuest && data && (
+        <div
+          className="fixed inset-0 z-[70] flex items-end justify-center bg-background/70 p-3 backdrop-blur-sm sm:items-center"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Quest outcome"
+        >
+          <div className="w-full max-w-md rounded-3xl border border-border bg-card p-5 shadow-2xl">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="eyebrow">Five-second learning loop</p>
+                <h2 className="mt-1 text-xl font-bold">{closingQuest.title}</h2>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={closeOutcome}
+                aria-label="Close outcome flow"
               >
-                <Loader2
-                  className="h-7 w-7 animate-spin text-primary"
-                  aria-hidden="true"
-                />
-                <p className="text-sm text-muted-foreground">
-                  Gathering the latest from your pack…
-                </p>
-              </div>
-            ) : feedError ? (
-              <div className="flex min-h-52 flex-col items-center justify-center px-6 py-12 text-center">
-                <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-2xl bg-destructive/10 text-destructive">
-                  <PawPrint className="h-5 w-5" aria-hidden="true" />
+                <X className="h-5 w-5" aria-hidden="true" />
+              </Button>
+            </div>
+
+            {completionMessage ? (
+              <div className="mt-5 rounded-2xl bg-primary/10 p-5 text-center">
+                <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-primary text-primary-foreground">
+                  <PawPrint className="h-6 w-6" aria-hidden="true" />
                 </div>
-                <h3 className="font-semibold">The feed could not load</h3>
-                <p className="mt-1 max-w-xs text-sm leading-relaxed text-muted-foreground">
-                  Your relationship-learning tools still work. Try the community feed
-                  again when the connection settles.
+                <p className="mt-3 font-semibold leading-relaxed">{completionMessage}</p>
+                <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                  The result now informs future quest ranking for this dog-owner pair.
                 </p>
-                <Button
-                  variant="outline"
-                  className="mt-5 bg-transparent"
-                  onClick={() => queryClient.invalidateQueries({ queryKey: ['feed'] })}
-                >
-                  Try again
-                </Button>
-              </div>
-            ) : posts.length === 0 ? (
-              <div className="flex min-h-56 flex-col items-center justify-center px-6 py-12 text-center">
-                <div className="brand-mark mb-4 flex h-12 w-12 items-center justify-center rounded-2xl">
-                  <PawPrint
-                    className="h-6 w-6 text-primary-foreground"
-                    aria-hidden="true"
-                  />
-                </div>
-                <h3 className="text-base font-semibold">Your pack is quiet for now</h3>
-                <p className="mt-1 max-w-xs text-sm leading-relaxed text-muted-foreground">
-                  Share a meaningful walk, play session, lesson, or park moment when
-                  there is something worth remembering.
-                </p>
-                <div className="mt-5 flex flex-wrap justify-center gap-2">
-                  <Button asChild>
-                    <Link href="/discover">Find matches</Link>
-                  </Button>
+                <div className="mt-4 flex justify-center gap-2">
+                  <Button onClick={closeOutcome}>Done</Button>
                   <Button variant="outline" asChild className="bg-transparent">
-                    <Link href="/camera">Create a post</Link>
+                    <Link href="/library">Add a memory</Link>
                   </Button>
                 </div>
               </div>
             ) : (
-              <div className="divide-y divide-border/50">
-                {posts.map((post, index) => (
-                  <PostCard
-                    key={post.id}
-                    post={post}
-                    onLike={handleLike}
-                    onMediaClick={
-                      post.mediaUrl ? () => setFullScreenIndex(index) : undefined
-                    }
-                  />
-                ))}
-              </div>
+              <>
+                {safeOptOut ? (
+                  <div className="mt-5 rounded-2xl border border-primary/20 bg-primary/[0.05] p-4">
+                    <p className="font-semibold text-primary">You listened.</p>
+                    <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                      Woof will treat giving space or ending the interaction as successful dog
+                      literacy.
+                    </p>
+                  </div>
+                ) : !dogExperience ? (
+                  <div className="mt-5">
+                    <p className="text-sm font-semibold">How was it for {data.pet.name}?</p>
+                    <div className="mt-3 grid grid-cols-3 gap-2">
+                      {dogChoices.map((choice) => (
+                        <button
+                          key={choice.value}
+                          type="button"
+                          onClick={() => setDogExperience(choice.value)}
+                          className="rounded-2xl border border-border bg-background/55 p-3 text-center transition-colors hover:border-primary/40 hover:bg-primary/[0.05]"
+                        >
+                          <span className="block text-2xl" aria-hidden="true">
+                            {choice.emoji}
+                          </span>
+                          <span className="mt-1 block text-xs font-semibold">{choice.label}</span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+
+                {(dogExperience || safeOptOut) && (
+                  <div className="mt-5">
+                    <p className="text-sm font-semibold">How was it for you?</p>
+                    <div className="mt-3 grid grid-cols-3 gap-2">
+                      {ownerChoices.map((choice) => (
+                        <button
+                          key={choice.value}
+                          type="button"
+                          disabled={completeMutation.isPending}
+                          onClick={() =>
+                            completeMutation.mutate({
+                              quest: closingQuest,
+                              ownerExperience: choice.value,
+                            })
+                          }
+                          className="rounded-2xl border border-border bg-background/55 p-3 text-center transition-colors hover:border-primary/40 hover:bg-primary/[0.05] disabled:opacity-50"
+                        >
+                          <span className="block text-2xl" aria-hidden="true">
+                            {choice.emoji}
+                          </span>
+                          <span className="mt-1 block text-xs font-semibold">{choice.label}</span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {completeMutation.isPending && (
+                  <div
+                    className="mt-4 flex items-center justify-center gap-2 text-sm text-muted-foreground"
+                    role="status"
+                  >
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                    Learning from the outcome…
+                  </div>
+                )}
+                {completeMutation.isError && (
+                  <p className="mt-4 text-center text-sm text-destructive">
+                    That outcome could not be saved. Nothing was lost from your existing history.
+                  </p>
+                )}
+              </>
             )}
           </div>
-        </section>
-      </main>
-
-      {fullScreenIndex !== null && (
-        <FullScreenPostView
-          posts={posts.filter((post) => Boolean(post.mediaUrl))}
-          initialIndex={Math.max(
-            0,
-            posts
-              .slice(0, fullScreenIndex)
-              .filter((post) => Boolean(post.mediaUrl)).length,
-          )}
-          onClose={() => setFullScreenIndex(null)}
-          onLike={handleLike}
-        />
+        </div>
       )}
 
       <BottomNav />
-      <PWAInstallPrompt />
     </div>
   );
 }

--- a/apps/web/src/components/bottom-nav.tsx
+++ b/apps/web/src/components/bottom-nav.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import { Brain, Compass, HeartPulse, Home, User } from 'lucide-react';
+import { Brain, Compass, Map, PawPrint, Users } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 
 const navItems = [
-  { href: '/', icon: Home, label: 'Home' },
-  { href: '/discover', icon: Compass, label: 'Discover' },
-  { href: '/coach', icon: Brain, label: 'Coach', isSpecial: true },
-  { href: '/health', icon: HeartPulse, label: 'Health' },
-  { href: '/profile', icon: User, label: 'Profile' },
+  { href: '/', icon: PawPrint, label: 'Today' },
+  { href: '/compass', icon: Compass, label: 'Compass' },
+  { href: '/journey', icon: Map, label: 'Journey', isSpecial: true },
+  { href: '/coach', icon: Brain, label: 'Coach' },
+  { href: '/pack', icon: Users, label: 'Pack' },
 ];
 
 export function BottomNav() {
@@ -31,7 +31,7 @@ export function BottomNav() {
               <Link
                 key={item.href}
                 href={item.href}
-                aria-label="Open Woof Coach"
+                aria-label="Open Adventure Journey"
                 aria-current={isActive ? 'page' : undefined}
                 className={cn(
                   'group -mt-5 flex h-14 w-14 items-center justify-center rounded-2xl border brand-mark text-primary-foreground transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5',

--- a/apps/web/src/lib/api/adventure.spec.ts
+++ b/apps/web/src/lib/api/adventure.spec.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const transport = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.mock('./client', () => ({
+  apiClient: transport,
+}));
+
+import { adventureApi, type CompleteQuestInput } from './adventure';
+
+describe('adventureApi', () => {
+  beforeEach(() => {
+    transport.get.mockReset();
+    transport.post.mockReset();
+  });
+
+  it('reads the server-owned dashboard with an optional pet scope', async () => {
+    transport.get.mockResolvedValue({ quests: [] });
+
+    await adventureApi.getMine('pet-1');
+
+    expect(transport.get).toHaveBeenCalledWith('/adventure/me', {
+      params: { petId: 'pet-1' },
+    });
+  });
+
+  it('selects a quest using only quest identity and pet ownership context', async () => {
+    transport.post.mockResolvedValue({ ok: true });
+
+    await adventureApi.selectQuest('quest-1', 'pet-1');
+
+    expect(transport.post).toHaveBeenCalledWith('/adventure/quests/quest-1/select', {
+      petId: 'pet-1',
+    });
+  });
+
+  it('never adds client-controlled XP to quest completion payloads', async () => {
+    transport.post.mockResolvedValue({
+      reward: {
+        careEventId: 'event-1',
+        ledgerId: 'ledger-1',
+        bondXp: 12,
+        pathway: 'BOND',
+        policyVersion: 'bond-xp-v1',
+        explanation: 'Server decision',
+        duplicate: false,
+      },
+      message: 'Done',
+    });
+
+    const input: CompleteQuestInput = {
+      petId: 'pet-1',
+      dogExperience: 'comfortable',
+      ownerExperience: 'fine',
+      safeOptOut: true,
+      note: 'Stopped when the dog asked for space.',
+    };
+
+    await adventureApi.completeQuest('quest-1', input);
+
+    expect(transport.post).toHaveBeenCalledWith('/adventure/quests/quest-1/complete', input);
+    const sentBody = transport.post.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(sentBody).not.toHaveProperty('xp');
+    expect(sentBody).not.toHaveProperty('bondXp');
+    expect(sentBody).not.toHaveProperty('pathwayXp');
+  });
+});

--- a/apps/web/src/lib/api/adventure.ts
+++ b/apps/web/src/lib/api/adventure.ts
@@ -1,0 +1,90 @@
+import { apiClient } from './client';
+
+export type WellbeingPathway =
+  'MOVE' | 'EXPLORE' | 'ENRICH' | 'LEARN' | 'CONNECT' | 'CARE' | 'RECOVER' | 'BOND';
+
+export type AdventureQuest = {
+  id: string;
+  key: string;
+  title: string;
+  description: string;
+  why: string;
+  primaryPathway: WellbeingPathway;
+  pathways: WellbeingPathway[];
+  xp: number;
+  confidence: number;
+  href: string;
+  actionLabel: string;
+  variant: 'recommended' | 'alternative' | 'wildcard';
+  safeStopEligible: boolean;
+  personalRelevance: number;
+  expiresAt: string;
+};
+
+export type CompassPathway = {
+  pathway: WellbeingPathway;
+  label: string;
+  recentDays: number;
+  coverage: number;
+  xp: number;
+  lastEventAt: string | null;
+};
+
+export type AdventureDashboard = {
+  pet: {
+    id: string;
+    name: string;
+    species: string;
+    avatarUrl?: string | null;
+  };
+  generatedAt: string;
+  bondXp: number;
+  rhythm: {
+    activeWeeks: number;
+    windowWeeks: number;
+    label: string;
+  };
+  compass: CompassPathway[];
+  quests: AdventureQuest[];
+  learningSummary: string[];
+  principles: string[];
+  disclaimer: string;
+};
+
+export type CompleteQuestInput = {
+  petId: string;
+  dogExperience: 'loved_it' | 'comfortable' | 'not_their_thing';
+  ownerExperience: 'great' | 'fine' | 'a_lot_today';
+  safeOptOut?: boolean;
+  memoryAssetId?: string;
+  note?: string;
+};
+
+export type QuestCompletion = {
+  reward: {
+    careEventId: string;
+    ledgerId: string | null;
+    bondXp: number;
+    pathway: WellbeingPathway;
+    policyVersion: string;
+    explanation: string;
+    duplicate: boolean;
+  };
+  message: string;
+};
+
+export const adventureApi = {
+  getMine: (petId?: string) =>
+    apiClient.get<AdventureDashboard>('/adventure/me', {
+      params: petId ? { petId } : undefined,
+    }),
+
+  selectQuest: (questId: string, petId: string) =>
+    apiClient.post<{ ok: boolean }>(`/adventure/quests/${questId}/select`, { petId }),
+
+  dismissQuest: (questId: string, petId: string) =>
+    apiClient.post<{ ok: boolean }>(`/adventure/quests/${questId}/dismiss`, { petId }),
+
+  completeQuest: (questId: string, input: CompleteQuestInput) =>
+    apiClient.post<QuestCompletion>(`/adventure/quests/${questId}/complete`, input),
+};

--- a/apps/web/src/lib/api/pack.ts
+++ b/apps/web/src/lib/api/pack.ts
@@ -1,0 +1,29 @@
+import { apiClient } from './client';
+
+export type PackChallenge = {
+  id: string;
+  title: string;
+  description: string;
+  pathways: string[];
+  target: number;
+  unit: string;
+  total: number;
+  contributors: number;
+  myContribution: number;
+  progress: number;
+  completed: boolean;
+};
+
+export type PackChallengesResponse = {
+  generatedAt: string;
+  windowDays: number;
+  challenges: PackChallenge[];
+  principles: string[];
+};
+
+export const packApi = {
+  challenges: async () =>
+    apiClient.get<PackChallengesResponse>(
+      '/pack/challenges'
+    ) as unknown as Promise<PackChallengesResponse>,
+};

--- a/docs/ADVENTURE_QUALIFICATION.md
+++ b/docs/ADVENTURE_QUALIFICATION.md
@@ -1,0 +1,68 @@
+# Woof Adventure release qualification
+
+This document is the merge checkpoint for the Adventure System integration branch. The release is not merge-ready unless the exact PR head, and later the exact rebased merge candidate, satisfy these gates.
+
+## Repository gates
+
+- Prisma schema validates and remains formatter-clean.
+- The complete PostgreSQL migration chain applies to a fresh pgvector/PostgreSQL 15 database.
+- The current chain includes a forward-only normalization of the inherited Media Library index name so the physical database and Prisma datamodel can remain zero-diff.
+- The Adventure migration remains additive and contains no destructive `DROP`, `TRUNCATE`, or bulk `DELETE` operations.
+- The freshly migrated database matches the Prisma datamodel according to `prisma migrate diff`.
+- Prettier passes on all branch-owned Adventure, CareEvent, operational-health, Activity/Coach integration, Pack, Compass, Journey, navigation, API-client, onboarding, and repaired compatibility surfaces.
+- ESLint runs with zero warnings on the release-critical API and web surfaces touched by this stack.
+- The complete API TypeScript project type-checks.
+- The complete web TypeScript project type-checks. Type failures are blockers rather than something hidden with `ignoreBuildErrors`.
+- Adventure web transport contract tests pass and prove the browser never sends client-controlled XP in quest completion requests.
+- Bond XP policy contract tests pass.
+- Real PostgreSQL reward-ledger integrity and concurrency tests pass.
+- Quest-engine safety, media-ownership, snapshot, and telemetry-failure tests pass.
+- The full API Jest suite passes.
+- Production API and web builds pass.
+- API liveness remains dependency-free, while readiness performs a real database probe and fails closed with HTTP 503 if PostgreSQL is unavailable.
+- Production Swagger is disabled unless `API_DOCS_ENABLED=true` is explicitly configured.
+
+## Reward and safety invariants
+
+1. Clients never submit arbitrary XP values.
+2. A CareEvent dedupe key cannot mint reward twice for the same user.
+3. Concurrent requests for one user are serialized before cap and dedupe calculation.
+4. Anti-farming windows use trusted server issuance time rather than client-controlled occurrence timestamps.
+5. A future or invalid occurrence timestamp is normalized to server time before persistence, so it cannot make Compass or Rhythm appear artificially recent.
+6. Legitimate historical/offline occurrence timestamps are preserved.
+7. Zero-XP and safety-ineligible events do not degrade later legitimate rewards.
+8. Recovery can earn legitimate progress.
+9. A safe opt-out can earn Bond progress.
+10. A stressful or `not_their_thing` result does not inflate the original social/training pathway merely because a quest was closed.
+11. Optional media has only a tiny reward effect, and a memory bonus is accepted only for an owned `READY` media asset belonging to the pet.
+12. Raw distance, calories, duration, money spent, and photo volume do not multiply Bond XP without bound.
+13. Selected quests can be completed after a same-day deck reshuffle using a short-lived semantic snapshot, but current server RewardPolicy remains the only XP authority.
+14. The Pawprint Compass is opportunity coverage, never a health or ownership score.
+15. Pack challenges are cooperative aggregates, not raw-volume rankings.
+16. `emergency_now` Health Lens results suppress the global game navigation and never issue XP, confetti, or quest-completion treatment.
+17. Adventure and Pack public routes can be disabled at runtime with `ENABLE_ADVENTURE_SYSTEM=false` in production.
+18. Signed private-media upload URLs are returned ephemerally and are never persisted in Media Library records.
+
+## Operational gates
+
+Before production traffic is enabled:
+
+1. Take or verify a recoverable production database backup/snapshot.
+2. Apply migrations with `prisma migrate deploy`; never use an interactive development migration command against production.
+3. Verify `/api/v1/health/live` returns 200.
+4. Verify `/api/v1/health/ready` returns 200 and reports the database check as `up`.
+5. Deploy application code with `ENABLE_ADVENTURE_SYSTEM=false` first.
+6. Smoke-test authentication, pet ownership boundaries, activity persistence, Health Lens emergency suppression, private Media Library access, and Adventure-disabled behavior.
+7. Enable Adventure deliberately only after the database and application candidate are proven healthy.
+8. Observe reward-decision and application-error telemetry during rollout.
+9. Roll application behavior back by disabling Adventure/reverting code if necessary; preserve additive Adventure tables and immutable reward history unless a separate approved data-removal procedure exists.
+
+## Stack rule
+
+PR #6 is stacked on `agent/pet-media-library-v1`. Green CI on the stacked base is necessary but not sufficient for final merge. After the parent stack lands on `main`, rebase or restack the Adventure branch onto the resulting `main` and run the complete qualification pipeline again on that exact candidate.
+
+## Evidence policy
+
+A successful earlier commit is useful as a checkpoint but is not final merge evidence. Run #179 established the first fully green baseline across migrations, zero-diff Prisma parity, formatting/lint, both TypeScript projects, reward policy, real-PostgreSQL concurrency, Quest contracts, the complete API suite, and both production builds. Subsequent operational-hardening commits must pass the expanded workflow again.
+
+Do not mark the PR ready because an earlier commit was green. Record the final commit SHA and corresponding successful Adventure System CI run in the PR description before changing draft status.

--- a/docs/ADVENTURE_ROLLOUT.md
+++ b/docs/ADVENTURE_ROLLOUT.md
@@ -1,0 +1,74 @@
+# Adventure System rollout and rollback
+
+The Adventure System is designed for a staged launch. The database migration is additive, while the user-facing API can be disabled at runtime.
+
+## Production defaults
+
+- Keep `ENABLE_ADVENTURE_SYSTEM=false` until the migration and application version are deployed and smoke-tested.
+- Production must opt in explicitly with `ENABLE_ADVENTURE_SYSTEM=true`.
+- Development and CI may enable Adventure so the release path is exercised continuously.
+- The migration should be deployed before enabling Adventure routes.
+
+## Dark launch
+
+Before exposing the redesign broadly:
+
+1. deploy the additive migration;
+2. deploy the API and web build with the public Adventure feature flag disabled;
+3. verify API health, migration status, and error rate;
+4. enable Adventure in a staging or limited environment;
+5. exercise `GET /adventure/me`, quest selection, completion, duplicate completion, safe opt-out, Activity emission, Coach emission, Pack aggregation, Journey, and Health emergency suppression;
+6. verify one completion produces one CareEvent and one RewardLedger row;
+7. issue concurrent duplicate completions and confirm only one reward receipt is minted;
+8. confirm reward decision logs contain event semantics and receipt identifiers but no raw user or pet identifiers;
+9. inspect daily/pathway cap behavior and duplicate rate for unexpected patterns;
+10. enable production only after the exact release candidate has passed `Adventure System CI`.
+
+## Operational signals
+
+Watch at minimum:
+
+- Adventure endpoint 5xx rate;
+- database transaction/lock latency around reward issuance;
+- duplicate reward-request rate;
+- zero-XP rate and cap-hit rate by event type/pathway;
+- CareEvent rows without a RewardLedger row;
+- RewardLedger rows without a CareEvent row;
+- Activity/Coach reward-emission failures, which must never make the underlying saved action fail;
+- quest acceptance and completion without using screen time as a success target;
+- safe-opt-out frequency as a legitimate welfare signal, not a failure metric.
+
+The north-star product metric remains Weekly Meaningful Dyad Actions, not clicks, streak pressure, miles, or posting volume.
+
+## Incident rollback
+
+The safest rollback preserves data.
+
+1. Set `ENABLE_ADVENTURE_SYSTEM=false` to make public Adventure and Pack routes unavailable without deleting ledger history.
+2. If application code still causes a regression outside guarded routes, revert the application commit/PR and redeploy.
+3. Leave the additive Adventure tables in place during ordinary rollback. They are backward-compatible with older application code and contain useful immutable reward history.
+4. Do **not** automatically generate or execute a destructive down migration during an incident. Dropping `care_events`, `reward_ledger`, or `quest_interactions` destroys evidence needed to audit or recover the launch.
+5. If schema removal is ever required, treat it as a separate reviewed data-retention operation with an explicit backup and migration plan.
+
+## Parent-stack integration
+
+PR #6 currently targets `agent/pet-media-library-v1`. After that parent line is integrated into `main`:
+
+```bash
+git fetch origin main
+git rebase --onto origin/main agent/pet-media-library-v1 agent/woof-adventure-system-v1
+git push --force-with-lease origin agent/woof-adventure-system-v1
+```
+
+Then run the full qualification pipeline again. A green run from the old stacked merge SHA is not release evidence for the rebased candidate.
+
+## Go/no-go rule
+
+Go only when all of the following are true:
+
+- exact-head Adventure System CI is green;
+- the parent stack has landed and the rebased candidate is requalified;
+- production feature flag default is disabled until deliberate activation;
+- reward and quest concurrency tests are green against PostgreSQL;
+- Health emergency boundary remains free of game treatment;
+- rollback requires no destructive database action.

--- a/docs/WOOF_ADVENTURE_SYSTEM.md
+++ b/docs/WOOF_ADVENTURE_SYSTEM.md
@@ -1,0 +1,243 @@
+# Woof Adventure System
+
+Woof Adventure turns the product from a collection of pet features into one longitudinal game for the dog-owner pair.
+
+> The real dog is the character. The real world is the game world. The relationship is the progression.
+
+The system is intentionally designed around **individual fit**, not maximum exercise, maximum social exposure, screen time, or raw engagement.
+
+## Product surfaces
+
+| Surface     | Role                                                                                           |
+| ----------- | ---------------------------------------------------------------------------------------------- |
+| **Today**   | Personalized three-card Quest Deck with one recommended quest, an alternative, and a wildcard  |
+| **Compass** | Eight-pathway recent opportunity coverage, explicitly not a health score                       |
+| **Journey** | Adventure Book built on the private Media Library                                              |
+| **Coach**   | Reward-based Learn progression and dog-literacy feedback                                       |
+| **Pack**    | Compatibility-first social discovery and cooperative challenges                                |
+| **Health**  | Separate high-stakes Health Lens; emergency/illness flows are outside competitive gamification |
+
+### Pawprint Compass
+
+The eight pathways are:
+
+- `MOVE` — movement and conditioning
+- `EXPLORE` — nature, novelty, sniffing, sensory exploration
+- `ENRICH` — scent work, searching, puzzles, foraging
+- `LEARN` — reward-based training and communication
+- `CONNECT` — comfortable social experiences
+- `CARE` — private preventive-care support
+- `RECOVER` — rest and decompression
+- `BOND` — shared experiences that fit both halves of the pair
+
+Compass bars are **recent opportunity coverage**. They must never be described as health percentages, ownership quality, or veterinary assessment.
+
+## Daily Quest Engine
+
+`GET /api/v1/adventure/me` composes the existing Insights engine with Adventure-specific pathway coverage and recent outcome learning.
+
+The first version is deliberately rule-based and explainable:
+
+1. generate safe candidate quests from current Insights plus evergreen templates;
+2. map each candidate onto one primary wellbeing pathway;
+3. reward under-covered pathways without treating a full Compass as a universal prescription;
+4. apply a tightly capped recent dog-owner preference signal;
+5. prefer three different primary pathways when possible;
+6. generate deterministic daily quest IDs so clients cannot invent reward-bearing quests;
+7. let the owner choose.
+
+A future contextual bandit can replace the ranking layer only after sufficient real outcomes exist. It should optimize downstream fit and safety rather than app engagement.
+
+## Five-second outcome loop
+
+Every quest can close with two tiny questions:
+
+**Dog**
+
+- Loved it
+- Comfortable
+- Not their thing
+
+**Owner**
+
+- Great
+- Fine
+- A lot today
+
+For eligible social/training quests, `I listened and stopped` is a successful completion. It records a `SAFE_OPT_OUT` event on the `BOND` pathway rather than rewarding forced completion.
+
+A normal `not_their_thing` result is treated as preference evidence and is also credited to `BOND`, not to the original pathway. This prevents a stressful social interaction from inflating `CONNECT` progress simply because the owner pressed “complete.”
+
+## Trusted reward architecture
+
+The old client-controlled `/gamification/points`, `/badges`, `/streaks`, and raw leaderboard mutation/read surfaces are removed from the controller.
+
+The authoritative flow is:
+
+```text
+trusted domain action
+      ↓
+CareEvent
+      ↓
+safety eligibility
+      ↓
+server RewardPolicy
+      ↓
+immutable RewardLedger
+      ↓
+Bond XP + pathway history
+```
+
+The client never submits an XP amount.
+
+### Database
+
+Migration:
+
+`packages/database/prisma/migrations/20260821223000_add_woof_adventure_system/migration.sql`
+
+Tables:
+
+- `care_events`
+- `reward_ledger`
+- `quest_interactions`
+
+Important properties:
+
+- `(user_id, dedupe_key)` is unique for idempotency;
+- each reward ledger row maps one-to-one to a CareEvent;
+- evidence confidence is constrained to `[0,1]`;
+- pathway and visibility values are database-constrained;
+- high-value calculations happen in server code, not DTOs;
+- new Adventure reads are ledger-derived;
+- `users.total_points` is updated only as a temporary compatibility aggregate for old surfaces.
+
+## Reward policy
+
+Policy version: `bond-xp-v1`.
+
+The starting policy uses fixed event values plus conservative modifiers:
+
+- evidence confidence can only make a very small difference;
+- optional media is a tiny bonus;
+- novelty is capped;
+- repeated same-pathway actions decay;
+- repeated event types decay over seven days;
+- per-pathway and whole-day XP caps prevent volume farming;
+- safety-ineligible events issue zero XP;
+- recovery earns full legitimate credit;
+- safe opt-outs earn meaningful Bond XP.
+
+The system deliberately does **not** multiply reward by distance, duration, calories, money spent, or number of photos.
+
+## Domain integrations
+
+### Activities
+
+Completed activities with an owned pet emit trusted CareEvents. Current semantics include walking, running, hiking, enrichment, training, social outings, parallel walks, and recovery/decompression.
+
+Activity completion remains reliable during a rolling deployment even if reward emission fails. The activity is saved first and reward emission is additive.
+
+### Woof Coach
+
+Coach sessions now feed the same reward ledger:
+
+- comfortable training session → `TRAINING_SESSION / LEARN`;
+- stress signal + stopped early → `SAFE_OPT_OUT / BOND`;
+- concern signals without a safe stop → the session is stored but reward eligibility fails closed.
+
+Coach therefore rewards communication and judgment rather than repetitions at any cost.
+
+### Media Library / Journey
+
+Journey reads the existing private Media Library and albums. Photos remain optional. The experience is valuable even with no media.
+
+The reward policy caps any memory bonus so the system cannot become a photo farming game.
+
+### Pack
+
+`GET /api/v1/pack/challenges` exposes aggregate cooperative challenges. It returns community totals, contributor count, and the current user's contribution without publishing individual raw rankings.
+
+The first challenges are:
+
+- Sniff & Explore Week
+- Recovery Counts
+
+The social layer keeps compatibility-first discovery and shared events available while avoiding a “most miles wins” leaderboard.
+
+## Rhythm replaces streak pressure
+
+Adventure summary looks at meaningful activity across a rolling five-week window and describes the result as **Rhythm**.
+
+Missing a day never zeroes a streak. Recovery and other legitimate pathways can preserve rhythm.
+
+## Health boundary
+
+Health Lens stays structurally separate from the reward engine.
+
+Never gamify:
+
+- emergency severity;
+- diagnosis or symptom seriousness;
+- medications;
+- weight loss rankings;
+- veterinary spending;
+- forced proof photos;
+- fear/aggression as failure.
+
+Emergency Health Lens UX should remain free of XP, confetti, “quest completed” copy, or competitive surfaces.
+
+Preventive-care logging can later emit private, narrowly eligible `CARE` events, but clinical urgency must never enter the game economy.
+
+## Analytics north star
+
+The redesign should shift platform-level success toward **Weekly Meaningful Dyad Actions**.
+
+A meaningful dyad action has:
+
+1. a real action with or for the dog;
+2. a legitimate wellbeing pathway;
+3. passed safety eligibility;
+4. meaningful completion or outcome context.
+
+Recommended supporting metrics:
+
+- quest acceptance → completion;
+- comfortable/positive dog outcomes;
+- owner enjoyment;
+- repeated preferred experiences;
+- pathway diversity without universal quotas;
+- training progression with low stress;
+- recovery adoption;
+- safe-stop behavior;
+- positive social repeat rate;
+- nature/exploration frequency;
+- 30/90-day retained dyads.
+
+Do not optimize the quest policy for screen time, posts, likes, or notification opens.
+
+## Rollout
+
+1. deploy database migration before enabling the Adventure UI;
+2. deploy API with Adventure + CareEvent modules;
+3. verify the old client-controlled gamification mutation routes are absent;
+4. smoke `GET /adventure/me` with an existing pet;
+5. complete one quest and verify exactly one CareEvent + ledger row;
+6. retry the completion and confirm idempotent duplicate behavior;
+7. log a completed walk and verify trusted Activity emission;
+8. record a comfortable Coach session and verify Learn credit;
+9. record a Coach stress + stopped-early session and verify Bond safe-stop credit;
+10. verify Health Lens emergency UX contains no game reward treatment;
+11. validate Compass copy says opportunity coverage rather than health score;
+12. verify Pack exposes aggregate cooperation rather than raw individual rankings.
+
+## Future work after real-world outcome collection
+
+- richer owner preference learning and availability context;
+- route semantics, terrain, temperature, place novelty, and favorite-place inference;
+- private preventive Care Journey milestones;
+- household / multi-dog quests;
+- friend-scoped personalized leagues based on quest completion percentage rather than raw exercise volume;
+- configurable seasonal cooperative Pack challenges;
+- contextual quest ranking evaluated against the explainable rule-based baseline;
+- veterinary handoff built from structured longitudinal history, with explicit owner control.

--- a/packages/database/prisma/migrations/20260821223000_add_woof_adventure_system/migration.sql
+++ b/packages/database/prisma/migrations/20260821223000_add_woof_adventure_system/migration.sql
@@ -1,0 +1,103 @@
+-- Woof Adventure System v1
+-- Trusted domain events are the only source of Bond XP. The client never writes rewards directly.
+
+CREATE TABLE "care_events" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "pet_id" TEXT,
+    "event_type" TEXT NOT NULL,
+    "pathway" TEXT NOT NULL,
+    "occurred_at" TIMESTAMP(3) NOT NULL,
+    "source" TEXT NOT NULL,
+    "evidence_type" TEXT,
+    "evidence_confidence" DOUBLE PRECISION NOT NULL DEFAULT 0.65,
+    "context" JSONB,
+    "outcome" JSONB,
+    "dedupe_key" TEXT NOT NULL,
+    "visibility" TEXT NOT NULL DEFAULT 'PRIVATE',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "care_events_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "care_events_pathway_check" CHECK ("pathway" IN ('MOVE', 'EXPLORE', 'ENRICH', 'LEARN', 'CONNECT', 'CARE', 'RECOVER', 'BOND')),
+    CONSTRAINT "care_events_confidence_check" CHECK ("evidence_confidence" >= 0 AND "evidence_confidence" <= 1),
+    CONSTRAINT "care_events_visibility_check" CHECK ("visibility" IN ('PRIVATE', 'HOUSEHOLD', 'FRIENDS'))
+);
+
+CREATE UNIQUE INDEX "care_events_user_id_dedupe_key_key"
+    ON "care_events"("user_id", "dedupe_key");
+CREATE INDEX "care_events_user_id_occurred_at_idx"
+    ON "care_events"("user_id", "occurred_at" DESC);
+CREATE INDEX "care_events_pet_id_occurred_at_idx"
+    ON "care_events"("pet_id", "occurred_at" DESC);
+CREATE INDEX "care_events_pathway_occurred_at_idx"
+    ON "care_events"("pathway", "occurred_at" DESC);
+CREATE INDEX "care_events_event_type_idx"
+    ON "care_events"("event_type");
+
+ALTER TABLE "care_events"
+    ADD CONSTRAINT "care_events_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "care_events"
+    ADD CONSTRAINT "care_events_pet_id_fkey"
+    FOREIGN KEY ("pet_id") REFERENCES "pets"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE TABLE "reward_ledger" (
+    "id" TEXT NOT NULL,
+    "care_event_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "pet_id" TEXT,
+    "bond_xp" INTEGER NOT NULL,
+    "pathway_xp" JSONB NOT NULL,
+    "policy_version" TEXT NOT NULL,
+    "explanation" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "reward_ledger_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "reward_ledger_bond_xp_check" CHECK ("bond_xp" >= 0)
+);
+
+CREATE UNIQUE INDEX "reward_ledger_care_event_id_key"
+    ON "reward_ledger"("care_event_id");
+CREATE INDEX "reward_ledger_user_id_created_at_idx"
+    ON "reward_ledger"("user_id", "created_at" DESC);
+CREATE INDEX "reward_ledger_pet_id_created_at_idx"
+    ON "reward_ledger"("pet_id", "created_at" DESC);
+
+ALTER TABLE "reward_ledger"
+    ADD CONSTRAINT "reward_ledger_care_event_id_fkey"
+    FOREIGN KEY ("care_event_id") REFERENCES "care_events"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "reward_ledger"
+    ADD CONSTRAINT "reward_ledger_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "reward_ledger"
+    ADD CONSTRAINT "reward_ledger_pet_id_fkey"
+    FOREIGN KEY ("pet_id") REFERENCES "pets"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE TABLE "quest_interactions" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "pet_id" TEXT NOT NULL,
+    "quest_id" TEXT NOT NULL,
+    "interaction" TEXT NOT NULL,
+    "pathway" TEXT NOT NULL,
+    "context" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "quest_interactions_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "quest_interactions_interaction_check" CHECK ("interaction" IN ('SHOWN', 'SELECTED', 'DISMISSED', 'COMPLETED')),
+    CONSTRAINT "quest_interactions_pathway_check" CHECK ("pathway" IN ('MOVE', 'EXPLORE', 'ENRICH', 'LEARN', 'CONNECT', 'CARE', 'RECOVER', 'BOND'))
+);
+
+CREATE UNIQUE INDEX "quest_interactions_user_id_pet_id_quest_id_interaction_key"
+    ON "quest_interactions"("user_id", "pet_id", "quest_id", "interaction");
+CREATE INDEX "quest_interactions_user_pet_created_at_idx"
+    ON "quest_interactions"("user_id", "pet_id", "created_at" DESC);
+CREATE INDEX "quest_interactions_quest_id_idx"
+    ON "quest_interactions"("quest_id");
+
+ALTER TABLE "quest_interactions"
+    ADD CONSTRAINT "quest_interactions_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "quest_interactions"
+    ADD CONSTRAINT "quest_interactions_pet_id_fkey"
+    FOREIGN KEY ("pet_id") REFERENCES "pets"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/migrations/20260822000500_align_media_reference_index_name/migration.sql
+++ b/packages/database/prisma/migrations/20260822000500_align_media_reference_index_name/migration.sql
@@ -1,0 +1,7 @@
+-- PostgreSQL truncates identifiers to 63 bytes. The original Media Library
+-- migration supplied a 64-character index name, while Prisma's generated
+-- datamodel name truncates at a different boundary. Rename the physical index
+-- forward-only so migration history and the Prisma datamodel converge.
+
+ALTER INDEX "media_external_references_owner_id_provider_provider_item_id_id"
+RENAME TO "media_external_references_owner_id_provider_provider_item_i_idx";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -56,6 +56,9 @@ model User {
   mediaAssets              MediaAsset[]
   mediaAlbums              MediaAlbum[]
   mediaExternalReferences  MediaExternalReference[]
+  careEvents               CareEvent[]
+  rewardLedgerEntries      RewardLedger[]
+  questInteractions        QuestInteraction[]
 
   @@map("users")
 }
@@ -87,6 +90,9 @@ model Pet {
   mediaAssets             MediaAsset[]
   mediaAlbums             MediaAlbum[]
   mediaExternalReferences MediaExternalReference[]
+  careEvents              CareEvent[]
+  rewardLedgerEntries     RewardLedger[]
+  questInteractions       QuestInteraction[]
 
   @@index([ownerId])
   @@map("pets")
@@ -982,4 +988,75 @@ model MediaExternalReference {
   @@index([ownerId, provider, providerItemId])
   @@index([petId, provider])
   @@map("media_external_references")
+}
+
+// ============================================
+// WOOF ADVENTURE SYSTEM
+// ============================================
+
+model CareEvent {
+  id                 String   @id
+  userId             String   @map("user_id")
+  petId              String?  @map("pet_id")
+  eventType          String   @map("event_type")
+  pathway            String
+  occurredAt         DateTime @map("occurred_at")
+  source             String
+  evidenceType       String?  @map("evidence_type")
+  evidenceConfidence Float    @default(0.65) @map("evidence_confidence")
+  context            Json?
+  outcome            Json?
+  dedupeKey          String   @map("dedupe_key")
+  visibility         String   @default("PRIVATE")
+  createdAt          DateTime @default(now()) @map("created_at")
+
+  user   User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  pet    Pet?          @relation(fields: [petId], references: [id], onDelete: SetNull)
+  reward RewardLedger?
+
+  @@unique([userId, dedupeKey], map: "care_events_user_id_dedupe_key_key")
+  @@index([userId, occurredAt(sort: Desc)], map: "care_events_user_id_occurred_at_idx")
+  @@index([petId, occurredAt(sort: Desc)], map: "care_events_pet_id_occurred_at_idx")
+  @@index([pathway, occurredAt(sort: Desc)], map: "care_events_pathway_occurred_at_idx")
+  @@index([eventType], map: "care_events_event_type_idx")
+  @@map("care_events")
+}
+
+model RewardLedger {
+  id            String   @id
+  careEventId   String   @unique(map: "reward_ledger_care_event_id_key") @map("care_event_id")
+  userId        String   @map("user_id")
+  petId         String?  @map("pet_id")
+  bondXp        Int      @map("bond_xp")
+  pathwayXp     Json     @map("pathway_xp")
+  policyVersion String   @map("policy_version")
+  explanation   String
+  createdAt     DateTime @default(now()) @map("created_at")
+
+  careEvent CareEvent @relation(fields: [careEventId], references: [id], onDelete: Cascade)
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  pet       Pet?      @relation(fields: [petId], references: [id], onDelete: SetNull)
+
+  @@index([userId, createdAt(sort: Desc)], map: "reward_ledger_user_id_created_at_idx")
+  @@index([petId, createdAt(sort: Desc)], map: "reward_ledger_pet_id_created_at_idx")
+  @@map("reward_ledger")
+}
+
+model QuestInteraction {
+  id          String   @id
+  userId      String   @map("user_id")
+  petId       String   @map("pet_id")
+  questId     String   @map("quest_id")
+  interaction String
+  pathway     String
+  context     Json?
+  createdAt   DateTime @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  pet  Pet  @relation(fields: [petId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, petId, questId, interaction], map: "quest_interactions_user_id_pet_id_quest_id_interaction_key")
+  @@index([userId, petId, createdAt(sort: Desc)], map: "quest_interactions_user_pet_created_at_idx")
+  @@index([questId], map: "quest_interactions_quest_id_idx")
+  @@map("quest_interactions")
 }


### PR DESCRIPTION
## Product thesis

This stacked redesign turns Woof into a personalized real-world life game for the dog-owner pair: the real dog is the character, the real world is the game world, and the relationship is the progression.

It is intentionally stacked on `agent/pet-media-library-v1` so the Adventure Book can use the private Media Library and the branch inherits Coach, Health Lens, and Behavior Vision work already present in that line. It should not merge independently of that parent integration.

## What this PR changes

### 1. Trusted CareEvent → RewardLedger architecture

Adds a migration-backed reward core:

- `care_events`
- `reward_ledger`
- `quest_interactions`
- unique per-user dedupe keys
- constrained eight-pathway taxonomy
- immutable reward receipts
- server-owned reward policy

The client no longer has endpoints that can directly award arbitrary points, badges, or streak mutations. The old raw points leaderboard route is removed from the controller.

### 2. Bond XP with anti-farming economics

`bond-xp-v1` uses fixed server values plus conservative modifiers:

- daily global and pathway caps
- repeated-action diminishing returns
- tiny evidence-confidence effect
- tiny optional-memory bonus
- capped novelty bonus
- no multiplier for miles, calories, duration, money, or photos
- full legitimate Recovery credit
- meaningful `SAFE_OPT_OUT` credit
- safety-ineligible events fail closed at zero XP

Contract tests cover recovery, safe opt-outs, media influence, repetition decay, daily caps, and safety failure.

### 3. Personalized three-card Quest Deck

`GET /adventure/me` composes the existing Insights engine with pathway coverage and recent dyad outcomes.

The current explainable policy:

- generates a best quest, alternative, and wildcard
- prefers distinct wellbeing pathways
- balances recent opportunity gaps
- learns small preference signals from dog + owner outcomes
- uses deterministic daily quest IDs
- never accepts client-supplied XP

### 4. Five-second outcome loop

Home now closes quests with:

Dog:
- Loved it
- Comfortable
- Not their thing

Owner:
- Great
- Fine
- A lot today

For eligible Learn/Connect quests, **I listened and stopped** is a first-class successful outcome. A stressful/not-their-thing outcome does not inflate the original pathway merely because a quest was marked complete.

### 5. Pawprint Compass

Adds Move, Explore, Enrich, Learn, Connect, Care, Recover, and Bond as recent opportunity pathways.

The UI explicitly describes the Compass as opportunity coverage, not a health score or ownership grade.

### 6. Journey / Adventure Book

Adds a Journey surface built on the existing private Media Library:

- albums become collections/stamps
- recent kept media become Adventure Book pages
- favorites are visible
- photos remain optional and low-value in the reward economy

### 7. Coach integration

Woof Coach now emits trusted domain outcomes:

- comfortable training → Learn
- concern signals + stopped early → Bond / safe opt-out
- concern signals without the safe stop → no reward eligibility

This preserves the existing reward-based progression logic while making dog literacy part of the game economy.

### 8. Real activity integration

Completed Activities emit trusted CareEvents after the activity is safely persisted. Reward emission is additive and cannot make activity logging fail during a rolling deployment.

Current semantics include walk, run, hike, enrichment, training, social, parallel walk, and recovery/decompression.

### 9. Cooperative Pack

Replaces the product concept of a raw-volume leaderboard with aggregate community challenges:

- Sniff & Explore Week
- Recovery Counts

Pack reports total contributions, contributor count, and the current user's contribution. Nobody is ranked by miles or medical behavior.

### 10. Rhythm replaces streak pressure

The Adventure summary reports meaningful activity across a rolling five-week window. Missing one day does not destroy progress, and Recovery can count toward a healthy rhythm.

### 11. Health boundary

Health Lens remains outside competitive gamification. The Compass and docs make the boundary explicit: emergency severity, illness, medication, weight loss, veterinary spending, fear/aggression, and proof photos are not game targets.

## Migration

Apply:

`packages/database/prisma/migrations/20260821223000_add_woof_adventure_system/migration.sql`

before enabling the Adventure UI.

## Qualification

Adds `.github/workflows/adventure-system-ci.yml` with:

- frozen lockfile install
- Prisma generation
- full migration chain
- Prettier check
- monorepo lint
- monorepo type-check
- reward contract tests
- API tests
- API production build
- Web production build

## Documentation

See `docs/WOOF_ADVENTURE_SYSTEM.md` for architecture, reward invariants, domain integration, rollout checklist, analytics north star, and future contextual-ranking plan.

## Review state

This PR is intentionally **draft**. The next step is to drive the exact PR head through the new qualification workflow and fix every concrete formatting/type/test/build failure before marking it ready.