### PR TITLE
dogOS foundation: households and shared multi-pet activity sessions

### DIFF
--- a/.github/workflows/dogos-foundation-ci.yml
+++ b/.github/workflows/dogos-foundation-ci.yml
@@ -1,0 +1,142 @@
+name: dogOS Foundation CI
+
+on:
+  pull_request:
+    paths:
+      - 'apps/api/src/activities/**'
+      - 'apps/api/src/households/**'
+      - 'apps/api/src/dogos/**'
+      - 'apps/api/src/pets/pets.controller.ts'
+      - 'apps/api/src/pets/pets.module.ts'
+      - 'apps/api/src/pets/pets.service.ts'
+      - 'apps/api/src/app.module.ts'
+      - 'apps/mobile/**'
+      - 'packages/database/prisma/schema.prisma'
+      - 'packages/database/prisma/migrations/20260822064500_add_dogos_household_core/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/dogos-foundation-ci.yml'
+      - 'docs/DOGOS_ARCHITECTURE.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-foundation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  qualify:
+    name: dogOS household + multi-pet qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+      SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_shadow
+      JWT_SECRET: ci-only-dogos-secret
+      NODE_ENV: test
+      ML_SERVICE_ENABLED: 'false'
+      ENABLE_ADVENTURE_SYSTEM: 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate Prisma schema
+        run: pnpm --filter @woof/database exec prisma validate
+
+      - name: Check Prisma schema formatting
+        run: |
+          pnpm --filter @woof/database exec prisma format
+          git diff --exit-code -- packages/database/prisma/schema.prisma
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject destructive dogOS migration operations
+        run: |
+          migration="packages/database/prisma/migrations/20260822064500_add_dogos_household_core/migration.sql"
+          if grep -Ein '\b(DROP[[:space:]]+(TABLE|COLUMN|INDEX|CONSTRAINT)|TRUNCATE|DELETE[[:space:]]+FROM)\b' "$migration"; then
+            echo "dogOS foundation migration must remain additive; destructive SQL was detected."
+            exit 1
+          fi
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Verify migrated database matches Prisma datamodel
+        run: >-
+          pnpm --filter @woof/database exec prisma migrate diff
+          --from-url "$DATABASE_URL"
+          --to-schema-datamodel prisma/schema.prisma
+          --exit-code
+
+      - name: Check dogOS formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/activities
+          apps/api/src/households
+          apps/api/src/pets/pets.controller.ts
+          apps/api/src/pets/pets.module.ts
+          apps/api/src/pets/pets.service.ts
+          apps/api/src/app.module.ts
+          apps/mobile/package.json
+          apps/mobile/src/api/activities.ts
+          apps/mobile/src/api/goals.ts
+          apps/mobile/src/api/pets.ts
+          apps/mobile/src/api/social.ts
+          apps/mobile/src/types/activity.ts
+          apps/mobile/src/utils/animations.ts
+          .github/workflows/dogos-foundation-ci.yml
+
+      - name: Lint dogOS API surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          'src/activities/**/*.ts'
+          'src/households/**/*.ts'
+          src/pets/pets.controller.ts
+          src/pets/pets.module.ts
+          src/pets/pets.service.ts
+          src/app.module.ts
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Type-check mobile client
+        run: pnpm --filter @woof/mobile type-check
+
+      - name: Run household contract tests
+        run: pnpm --filter @woof/api exec jest src/households/households.service.spec.ts --runInBand
+
+      - name: Run multi-pet activity contract tests
+        run: pnpm --filter @woof/api exec jest src/activities/activities.service.spec.ts --runInBand
+
+      - name: Build API
+        run: pnpm --filter @woof/api build

--- a/.github/workflows/dogos-foundation-ci.yml
+++ b/.github/workflows/dogos-foundation-ci.yml
@@ -107,14 +107,10 @@ jobs:
           apps/api/src/pets/pets.module.ts
           apps/api/src/pets/pets.service.ts
           apps/api/src/app.module.ts
-          apps/mobile/package.json
           apps/mobile/src/api/activities.ts
-          apps/mobile/src/api/goals.ts
-          apps/mobile/src/api/pets.ts
-          apps/mobile/src/api/social.ts
           apps/mobile/src/types/activity.ts
-          apps/mobile/src/utils/animations.ts
           .github/workflows/dogos-foundation-ci.yml
+          docs/DOGOS_ARCHITECTURE.md
 
       - name: Lint dogOS API surface
         run: >-
@@ -125,6 +121,9 @@ jobs:
           src/pets/pets.module.ts
           src/pets/pets.service.ts
           src/app.module.ts
+
+      - name: Lint mobile client
+        run: pnpm --filter @woof/mobile lint
 
       - name: Type-check API
         run: pnpm --filter @woof/api type-check

--- a/apps/api/src/activities/activities.controller.ts
+++ b/apps/api/src/activities/activities.controller.ts
@@ -10,12 +10,7 @@ import {
   Request,
   UseGuards,
 } from '@nestjs/common';
-import {
-  ApiBearerAuth,
-  ApiOperation,
-  ApiResponse,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import type { AuthenticatedRequest } from '../auth/authenticated-request';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { ActivitiesService } from './activities.service';
@@ -29,41 +24,41 @@ export class ActivitiesController {
   constructor(private readonly activitiesService: ActivitiesService) {}
 
   @Post()
-  @ApiOperation({ summary: 'Create an activity for the authenticated owner' })
+  @ApiOperation({ summary: 'Create one household activity for the authenticated recorder' })
   @ApiResponse({ status: 201, description: 'Activity created successfully' })
   async create(@Request() req: AuthenticatedRequest, @Body() dto: CreateActivityDto) {
     return this.activitiesService.create(req.user.sub, dto);
   }
 
   @Get()
-  @ApiOperation({ summary: 'Get the authenticated owner’s activities' })
+  @ApiOperation({ summary: 'Get activities visible through the authenticated household context' })
   async findAll(
     @Request() req: AuthenticatedRequest,
     @Query('skip') skip?: number,
     @Query('take') take?: number,
-    @Query('petId') petId?: string,
+    @Query('petId') petId?: string
   ) {
     return this.activitiesService.findAll(req.user.sub, skip, take, petId);
   }
 
   @Get(':id')
-  @ApiOperation({ summary: 'Get one owned activity' })
+  @ApiOperation({ summary: 'Get one household-visible activity' })
   async findOne(@Request() req: AuthenticatedRequest, @Param('id') id: string) {
     return this.activitiesService.findById(req.user.sub, id);
   }
 
   @Put(':id')
-  @ApiOperation({ summary: 'Update one owned activity' })
+  @ApiOperation({ summary: 'Update one activity recorded by the authenticated user' })
   async update(
     @Request() req: AuthenticatedRequest,
     @Param('id') id: string,
-    @Body() dto: UpdateActivityDto,
+    @Body() dto: UpdateActivityDto
   ) {
     return this.activitiesService.update(req.user.sub, id, dto);
   }
 
   @Delete(':id')
-  @ApiOperation({ summary: 'Delete one owned activity' })
+  @ApiOperation({ summary: 'Delete one activity recorded by the authenticated user' })
   async delete(@Request() req: AuthenticatedRequest, @Param('id') id: string) {
     return this.activitiesService.delete(req.user.sub, id);
   }

--- a/apps/api/src/activities/activities.module.ts
+++ b/apps/api/src/activities/activities.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { CareEventsModule } from '../care-events/care-events.module';
+import { HouseholdsModule } from '../households/households.module';
 import { ActivitiesController } from './activities.controller';
 import { ActivitiesService } from './activities.service';
 
 @Module({
-  imports: [CareEventsModule],
+  imports: [CareEventsModule, HouseholdsModule],
   providers: [ActivitiesService],
   controllers: [ActivitiesController],
   exports: [ActivitiesService],

--- a/apps/api/src/activities/activities.service.spec.ts
+++ b/apps/api/src/activities/activities.service.spec.ts
@@ -1,0 +1,188 @@
+import { BadRequestException } from '@nestjs/common';
+import { CareEventsService } from '../care-events/care-events.service';
+import { HouseholdsService } from '../households/households.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { ActivitiesService } from './activities.service';
+
+describe('ActivitiesService dogOS participation', () => {
+  const userId = '11111111-1111-4111-8111-111111111111';
+  const householdId = '22222222-2222-4222-8222-222222222222';
+  const petA = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const petB = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+  function createHarness() {
+    const prisma = {
+      activity: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        count: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+    const careEvents = {
+      record: jest.fn().mockResolvedValue({}),
+    };
+    const households = {
+      assertPetAccessible: jest.fn().mockResolvedValue({ id: petA }),
+      resolveActivityHousehold: jest.fn().mockResolvedValue(householdId),
+      householdActivityWhere: jest.fn().mockReturnValue({ userId }),
+    };
+
+    return {
+      prisma,
+      careEvents,
+      households,
+      service: new ActivitiesService(
+        prisma as unknown as PrismaService,
+        careEvents as unknown as CareEventsService,
+        households as unknown as HouseholdsService
+      ),
+    };
+  }
+
+  it('stores one real activity with two pet participants instead of duplicating the walk', async () => {
+    const { service, prisma, households } = createHarness();
+    const startedAt = '2026-08-21T17:00:00.000Z';
+    const endedAt = '2026-08-21T17:30:00.000Z';
+
+    prisma.activity.create.mockResolvedValue({
+      id: 'activity-1',
+      userId,
+      householdId,
+      petId: petA,
+      type: 'WALK',
+      startedAt: new Date(startedAt),
+      endedAt: new Date(endedAt),
+      route: null,
+      petParticipants: [{ petId: petA }, { petId: petB }],
+    });
+
+    const result = await service.create(userId, {
+      type: 'WALK',
+      petIds: [petA, petB],
+      startedAt,
+      endedAt,
+    });
+
+    expect(result.id).toBe('activity-1');
+    expect(households.assertPetAccessible).toHaveBeenCalledTimes(2);
+    expect(households.resolveActivityHousehold).toHaveBeenCalledWith(
+      userId,
+      [petA, petB],
+      undefined
+    );
+    expect(prisma.activity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId,
+          householdId,
+          petId: petA,
+          humanParticipants: {
+            create: {
+              userId,
+              role: 'RECORDER',
+            },
+          },
+          petParticipants: {
+            create: [
+              { petId: petA, metrics: undefined },
+              { petId: petB, metrics: undefined },
+            ],
+          },
+        }),
+      })
+    );
+  });
+
+  it('emits one trusted reward event per participating pet with stable dedupe keys', async () => {
+    const { service, prisma, careEvents } = createHarness();
+    prisma.activity.create.mockResolvedValue({
+      id: 'activity-2',
+      userId,
+      householdId,
+      petId: petA,
+      type: 'WALK',
+      startedAt: new Date('2026-08-21T17:00:00.000Z'),
+      endedAt: new Date('2026-08-21T17:30:00.000Z'),
+      route: null,
+      petParticipants: [{ petId: petA }, { petId: petB }],
+    });
+
+    await service.create(userId, {
+      type: 'WALK',
+      petIds: [petA, petB],
+      startedAt: '2026-08-21T17:00:00.000Z',
+      endedAt: '2026-08-21T17:30:00.000Z',
+    });
+
+    expect(careEvents.record).toHaveBeenCalledTimes(2);
+    expect(careEvents.record).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        userId,
+        petId: petA,
+        pathway: 'MOVE',
+        dedupeKey: 'activity:activity-2:completed',
+        context: expect.objectContaining({ participantCount: 2 }),
+      })
+    );
+    expect(careEvents.record).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        userId,
+        petId: petB,
+        pathway: 'MOVE',
+        dedupeKey: `activity:activity-2:pet:${petB}:completed`,
+      })
+    );
+  });
+
+  it('preserves legacy single-pet input while moving storage to participant rows', async () => {
+    const { service, prisma } = createHarness();
+    prisma.activity.create.mockResolvedValue({
+      id: 'activity-legacy',
+      userId,
+      householdId,
+      petId: petA,
+      type: 'PLAY',
+      startedAt: new Date('2026-08-21T17:00:00.000Z'),
+      endedAt: null,
+      route: null,
+      petParticipants: [{ petId: petA }],
+    });
+
+    await service.create(userId, {
+      type: 'PLAY',
+      petId: petA,
+      startedAt: '2026-08-21T17:00:00.000Z',
+    });
+
+    expect(prisma.activity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          petId: petA,
+          petParticipants: {
+            create: [{ petId: petA, metrics: undefined }],
+          },
+        }),
+      })
+    );
+  });
+
+  it('rejects impossible activity chronology before writing an activity', async () => {
+    const { service, prisma } = createHarness();
+
+    await expect(
+      service.create(userId, {
+        type: 'WALK',
+        petIds: [petA],
+        startedAt: '2026-08-21T18:00:00.000Z',
+        endedAt: '2026-08-21T17:00:00.000Z',
+      })
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(prisma.activity.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/activities/activities.service.ts
+++ b/apps/api/src/activities/activities.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, Logger, NotFoundException } from '@nes
 import { Prisma } from '@woof/database';
 import { CareEventsService } from '../care-events/care-events.service';
 import type { WellbeingPathway } from '../care-events/care-event.types';
+import { HouseholdsService } from '../households/households.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateActivityDto, UpdateActivityDto } from './dto/activity.dto';
 
@@ -11,14 +12,21 @@ export class ActivitiesService {
 
   constructor(
     private readonly prisma: PrismaService,
-    private readonly careEvents: CareEventsService
+    private readonly careEvents: CareEventsService,
+    private readonly households: HouseholdsService
   ) {}
 
   async create(userId: string, dto: CreateActivityDto) {
-    if (dto.petId) {
-      await this.assertOwnedPet(userId, dto.petId);
+    const petIds = this.normalizePetIds(dto.petIds, dto.petId);
+    for (const petId of petIds) {
+      await this.households.assertPetAccessible(userId, petId);
     }
 
+    const householdId = await this.households.resolveActivityHousehold(
+      userId,
+      petIds,
+      dto.householdId
+    );
     const startedAt = dto.startedAt ? new Date(dto.startedAt) : new Date();
     const endedAt = dto.endedAt ? new Date(dto.endedAt) : null;
     this.assertChronology(startedAt, endedAt);
@@ -26,7 +34,8 @@ export class ActivitiesService {
     const activity = await this.prisma.activity.create({
       data: {
         userId,
-        petId: dto.petId,
+        petId: petIds[0] ?? null,
+        householdId,
         startedAt,
         endedAt,
         type: dto.type,
@@ -34,12 +43,28 @@ export class ActivitiesService {
         humanMetrics: this.json(dto.humanMetrics),
         petMetrics: this.json(dto.petMetrics),
         jointMetrics: this.json(dto.jointMetrics),
+        humanParticipants: {
+          create: {
+            userId,
+            role: 'RECORDER',
+          },
+        },
+        ...(petIds.length
+          ? {
+              petParticipants: {
+                create: petIds.map((petId) => ({
+                  petId,
+                  metrics: this.json(dto.petMetrics),
+                })),
+              },
+            }
+          : {}),
       },
       include: this.activityInclude(),
     });
 
-    if (activity.endedAt && activity.petId) {
-      await this.emitActivityCareEvent(userId, activity);
+    if (activity.endedAt) {
+      await this.emitActivityCareEvents(userId, activity);
     }
 
     return activity;
@@ -50,12 +75,20 @@ export class ActivitiesService {
     const safeTake = Math.max(1, Math.min(Number(take) || 20, 100));
 
     if (petId) {
-      await this.assertOwnedPet(userId, petId);
+      await this.households.assertPetAccessible(userId, petId);
     }
 
     const where: Prisma.ActivityWhereInput = {
-      userId,
-      ...(petId ? { petId } : {}),
+      AND: [
+        this.households.householdActivityWhere(userId),
+        ...(petId
+          ? [
+              {
+                OR: [{ petId }, { petParticipants: { some: { petId } } }],
+              } satisfies Prisma.ActivityWhereInput,
+            ]
+          : []),
+      ],
     };
 
     const [activities, total] = await Promise.all([
@@ -77,7 +110,10 @@ export class ActivitiesService {
 
   async findById(userId: string, id: string) {
     const activity = await this.prisma.activity.findFirst({
-      where: { id, userId },
+      where: {
+        id,
+        AND: [this.households.householdActivityWhere(userId)],
+      },
       include: {
         ...this.activityInclude(),
         posts: {
@@ -101,10 +137,26 @@ export class ActivitiesService {
 
   async update(userId: string, id: string, dto: UpdateActivityDto) {
     const existing = await this.assertOwnedActivity(userId, id);
+    const participantUpdateRequested = dto.petIds !== undefined || dto.petId !== undefined;
+    const petIds = participantUpdateRequested
+      ? this.normalizePetIds(dto.petIds, dto.petId)
+      : this.normalizePetIds(
+          existing.petParticipants.map((participant) => participant.petId),
+          existing.petId ?? undefined
+        );
 
-    if (dto.petId) {
-      await this.assertOwnedPet(userId, dto.petId);
+    for (const petId of petIds) {
+      await this.households.assertPetAccessible(userId, petId);
     }
+
+    const householdId =
+      participantUpdateRequested || dto.householdId !== undefined || !existing.householdId
+        ? await this.households.resolveActivityHousehold(
+            userId,
+            petIds,
+            dto.householdId ?? existing.householdId ?? undefined
+          )
+        : existing.householdId;
 
     const startedAt = dto.startedAt ? new Date(dto.startedAt) : existing.startedAt;
     const endedAt = dto.endedAt ? new Date(dto.endedAt) : existing.endedAt;
@@ -113,7 +165,8 @@ export class ActivitiesService {
     const activity = await this.prisma.activity.update({
       where: { id },
       data: {
-        ...(dto.petId !== undefined ? { petId: dto.petId } : {}),
+        ...(participantUpdateRequested ? { petId: petIds[0] ?? null } : {}),
+        ...(householdId !== existing.householdId ? { householdId } : {}),
         ...(dto.startedAt !== undefined ? { startedAt } : {}),
         ...(dto.endedAt !== undefined ? { endedAt } : {}),
         ...(dto.type !== undefined ? { type: dto.type } : {}),
@@ -121,12 +174,32 @@ export class ActivitiesService {
         ...(dto.humanMetrics !== undefined ? { humanMetrics: this.json(dto.humanMetrics) } : {}),
         ...(dto.petMetrics !== undefined ? { petMetrics: this.json(dto.petMetrics) } : {}),
         ...(dto.jointMetrics !== undefined ? { jointMetrics: this.json(dto.jointMetrics) } : {}),
+        ...(participantUpdateRequested
+          ? {
+              petParticipants: {
+                deleteMany: {},
+                create: petIds.map((petId) => ({
+                  petId,
+                  metrics: this.json(dto.petMetrics),
+                })),
+              },
+            }
+          : dto.petMetrics !== undefined
+            ? {
+                petParticipants: {
+                  updateMany: {
+                    where: {},
+                    data: { metrics: this.json(dto.petMetrics) },
+                  },
+                },
+              }
+            : {}),
       },
       include: this.activityInclude(),
     });
 
-    if (activity.endedAt && activity.petId) {
-      await this.emitActivityCareEvent(userId, activity);
+    if (activity.endedAt) {
+      await this.emitActivityCareEvents(userId, activity);
     }
 
     return activity;
@@ -137,7 +210,7 @@ export class ActivitiesService {
     return this.prisma.activity.delete({ where: { id } });
   }
 
-  private async emitActivityCareEvent(
+  private async emitActivityCareEvents(
     userId: string,
     activity: {
       id: string;
@@ -146,44 +219,59 @@ export class ActivitiesService {
       startedAt: Date;
       endedAt: Date | null;
       route: unknown;
+      petParticipants: Array<{ petId: string }>;
     }
   ) {
-    if (!activity.petId || !activity.endedAt) return;
+    if (!activity.endedAt) return;
     const semantic = this.activitySemantic(activity.type);
     if (!semantic) return;
+
+    const petIds = this.normalizePetIds(
+      activity.petParticipants.map((participant) => participant.petId),
+      activity.petId ?? undefined
+    );
+    if (!petIds.length) return;
 
     const durationMinutes = Math.max(
       0,
       Math.round((activity.endedAt.getTime() - activity.startedAt.getTime()) / 60000)
     );
 
-    try {
-      await this.careEvents.record({
-        userId,
-        petId: activity.petId,
-        eventType: semantic.eventType,
-        pathway: semantic.pathway,
-        occurredAt: activity.endedAt,
-        source: 'ACTIVITIES',
-        evidenceType: 'ACTIVITY',
-        evidenceConfidence: 0.78,
-        dedupeKey: `activity:${activity.id}:completed`,
-        context: {
-          activityId: activity.id,
-          activityType: activity.type.toUpperCase(),
-          durationMinutes,
-          routePresent: Boolean(activity.route),
-        },
-      });
-    } catch (error) {
-      // Rewards are additive product infrastructure. Logging an activity must remain
-      // reliable during a rolling deployment even if the new ledger migration has
-      // not reached this API instance yet.
-      this.logger.warn(
-        `Activity ${activity.id} saved, but Adventure reward emission failed: ${
-          error instanceof Error ? error.message : 'unknown error'
-        }`
-      );
+    for (const [index, petId] of petIds.entries()) {
+      try {
+        await this.careEvents.record({
+          userId,
+          petId,
+          eventType: semantic.eventType,
+          pathway: semantic.pathway,
+          occurredAt: activity.endedAt,
+          source: 'ACTIVITIES',
+          evidenceType: 'ACTIVITY',
+          evidenceConfidence: 0.78,
+          // Preserve the historical key for the primary participant so an old
+          // single-pet activity cannot earn twice after the dogOS migration.
+          dedupeKey:
+            index === 0
+              ? `activity:${activity.id}:completed`
+              : `activity:${activity.id}:pet:${petId}:completed`,
+          context: {
+            activityId: activity.id,
+            activityType: activity.type.toUpperCase(),
+            durationMinutes,
+            routePresent: Boolean(activity.route),
+            participantCount: petIds.length,
+          },
+        });
+      } catch (error) {
+        // Rewards are additive product infrastructure. Logging an activity must
+        // remain reliable during a rolling deployment even if the ledger path is
+        // temporarily unavailable.
+        this.logger.warn(
+          `Activity ${activity.id} saved, but one Adventure reward emission failed: ${
+            error instanceof Error ? error.message : 'unknown error'
+          }`
+        );
+      }
     }
   }
 
@@ -219,21 +307,19 @@ export class ActivitiesService {
     }
   }
 
-  private async assertOwnedPet(userId: string, petId: string) {
-    const pet = await this.prisma.pet.findFirst({
-      where: { id: petId, ownerId: userId },
-      select: { id: true },
-    });
-    if (!pet) {
-      throw new NotFoundException('Pet not found');
-    }
-    return pet;
-  }
-
   private async assertOwnedActivity(userId: string, id: string) {
     const activity = await this.prisma.activity.findFirst({
       where: { id, userId },
-      select: { id: true, startedAt: true, endedAt: true },
+      select: {
+        id: true,
+        petId: true,
+        householdId: true,
+        startedAt: true,
+        endedAt: true,
+        petParticipants: {
+          select: { petId: true },
+        },
+      },
     });
     if (!activity) {
       throw new NotFoundException(`Activity with ID ${id} not found`);
@@ -245,6 +331,10 @@ export class ActivitiesService {
     if (endedAt && endedAt.getTime() < startedAt.getTime()) {
       throw new BadRequestException('Activity end time cannot precede start time');
     }
+  }
+
+  private normalizePetIds(petIds?: string[], legacyPetId?: string) {
+    return [...new Set([...(petIds ?? []), ...(legacyPetId ? [legacyPetId] : [])])];
   }
 
   private json(value?: Record<string, unknown>) {
@@ -266,6 +356,38 @@ export class ActivitiesService {
           name: true,
           species: true,
           avatarUrl: true,
+        },
+      },
+      household: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+      humanParticipants: {
+        select: {
+          role: true,
+          user: {
+            select: {
+              id: true,
+              handle: true,
+              avatarUrl: true,
+            },
+          },
+        },
+      },
+      petParticipants: {
+        select: {
+          metrics: true,
+          petId: true,
+          pet: {
+            select: {
+              id: true,
+              name: true,
+              species: true,
+              avatarUrl: true,
+            },
+          },
         },
       },
     } satisfies Prisma.ActivityInclude;

--- a/apps/api/src/activities/dto/activity.dto.ts
+++ b/apps/api/src/activities/dto/activity.dto.ts
@@ -1,5 +1,8 @@
 import { Transform } from 'class-transformer';
 import {
+  ArrayMaxSize,
+  ArrayUnique,
+  IsArray,
   IsDateString,
   IsIn,
   IsObject,
@@ -16,13 +19,34 @@ const ACTIVITY_TYPES = [
   'TRAINING',
   'GROOMING',
   'VET_VISIT',
+  'ENRICHMENT',
+  'SCENT',
+  'PUZZLE',
+  'SOCIAL',
+  'MEETUP',
+  'PARALLEL_WALK',
+  'RECOVERY',
+  'REST',
+  'DECOMPRESSION',
   'OTHER',
 ];
 
 export class CreateActivityDto {
+  /** Legacy single-pet field. dogOS clients should prefer petIds. */
   @IsOptional()
   @IsUUID()
   petId?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  @ArrayMaxSize(16)
+  @IsUUID('4', { each: true })
+  petIds?: string[];
+
+  @IsOptional()
+  @IsUUID()
+  householdId?: string;
 
   @IsOptional()
   @IsDateString()
@@ -58,6 +82,17 @@ export class UpdateActivityDto {
   @IsOptional()
   @IsUUID()
   petId?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  @ArrayMaxSize(16)
+  @IsUUID('4', { each: true })
+  petIds?: string[];
+
+  @IsOptional()
+  @IsUUID()
+  householdId?: string;
 
   @IsOptional()
   @IsDateString()

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -20,6 +20,7 @@ import { EventsModule } from './events/events.module';
 import { GamificationModule } from './gamification/gamification.module';
 import { GoalsModule } from './goals/goals.module';
 import { HealthLensModule } from './health-lens/health-lens.module';
+import { HouseholdsModule } from './households/households.module';
 import { InsightsModule } from './insights/insights.module';
 import { MediaLibraryModule } from './media-library/media-library.module';
 import { MeetupProposalsModule } from './meetup-proposals/meetup-proposals.module';
@@ -62,6 +63,7 @@ export const throttlerOptions: ThrottlerModuleOptions = {
     AuthModule,
     UsersModule,
     PetsModule,
+    HouseholdsModule,
     ActivitiesModule,
     AdventureModule,
     SocialModule,

--- a/apps/api/src/households/dto/household.dto.ts
+++ b/apps/api/src/households/dto/household.dto.ts
@@ -1,0 +1,13 @@
+import { IsOptional, IsString, Length } from 'class-validator';
+
+export class UpdateHouseholdDto {
+  @IsOptional()
+  @IsString()
+  @Length(1, 80)
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(1, 80)
+  timezone?: string;
+}

--- a/apps/api/src/households/households.controller.ts
+++ b/apps/api/src/households/households.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { AuthenticatedRequest } from '../auth/authenticated-request';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { UpdateHouseholdDto } from './dto/household.dto';
+import { HouseholdsService } from './households.service';
+
+@ApiTags('households')
+@Controller('households')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class HouseholdsController {
+  constructor(private readonly households: HouseholdsService) {}
+
+  @Get('me')
+  @ApiOperation({ summary: 'Get dogOS households for the authenticated user' })
+  getMine(@Request() req: AuthenticatedRequest) {
+    return this.households.getMine(req.user.sub);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update a managed household' })
+  update(
+    @Request() req: AuthenticatedRequest,
+    @Param('id') id: string,
+    @Body() dto: UpdateHouseholdDto
+  ) {
+    return this.households.update(req.user.sub, id, dto);
+  }
+
+  @Post(':id/pets/:petId')
+  @ApiOperation({ summary: 'Add one owned pet to a managed household' })
+  addPet(
+    @Request() req: AuthenticatedRequest,
+    @Param('id') id: string,
+    @Param('petId') petId: string
+  ) {
+    return this.households.addOwnedPet(req.user.sub, id, petId);
+  }
+
+  @Delete(':id/pets/:petId')
+  @ApiOperation({ summary: 'Remove one pet from a managed household without deleting the pet' })
+  removePet(
+    @Request() req: AuthenticatedRequest,
+    @Param('id') id: string,
+    @Param('petId') petId: string
+  ) {
+    return this.households.removePet(req.user.sub, id, petId);
+  }
+}

--- a/apps/api/src/households/households.module.ts
+++ b/apps/api/src/households/households.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { HouseholdsController } from './households.controller';
+import { HouseholdsService } from './households.service';
+
+@Module({
+  providers: [HouseholdsService],
+  controllers: [HouseholdsController],
+  exports: [HouseholdsService],
+})
+export class HouseholdsModule {}

--- a/apps/api/src/households/households.service.spec.ts
+++ b/apps/api/src/households/households.service.spec.ts
@@ -1,0 +1,141 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { createHash } from 'crypto';
+import { PrismaService } from '../prisma/prisma.service';
+import { HouseholdsService } from './households.service';
+
+describe('HouseholdsService', () => {
+  const userId = '11111111-1111-4111-8111-111111111111';
+  const petA = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+  const petB = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+  const deterministicHouseholdId = (id: string) => {
+    const hex = createHash('md5').update(`dogos-household:${id}`).digest('hex');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  };
+
+  function createHarness() {
+    const tx = {
+      household: {
+        upsert: jest.fn().mockResolvedValue({}),
+      },
+      householdMember: {
+        upsert: jest.fn().mockResolvedValue({}),
+      },
+      householdPet: {
+        upsert: jest.fn().mockResolvedValue({}),
+      },
+      pet: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    };
+
+    const prisma = {
+      householdMember: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+      },
+      householdPet: {
+        findUnique: jest.fn(),
+        upsert: jest.fn(),
+        update: jest.fn(),
+      },
+      household: {
+        update: jest.fn(),
+      },
+      pet: {
+        findFirst: jest.fn(),
+      },
+      $transaction: jest.fn(async (callback: (client: typeof tx) => Promise<unknown>) =>
+        callback(tx)
+      ),
+    };
+
+    return {
+      tx,
+      prisma,
+      service: new HouseholdsService(prisma as unknown as PrismaService),
+    };
+  }
+
+  it('always resolves the deterministic personal household, not an arbitrary membership', async () => {
+    const { prisma, service } = createHarness();
+    const expectedId = deterministicHouseholdId(userId);
+    prisma.householdMember.findUnique.mockResolvedValue({ status: 'ACTIVE', role: 'OWNER' });
+
+    await expect(service.ensurePersonalHousehold(userId)).resolves.toBe(expectedId);
+    expect(prisma.householdMember.findUnique).toHaveBeenCalledWith({
+      where: {
+        householdId_userId: {
+          householdId: expectedId,
+          userId,
+        },
+      },
+      select: { status: true, role: true },
+    });
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('bootstraps the owner and all existing owned pets into a missing personal household', async () => {
+    const { prisma, service, tx } = createHarness();
+    const expectedId = deterministicHouseholdId(userId);
+    prisma.householdMember.findUnique.mockResolvedValue(null);
+    tx.pet.findMany.mockResolvedValue([{ id: petA }, { id: petB }]);
+
+    await expect(service.ensurePersonalHousehold(userId)).resolves.toBe(expectedId);
+
+    expect(tx.household.upsert).toHaveBeenCalledWith({
+      where: { id: expectedId },
+      update: {},
+      create: { id: expectedId, name: 'My household' },
+    });
+    expect(tx.householdMember.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          householdId_userId: {
+            householdId: expectedId,
+            userId,
+          },
+        },
+      })
+    );
+    expect(tx.householdPet.upsert).toHaveBeenCalledTimes(2);
+  });
+
+  it('selects one household only when every chosen pet participates in that household', async () => {
+    const { prisma, service } = createHarness();
+    prisma.householdMember.findMany.mockResolvedValue([
+      {
+        householdId: 'household-together',
+        household: { pets: [{ petId: petA }, { petId: petB }] },
+      },
+    ]);
+
+    await expect(service.resolveActivityHousehold(userId, [petA, petB])).resolves.toBe(
+      'household-together'
+    );
+  });
+
+  it('rejects a fake shared activity when the selected pets only exist in separate households', async () => {
+    const { prisma, service } = createHarness();
+    prisma.householdMember.findMany.mockResolvedValue([
+      { householdId: 'household-a', household: { pets: [{ petId: petA }] } },
+      { householdId: 'household-b', household: { pets: [{ petId: petB }] } },
+    ]);
+    prisma.pet.findFirst.mockResolvedValue({ id: petA });
+
+    await expect(service.resolveActivityHousehold(userId, [petA, petB])).rejects.toBeInstanceOf(
+      BadRequestException
+    );
+  });
+
+  it('keeps household mutations manager-only', async () => {
+    const { prisma, service } = createHarness();
+    prisma.householdMember.findFirst.mockResolvedValue({ role: 'MEMBER' });
+
+    await expect(service.update(userId, 'household-a', { name: 'Pack HQ' })).rejects.toBeInstanceOf(
+      ForbiddenException
+    );
+    expect(prisma.household.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/households/households.service.ts
+++ b/apps/api/src/households/households.service.ts
@@ -1,0 +1,350 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { createHash } from 'crypto';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+import { UpdateHouseholdDto } from './dto/household.dto';
+
+@Injectable()
+export class HouseholdsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getMine(userId: string) {
+    await this.ensurePersonalHousehold(userId);
+
+    const memberships = await this.prisma.householdMember.findMany({
+      where: { userId, status: 'ACTIVE' },
+      include: {
+        household: {
+          include: {
+            members: {
+              where: { status: 'ACTIVE' },
+              select: {
+                id: true,
+                role: true,
+                status: true,
+                joinedAt: true,
+                user: {
+                  select: {
+                    id: true,
+                    handle: true,
+                    avatarUrl: true,
+                  },
+                },
+              },
+              orderBy: { joinedAt: 'asc' },
+            },
+            pets: {
+              where: { status: 'ACTIVE' },
+              select: {
+                id: true,
+                status: true,
+                joinedAt: true,
+                pet: {
+                  select: {
+                    id: true,
+                    name: true,
+                    species: true,
+                    breed: true,
+                    birthdate: true,
+                    avatarUrl: true,
+                  },
+                },
+              },
+              orderBy: { joinedAt: 'asc' },
+            },
+          },
+        },
+      },
+      orderBy: { joinedAt: 'asc' },
+    });
+
+    return memberships.map((membership) => ({
+      ...membership.household,
+      viewerRole: membership.role,
+    }));
+  }
+
+  async ensurePersonalHousehold(userId: string): Promise<string> {
+    // A dogOS account always owns one deterministic personal household. Do not
+    // use the user's first active membership here: once household invitations
+    // exist, that could attach a newly created pet to somebody else's household.
+    const householdId = this.deterministicUuid(`dogos-household:${userId}`);
+    const existing = await this.prisma.householdMember.findUnique({
+      where: {
+        householdId_userId: {
+          householdId,
+          userId,
+        },
+      },
+      select: { status: true, role: true },
+    });
+
+    if (existing?.status === 'ACTIVE' && existing.role === 'OWNER') {
+      return householdId;
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.household.upsert({
+        where: { id: householdId },
+        update: {},
+        create: {
+          id: householdId,
+          name: 'My household',
+        },
+      });
+
+      await tx.householdMember.upsert({
+        where: {
+          householdId_userId: {
+            householdId,
+            userId,
+          },
+        },
+        update: { status: 'ACTIVE', role: 'OWNER' },
+        create: {
+          householdId,
+          userId,
+          role: 'OWNER',
+          status: 'ACTIVE',
+        },
+      });
+
+      const ownedPets = await tx.pet.findMany({
+        where: { ownerId: userId },
+        select: { id: true },
+      });
+
+      for (const pet of ownedPets) {
+        await tx.householdPet.upsert({
+          where: {
+            householdId_petId: {
+              householdId,
+              petId: pet.id,
+            },
+          },
+          update: { status: 'ACTIVE' },
+          create: {
+            householdId,
+            petId: pet.id,
+            status: 'ACTIVE',
+          },
+        });
+      }
+    });
+
+    return householdId;
+  }
+
+  async update(userId: string, householdId: string, dto: UpdateHouseholdDto) {
+    await this.assertCanManage(userId, householdId);
+
+    return this.prisma.household.update({
+      where: { id: householdId },
+      data: {
+        ...(dto.name !== undefined ? { name: dto.name.trim() } : {}),
+        ...(dto.timezone !== undefined ? { timezone: dto.timezone.trim() } : {}),
+      },
+    });
+  }
+
+  async addOwnedPet(userId: string, householdId: string, petId: string) {
+    await this.assertCanManage(userId, householdId);
+
+    const pet = await this.prisma.pet.findFirst({
+      where: { id: petId, ownerId: userId },
+      select: { id: true },
+    });
+    if (!pet) throw new NotFoundException('Pet not found');
+
+    return this.prisma.householdPet.upsert({
+      where: {
+        householdId_petId: {
+          householdId,
+          petId,
+        },
+      },
+      update: { status: 'ACTIVE' },
+      create: {
+        householdId,
+        petId,
+        status: 'ACTIVE',
+      },
+      include: {
+        pet: {
+          select: {
+            id: true,
+            name: true,
+            species: true,
+            breed: true,
+            avatarUrl: true,
+          },
+        },
+      },
+    });
+  }
+
+  async removePet(userId: string, householdId: string, petId: string) {
+    await this.assertCanManage(userId, householdId);
+
+    const link = await this.prisma.householdPet.findUnique({
+      where: {
+        householdId_petId: {
+          householdId,
+          petId,
+        },
+      },
+      select: { id: true },
+    });
+    if (!link) throw new NotFoundException('Household pet not found');
+
+    return this.prisma.householdPet.update({
+      where: { id: link.id },
+      data: { status: 'INACTIVE' },
+    });
+  }
+
+  async attachNewOwnedPet(userId: string, petId: string) {
+    const householdId = await this.ensurePersonalHousehold(userId);
+    await this.prisma.householdPet.upsert({
+      where: {
+        householdId_petId: {
+          householdId,
+          petId,
+        },
+      },
+      update: { status: 'ACTIVE' },
+      create: {
+        householdId,
+        petId,
+        status: 'ACTIVE',
+      },
+    });
+    return householdId;
+  }
+
+  async assertPetAccessible(userId: string, petId: string) {
+    const pet = await this.prisma.pet.findFirst({
+      where: {
+        id: petId,
+        OR: [
+          { ownerId: userId },
+          {
+            householdMemberships: {
+              some: {
+                status: 'ACTIVE',
+                household: {
+                  members: {
+                    some: {
+                      userId,
+                      status: 'ACTIVE',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+      select: { id: true },
+    });
+
+    if (!pet) throw new NotFoundException('Pet not found');
+    return pet;
+  }
+
+  async resolveActivityHousehold(
+    userId: string,
+    petIds: string[],
+    requestedHouseholdId?: string
+  ): Promise<string> {
+    const uniquePetIds = [...new Set(petIds)];
+
+    const memberships = await this.prisma.householdMember.findMany({
+      where: {
+        userId,
+        status: 'ACTIVE',
+        ...(requestedHouseholdId ? { householdId: requestedHouseholdId } : {}),
+      },
+      select: {
+        householdId: true,
+        household: {
+          select: {
+            pets: {
+              where: { status: 'ACTIVE' },
+              select: { petId: true },
+            },
+          },
+        },
+      },
+      orderBy: { joinedAt: 'asc' },
+    });
+
+    if (!memberships.length && requestedHouseholdId) {
+      throw new NotFoundException('Household not found');
+    }
+
+    if (!memberships.length) {
+      await this.ensurePersonalHousehold(userId);
+      return this.resolveActivityHousehold(userId, uniquePetIds, requestedHouseholdId);
+    }
+
+    if (!uniquePetIds.length) return memberships[0].householdId;
+
+    for (const membership of memberships) {
+      const accessible = new Set(membership.household.pets.map((link) => link.petId));
+      if (uniquePetIds.every((petId) => accessible.has(petId))) {
+        return membership.householdId;
+      }
+    }
+
+    for (const petId of uniquePetIds) {
+      await this.assertPetAccessible(userId, petId);
+    }
+
+    throw new BadRequestException('Selected pets must belong to one shared household');
+  }
+
+  householdActivityWhere(userId: string): Prisma.ActivityWhereInput {
+    return {
+      OR: [
+        { userId },
+        {
+          household: {
+            members: {
+              some: {
+                userId,
+                status: 'ACTIVE',
+              },
+            },
+          },
+        },
+      ],
+    };
+  }
+
+  private async assertCanManage(userId: string, householdId: string) {
+    const membership = await this.prisma.householdMember.findFirst({
+      where: {
+        householdId,
+        userId,
+        status: 'ACTIVE',
+      },
+      select: { role: true },
+    });
+
+    if (!membership) throw new NotFoundException('Household not found');
+    if (!['OWNER', 'ADMIN'].includes(membership.role)) {
+      throw new ForbiddenException('Household manager access required');
+    }
+  }
+
+  private deterministicUuid(input: string) {
+    const hex = createHash('md5').update(input).digest('hex');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+}

--- a/apps/api/src/pets/pets.controller.ts
+++ b/apps/api/src/pets/pets.controller.ts
@@ -37,9 +37,19 @@ export class PetsController {
   async findAll(
     @Query('skip') skip?: number,
     @Query('take') take?: number,
-    @Query('ownerId') ownerId?: string,
+    @Query('ownerId') ownerId?: string
   ) {
     return this.petsService.findAll(skip, take, ownerId);
+  }
+
+  @Get('me')
+  @ApiOperation({ summary: 'Get pets owned by the authenticated user' })
+  async findMine(
+    @Request() req: AuthenticatedRequest,
+    @Query('skip') skip?: number,
+    @Query('take') take?: number
+  ) {
+    return this.petsService.findAll(skip, take, req.user.sub);
   }
 
   @Get(':id')
@@ -57,7 +67,7 @@ export class PetsController {
   async update(
     @Request() req: AuthenticatedRequest,
     @Param('id') id: string,
-    @Body() updatePetDto: UpdatePetDto,
+    @Body() updatePetDto: UpdatePetDto
   ) {
     return this.petsService.updateOwned(id, req.user.sub, updatePetDto);
   }

--- a/apps/api/src/pets/pets.module.ts
+++ b/apps/api/src/pets/pets.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
-import { PetsService } from './pets.service';
+import { HouseholdsModule } from '../households/households.module';
 import { PetsController } from './pets.controller';
+import { PetsService } from './pets.service';
 
 @Module({
+  imports: [HouseholdsModule],
   providers: [PetsService],
   controllers: [PetsController],
   exports: [PetsService],

--- a/apps/api/src/pets/pets.service.ts
+++ b/apps/api/src/pets/pets.service.ts
@@ -1,15 +1,29 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@woof/database';
+import { HouseholdsService } from '../households/households.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreatePetDto, UpdatePetDto } from './dto/create-pet.dto';
 
 @Injectable()
 export class PetsService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly households: HouseholdsService
+  ) {}
 
   async create(ownerId: string, data: CreatePetDto) {
+    const householdId = await this.households.ensurePersonalHousehold(ownerId);
+
     return this.prisma.pet.create({
-      data: this.toCreateInput(ownerId, data),
+      data: {
+        ...this.toCreateInput(ownerId, data),
+        householdMemberships: {
+          create: {
+            householdId,
+            status: 'ACTIVE',
+          },
+        },
+      },
       include: {
         owner: {
           select: {
@@ -18,6 +32,10 @@ export class PetsService {
             avatarUrl: true,
             isVerified: true,
           },
+        },
+        householdMemberships: {
+          where: { status: 'ACTIVE' },
+          select: { householdId: true },
         },
       },
     });

--- a/apps/mobile/src/api/activities.ts
+++ b/apps/mobile/src/api/activities.ts
@@ -1,21 +1,93 @@
-import apiClient from './client';
 import { Activity, CreateActivityDto, PaginatedResponse } from '../types';
+import type { CreateActivityRequest, UpdateActivityRequest } from '../types/activity';
+import apiClient from './client';
+
+type MobileActivityWrite = CreateActivityRequest | CreateActivityDto;
+
+type ActivityListResponse = {
+  activities: Activity[];
+  total: number;
+  skip: number;
+  take: number;
+};
+
+function isLegacyActivityWrite(data: MobileActivityWrite): data is CreateActivityDto {
+  return 'startTime' in data || 'duration' in data || 'title' in data;
+}
+
+/**
+ * Keep the currently shipped mobile form contract working while all new dogOS
+ * surfaces move to the canonical server contract. This translation happens on
+ * the client boundary so the API can stay strict (`forbidNonWhitelisted`) and
+ * old apps do not need a synchronized release.
+ */
+export function normalizeActivityWrite(data: MobileActivityWrite): CreateActivityRequest {
+  if (!isLegacyActivityWrite(data)) return data;
+
+  const startedAt = data.startTime;
+  const endedAt =
+    data.endTime ??
+    (data.duration > 0
+      ? new Date(new Date(startedAt).getTime() + data.duration * 60_000).toISOString()
+      : undefined);
+
+  const location = data.location
+    ? {
+        latitude: data.location.latitude,
+        longitude: data.location.longitude,
+        ...(data.location.address ? { address: data.location.address } : {}),
+      }
+    : undefined;
+
+  return {
+    petId: data.petId,
+    type: data.type,
+    startedAt,
+    endedAt,
+    ...(location ? { route: { start: location } } : {}),
+    humanMetrics: {
+      durationMinutes: data.duration,
+      ...(data.distance !== undefined ? { distanceMeters: data.distance } : {}),
+      ...(data.title ? { legacyTitle: data.title } : {}),
+      ...(data.description ? { legacyDescription: data.description } : {}),
+    },
+  };
+}
 
 export const activitiesApi = {
   async getActivities(page: number = 1, limit: number = 20): Promise<PaginatedResponse<Activity>> {
-    return apiClient.get('/activities', { params: { page, limit } });
+    const safePage = Math.max(1, page);
+    const safeLimit = Math.max(1, limit);
+    const skip = (safePage - 1) * safeLimit;
+    const response = await apiClient.get<ActivityListResponse>('/activities', {
+      params: { skip, take: safeLimit },
+    });
+
+    return {
+      data: response.activities,
+      total: response.total,
+      page: safePage,
+      limit: response.take,
+      hasMore: response.skip + response.activities.length < response.total,
+    };
   },
 
   async getActivityById(id: string): Promise<Activity> {
     return apiClient.get(`/activities/${id}`);
   },
 
-  async createActivity(data: CreateActivityDto): Promise<Activity> {
-    return apiClient.post('/activities', data);
+  async createActivity(data: MobileActivityWrite): Promise<Activity> {
+    return apiClient.post('/activities', normalizeActivityWrite(data));
   },
 
-  async updateActivity(id: string, data: Partial<CreateActivityDto>): Promise<Activity> {
-    return apiClient.patch(`/activities/${id}`, data);
+  async updateActivity(
+    id: string,
+    data: UpdateActivityRequest | Partial<CreateActivityDto>
+  ): Promise<Activity> {
+    const payload = isLegacyActivityWrite(data as MobileActivityWrite)
+      ? normalizeActivityWrite(data as CreateActivityDto)
+      : data;
+    return apiClient.put(`/activities/${id}`, payload);
   },
 
   async deleteActivity(id: string): Promise<void> {
@@ -23,8 +95,10 @@ export const activitiesApi = {
   },
 
   async getMyActivities(petId?: string): Promise<Activity[]> {
-    const params = petId ? { petId } : {};
-    return apiClient.get('/activities/my-activities', { params });
+    const response = await apiClient.get<ActivityListResponse>('/activities', {
+      params: { ...(petId ? { petId } : {}), skip: 0, take: 100 },
+    });
+    return response.activities;
   },
 
   async uploadActivityPhotos(activityId: string, photoUris: string[]): Promise<{ urls: string[] }> {

--- a/apps/mobile/src/types/activity.ts
+++ b/apps/mobile/src/types/activity.ts
@@ -1,0 +1,45 @@
+export type DogOsActivityType =
+  | 'WALK'
+  | 'RUN'
+  | 'PLAY'
+  | 'HIKE'
+  | 'TRAINING'
+  | 'GROOMING'
+  | 'VET_VISIT'
+  | 'ENRICHMENT'
+  | 'SCENT'
+  | 'PUZZLE'
+  | 'SOCIAL'
+  | 'MEETUP'
+  | 'PARALLEL_WALK'
+  | 'RECOVERY'
+  | 'REST'
+  | 'DECOMPRESSION'
+  | 'OTHER';
+
+export type DogOsActivityTypeInput = DogOsActivityType | Lowercase<DogOsActivityType>;
+
+/**
+ * Canonical dogOS activity write contract.
+ *
+ * `petIds` is the preferred multi-pet field. `petId` remains accepted so old
+ * clients can roll forward without a flag-day release. If both are supplied,
+ * the server de-duplicates them into one household activity.
+ */
+export interface CreateActivityRequest {
+  petIds?: string[];
+
+  /** @deprecated Prefer `petIds`, even for a one-dog activity. */
+  petId?: string;
+
+  householdId?: string;
+  startedAt?: string;
+  endedAt?: string;
+  type: DogOsActivityTypeInput;
+  route?: Record<string, unknown>;
+  humanMetrics?: Record<string, unknown>;
+  petMetrics?: Record<string, unknown>;
+  jointMetrics?: Record<string, unknown>;
+}
+
+export type UpdateActivityRequest = Partial<CreateActivityRequest>;

--- a/docs/DOGOS_ARCHITECTURE.md
+++ b/docs/DOGOS_ARCHITECTURE.md
@@ -1,0 +1,111 @@
+# dogOS Architecture
+
+## Product thesis
+
+dogOS is the household operating layer for life with dogs. The product should reduce care work, create more opportunities for a good relationship, or ideally do both.
+
+North star: **I take both dogs for a walk. I tap once. dogOS understands everything else.**
+
+## Foundation boundary
+
+The household is the coordination and authorization boundary:
+
+```text
+Household
+├── humans
+├── pets
+└── shared real-world activities
+    ├── human participants
+    └── pet participants
+```
+
+One physical event is one `Activity`. A walk involving multiple dogs is represented by one activity with multiple `ActivityPetParticipant` rows, never duplicated activity records.
+
+## Activity write contract
+
+The canonical client request is:
+
+```ts
+interface CreateActivityRequest {
+  petIds?: string[];
+  /** @deprecated Prefer petIds, even for one dog. */
+  petId?: string;
+  householdId?: string;
+  startedAt?: string;
+  endedAt?: string;
+  type: string;
+  route?: Record<string, unknown>;
+  humanMetrics?: Record<string, unknown>;
+  petMetrics?: Record<string, unknown>;
+  jointMetrics?: Record<string, unknown>;
+}
+```
+
+`petIds` is canonical. `petId` remains accepted for old clients. When either or both are present, the server de-duplicates the set and resolves a single household containing the selected pets. A request cannot combine pets from unrelated households.
+
+The currently shipped mobile form contract is normalized at the mobile API boundary before it reaches Nest validation. This preserves strict server-side whitelisting while allowing an incremental client rollout.
+
+## Reward semantics
+
+Adventure rewards remain server-authoritative:
+
+```text
+Activity -> CareEvent -> RewardPolicy -> RewardLedger
+```
+
+A shared activity may create one trusted care event per participating pet. The historical primary-pet dedupe key is retained so migrating a single-pet record cannot create a second reward. Additional pets receive stable pet-specific dedupe keys.
+
+## Privacy and safety invariants
+
+- Household and pet access fail closed.
+- Operational logs must not contain raw user, household, pet, token, location, or health identifiers unless a separately reviewed operational requirement explicitly demands it.
+- Nearby discovery must use an explicit privacy-preserving backend and consent model; clients must not emulate it by downloading broad owner/location data.
+- Tracker or behavioral deviations are signals, not diagnoses.
+- Medical or emergency flows are never gamified.
+- Connector access is least-privilege and revocable.
+
+## Database and rollout invariants
+
+- New dogOS schema changes are additive-only.
+- Existing `Pet.ownerId` and `Activity.petId` remain compatibility shims during migration.
+- Prisma `String @default(uuid())` identifiers in this repository are stored as PostgreSQL `TEXT` unless explicitly annotated otherwise.
+- Every dogOS layer begins dark behind a feature flag where it changes user-visible behavior.
+- Rollback means disable the feature and/or revert application code; additive history is retained rather than destructively down-migrated.
+
+## Layering
+
+```text
+dogOS
+├── Today
+│   ├── Adventure
+│   ├── Autopilot
+│   └── Our Story
+├── Household Wellbeing Graph
+│   ├── Humans
+│   ├── Pets
+│   ├── Activities
+│   ├── Care
+│   └── Costs
+└── Connectors
+    ├── calendars and weather
+    ├── wearables and care records
+    ├── providers
+    └── retail/services where sanctioned integrations exist
+```
+
+Higher layers compose lower-layer truth instead of creating parallel copies. Autopilot derives signals from household activities and care. Our Story composes activities, care events, Adventure events, and private media. Connectors normalize sanctioned external data into dogOS contracts. Concierge orchestrates those layers rather than owning a second recommendation database.
+
+## Phase 4A qualification contract
+
+The dogOS Foundation CI lane owns:
+
+1. frozen dependency installation;
+2. Prisma validation, canonical formatting, generation, full migration deploy, destructive-operation audit, and zero database/datamodel drift;
+3. Prettier on dogOS and touched mobile compatibility surfaces;
+4. zero-warning API lint on household/activity/pet integration surfaces;
+5. API and full mobile TypeScript checks;
+6. household authorization contracts;
+7. multi-pet activity/reward contracts; and
+8. production API build.
+
+The parent Adventure qualification must remain green on the same candidate head. PR #8 stays draft while its parent release branches remain unlanded; after the parent stack reaches `main`, dogOS must be restacked and qualified again.

--- a/packages/database/prisma/migrations/20260822064500_add_dogos_household_core/migration.sql
+++ b/packages/database/prisma/migrations/20260822064500_add_dogos_household_core/migration.sql
@@ -1,0 +1,163 @@
+-- dogOS household + multi-pet activity foundation
+-- Additive-only migration. Existing owner/pet/activity columns are retained for
+-- rolling compatibility while dogOS moves to household-scoped participation.
+--
+-- Prisma String @default(uuid()) is stored as TEXT in this schema unless the
+-- field is explicitly annotated @db.Uuid. Keep all dogOS identifiers and
+-- foreign keys aligned with the existing users/pets/activities TEXT ids.
+
+CREATE TABLE "households" (
+  "id" TEXT NOT NULL,
+  "name" TEXT NOT NULL DEFAULT 'My household',
+  "timezone" TEXT,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "households_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "household_members" (
+  "id" TEXT NOT NULL,
+  "household_id" TEXT NOT NULL,
+  "user_id" TEXT NOT NULL,
+  "role" TEXT NOT NULL DEFAULT 'MEMBER',
+  "status" TEXT NOT NULL DEFAULT 'ACTIVE',
+  "joined_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "household_members_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "household_pets" (
+  "id" TEXT NOT NULL,
+  "household_id" TEXT NOT NULL,
+  "pet_id" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'ACTIVE',
+  "joined_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "household_pets_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "activities" ADD COLUMN "household_id" TEXT;
+
+CREATE TABLE "activity_human_participants" (
+  "id" TEXT NOT NULL,
+  "activity_id" TEXT NOT NULL,
+  "user_id" TEXT NOT NULL,
+  "role" TEXT NOT NULL DEFAULT 'PARTICIPANT',
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "activity_human_participants_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "activity_pet_participants" (
+  "id" TEXT NOT NULL,
+  "activity_id" TEXT NOT NULL,
+  "pet_id" TEXT NOT NULL,
+  "metrics" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "activity_pet_participants_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "household_members_household_id_user_id_key"
+  ON "household_members"("household_id", "user_id");
+CREATE INDEX "household_members_user_id_status_idx"
+  ON "household_members"("user_id", "status");
+
+CREATE UNIQUE INDEX "household_pets_household_id_pet_id_key"
+  ON "household_pets"("household_id", "pet_id");
+CREATE INDEX "household_pets_pet_id_status_idx"
+  ON "household_pets"("pet_id", "status");
+
+CREATE INDEX "activities_household_id_started_at_idx"
+  ON "activities"("household_id", "started_at");
+
+CREATE UNIQUE INDEX "activity_human_participants_activity_id_user_id_key"
+  ON "activity_human_participants"("activity_id", "user_id");
+CREATE INDEX "activity_human_participants_user_id_idx"
+  ON "activity_human_participants"("user_id");
+
+CREATE UNIQUE INDEX "activity_pet_participants_activity_id_pet_id_key"
+  ON "activity_pet_participants"("activity_id", "pet_id");
+CREATE INDEX "activity_pet_participants_pet_id_idx"
+  ON "activity_pet_participants"("pet_id");
+
+ALTER TABLE "household_members"
+  ADD CONSTRAINT "household_members_household_id_fkey"
+  FOREIGN KEY ("household_id") REFERENCES "households"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "household_members"
+  ADD CONSTRAINT "household_members_user_id_fkey"
+  FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "household_pets"
+  ADD CONSTRAINT "household_pets_household_id_fkey"
+  FOREIGN KEY ("household_id") REFERENCES "households"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "household_pets"
+  ADD CONSTRAINT "household_pets_pet_id_fkey"
+  FOREIGN KEY ("pet_id") REFERENCES "pets"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "activities"
+  ADD CONSTRAINT "activities_household_id_fkey"
+  FOREIGN KEY ("household_id") REFERENCES "households"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "activity_human_participants"
+  ADD CONSTRAINT "activity_human_participants_activity_id_fkey"
+  FOREIGN KEY ("activity_id") REFERENCES "activities"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "activity_human_participants"
+  ADD CONSTRAINT "activity_human_participants_user_id_fkey"
+  FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "activity_pet_participants"
+  ADD CONSTRAINT "activity_pet_participants_activity_id_fkey"
+  FOREIGN KEY ("activity_id") REFERENCES "activities"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "activity_pet_participants"
+  ADD CONSTRAINT "activity_pet_participants_pet_id_fkey"
+  FOREIGN KEY ("pet_id") REFERENCES "pets"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Every existing account receives one deterministic personal household.
+-- Cast the MD5 through uuid only to produce the same hyphenated UUID-shaped text
+-- emitted by HouseholdsService.deterministicUuid; the stored database type is TEXT.
+INSERT INTO "households" ("id", "name", "created_at", "updated_at")
+SELECT md5('dogos-household:' || u."id")::uuid::text,
+       'My household',
+       CURRENT_TIMESTAMP,
+       CURRENT_TIMESTAMP
+FROM "users" u
+ON CONFLICT ("id") DO NOTHING;
+
+INSERT INTO "household_members" ("id", "household_id", "user_id", "role", "status", "joined_at")
+SELECT md5('dogos-household-member:' || u."id")::uuid::text,
+       md5('dogos-household:' || u."id")::uuid::text,
+       u."id",
+       'OWNER',
+       'ACTIVE',
+       CURRENT_TIMESTAMP
+FROM "users" u
+ON CONFLICT ("household_id", "user_id") DO NOTHING;
+
+INSERT INTO "household_pets" ("id", "household_id", "pet_id", "status", "joined_at")
+SELECT md5('dogos-household-pet:' || p."id")::uuid::text,
+       md5('dogos-household:' || p."owner_id")::uuid::text,
+       p."id",
+       'ACTIVE',
+       CURRENT_TIMESTAMP
+FROM "pets" p
+ON CONFLICT ("household_id", "pet_id") DO NOTHING;
+
+UPDATE "activities" a
+SET "household_id" = md5('dogos-household:' || a."user_id")::uuid::text
+WHERE a."household_id" IS NULL;
+
+INSERT INTO "activity_human_participants" ("id", "activity_id", "user_id", "role", "created_at")
+SELECT md5('dogos-activity-human:' || a."id" || ':' || a."user_id")::uuid::text,
+       a."id",
+       a."user_id",
+       'RECORDER',
+       a."created_at"
+FROM "activities" a
+ON CONFLICT ("activity_id", "user_id") DO NOTHING;
+
+INSERT INTO "activity_pet_participants" ("id", "activity_id", "pet_id", "metrics", "created_at")
+SELECT md5('dogos-activity-pet:' || a."id" || ':' || a."pet_id")::uuid::text,
+       a."id",
+       a."pet_id",
+       a."pet_metrics",
+       a."created_at"
+FROM "activities" a
+WHERE a."pet_id" IS NOT NULL
+ON CONFLICT ("activity_id", "pet_id") DO NOTHING;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -33,32 +33,34 @@ model User {
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt @map("updated_at")
 
-  pets                     Pet[]
-  activities               Activity[]
-  posts                    Post[]
-  likes                    Like[]
-  comments                 Comment[]
-  notifications            Notification[]
-  integrationTokens        IntegrationToken[]
-  mutualGoals              MutualGoal[]
-  meetups                  Meetup[]
-  meetupInvites            MeetupInvite[]
-  redeemedRewards          Reward[]
-  quizResponses            QuizResponse[]
-  featureVector            MLFeatureVector?
-  conversationParticipants ConversationParticipant[]
-  messages                 Message[]
-  verifications            Verification[]            @relation("UserVerifications")
-  hostedEvents             CommunityEvent[]          @relation("EventHost")
-  eventRsvps               EventRSVP[]               @relation("EventRSVPs")
-  eventFeedbacks           EventFeedback[]           @relation("EventFeedbacks")
-  locationPings            LocationPing[]            @relation("UserLocationPings")
-  mediaAssets              MediaAsset[]
-  mediaAlbums              MediaAlbum[]
-  mediaExternalReferences  MediaExternalReference[]
-  careEvents               CareEvent[]
-  rewardLedgerEntries      RewardLedger[]
-  questInteractions        QuestInteraction[]
+  pets                      Pet[]
+  activities                Activity[]
+  householdMemberships      HouseholdMember[]
+  activityHumanParticipants ActivityHumanParticipant[]
+  posts                     Post[]
+  likes                     Like[]
+  comments                  Comment[]
+  notifications             Notification[]
+  integrationTokens         IntegrationToken[]
+  mutualGoals               MutualGoal[]
+  meetups                   Meetup[]
+  meetupInvites             MeetupInvite[]
+  redeemedRewards           Reward[]
+  quizResponses             QuizResponse[]
+  featureVector             MLFeatureVector?
+  conversationParticipants  ConversationParticipant[]
+  messages                  Message[]
+  verifications             Verification[]             @relation("UserVerifications")
+  hostedEvents              CommunityEvent[]           @relation("EventHost")
+  eventRsvps                EventRSVP[]                @relation("EventRSVPs")
+  eventFeedbacks            EventFeedback[]            @relation("EventFeedbacks")
+  locationPings             LocationPing[]             @relation("UserLocationPings")
+  mediaAssets               MediaAsset[]
+  mediaAlbums               MediaAlbum[]
+  mediaExternalReferences   MediaExternalReference[]
+  careEvents                CareEvent[]
+  rewardLedgerEntries       RewardLedger[]
+  questInteractions         QuestInteraction[]
 
   @@map("users")
 }
@@ -81,6 +83,8 @@ model Pet {
   owner                   User                     @relation(fields: [ownerId], references: [id], onDelete: Cascade)
   devices                 Device[]
   activities              Activity[]
+  householdMemberships    HouseholdPet[]
+  activityParticipations  ActivityPetParticipant[]
   posts                   Post[]
   mutualGoals             MutualGoal[]
   meetupInvites           MeetupInvite[]
@@ -114,6 +118,55 @@ model Device {
 }
 
 // ============================================
+// dogOS HOUSEHOLDS
+// ============================================
+
+model Household {
+  id        String   @id @default(uuid())
+  name      String   @default("My household")
+  timezone  String?
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  members    HouseholdMember[]
+  pets       HouseholdPet[]
+  activities Activity[]
+
+  @@map("households")
+}
+
+model HouseholdMember {
+  id          String   @id @default(uuid())
+  householdId String   @map("household_id")
+  userId      String   @map("user_id")
+  role        String   @default("MEMBER")
+  status      String   @default("ACTIVE")
+  joinedAt    DateTime @default(now()) @map("joined_at")
+
+  household Household @relation(fields: [householdId], references: [id], onDelete: Cascade)
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([householdId, userId])
+  @@index([userId, status])
+  @@map("household_members")
+}
+
+model HouseholdPet {
+  id          String   @id @default(uuid())
+  householdId String   @map("household_id")
+  petId       String   @map("pet_id")
+  status      String   @default("ACTIVE")
+  joinedAt    DateTime @default(now()) @map("joined_at")
+
+  household Household @relation(fields: [householdId], references: [id], onDelete: Cascade)
+  pet       Pet       @relation(fields: [petId], references: [id], onDelete: Cascade)
+
+  @@unique([householdId, petId])
+  @@index([petId, status])
+  @@map("household_pets")
+}
+
+// ============================================
 // ACTIVITIES & FITNESS
 // ============================================
 
@@ -121,23 +174,58 @@ model Activity {
   id           String    @id @default(uuid())
   userId       String    @map("user_id")
   petId        String?   @map("pet_id")
+  householdId  String?   @map("household_id")
   startedAt    DateTime  @map("started_at")
   endedAt      DateTime? @map("ended_at")
   type         String // WALK, RUN, PLAY, HIKE
   route        Json? // GeoJSON
   humanMetrics Json?     @map("human_metrics") // {steps, calories, hr_avg}
-  petMetrics   Json?     @map("pet_metrics") // {distance, active_time}
+  petMetrics   Json?     @map("pet_metrics") // legacy primary-pet metrics
   jointMetrics Json?     @map("joint_metrics") // {sync_score}
   createdAt    DateTime  @default(now()) @map("created_at")
 
-  user  User   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  pet   Pet?   @relation(fields: [petId], references: [id], onDelete: SetNull)
-  posts Post[]
+  user              User                       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  pet               Pet?                       @relation(fields: [petId], references: [id], onDelete: SetNull)
+  household         Household?                 @relation(fields: [householdId], references: [id], onDelete: SetNull)
+  humanParticipants ActivityHumanParticipant[]
+  petParticipants   ActivityPetParticipant[]
+  posts             Post[]
 
   @@index([userId])
   @@index([petId])
+  @@index([householdId, startedAt])
   @@index([startedAt])
   @@map("activities")
+}
+
+model ActivityHumanParticipant {
+  id         String   @id @default(uuid())
+  activityId String   @map("activity_id")
+  userId     String   @map("user_id")
+  role       String   @default("PARTICIPANT")
+  createdAt  DateTime @default(now()) @map("created_at")
+
+  activity Activity @relation(fields: [activityId], references: [id], onDelete: Cascade)
+  user     User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([activityId, userId])
+  @@index([userId])
+  @@map("activity_human_participants")
+}
+
+model ActivityPetParticipant {
+  id         String   @id @default(uuid())
+  activityId String   @map("activity_id")
+  petId      String   @map("pet_id")
+  metrics    Json?
+  createdAt  DateTime @default(now()) @map("created_at")
+
+  activity Activity @relation(fields: [activityId], references: [id], onDelete: Cascade)
+  pet      Pet      @relation(fields: [petId], references: [id], onDelete: Cascade)
+
+  @@unique([activityId, petId])
+  @@index([petId])
+  @@map("activity_pet_participants")
 }
 
 model MutualGoal {


### PR DESCRIPTION
## dogOS thesis

This is the first architectural slice of Woof as **dogOS**: one calm interface over life with dogs, rather than another isolated training/tracking app.

The load-bearing change is to make the **household** the coordination boundary and to make one real-world activity capable of containing **multiple human and pet participants**.

> North star: **I take both dogs for a walk. I tap once. dogOS understands everything else.**

## Final stack state

PR #7 Media Library / intelligence and PR #6 Adventure are merged. This PR has been cleanly restacked directly onto final Adventure `main` at `f23ba716d7c39d9c1bb34da49735b8ad0440d6f8`.

The historical stacked branch was reduced to the actual dogOS Foundation delta. Baseline-only mobile repairs and stale package/lockfile changes were intentionally dropped so the strict platform guarantees already landed in #7 and #6 remain authoritative.

## Phase 4A: dogOS Foundation

- additive `Household`, `HouseholdMember`, and `HouseholdPet` persistence
- deterministic personal-household bootstrap for existing/new accounts
- additive `ActivityHumanParticipant` and `ActivityPetParticipant` persistence
- compatibility-preserving `Activity.petId` + `Pet.ownerId` fields retained during migration
- existing activities backfilled into personal households and participant rows
- authenticated household snapshot and household pet-management API
- new pets join the owner's personal household automatically
- activity creation accepts canonical `petIds[]`, optional `householdId`, and deprecated `petId`
- legacy `petId` is upgraded server-side into the same household-participant storage path
- one shared activity emits one trusted Adventure care/reward event per participating pet
- historical primary-pet reward dedupe key is preserved to avoid double awards after migration
- household members can read shared household activity history; mutation remains recorder-owned for this first slice
- mobile activity request/response contract matches server pagination and the multi-pet model
- strict mobile lint remains `expo lint --max-warnings=0`

## Exact-head qualification

**Qualified head:** `c051bb18b802126cfe1e1f17e96720da179c3094`

**dogOS Foundation CI:** run `32601681170` / #24 — **green**

- frozen lockfile install
- Prisma validate + format + generate
- additive-migration destructive-SQL audit
- full migration deploy
- zero Prisma/database drift
- dogOS release-surface formatting
- zero-warning dogOS API lint
- strict zero-warning mobile lint
- API type-check
- mobile type-check
- household authorization/bootstrapping contract tests
- multi-pet activity/reward contract tests
- API production build

**Inherited Adventure System CI:** run `32601681371` / #292 — **green** on the same exact head.

**Root CI:** run `32601681259` / #280 — **green** on the same exact head, including full static quality gates, backend unit/API tests, Chromium smoke/accessibility/visual contracts, ML policy contracts, and API/Web production builds.

## Safety / privacy invariants

- additive-only migration
- household access is membership-scoped
- pet access fails closed
- no raw household/user identifiers are added to operational logs
- Adventure reward policy remains server-authoritative
- emergency and Health Lens boundaries remain unchanged
- backward-compatible single-pet clients remain supported
- recorder ownership remains required for activity mutation

## Focused contract coverage

The foundation includes nine focused service contracts covering deterministic personal household selection, existing-pet bootstrap, coherent shared-household selection, cross-household rejection, manager-only mutations, one multi-pet activity row, one trusted reward event per participating pet with stable dedupe keys, legacy single-pet compatibility, and impossible chronology rejection.

## Next dogOS slices

1. **Autopilot** — tracker ingestion, rhythm-aware suggestions, reminders, baseline-change alerts
2. **Our Story** — unified longitudinal timeline, milestones, curated private memories, life statistics
3. **Connectors** — normalized wearable/vet/service/retail integration boundary with OAuth/webhook contracts
4. **Concierge** — context-aware daily briefing, bounded nudges, predictive preparation, life-change adaptation

Each slice will ship behind its own feature flag and remain independently reviewable and rollbackable.