### PR TITLE
dogOS Autopilot: trusted tracker summaries, reminders, and bounded signals

### DIFF
--- a/.github/workflows/dogos-autopilot-ci.yml
+++ b/.github/workflows/dogos-autopilot-ci.yml
@@ -72,15 +72,21 @@ jobs:
         run: pnpm --filter @woof/database db:migrate:deploy
 
       - name: Check Autopilot formatting
-        run: >-
-          pnpm exec prettier --check
-          apps/api/.env.example
-          apps/api/src/autopilot
-          apps/api/src/care-events/care-event.types.ts
-          apps/api/src/app.module.ts
-          apps/api/src/config/env.validation.ts
-          .github/workflows/dogos-autopilot-ci.yml
-          docs/DOGOS_AUTOPILOT.md
+        run: |
+          pnpm exec prettier --write \
+            apps/api/src/autopilot \
+            apps/api/src/care-events/care-event.types.ts \
+            apps/api/src/app.module.ts \
+            apps/api/src/config/env.validation.ts \
+            .github/workflows/dogos-autopilot-ci.yml \
+            docs/DOGOS_AUTOPILOT.md
+          git diff --exit-code -- \
+            apps/api/src/autopilot \
+            apps/api/src/care-events/care-event.types.ts \
+            apps/api/src/app.module.ts \
+            apps/api/src/config/env.validation.ts \
+            .github/workflows/dogos-autopilot-ci.yml \
+            docs/DOGOS_AUTOPILOT.md
 
       - name: Lint Autopilot release surface
         run: >-

--- a/.github/workflows/dogos-autopilot-ci.yml
+++ b/.github/workflows/dogos-autopilot-ci.yml
@@ -1,0 +1,113 @@
+name: dogOS Autopilot CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/autopilot/**'
+      - 'apps/api/src/care-events/care-event.types.ts'
+      - 'apps/api/src/app.module.ts'
+      - 'apps/api/src/config/env.validation.ts'
+      - 'apps/api/.env.example'
+      - '.github/workflows/dogos-autopilot-ci.yml'
+      - 'docs/DOGOS_AUTOPILOT.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-autopilot-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  qualify:
+    name: Autopilot observation + reminder qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+      SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_shadow
+      JWT_SECRET: ci-only-autopilot-secret
+      NODE_ENV: test
+      ML_SERVICE_ENABLED: 'false'
+      ENABLE_ADVENTURE_SYSTEM: 'true'
+      ENABLE_DOGOS_AUTOPILOT: 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Apply inherited migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check Autopilot formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/.env.example
+          apps/api/src/autopilot
+          apps/api/src/care-events/care-event.types.ts
+          apps/api/src/app.module.ts
+          apps/api/src/config/env.validation.ts
+          .github/workflows/dogos-autopilot-ci.yml
+          docs/DOGOS_AUTOPILOT.md
+
+      - name: Lint Autopilot release surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          'src/autopilot/**/*.ts'
+          src/care-events/care-event.types.ts
+          src/app.module.ts
+          src/config/env.validation.ts
+
+      - name: Reject direct canonical pet mutations from Autopilot
+        run: |
+          if grep -REn '\.(pet)\.(create|update|delete|upsert|createMany|updateMany|deleteMany)\b' apps/api/src/autopilot; then
+            echo 'Autopilot providers/signals must never mutate canonical Pet records directly.'
+            exit 1
+          fi
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Run provider privacy contracts
+        run: pnpm --filter @woof/api exec jest src/autopilot/provider-adapters.spec.ts --runInBand
+
+      - name: Run Autopilot service contracts
+        run: pnpm --filter @woof/api exec jest src/autopilot/autopilot.service.spec.ts --runInBand
+
+      - name: Run Adventure reward policy contracts
+        run: pnpm --filter @woof/api exec jest src/care-events/reward-policy.spec.ts --runInBand
+
+      - name: Build API
+        run: pnpm --filter @woof/api build

--- a/.github/workflows/dogos-autopilot-ci.yml
+++ b/.github/workflows/dogos-autopilot-ci.yml
@@ -12,6 +12,7 @@ on:
       - 'apps/web/src/app/autopilot/**'
       - 'apps/web/src/components/bottom-nav.tsx'
       - 'apps/web/src/lib/api/autopilot.ts'
+      - 'apps/web/src/lib/api/autopilot.spec.ts'
       - 'apps/web/src/lib/api/households.ts'
       - '.github/workflows/dogos-autopilot-ci.yml'
       - 'docs/DOGOS_AUTOPILOT.md'
@@ -86,6 +87,7 @@ jobs:
             apps/web/src/app/autopilot \
             apps/web/src/components/bottom-nav.tsx \
             apps/web/src/lib/api/autopilot.ts \
+            apps/web/src/lib/api/autopilot.spec.ts \
             apps/web/src/lib/api/households.ts \
             .github/workflows/dogos-autopilot-ci.yml \
             docs/DOGOS_AUTOPILOT.md
@@ -97,6 +99,7 @@ jobs:
             apps/web/src/app/autopilot \
             apps/web/src/components/bottom-nav.tsx \
             apps/web/src/lib/api/autopilot.ts \
+            apps/web/src/lib/api/autopilot.spec.ts \
             apps/web/src/lib/api/households.ts \
             .github/workflows/dogos-autopilot-ci.yml \
             docs/DOGOS_AUTOPILOT.md
@@ -115,6 +118,7 @@ jobs:
           src/app/autopilot/page.tsx
           src/components/bottom-nav.tsx
           src/lib/api/autopilot.ts
+          src/lib/api/autopilot.spec.ts
           src/lib/api/households.ts
 
       - name: Reject direct canonical pet mutations from Autopilot

--- a/.github/workflows/dogos-autopilot-ci.yml
+++ b/.github/workflows/dogos-autopilot-ci.yml
@@ -9,6 +9,10 @@ on:
       - 'apps/api/src/app.module.ts'
       - 'apps/api/src/config/env.validation.ts'
       - 'apps/api/.env.example'
+      - 'apps/web/src/app/autopilot/**'
+      - 'apps/web/src/components/bottom-nav.tsx'
+      - 'apps/web/src/lib/api/autopilot.ts'
+      - 'apps/web/src/lib/api/households.ts'
       - '.github/workflows/dogos-autopilot-ci.yml'
       - 'docs/DOGOS_AUTOPILOT.md'
 
@@ -22,6 +26,7 @@ concurrency:
 env:
   NODE_VERSION: '20.20.2'
   PNPM_VERSION: '8.15.1'
+  NEXT_PUBLIC_API_URL: http://127.0.0.1:59999/api/v1
 
 jobs:
   qualify:
@@ -78,6 +83,10 @@ jobs:
             apps/api/src/care-events/care-event.types.ts \
             apps/api/src/app.module.ts \
             apps/api/src/config/env.validation.ts \
+            apps/web/src/app/autopilot \
+            apps/web/src/components/bottom-nav.tsx \
+            apps/web/src/lib/api/autopilot.ts \
+            apps/web/src/lib/api/households.ts \
             .github/workflows/dogos-autopilot-ci.yml \
             docs/DOGOS_AUTOPILOT.md
           git diff --exit-code -- \
@@ -85,16 +94,28 @@ jobs:
             apps/api/src/care-events/care-event.types.ts \
             apps/api/src/app.module.ts \
             apps/api/src/config/env.validation.ts \
+            apps/web/src/app/autopilot \
+            apps/web/src/components/bottom-nav.tsx \
+            apps/web/src/lib/api/autopilot.ts \
+            apps/web/src/lib/api/households.ts \
             .github/workflows/dogos-autopilot-ci.yml \
             docs/DOGOS_AUTOPILOT.md
 
-      - name: Lint Autopilot release surface
+      - name: Lint Autopilot API surface
         run: >-
           pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
           'src/autopilot/**/*.ts'
           src/care-events/care-event.types.ts
           src/app.module.ts
           src/config/env.validation.ts
+
+      - name: Lint Autopilot web surface
+        run: >-
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/app/autopilot/page.tsx
+          src/components/bottom-nav.tsx
+          src/lib/api/autopilot.ts
+          src/lib/api/households.ts
 
       - name: Reject direct canonical pet mutations from Autopilot
         run: |
@@ -106,6 +127,9 @@ jobs:
       - name: Type-check API
         run: pnpm --filter @woof/api type-check
 
+      - name: Type-check web app
+        run: pnpm --filter @woof/web type-check
+
       - name: Run provider privacy contracts
         run: pnpm --filter @woof/api exec jest src/autopilot/provider-adapters.spec.ts --runInBand
 
@@ -115,5 +139,13 @@ jobs:
       - name: Run Adventure reward policy contracts
         run: pnpm --filter @woof/api exec jest src/care-events/reward-policy.spec.ts --runInBand
 
+      - name: Run web contracts
+        run: pnpm --filter @woof/web test
+
       - name: Build API
         run: pnpm --filter @woof/api build
+
+      - name: Build web app
+        env:
+          NEXT_PUBLIC_API_URL: https://api.example.com/api/v1
+        run: pnpm --filter @woof/web build

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -17,6 +17,11 @@ JWT_EXPIRES_IN=7d
 # CORS
 CORS_ORIGIN=http://localhost:3000,http://localhost:3001
 
+# Feature rollouts
+# Experimental product surfaces default on outside production and disappear when disabled.
+ENABLE_ADVENTURE_SYSTEM=true
+ENABLE_DOGOS_AUTOPILOT=true
+
 # File Upload
 MAX_FILE_SIZE=10485760
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -9,6 +9,7 @@ import { AdventureModule } from './adventure/adventure.module';
 import { AnalyticsModule } from './analytics/analytics.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AutopilotModule } from './autopilot/autopilot.module';
 import { AuthModule } from './auth/auth.module';
 import { BehaviorVisionModule } from './behavior-vision/behavior-vision.module';
 import { ChatModule } from './chat/chat.module';
@@ -66,6 +67,7 @@ export const throttlerOptions: ThrottlerModuleOptions = {
     HouseholdsModule,
     ActivitiesModule,
     AdventureModule,
+    AutopilotModule,
     SocialModule,
     MeetupsModule,
     CompatibilityModule,

--- a/apps/api/src/autopilot/autopilot-enabled.guard.ts
+++ b/apps/api/src/autopilot/autopilot-enabled.guard.ts
@@ -1,0 +1,17 @@
+import { CanActivate, Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class AutopilotEnabledGuard implements CanActivate {
+  constructor(private readonly config: ConfigService) {}
+
+  canActivate(): boolean {
+    const configured = this.config.get<string>('ENABLE_DOGOS_AUTOPILOT');
+    const enabled =
+      configured === 'true' ||
+      (configured !== 'false' && this.config.get<string>('NODE_ENV') !== 'production');
+
+    if (!enabled) throw new NotFoundException();
+    return true;
+  }
+}

--- a/apps/api/src/autopilot/autopilot.controller.ts
+++ b/apps/api/src/autopilot/autopilot.controller.ts
@@ -26,7 +26,7 @@ export class AutopilotController {
   ingestObservation(
     @Request() req: AuthenticatedRequest,
     @Param('provider') provider: string,
-    @Body() dto: IngestTrackerObservationDto,
+    @Body() dto: IngestTrackerObservationDto
   ) {
     return this.autopilot.ingestProviderObservation(req.user.sub, provider, dto);
   }

--- a/apps/api/src/autopilot/autopilot.controller.ts
+++ b/apps/api/src/autopilot/autopilot.controller.ts
@@ -1,0 +1,51 @@
+import { Body, Controller, Delete, Get, Param, Post, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { AuthenticatedRequest } from '../auth/authenticated-request';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AutopilotEnabledGuard } from './autopilot-enabled.guard';
+import { AutopilotService } from './autopilot.service';
+import { CreateCareReminderDto, IngestTrackerObservationDto } from './dto/autopilot.dto';
+
+@ApiTags('autopilot')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, AutopilotEnabledGuard)
+@Controller('autopilot')
+export class AutopilotController {
+  constructor(private readonly autopilot: AutopilotService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get reminders, non-diagnostic signals, and provider capabilities' })
+  getDashboard(@Request() req: AuthenticatedRequest) {
+    return this.autopilot.getDashboard(req.user.sub);
+  }
+
+  @Post('observations/:provider')
+  @ApiOperation({
+    summary: 'Normalize a connected tracker summary into a private zero-reward observation',
+  })
+  ingestObservation(
+    @Request() req: AuthenticatedRequest,
+    @Param('provider') provider: string,
+    @Body() dto: IngestTrackerObservationDto,
+  ) {
+    return this.autopilot.ingestProviderObservation(req.user.sub, provider, dto);
+  }
+
+  @Post('reminders')
+  @ApiOperation({ summary: 'Schedule a dogOS care reminder' })
+  createReminder(@Request() req: AuthenticatedRequest, @Body() dto: CreateCareReminderDto) {
+    return this.autopilot.createReminder(req.user.sub, dto);
+  }
+
+  @Delete('reminders/:id')
+  @ApiOperation({ summary: 'Cancel a scheduled care reminder' })
+  cancelReminder(@Request() req: AuthenticatedRequest, @Param('id') id: string) {
+    return this.autopilot.cancelReminder(req.user.sub, id);
+  }
+
+  @Post('signals/:id/acknowledge')
+  @ApiOperation({ summary: 'Acknowledge a non-diagnostic Autopilot signal' })
+  acknowledgeSignal(@Request() req: AuthenticatedRequest, @Param('id') id: string) {
+    return this.autopilot.acknowledgeSignal(req.user.sub, id);
+  }
+}

--- a/apps/api/src/autopilot/autopilot.module.ts
+++ b/apps/api/src/autopilot/autopilot.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { CareEventsModule } from '../care-events/care-events.module';
+import { HouseholdsModule } from '../households/households.module';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { AutopilotEnabledGuard } from './autopilot-enabled.guard';
+import { AutopilotController } from './autopilot.controller';
+import { AutopilotService } from './autopilot.service';
+
+@Module({
+  imports: [CareEventsModule, HouseholdsModule, NotificationsModule],
+  controllers: [AutopilotController],
+  providers: [AutopilotEnabledGuard, AutopilotService],
+  exports: [AutopilotService],
+})
+export class AutopilotModule {}

--- a/apps/api/src/autopilot/autopilot.service.spec.ts
+++ b/apps/api/src/autopilot/autopilot.service.spec.ts
@@ -8,6 +8,17 @@ const userId = '11111111-1111-4111-8111-111111111111';
 const petId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 
 function createHarness() {
+  const careEvents = {
+    record: jest.fn().mockResolvedValue({
+      careEventId: 'care-event-1',
+      ledgerId: 'ledger-1',
+      bondXp: 0,
+      pathway: 'MOVE',
+      policyVersion: 'bond-xp-v1',
+      explanation: 'not eligible',
+      duplicate: false,
+    }),
+  };
   const txNotification = {
     findFirst: jest.fn(),
     create: jest.fn().mockImplementation(({ data }) =>
@@ -26,6 +37,22 @@ function createHarness() {
   };
   const prisma = {
     pet: { findFirst: jest.fn().mockResolvedValue({ id: petId }) },
+    careEvent: {
+      findFirst: jest.fn().mockImplementation(() => {
+        const input = careEvents.record.mock.calls.at(-1)?.[0] as
+          | {
+              eventType?: string;
+              occurredAt?: Date;
+              context?: Record<string, unknown>;
+            }
+          | undefined;
+        return Promise.resolve({
+          eventType: input?.eventType ?? 'TRACKER_DAILY_ACTIVITY',
+          occurredAt: input?.occurredAt ?? new Date('2026-08-22T08:00:00.000Z'),
+          context: input?.context ?? {},
+        });
+      }),
+    },
     notification: {
       create: jest.fn().mockImplementation(({ data }) =>
         Promise.resolve({
@@ -44,17 +71,6 @@ function createHarness() {
     $transaction: jest.fn(async (callback: (client: typeof tx) => Promise<unknown>) =>
       callback(tx)
     ),
-  };
-  const careEvents = {
-    record: jest.fn().mockResolvedValue({
-      careEventId: 'care-event-1',
-      ledgerId: 'ledger-1',
-      bondXp: 0,
-      pathway: 'MOVE',
-      policyVersion: 'bond-xp-v1',
-      explanation: 'not eligible',
-      duplicate: false,
-    }),
   };
   const households = {
     assertPetAccessible: jest.fn().mockResolvedValue({ id: petId }),
@@ -103,16 +119,19 @@ describe('AutopilotService', () => {
         safetyEligible: false,
         dedupeKey: `autopilot:fi:${petId}:fi-day-1`,
         context: expect.objectContaining({
+          provider: 'FI',
+          externalEventId: 'fi-day-1',
           privacyClass: 'SUMMARY_ONLY',
           nonDiagnostic: true,
           activityMinutes: 74,
         }),
       })
     );
+    expect(result.observation.metrics.activityMinutes).toBe(74);
   });
 
-  it('repairs a missing signal when a provider replay finds the CareEvent already committed', async () => {
-    const { service, careEvents, tx, txNotification } = createHarness();
+  it('repairs a missing signal from the persisted CareEvent rather than altered replay metrics', async () => {
+    const { service, careEvents, prisma, tx, txNotification } = createHarness();
     careEvents.record.mockResolvedValue({
       careEventId: 'care-event-existing',
       ledgerId: 'ledger-existing',
@@ -122,23 +141,38 @@ describe('AutopilotService', () => {
       explanation: 'duplicate',
       duplicate: true,
     });
+    prisma.careEvent.findFirst.mockResolvedValue({
+      eventType: 'TRACKER_DEVICE_STATUS',
+      occurredAt: new Date('2026-08-22T08:00:00.000Z'),
+      context: {
+        provider: 'TRACTIVE',
+        externalEventId: 'same-event',
+        observationKind: 'DEVICE_STATUS',
+        batteryPercent: 9,
+        deviceState: 'ONLINE',
+      },
+    });
     txNotification.findFirst.mockResolvedValue(null);
 
     const result = await service.ingestProviderObservation(userId, 'tractive', {
       petId,
       externalEventId: 'same-event',
       kind: 'DEVICE_STATUS',
-      observedAt: '2026-08-22T08:00:00.000Z',
-      payload: { batteryPercent: 9 },
+      observedAt: '2026-08-22T12:00:00.000Z',
+      payload: { batteryPercent: 80 },
     });
 
     expect(result.duplicate).toBe(true);
+    expect(result.observation.metrics.batteryPercent).toBe(9);
+    expect(result.observation.observedAt.toISOString()).toBe('2026-08-22T08:00:00.000Z');
     expect(result.signal).toEqual(
       expect.objectContaining({
         id: 'signal-new',
         payload: expect.objectContaining({
           sourceCareEventId: 'care-event-existing',
           signalType: 'TRACKER_BATTERY_LOW',
+          observedAt: '2026-08-22T08:00:00.000Z',
+          evidence: { batteryPercent: 9, provider: 'TRACTIVE' },
         }),
       })
     );
@@ -147,7 +181,7 @@ describe('AutopilotService', () => {
   });
 
   it('returns an existing replay signal without duplicating it, even after acknowledgement', async () => {
-    const { service, careEvents, txNotification } = createHarness();
+    const { service, careEvents, prisma, txNotification } = createHarness();
     careEvents.record.mockResolvedValue({
       careEventId: 'care-event-existing',
       ledgerId: 'ledger-existing',
@@ -156,6 +190,16 @@ describe('AutopilotService', () => {
       policyVersion: 'bond-xp-v1',
       explanation: 'duplicate',
       duplicate: true,
+    });
+    prisma.careEvent.findFirst.mockResolvedValue({
+      eventType: 'TRACKER_DEVICE_STATUS',
+      occurredAt: new Date('2026-08-22T08:00:00.000Z'),
+      context: {
+        provider: 'TRACTIVE',
+        externalEventId: 'same-event',
+        observationKind: 'DEVICE_STATUS',
+        batteryPercent: 9,
+      },
     });
     txNotification.findFirst.mockResolvedValue({
       id: 'signal-existing',

--- a/apps/api/src/autopilot/autopilot.service.spec.ts
+++ b/apps/api/src/autopilot/autopilot.service.spec.ts
@@ -1,0 +1,262 @@
+import { CareEventsService } from '../care-events/care-events.service';
+import { HouseholdsService } from '../households/households.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AutopilotService } from './autopilot.service';
+
+const userId = '11111111-1111-4111-8111-111111111111';
+const petId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function createHarness() {
+  const txNotification = {
+    findFirst: jest.fn(),
+    update: jest.fn(),
+  };
+  const tx = {
+    $queryRaw: jest.fn().mockResolvedValue([{ acquired: true }]),
+    notification: txNotification,
+  };
+  const prisma = {
+    pet: { findFirst: jest.fn().mockResolvedValue({ id: petId }) },
+    notification: {
+      create: jest.fn().mockImplementation(({ data }) =>
+        Promise.resolve({ id: `notification-${Math.random()}`, ...data, readAt: null, createdAt: new Date() }),
+      ),
+      findMany: jest.fn().mockResolvedValue([]),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn(),
+    },
+    $queryRaw: jest.fn().mockResolvedValue([]),
+    $transaction: jest.fn(async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx)),
+  };
+  const careEvents = {
+    record: jest.fn().mockResolvedValue({
+      careEventId: 'care-event-1',
+      ledgerId: 'ledger-1',
+      bondXp: 0,
+      pathway: 'MOVE',
+      policyVersion: 'bond-xp-v1',
+      explanation: 'not eligible',
+      duplicate: false,
+    }),
+  };
+  const households = {
+    assertPetAccessible: jest.fn().mockResolvedValue({ id: petId }),
+  };
+  const notifications = {
+    sendPushNotification: jest.fn().mockResolvedValue({ success: true }),
+  };
+
+  return {
+    prisma,
+    tx,
+    txNotification,
+    careEvents,
+    households,
+    notifications,
+    service: new AutopilotService(
+      prisma as unknown as PrismaService,
+      careEvents as unknown as CareEventsService,
+      households as unknown as HouseholdsService,
+      notifications as unknown as NotificationsService,
+    ),
+  };
+}
+
+describe('AutopilotService', () => {
+  it('records wearable summaries as private zero-reward CareEvents', async () => {
+    const { service, careEvents } = createHarness();
+
+    const result = await service.ingestProviderObservation(userId, 'fi', {
+      petId,
+      externalEventId: 'fi-day-1',
+      kind: 'DAILY_ACTIVITY',
+      observedAt: '2026-08-22T08:00:00.000Z',
+      payload: { activityMinutes: 74, steps: 9200 },
+    });
+
+    expect(result.bondXp).toBe(0);
+    expect(careEvents.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId,
+        petId,
+        eventType: 'TRACKER_DAILY_ACTIVITY',
+        source: 'AUTOPILOT_FI',
+        evidenceType: 'WEARABLE',
+        visibility: 'PRIVATE',
+        safetyEligible: false,
+        dedupeKey: `autopilot:fi:${petId}:fi-day-1`,
+        context: expect.objectContaining({
+          privacyClass: 'SUMMARY_ONLY',
+          nonDiagnostic: true,
+          activityMinutes: 74,
+        }),
+      }),
+    );
+  });
+
+  it('does not create a second signal when a provider event is replayed', async () => {
+    const { service, careEvents, prisma } = createHarness();
+    careEvents.record.mockResolvedValue({
+      careEventId: 'care-event-existing',
+      ledgerId: 'ledger-existing',
+      bondXp: 0,
+      pathway: 'CARE',
+      policyVersion: 'bond-xp-v1',
+      explanation: 'duplicate',
+      duplicate: true,
+    });
+
+    const result = await service.ingestProviderObservation(userId, 'tractive', {
+      petId,
+      externalEventId: 'same-event',
+      kind: 'DEVICE_STATUS',
+      observedAt: '2026-08-22T08:00:00.000Z',
+      payload: { batteryPercent: 9 },
+    });
+
+    expect(result.duplicate).toBe(true);
+    expect(result.signal).toBeNull();
+    expect(prisma.notification.create).not.toHaveBeenCalled();
+  });
+
+  it('requires a meaningful baseline before producing a lower-activity check-in', async () => {
+    const { service, prisma } = createHarness();
+    prisma.$queryRaw.mockResolvedValue([
+      { activity_minutes: 80 },
+      { activity_minutes: 75 },
+      { activity_minutes: 78 },
+      { activity_minutes: 82 },
+      { activity_minutes: 76 },
+    ]);
+
+    const result = await service.ingestProviderObservation(userId, 'fi', {
+      petId,
+      externalEventId: 'fi-low-sparse',
+      kind: 'DAILY_ACTIVITY',
+      observedAt: '2026-08-22T08:00:00.000Z',
+      payload: { activityMinutes: 18 },
+    });
+
+    expect(result.signal).toBeNull();
+    expect(prisma.notification.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a non-diagnostic check-in only for a large drop against six or more prior summaries', async () => {
+    const { service, prisma } = createHarness();
+    prisma.$queryRaw.mockResolvedValue([
+      { activity_minutes: 80 },
+      { activity_minutes: 76 },
+      { activity_minutes: 78 },
+      { activity_minutes: 82 },
+      { activity_minutes: 74 },
+      { activity_minutes: 79 },
+      { activity_minutes: 81 },
+    ]);
+
+    const result = await service.ingestProviderObservation(userId, 'tractive', {
+      petId,
+      externalEventId: 'tractive-low-1',
+      kind: 'DAILY_ACTIVITY',
+      observedAt: '2026-08-22T08:00:00.000Z',
+      payload: { activeMinutes: 25 },
+    });
+
+    expect(result.signal?.payload).toEqual(
+      expect.objectContaining({
+        signalType: 'ACTIVITY_BELOW_RECENT_BASELINE',
+        level: 'CHECK_IN',
+        nonDiagnostic: true,
+        evidence: expect.objectContaining({
+          currentActivityMinutes: 25,
+          baselineSamples: 7,
+          provider: 'TRACTIVE',
+        }),
+      }),
+    );
+  });
+
+  it('creates an informational low-battery signal without health claims', async () => {
+    const { service } = createHarness();
+
+    const result = await service.ingestProviderObservation(userId, 'fi', {
+      petId,
+      externalEventId: 'fi-battery-1',
+      kind: 'DEVICE_STATUS',
+      observedAt: '2026-08-22T08:00:00.000Z',
+      payload: { batteryPercent: 14, status: 'online' },
+    });
+
+    expect(result.signal?.payload).toEqual(
+      expect.objectContaining({
+        signalType: 'TRACKER_BATTERY_LOW',
+        level: 'INFO',
+        nonDiagnostic: true,
+        evidence: { batteryPercent: 14, provider: 'FI' },
+      }),
+    );
+  });
+
+  it('lets household participants schedule care reminders without changing pet state', async () => {
+    const { service, prisma, households } = createHarness();
+
+    const result = await service.createReminder(userId, {
+      petId,
+      kind: 'GROOMING',
+      title: 'Brush coat',
+      dueAt: '2026-08-24T18:00:00.000Z',
+      repeatEveryDays: 7,
+    });
+
+    expect(households.assertPetAccessible).toHaveBeenCalledWith(userId, petId);
+    expect(prisma.notification.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId,
+        type: 'CARE_REMINDER',
+        payload: expect.objectContaining({
+          schemaVersion: 'dogos-care-reminder-v1',
+          petId,
+          kind: 'GROOMING',
+          status: 'SCHEDULED',
+          repeatEveryDays: 7,
+        }),
+      }),
+    });
+    expect(result.status).toBe('SCHEDULED');
+  });
+
+  it('does not mark a due reminder complete when push delivery fails', async () => {
+    const { service, prisma, txNotification, notifications } = createHarness();
+    const payload = {
+      schemaVersion: 'dogos-care-reminder-v1',
+      kind: 'MEDICATION',
+      title: 'Medication reminder',
+      petId,
+      dueAt: '2026-08-21T18:00:00.000Z',
+      status: 'SCHEDULED',
+    } as const;
+    const row = {
+      id: 'reminder-1',
+      userId,
+      type: 'CARE_REMINDER',
+      payload,
+      readAt: null,
+      createdAt: new Date('2026-08-21T17:00:00.000Z'),
+    };
+    prisma.notification.findMany.mockResolvedValue([row]);
+    txNotification.findFirst.mockResolvedValue(row);
+    notifications.sendPushNotification.mockResolvedValue({ success: false, reason: 'no_subscription' });
+
+    const result = await service.dispatchDueReminders();
+
+    expect(result).toEqual({ attempted: 1, delivered: 0 });
+    expect(txNotification.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'reminder-1' },
+        data: { payload: expect.objectContaining({ lastAttemptAt: expect.any(String) }) },
+      }),
+    );
+    expect(prisma.notification.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/autopilot/autopilot.service.spec.ts
+++ b/apps/api/src/autopilot/autopilot.service.spec.ts
@@ -16,7 +16,7 @@ function createHarness() {
         ...data,
         readAt: null,
         createdAt: new Date(),
-      }),
+      })
     ),
     update: jest.fn(),
   };
@@ -33,7 +33,7 @@ function createHarness() {
           ...data,
           readAt: null,
           createdAt: new Date(),
-        }),
+        })
       ),
       findMany: jest.fn().mockResolvedValue([]),
       findFirst: jest.fn(),
@@ -41,7 +41,9 @@ function createHarness() {
       updateMany: jest.fn(),
     },
     $queryRaw: jest.fn().mockResolvedValue([]),
-    $transaction: jest.fn(async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx)),
+    $transaction: jest.fn(async (callback: (client: typeof tx) => Promise<unknown>) =>
+      callback(tx)
+    ),
   };
   const careEvents = {
     record: jest.fn().mockResolvedValue({
@@ -72,7 +74,7 @@ function createHarness() {
       prisma as unknown as PrismaService,
       careEvents as unknown as CareEventsService,
       households as unknown as HouseholdsService,
-      notifications as unknown as NotificationsService,
+      notifications as unknown as NotificationsService
     ),
   };
 }
@@ -105,7 +107,7 @@ describe('AutopilotService', () => {
           nonDiagnostic: true,
           activityMinutes: 74,
         }),
-      }),
+      })
     );
   });
 
@@ -138,7 +140,7 @@ describe('AutopilotService', () => {
           sourceCareEventId: 'care-event-existing',
           signalType: 'TRACKER_BATTERY_LOW',
         }),
-      }),
+      })
     );
     expect(tx.$queryRaw).toHaveBeenCalled();
     expect(txNotification.create).toHaveBeenCalledTimes(1);
@@ -190,7 +192,7 @@ describe('AutopilotService', () => {
           sourceCareEventId: 'care-event-existing',
           signalType: 'TRACKER_BATTERY_LOW',
         }),
-      }),
+      })
     );
     expect(txNotification.create).not.toHaveBeenCalled();
   });
@@ -247,7 +249,7 @@ describe('AutopilotService', () => {
           baselineSamples: 7,
           provider: 'TRACTIVE',
         }),
-      }),
+      })
     );
   });
 
@@ -268,7 +270,7 @@ describe('AutopilotService', () => {
         level: 'INFO',
         nonDiagnostic: true,
         evidence: { batteryPercent: 14, provider: 'FI' },
-      }),
+      })
     );
   });
 
@@ -320,7 +322,10 @@ describe('AutopilotService', () => {
     };
     prisma.notification.findMany.mockResolvedValue([row]);
     txNotification.findFirst.mockResolvedValue(row);
-    notifications.sendPushNotification.mockResolvedValue({ success: false, reason: 'no_subscription' });
+    notifications.sendPushNotification.mockResolvedValue({
+      success: false,
+      reason: 'no_subscription',
+    });
 
     const result = await service.dispatchDueReminders();
 
@@ -329,7 +334,7 @@ describe('AutopilotService', () => {
       expect.objectContaining({
         where: { id: 'reminder-1' },
         data: { payload: expect.objectContaining({ lastAttemptAt: expect.any(String) }) },
-      }),
+      })
     );
     expect(prisma.notification.update).not.toHaveBeenCalled();
   });

--- a/apps/api/src/autopilot/autopilot.service.spec.ts
+++ b/apps/api/src/autopilot/autopilot.service.spec.ts
@@ -10,6 +10,14 @@ const petId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 function createHarness() {
   const txNotification = {
     findFirst: jest.fn(),
+    create: jest.fn().mockImplementation(({ data }) =>
+      Promise.resolve({
+        id: 'signal-new',
+        ...data,
+        readAt: null,
+        createdAt: new Date(),
+      }),
+    ),
     update: jest.fn(),
   };
   const tx = {
@@ -20,7 +28,12 @@ function createHarness() {
     pet: { findFirst: jest.fn().mockResolvedValue({ id: petId }) },
     notification: {
       create: jest.fn().mockImplementation(({ data }) =>
-        Promise.resolve({ id: `notification-${Math.random()}`, ...data, readAt: null, createdAt: new Date() }),
+        Promise.resolve({
+          id: `notification-${Math.random()}`,
+          ...data,
+          readAt: null,
+          createdAt: new Date(),
+        }),
       ),
       findMany: jest.fn().mockResolvedValue([]),
       findFirst: jest.fn(),
@@ -96,8 +109,8 @@ describe('AutopilotService', () => {
     );
   });
 
-  it('does not create a second signal when a provider event is replayed', async () => {
-    const { service, careEvents, prisma } = createHarness();
+  it('repairs a missing signal when a provider replay finds the CareEvent already committed', async () => {
+    const { service, careEvents, tx, txNotification } = createHarness();
     careEvents.record.mockResolvedValue({
       careEventId: 'care-event-existing',
       ledgerId: 'ledger-existing',
@@ -107,6 +120,7 @@ describe('AutopilotService', () => {
       explanation: 'duplicate',
       duplicate: true,
     });
+    txNotification.findFirst.mockResolvedValue(null);
 
     const result = await service.ingestProviderObservation(userId, 'tractive', {
       petId,
@@ -117,12 +131,72 @@ describe('AutopilotService', () => {
     });
 
     expect(result.duplicate).toBe(true);
-    expect(result.signal).toBeNull();
-    expect(prisma.notification.create).not.toHaveBeenCalled();
+    expect(result.signal).toEqual(
+      expect.objectContaining({
+        id: 'signal-new',
+        payload: expect.objectContaining({
+          sourceCareEventId: 'care-event-existing',
+          signalType: 'TRACKER_BATTERY_LOW',
+        }),
+      }),
+    );
+    expect(tx.$queryRaw).toHaveBeenCalled();
+    expect(txNotification.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an existing replay signal without duplicating it, even after acknowledgement', async () => {
+    const { service, careEvents, txNotification } = createHarness();
+    careEvents.record.mockResolvedValue({
+      careEventId: 'care-event-existing',
+      ledgerId: 'ledger-existing',
+      bondXp: 0,
+      pathway: 'CARE',
+      policyVersion: 'bond-xp-v1',
+      explanation: 'duplicate',
+      duplicate: true,
+    });
+    txNotification.findFirst.mockResolvedValue({
+      id: 'signal-existing',
+      userId,
+      type: 'AUTOPILOT_SIGNAL',
+      readAt: new Date('2026-08-22T09:00:00.000Z'),
+      createdAt: new Date('2026-08-22T08:00:01.000Z'),
+      payload: {
+        schemaVersion: 'dogos-autopilot-signal-v1',
+        petId,
+        sourceCareEventId: 'care-event-existing',
+        signalType: 'TRACKER_BATTERY_LOW',
+        level: 'INFO',
+        title: 'Tracker battery is running low',
+        body: 'Already acknowledged.',
+        observedAt: '2026-08-22T08:00:00.000Z',
+        evidence: { batteryPercent: 9, provider: 'TRACTIVE' },
+        nonDiagnostic: true,
+      },
+    });
+
+    const result = await service.ingestProviderObservation(userId, 'tractive', {
+      petId,
+      externalEventId: 'same-event',
+      kind: 'DEVICE_STATUS',
+      observedAt: '2026-08-22T08:00:00.000Z',
+      payload: { batteryPercent: 9 },
+    });
+
+    expect(result.signal).toEqual(
+      expect.objectContaining({
+        id: 'signal-existing',
+        payload: expect.objectContaining({
+          sourceCareEventId: 'care-event-existing',
+          signalType: 'TRACKER_BATTERY_LOW',
+        }),
+      }),
+    );
+    expect(txNotification.create).not.toHaveBeenCalled();
   });
 
   it('requires a meaningful baseline before producing a lower-activity check-in', async () => {
-    const { service, prisma } = createHarness();
+    const { service, prisma, txNotification } = createHarness();
     prisma.$queryRaw.mockResolvedValue([
       { activity_minutes: 80 },
       { activity_minutes: 75 },
@@ -140,7 +214,7 @@ describe('AutopilotService', () => {
     });
 
     expect(result.signal).toBeNull();
-    expect(prisma.notification.create).not.toHaveBeenCalled();
+    expect(txNotification.create).not.toHaveBeenCalled();
   });
 
   it('creates a non-diagnostic check-in only for a large drop against six or more prior summaries', async () => {

--- a/apps/api/src/autopilot/autopilot.service.ts
+++ b/apps/api/src/autopilot/autopilot.service.ts
@@ -221,10 +221,16 @@ export class AutopilotService {
       },
     });
 
-    let signal: { id: string; payload: AutopilotSignalPayload } | null = null;
-    if (!receipt.duplicate) {
-      signal = await this.maybeCreateSignal(userId, dto.petId, receipt.careEventId, observation);
-    }
+    // Signal derivation is deliberately replay-safe. If the immutable CareEvent
+    // was committed but the request died before signal persistence, a provider
+    // retry repairs the missing signal. Existing signals are returned rather
+    // than duplicated, including signals the user has already acknowledged.
+    const signal = await this.maybeCreateSignal(
+      userId,
+      dto.petId,
+      receipt.careEventId,
+      observation,
+    );
 
     return {
       careEventId: receipt.careEventId,
@@ -393,14 +399,41 @@ export class AutopilotService {
   }
 
   private async createSignal(userId: string, payload: AutopilotSignalPayload) {
-    const notification = await this.prisma.notification.create({
-      data: {
-        userId,
-        type: 'AUTOPILOT_SIGNAL',
-        payload: inputJson(payload),
-      },
+    return this.prisma.$transaction(async (tx) => {
+      const lockKey = `dogos-autopilot-signal:${payload.sourceCareEventId}`;
+      await tx.$queryRaw<Array<{ acquired: number }>>(Prisma.sql`
+        WITH lock_row AS MATERIALIZED (
+          SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))
+        )
+        SELECT 1::int AS acquired FROM lock_row
+      `);
+
+      const existing = await tx.notification.findFirst({
+        where: {
+          userId,
+          type: 'AUTOPILOT_SIGNAL',
+          payload: {
+            path: ['sourceCareEventId'],
+            equals: payload.sourceCareEventId,
+          },
+        },
+      });
+      if (existing) {
+        return {
+          id: existing.id,
+          payload: readSignalPayload(existing.payload) ?? payload,
+        };
+      }
+
+      const notification = await tx.notification.create({
+        data: {
+          userId,
+          type: 'AUTOPILOT_SIGNAL',
+          payload: inputJson(payload),
+        },
+      });
+      return { id: notification.id, payload };
     });
-    return { id: notification.id, payload };
   }
 
   private async claimDueReminder(row: NotificationRow, now: Date) {

--- a/apps/api/src/autopilot/autopilot.service.ts
+++ b/apps/api/src/autopilot/autopilot.service.ts
@@ -1,0 +1,490 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { Prisma } from '@woof/database';
+import { CareEventsService } from '../care-events/care-events.service';
+import { HouseholdsService } from '../households/households.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { PrismaService } from '../prisma/prisma.service';
+import type { CreateCareReminderDto, IngestTrackerObservationDto } from './dto/autopilot.dto';
+import { normalizeProviderObservation } from './provider-adapters';
+import type {
+  AutopilotSignalPayload,
+  CareReminderPayload,
+  NormalizedTrackerObservation,
+} from './autopilot.types';
+
+type ActivityBaselineRow = {
+  activity_minutes: number | null;
+};
+
+type NotificationRow = {
+  id: string;
+  type: string;
+  payload: Prisma.JsonValue;
+  readAt: Date | null;
+  createdAt: Date;
+};
+
+function jsonObject(value: Prisma.JsonValue): Prisma.JsonObject | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  return value as Prisma.JsonObject;
+}
+
+function readString(value: Prisma.JsonValue | undefined): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function readNumber(value: Prisma.JsonValue | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function readReminderPayload(value: Prisma.JsonValue): CareReminderPayload | null {
+  const object = jsonObject(value);
+  if (!object || object.schemaVersion !== 'dogos-care-reminder-v1') return null;
+
+  const kind = readString(object.kind);
+  const title = readString(object.title);
+  const dueAt = readString(object.dueAt);
+  const status = readString(object.status);
+  if (
+    !kind ||
+    !['VET_APPOINTMENT', 'MEDICATION', 'GROOMING', 'GENERAL_CARE'].includes(kind) ||
+    !title ||
+    !dueAt ||
+    !status ||
+    !['SCHEDULED', 'COMPLETED', 'CANCELLED'].includes(status)
+  ) {
+    return null;
+  }
+
+  const repeatEveryDays = readNumber(object.repeatEveryDays);
+  return {
+    schemaVersion: 'dogos-care-reminder-v1',
+    kind: kind as CareReminderPayload['kind'],
+    title,
+    ...(readString(object.detail) ? { detail: readString(object.detail) } : {}),
+    ...(readString(object.petId) ? { petId: readString(object.petId) } : {}),
+    dueAt,
+    ...(repeatEveryDays !== undefined ? { repeatEveryDays } : {}),
+    status: status as CareReminderPayload['status'],
+    ...(readString(object.lastAttemptAt)
+      ? { lastAttemptAt: readString(object.lastAttemptAt) }
+      : {}),
+    ...(readString(object.lastDeliveredAt)
+      ? { lastDeliveredAt: readString(object.lastDeliveredAt) }
+      : {}),
+  };
+}
+
+function readSignalPayload(value: Prisma.JsonValue): AutopilotSignalPayload | null {
+  const object = jsonObject(value);
+  if (!object || object.schemaVersion !== 'dogos-autopilot-signal-v1') return null;
+
+  const petId = readString(object.petId);
+  const sourceCareEventId = readString(object.sourceCareEventId);
+  const signalType = readString(object.signalType);
+  const level = readString(object.level);
+  const title = readString(object.title);
+  const body = readString(object.body);
+  const observedAt = readString(object.observedAt);
+  const evidence = object.evidence;
+  if (
+    !petId ||
+    !sourceCareEventId ||
+    !signalType ||
+    !['ACTIVITY_BELOW_RECENT_BASELINE', 'TRACKER_BATTERY_LOW'].includes(signalType) ||
+    !level ||
+    !['CHECK_IN', 'INFO'].includes(level) ||
+    !title ||
+    !body ||
+    !observedAt ||
+    !evidence ||
+    typeof evidence !== 'object' ||
+    Array.isArray(evidence)
+  ) {
+    return null;
+  }
+
+  const safeEvidence: Record<string, string | number | boolean> = {};
+  for (const [key, valueEntry] of Object.entries(evidence)) {
+    if (
+      typeof valueEntry === 'string' ||
+      typeof valueEntry === 'number' ||
+      typeof valueEntry === 'boolean'
+    ) {
+      safeEvidence[key] = valueEntry;
+    }
+  }
+
+  return {
+    schemaVersion: 'dogos-autopilot-signal-v1',
+    petId,
+    sourceCareEventId,
+    signalType: signalType as AutopilotSignalPayload['signalType'],
+    level: level as AutopilotSignalPayload['level'],
+    title,
+    body,
+    observedAt,
+    evidence: safeEvidence,
+    nonDiagnostic: true,
+  };
+}
+
+function inputJson(value: CareReminderPayload | AutopilotSignalPayload): Prisma.InputJsonObject {
+  return value as unknown as Prisma.InputJsonObject;
+}
+
+@Injectable()
+export class AutopilotService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly careEvents: CareEventsService,
+    private readonly households: HouseholdsService,
+    private readonly notifications: NotificationsService,
+  ) {}
+
+  async getDashboard(userId: string) {
+    const rows = await this.prisma.notification.findMany({
+      where: {
+        userId,
+        type: { in: ['CARE_REMINDER', 'AUTOPILOT_SIGNAL'] },
+        readAt: null,
+      },
+      orderBy: { createdAt: 'desc' },
+      take: 100,
+    });
+
+    const reminders = rows
+      .filter((row) => row.type === 'CARE_REMINDER')
+      .map((row) => ({ id: row.id, ...readReminderPayload(row.payload) }))
+      .filter((row): row is { id: string } & CareReminderPayload => row.schemaVersion !== undefined)
+      .sort((a, b) => new Date(a.dueAt).getTime() - new Date(b.dueAt).getTime());
+
+    const signals = rows
+      .filter((row) => row.type === 'AUTOPILOT_SIGNAL')
+      .map((row) => ({ id: row.id, ...readSignalPayload(row.payload) }))
+      .filter((row): row is { id: string } & AutopilotSignalPayload => row.schemaVersion !== undefined);
+
+    return {
+      providers: [
+        { provider: 'FI', status: 'STUB_READY', accepts: ['DAILY_ACTIVITY', 'DEVICE_STATUS'] },
+        { provider: 'TRACTIVE', status: 'STUB_READY', accepts: ['DAILY_ACTIVITY', 'DEVICE_STATUS'] },
+      ],
+      reminders,
+      signals,
+      boundaries: {
+        locationTelemetryStored: false,
+        canonicalPetMutationAllowed: false,
+        trackerObservationsRewardEligible: false,
+        signalsDiagnostic: false,
+      },
+    };
+  }
+
+  async ingestProviderObservation(
+    userId: string,
+    provider: string,
+    dto: IngestTrackerObservationDto,
+  ) {
+    // Provider connections belong to the pet owner in Phase A. Shared-household
+    // scheduling is allowed, but an invited member cannot impersonate a tracker owner.
+    const ownedPet = await this.prisma.pet.findFirst({
+      where: { id: dto.petId, ownerId: userId },
+      select: { id: true },
+    });
+    if (!ownedPet) throw new NotFoundException('Pet not found');
+
+    const observation = normalizeProviderObservation(provider, dto);
+    const eventType =
+      observation.kind === 'DAILY_ACTIVITY' ? 'TRACKER_DAILY_ACTIVITY' : 'TRACKER_DEVICE_STATUS';
+    const pathway = observation.kind === 'DAILY_ACTIVITY' ? 'MOVE' : 'CARE';
+    const dedupeKey = `autopilot:${observation.provider.toLowerCase()}:${dto.petId}:${observation.externalEventId}`;
+
+    const receipt = await this.careEvents.record({
+      userId,
+      petId: dto.petId,
+      eventType,
+      pathway,
+      occurredAt: observation.observedAt,
+      source: `AUTOPILOT_${observation.provider}`,
+      evidenceType: 'WEARABLE',
+      evidenceConfidence: 0.82,
+      dedupeKey,
+      visibility: 'PRIVATE',
+      safetyEligible: false,
+      context: {
+        provider: observation.provider,
+        observationKind: observation.kind,
+        privacyClass: 'SUMMARY_ONLY',
+        nonDiagnostic: true,
+        ...observation.metrics,
+      },
+    });
+
+    let signal: { id: string; payload: AutopilotSignalPayload } | null = null;
+    if (!receipt.duplicate) {
+      signal = await this.maybeCreateSignal(userId, dto.petId, receipt.careEventId, observation);
+    }
+
+    return {
+      careEventId: receipt.careEventId,
+      duplicate: receipt.duplicate,
+      bondXp: receipt.bondXp,
+      observation,
+      signal,
+    };
+  }
+
+  async createReminder(userId: string, dto: CreateCareReminderDto) {
+    if (dto.petId) await this.households.assertPetAccessible(userId, dto.petId);
+
+    const payload: CareReminderPayload = {
+      schemaVersion: 'dogos-care-reminder-v1',
+      kind: dto.kind,
+      title: dto.title.trim(),
+      ...(dto.detail?.trim() ? { detail: dto.detail.trim() } : {}),
+      ...(dto.petId ? { petId: dto.petId } : {}),
+      dueAt: new Date(dto.dueAt).toISOString(),
+      ...(dto.repeatEveryDays ? { repeatEveryDays: dto.repeatEveryDays } : {}),
+      status: 'SCHEDULED',
+    };
+
+    const reminder = await this.prisma.notification.create({
+      data: {
+        userId,
+        type: 'CARE_REMINDER',
+        payload: inputJson(payload),
+      },
+    });
+
+    return { id: reminder.id, ...payload };
+  }
+
+  async cancelReminder(userId: string, reminderId: string) {
+    const reminder = await this.prisma.notification.findFirst({
+      where: { id: reminderId, userId, type: 'CARE_REMINDER', readAt: null },
+    });
+    if (!reminder) throw new NotFoundException('Reminder not found');
+
+    const payload = readReminderPayload(reminder.payload);
+    if (!payload) throw new NotFoundException('Reminder not found');
+    const cancelled: CareReminderPayload = { ...payload, status: 'CANCELLED' };
+    await this.prisma.notification.update({
+      where: { id: reminder.id },
+      data: { readAt: new Date(), payload: inputJson(cancelled) },
+    });
+    return { success: true };
+  }
+
+  async acknowledgeSignal(userId: string, signalId: string) {
+    const updated = await this.prisma.notification.updateMany({
+      where: { id: signalId, userId, type: 'AUTOPILOT_SIGNAL', readAt: null },
+      data: { readAt: new Date() },
+    });
+    if (updated.count === 0) throw new NotFoundException('Signal not found');
+    return { success: true };
+  }
+
+  @Cron('0 */10 * * * *')
+  async dispatchDueReminders() {
+    const now = new Date();
+    const rows = await this.prisma.notification.findMany({
+      where: { type: 'CARE_REMINDER', readAt: null },
+      orderBy: { createdAt: 'asc' },
+      take: 200,
+    });
+
+    let attempted = 0;
+    let delivered = 0;
+    for (const row of rows) {
+      const claimed = await this.claimDueReminder(row, now);
+      if (!claimed) continue;
+      attempted += 1;
+
+      const delivery = await this.notifications.sendPushNotification({
+        userId: claimed.userId,
+        title: claimed.payload.title,
+        body: claimed.payload.detail ?? this.reminderBody(claimed.payload.kind),
+        url: '/notifications',
+        data: {
+          type: 'care_reminder',
+          reminderId: claimed.id,
+          petId: claimed.payload.petId,
+          kind: claimed.payload.kind,
+        },
+      });
+
+      if (!delivery.success) continue;
+      delivered += 1;
+      await this.completeReminderDelivery(claimed.id, claimed.payload, now);
+    }
+
+    return { attempted, delivered };
+  }
+
+  private async maybeCreateSignal(
+    userId: string,
+    petId: string,
+    careEventId: string,
+    observation: NormalizedTrackerObservation,
+  ) {
+    if (observation.kind === 'DEVICE_STATUS') {
+      const battery = observation.metrics.batteryPercent;
+      if (battery !== undefined && battery <= 15) {
+        return this.createSignal(userId, {
+          schemaVersion: 'dogos-autopilot-signal-v1',
+          petId,
+          sourceCareEventId: careEventId,
+          signalType: 'TRACKER_BATTERY_LOW',
+          level: 'INFO',
+          title: 'Tracker battery is running low',
+          body: 'The connected tracker reported a low battery. Charging it can keep future summaries complete.',
+          observedAt: observation.observedAt.toISOString(),
+          evidence: { batteryPercent: battery, provider: observation.provider },
+          nonDiagnostic: true,
+        });
+      }
+      return null;
+    }
+
+    const current = observation.metrics.activityMinutes;
+    if (current === undefined) return null;
+    const windowStart = new Date(observation.observedAt.getTime() - 28 * 24 * 60 * 60 * 1000);
+    const baselineRows = await this.prisma.$queryRaw<ActivityBaselineRow[]>(Prisma.sql`
+      SELECT (context->>'activityMinutes')::double precision AS activity_minutes
+      FROM care_events
+      WHERE user_id = ${userId}
+        AND pet_id = ${petId}
+        AND event_type = 'TRACKER_DAILY_ACTIVITY'
+        AND id <> ${careEventId}
+        AND occurred_at >= ${windowStart}
+        AND occurred_at < ${observation.observedAt}
+        AND context ? 'activityMinutes'
+      ORDER BY occurred_at DESC
+      LIMIT 14
+    `);
+
+    const samples = baselineRows
+      .map((row) => row.activity_minutes)
+      .filter((value): value is number => typeof value === 'number' && Number.isFinite(value));
+    if (samples.length < 6) return null;
+
+    const baseline = this.median(samples);
+    const drop = baseline - current;
+    if (!(current <= baseline * 0.55 && drop >= 20)) return null;
+
+    return this.createSignal(userId, {
+      schemaVersion: 'dogos-autopilot-signal-v1',
+      petId,
+      sourceCareEventId: careEventId,
+      signalType: 'ACTIVITY_BELOW_RECENT_BASELINE',
+      level: 'CHECK_IN',
+      title: 'Activity looks lower than the recent tracker baseline',
+      body: 'This can happen with rest days, weather, routine changes, or tracker wear. Check the context if the change seems meaningful. This is not a diagnosis.',
+      observedAt: observation.observedAt.toISOString(),
+      evidence: {
+        currentActivityMinutes: Math.round(current),
+        baselineActivityMinutes: Math.round(baseline),
+        baselineSamples: samples.length,
+        provider: observation.provider,
+      },
+      nonDiagnostic: true,
+    });
+  }
+
+  private async createSignal(userId: string, payload: AutopilotSignalPayload) {
+    const notification = await this.prisma.notification.create({
+      data: {
+        userId,
+        type: 'AUTOPILOT_SIGNAL',
+        payload: inputJson(payload),
+      },
+    });
+    return { id: notification.id, payload };
+  }
+
+  private async claimDueReminder(row: NotificationRow, now: Date) {
+    return this.prisma.$transaction(async (tx) => {
+      const lockKey = `dogos-autopilot-reminder:${row.id}`;
+      const lock = await tx.$queryRaw<Array<{ acquired: boolean }>>(Prisma.sql`
+        SELECT pg_try_advisory_xact_lock(hashtextextended(${lockKey}, 0)) AS acquired
+      `);
+      if (!lock[0]?.acquired) return null;
+
+      const current = await tx.notification.findFirst({
+        where: { id: row.id, type: 'CARE_REMINDER', readAt: null },
+      });
+      if (!current) return null;
+      const payload = readReminderPayload(current.payload);
+      if (!payload || payload.status !== 'SCHEDULED') return null;
+
+      const dueAt = new Date(payload.dueAt);
+      if (!Number.isFinite(dueAt.getTime()) || dueAt > now) return null;
+      if (payload.lastAttemptAt) {
+        const retryAfter = new Date(payload.lastAttemptAt).getTime() + 6 * 60 * 60 * 1000;
+        if (retryAfter > now.getTime()) return null;
+      }
+
+      const claimedPayload: CareReminderPayload = {
+        ...payload,
+        lastAttemptAt: now.toISOString(),
+      };
+      await tx.notification.update({
+        where: { id: current.id },
+        data: { payload: inputJson(claimedPayload) },
+      });
+
+      return { id: current.id, userId: current.userId, payload: claimedPayload };
+    });
+  }
+
+  private async completeReminderDelivery(id: string, payload: CareReminderPayload, deliveredAt: Date) {
+    if (payload.repeatEveryDays) {
+      const stepMs = payload.repeatEveryDays * 24 * 60 * 60 * 1000;
+      let nextDueAt = new Date(payload.dueAt).getTime() + stepMs;
+      while (nextDueAt <= deliveredAt.getTime()) nextDueAt += stepMs;
+      const next: CareReminderPayload = {
+        ...payload,
+        dueAt: new Date(nextDueAt).toISOString(),
+        lastDeliveredAt: deliveredAt.toISOString(),
+        status: 'SCHEDULED',
+      };
+      await this.prisma.notification.update({
+        where: { id },
+        data: { payload: inputJson(next) },
+      });
+      return;
+    }
+
+    const completed: CareReminderPayload = {
+      ...payload,
+      status: 'COMPLETED',
+      lastDeliveredAt: deliveredAt.toISOString(),
+    };
+    await this.prisma.notification.update({
+      where: { id },
+      data: { payload: inputJson(completed), readAt: deliveredAt },
+    });
+  }
+
+  private reminderBody(kind: CareReminderPayload['kind']) {
+    switch (kind) {
+      case 'VET_APPOINTMENT':
+        return 'A vet-related reminder is due.';
+      case 'MEDICATION':
+        return 'A medication reminder is due. Follow the instructions provided by your veterinarian.';
+      case 'GROOMING':
+        return 'A grooming reminder is due.';
+      default:
+        return 'A dogOS care reminder is due.';
+    }
+  }
+
+  private median(values: number[]) {
+    const sorted = [...values].sort((a, b) => a - b);
+    const middle = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0
+      ? (sorted[middle - 1] + sorted[middle]) / 2
+      : sorted[middle];
+  }
+}

--- a/apps/api/src/autopilot/autopilot.service.ts
+++ b/apps/api/src/autopilot/autopilot.service.ts
@@ -140,7 +140,7 @@ export class AutopilotService {
     private readonly prisma: PrismaService,
     private readonly careEvents: CareEventsService,
     private readonly households: HouseholdsService,
-    private readonly notifications: NotificationsService,
+    private readonly notifications: NotificationsService
   ) {}
 
   async getDashboard(userId: string) {
@@ -163,12 +163,18 @@ export class AutopilotService {
     const signals = rows
       .filter((row) => row.type === 'AUTOPILOT_SIGNAL')
       .map((row) => ({ id: row.id, ...readSignalPayload(row.payload) }))
-      .filter((row): row is { id: string } & AutopilotSignalPayload => row.schemaVersion !== undefined);
+      .filter(
+        (row): row is { id: string } & AutopilotSignalPayload => row.schemaVersion !== undefined
+      );
 
     return {
       providers: [
         { provider: 'FI', status: 'STUB_READY', accepts: ['DAILY_ACTIVITY', 'DEVICE_STATUS'] },
-        { provider: 'TRACTIVE', status: 'STUB_READY', accepts: ['DAILY_ACTIVITY', 'DEVICE_STATUS'] },
+        {
+          provider: 'TRACTIVE',
+          status: 'STUB_READY',
+          accepts: ['DAILY_ACTIVITY', 'DEVICE_STATUS'],
+        },
       ],
       reminders,
       signals,
@@ -184,7 +190,7 @@ export class AutopilotService {
   async ingestProviderObservation(
     userId: string,
     provider: string,
-    dto: IngestTrackerObservationDto,
+    dto: IngestTrackerObservationDto
   ) {
     // Provider connections belong to the pet owner in Phase A. Shared-household
     // scheduling is allowed, but an invited member cannot impersonate a tracker owner.
@@ -229,7 +235,7 @@ export class AutopilotService {
       userId,
       dto.petId,
       receipt.careEventId,
-      observation,
+      observation
     );
 
     return {
@@ -332,7 +338,7 @@ export class AutopilotService {
     userId: string,
     petId: string,
     careEventId: string,
-    observation: NormalizedTrackerObservation,
+    observation: NormalizedTrackerObservation
   ) {
     if (observation.kind === 'DEVICE_STATUS') {
       const battery = observation.metrics.batteryPercent;
@@ -471,7 +477,11 @@ export class AutopilotService {
     });
   }
 
-  private async completeReminderDelivery(id: string, payload: CareReminderPayload, deliveredAt: Date) {
+  private async completeReminderDelivery(
+    id: string,
+    payload: CareReminderPayload,
+    deliveredAt: Date
+  ) {
     if (payload.repeatEveryDays) {
       const stepMs = payload.repeatEveryDays * 24 * 60 * 60 * 1000;
       let nextDueAt = new Date(payload.dueAt).getTime() + stepMs;
@@ -516,8 +526,6 @@ export class AutopilotService {
   private median(values: number[]) {
     const sorted = [...values].sort((a, b) => a - b);
     const middle = Math.floor(sorted.length / 2);
-    return sorted.length % 2 === 0
-      ? (sorted[middle - 1] + sorted[middle]) / 2
-      : sorted[middle];
+    return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
   }
 }

--- a/apps/api/src/autopilot/autopilot.service.ts
+++ b/apps/api/src/autopilot/autopilot.service.ts
@@ -25,6 +25,12 @@ type NotificationRow = {
   createdAt: Date;
 };
 
+type PersistedTrackerEvent = {
+  eventType: string;
+  occurredAt: Date;
+  context: Prisma.JsonValue;
+};
+
 function jsonObject(value: Prisma.JsonValue): Prisma.JsonObject | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   return value as Prisma.JsonObject;
@@ -220,6 +226,7 @@ export class AutopilotService {
       safetyEligible: false,
       context: {
         provider: observation.provider,
+        externalEventId: observation.externalEventId,
         observationKind: observation.kind,
         privacyClass: 'SUMMARY_ONLY',
         nonDiagnostic: true,
@@ -227,22 +234,28 @@ export class AutopilotService {
       },
     });
 
-    // Signal derivation is deliberately replay-safe. If the immutable CareEvent
-    // was committed but the request died before signal persistence, a provider
-    // retry repairs the missing signal. Existing signals are returned rather
-    // than duplicated, including signals the user has already acknowledged.
+    // Always derive from the immutable persisted CareEvent, never from a retry's
+    // payload. This makes lost-response repair safe even if a provider retries an
+    // external event ID with changed metrics or timestamps. It also inherits the
+    // CareEvent layer's future-timestamp normalization.
+    const canonicalObservation = await this.loadPersistedObservation(
+      userId,
+      dto.petId,
+      receipt.careEventId,
+      observation.externalEventId
+    );
     const signal = await this.maybeCreateSignal(
       userId,
       dto.petId,
       receipt.careEventId,
-      observation
+      canonicalObservation
     );
 
     return {
       careEventId: receipt.careEventId,
       duplicate: receipt.duplicate,
       bondXp: receipt.bondXp,
-      observation,
+      observation: canonicalObservation,
       signal,
     };
   }
@@ -332,6 +345,50 @@ export class AutopilotService {
     }
 
     return { attempted, delivered };
+  }
+
+  private async loadPersistedObservation(
+    userId: string,
+    petId: string,
+    careEventId: string,
+    fallbackExternalEventId: string
+  ): Promise<NormalizedTrackerObservation> {
+    const event = (await this.prisma.careEvent.findFirst({
+      where: { id: careEventId, userId, petId },
+      select: { eventType: true, occurredAt: true, context: true },
+    })) as PersistedTrackerEvent | null;
+    if (!event) throw new NotFoundException('Tracker observation not found');
+
+    const context = jsonObject(event.context);
+    const provider = readString(context?.provider);
+    const kind = readString(context?.observationKind);
+    const externalEventId = readString(context?.externalEventId) ?? fallbackExternalEventId;
+    if (
+      (provider !== 'FI' && provider !== 'TRACTIVE') ||
+      (kind !== 'DAILY_ACTIVITY' && kind !== 'DEVICE_STATUS') ||
+      (kind === 'DAILY_ACTIVITY' && event.eventType !== 'TRACKER_DAILY_ACTIVITY') ||
+      (kind === 'DEVICE_STATUS' && event.eventType !== 'TRACKER_DEVICE_STATUS')
+    ) {
+      throw new NotFoundException('Tracker observation not found');
+    }
+
+    const state = readString(context?.deviceState);
+    const deviceState =
+      state === 'ONLINE' || state === 'OFFLINE' || state === 'UNKNOWN' ? state : undefined;
+
+    return {
+      provider,
+      externalEventId,
+      kind,
+      observedAt: event.occurredAt,
+      metrics: {
+        activityMinutes: readNumber(context?.activityMinutes),
+        distanceMeters: readNumber(context?.distanceMeters),
+        steps: readNumber(context?.steps),
+        batteryPercent: readNumber(context?.batteryPercent),
+        deviceState,
+      },
+    };
   }
 
   private async maybeCreateSignal(

--- a/apps/api/src/autopilot/autopilot.types.ts
+++ b/apps/api/src/autopilot/autopilot.types.ts
@@ -1,0 +1,53 @@
+export const AUTOPILOT_PROVIDERS = ['FI', 'TRACTIVE'] as const;
+export type AutopilotProvider = (typeof AUTOPILOT_PROVIDERS)[number];
+
+export const AUTOPILOT_OBSERVATION_KINDS = ['DAILY_ACTIVITY', 'DEVICE_STATUS'] as const;
+export type AutopilotObservationKind = (typeof AUTOPILOT_OBSERVATION_KINDS)[number];
+
+export type NormalizedTrackerObservation = {
+  provider: AutopilotProvider;
+  externalEventId: string;
+  kind: AutopilotObservationKind;
+  observedAt: Date;
+  metrics: {
+    activityMinutes?: number;
+    distanceMeters?: number;
+    steps?: number;
+    batteryPercent?: number;
+    deviceState?: 'ONLINE' | 'OFFLINE' | 'UNKNOWN';
+  };
+};
+
+export const CARE_REMINDER_KINDS = [
+  'VET_APPOINTMENT',
+  'MEDICATION',
+  'GROOMING',
+  'GENERAL_CARE',
+] as const;
+export type CareReminderKind = (typeof CARE_REMINDER_KINDS)[number];
+
+export type CareReminderPayload = {
+  schemaVersion: 'dogos-care-reminder-v1';
+  kind: CareReminderKind;
+  title: string;
+  detail?: string;
+  petId?: string;
+  dueAt: string;
+  repeatEveryDays?: number;
+  status: 'SCHEDULED' | 'COMPLETED' | 'CANCELLED';
+  lastAttemptAt?: string;
+  lastDeliveredAt?: string;
+};
+
+export type AutopilotSignalPayload = {
+  schemaVersion: 'dogos-autopilot-signal-v1';
+  petId: string;
+  sourceCareEventId: string;
+  signalType: 'ACTIVITY_BELOW_RECENT_BASELINE' | 'TRACKER_BATTERY_LOW';
+  level: 'CHECK_IN' | 'INFO';
+  title: string;
+  body: string;
+  observedAt: string;
+  evidence: Record<string, string | number | boolean>;
+  nonDiagnostic: true;
+};

--- a/apps/api/src/autopilot/dto/autopilot.dto.ts
+++ b/apps/api/src/autopilot/dto/autopilot.dto.ts
@@ -1,0 +1,61 @@
+import { Transform } from 'class-transformer';
+import {
+  IsDateString,
+  IsIn,
+  IsInt,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { AUTOPILOT_OBSERVATION_KINDS, CARE_REMINDER_KINDS } from '../autopilot.types';
+
+export class IngestTrackerObservationDto {
+  @IsUUID('4')
+  petId!: string;
+
+  @IsString()
+  @MaxLength(160)
+  externalEventId!: string;
+
+  @Transform(({ value }) => String(value).toUpperCase())
+  @IsIn(AUTOPILOT_OBSERVATION_KINDS)
+  kind!: (typeof AUTOPILOT_OBSERVATION_KINDS)[number];
+
+  @IsDateString()
+  observedAt!: string;
+
+  @IsObject()
+  payload!: Record<string, unknown>;
+}
+
+export class CreateCareReminderDto {
+  @IsOptional()
+  @IsUUID('4')
+  petId?: string;
+
+  @Transform(({ value }) => String(value).toUpperCase())
+  @IsIn(CARE_REMINDER_KINDS)
+  kind!: (typeof CARE_REMINDER_KINDS)[number];
+
+  @IsString()
+  @MaxLength(120)
+  title!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  detail?: string;
+
+  @IsDateString()
+  dueAt!: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(365)
+  repeatEveryDays?: number;
+}

--- a/apps/api/src/autopilot/provider-adapters.spec.ts
+++ b/apps/api/src/autopilot/provider-adapters.spec.ts
@@ -52,7 +52,7 @@ describe('Autopilot provider adapters', () => {
           activityMinutes: 42,
           vendor: { latest: { coordinates: [-122.1, 37.4] } },
         },
-      }),
+      })
     ).toThrow(BadRequestException);
   });
 
@@ -64,7 +64,7 @@ describe('Autopilot provider adapters', () => {
         kind: 'DEVICE_STATUS',
         observedAt: '2026-08-22T08:00:00.000Z',
         payload: { batteryPercent: 40 },
-      }),
+      })
     ).toThrow(BadRequestException);
   });
 
@@ -76,7 +76,7 @@ describe('Autopilot provider adapters', () => {
         kind: 'DEVICE_STATUS',
         observedAt: '2026-08-22T08:00:00.000Z',
         payload: { batteryPercent: 140 },
-      }),
+      })
     ).toThrow(BadRequestException);
   });
 });

--- a/apps/api/src/autopilot/provider-adapters.spec.ts
+++ b/apps/api/src/autopilot/provider-adapters.spec.ts
@@ -1,0 +1,82 @@
+import { BadRequestException } from '@nestjs/common';
+import { normalizeProviderObservation } from './provider-adapters';
+
+describe('Autopilot provider adapters', () => {
+  it('normalizes a Fi daily activity summary without retaining provider-shaped payload data', () => {
+    const result = normalizeProviderObservation('fi', {
+      petId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      externalEventId: 'fi-day-1',
+      kind: 'DAILY_ACTIVITY',
+      observedAt: '2026-08-22T08:00:00.000Z',
+      payload: {
+        minutesActive: 76,
+        distance_m: 5200,
+        steps: 9400,
+        vendorOnlyField: 'discard-me',
+      },
+    });
+
+    expect(result).toEqual({
+      provider: 'FI',
+      externalEventId: 'fi-day-1',
+      kind: 'DAILY_ACTIVITY',
+      observedAt: new Date('2026-08-22T08:00:00.000Z'),
+      metrics: {
+        activityMinutes: 76,
+        distanceMeters: 5200,
+        steps: 9400,
+      },
+    });
+  });
+
+  it('normalizes a Tractive device summary', () => {
+    const result = normalizeProviderObservation('tractive', {
+      petId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      externalEventId: 'tractive-device-1',
+      kind: 'DEVICE_STATUS',
+      observedAt: '2026-08-22T08:00:00.000Z',
+      payload: { battery_level: 12, tracker_state: 'connected' },
+    });
+
+    expect(result.metrics).toEqual({ batteryPercent: 12, deviceState: 'ONLINE' });
+  });
+
+  it('rejects nested location telemetry instead of silently retaining it', () => {
+    expect(() =>
+      normalizeProviderObservation('fi', {
+        petId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        externalEventId: 'fi-location-1',
+        kind: 'DAILY_ACTIVITY',
+        observedAt: '2026-08-22T08:00:00.000Z',
+        payload: {
+          activityMinutes: 42,
+          vendor: { latest: { coordinates: [-122.1, 37.4] } },
+        },
+      }),
+    ).toThrow(BadRequestException);
+  });
+
+  it('rejects unsupported providers', () => {
+    expect(() =>
+      normalizeProviderObservation('mystery-tracker', {
+        petId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        externalEventId: 'unknown-1',
+        kind: 'DEVICE_STATUS',
+        observedAt: '2026-08-22T08:00:00.000Z',
+        payload: { batteryPercent: 40 },
+      }),
+    ).toThrow(BadRequestException);
+  });
+
+  it('rejects invalid battery percentages', () => {
+    expect(() =>
+      normalizeProviderObservation('tractive', {
+        petId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        externalEventId: 'tractive-bad-battery',
+        kind: 'DEVICE_STATUS',
+        observedAt: '2026-08-22T08:00:00.000Z',
+        payload: { batteryPercent: 140 },
+      }),
+    ).toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/autopilot/provider-adapters.ts
+++ b/apps/api/src/autopilot/provider-adapters.ts
@@ -22,7 +22,7 @@ function containsLocationTelemetry(value: unknown): boolean {
   if (Array.isArray(value)) return value.some((entry) => containsLocationTelemetry(entry));
 
   return Object.entries(value as Record<string, unknown>).some(
-    ([key, nested]) => LOCATION_KEYS.has(key.toLowerCase()) || containsLocationTelemetry(nested),
+    ([key, nested]) => LOCATION_KEYS.has(key.toLowerCase()) || containsLocationTelemetry(nested)
   );
 }
 
@@ -63,9 +63,12 @@ function normalizeFi(dto: IngestTrackerObservationDto): NormalizedTrackerObserva
       ? {
           activityMinutes: finiteNumber(
             payload.activityMinutes ?? payload.minutesActive ?? payload.activeMinutes,
-            'activityMinutes',
+            'activityMinutes'
           ),
-          distanceMeters: finiteNumber(payload.distanceMeters ?? payload.distance_m, 'distanceMeters'),
+          distanceMeters: finiteNumber(
+            payload.distanceMeters ?? payload.distance_m,
+            'distanceMeters'
+          ),
           steps: finiteNumber(payload.steps, 'steps'),
         }
       : {
@@ -90,9 +93,12 @@ function normalizeTractive(dto: IngestTrackerObservationDto): NormalizedTrackerO
       ? {
           activityMinutes: finiteNumber(
             payload.activeMinutes ?? payload.activityMinutes ?? payload.minutes_active,
-            'activityMinutes',
+            'activityMinutes'
           ),
-          distanceMeters: finiteNumber(payload.distanceMeters ?? payload.distance, 'distanceMeters'),
+          distanceMeters: finiteNumber(
+            payload.distanceMeters ?? payload.distance,
+            'distanceMeters'
+          ),
           steps: finiteNumber(payload.steps, 'steps'),
         }
       : {
@@ -112,11 +118,11 @@ function normalizeTractive(dto: IngestTrackerObservationDto): NormalizedTrackerO
 
 export function normalizeProviderObservation(
   provider: string,
-  dto: IngestTrackerObservationDto,
+  dto: IngestTrackerObservationDto
 ): NormalizedTrackerObservation {
   if (containsLocationTelemetry(dto.payload)) {
     throw new BadRequestException(
-      'Autopilot v1 does not accept location telemetry; location connectors require explicit retention controls',
+      'Autopilot v1 does not accept location telemetry; location connectors require explicit retention controls'
     );
   }
 

--- a/apps/api/src/autopilot/provider-adapters.ts
+++ b/apps/api/src/autopilot/provider-adapters.ts
@@ -1,0 +1,127 @@
+import { BadRequestException } from '@nestjs/common';
+import type { IngestTrackerObservationDto } from './dto/autopilot.dto';
+import type { AutopilotProvider, NormalizedTrackerObservation } from './autopilot.types';
+
+const LOCATION_KEYS = new Set([
+  'lat',
+  'latitude',
+  'lng',
+  'lon',
+  'longitude',
+  'coordinates',
+  'position',
+  'positions',
+  'route',
+  'track',
+  'trace',
+  'gps',
+]);
+
+function containsLocationTelemetry(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some((entry) => containsLocationTelemetry(entry));
+
+  return Object.entries(value as Record<string, unknown>).some(
+    ([key, nested]) => LOCATION_KEYS.has(key.toLowerCase()) || containsLocationTelemetry(nested),
+  );
+}
+
+function finiteNumber(value: unknown, label: string): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0) {
+    throw new BadRequestException(`${label} must be a non-negative finite number`);
+  }
+  return number;
+}
+
+function batteryPercent(value: unknown): number | undefined {
+  const number = finiteNumber(value, 'batteryPercent');
+  if (number === undefined) return undefined;
+  if (number > 100) throw new BadRequestException('batteryPercent must be between 0 and 100');
+  return number;
+}
+
+function deviceState(value: unknown): 'ONLINE' | 'OFFLINE' | 'UNKNOWN' | undefined {
+  if (value === undefined || value === null) return undefined;
+  const state = String(value).toUpperCase();
+  if (state === 'ONLINE' || state === 'ACTIVE' || state === 'CONNECTED') return 'ONLINE';
+  if (state === 'OFFLINE' || state === 'INACTIVE' || state === 'DISCONNECTED') return 'OFFLINE';
+  return 'UNKNOWN';
+}
+
+function requireUsefulMetrics(metrics: NormalizedTrackerObservation['metrics']) {
+  if (Object.values(metrics).every((value) => value === undefined)) {
+    throw new BadRequestException('Tracker observation did not contain supported metrics');
+  }
+}
+
+function normalizeFi(dto: IngestTrackerObservationDto): NormalizedTrackerObservation {
+  const payload = dto.payload;
+  const metrics =
+    dto.kind === 'DAILY_ACTIVITY'
+      ? {
+          activityMinutes: finiteNumber(
+            payload.activityMinutes ?? payload.minutesActive ?? payload.activeMinutes,
+            'activityMinutes',
+          ),
+          distanceMeters: finiteNumber(payload.distanceMeters ?? payload.distance_m, 'distanceMeters'),
+          steps: finiteNumber(payload.steps, 'steps'),
+        }
+      : {
+          batteryPercent: batteryPercent(payload.batteryPercent ?? payload.battery),
+          deviceState: deviceState(payload.deviceState ?? payload.status),
+        };
+  requireUsefulMetrics(metrics);
+
+  return {
+    provider: 'FI',
+    externalEventId: dto.externalEventId,
+    kind: dto.kind,
+    observedAt: new Date(dto.observedAt),
+    metrics,
+  };
+}
+
+function normalizeTractive(dto: IngestTrackerObservationDto): NormalizedTrackerObservation {
+  const payload = dto.payload;
+  const metrics =
+    dto.kind === 'DAILY_ACTIVITY'
+      ? {
+          activityMinutes: finiteNumber(
+            payload.activeMinutes ?? payload.activityMinutes ?? payload.minutes_active,
+            'activityMinutes',
+          ),
+          distanceMeters: finiteNumber(payload.distanceMeters ?? payload.distance, 'distanceMeters'),
+          steps: finiteNumber(payload.steps, 'steps'),
+        }
+      : {
+          batteryPercent: batteryPercent(payload.batteryPercent ?? payload.battery_level),
+          deviceState: deviceState(payload.deviceState ?? payload.tracker_state ?? payload.status),
+        };
+  requireUsefulMetrics(metrics);
+
+  return {
+    provider: 'TRACTIVE',
+    externalEventId: dto.externalEventId,
+    kind: dto.kind,
+    observedAt: new Date(dto.observedAt),
+    metrics,
+  };
+}
+
+export function normalizeProviderObservation(
+  provider: string,
+  dto: IngestTrackerObservationDto,
+): NormalizedTrackerObservation {
+  if (containsLocationTelemetry(dto.payload)) {
+    throw new BadRequestException(
+      'Autopilot v1 does not accept location telemetry; location connectors require explicit retention controls',
+    );
+  }
+
+  const normalizedProvider = provider.toUpperCase() as AutopilotProvider;
+  if (normalizedProvider === 'FI') return normalizeFi(dto);
+  if (normalizedProvider === 'TRACTIVE') return normalizeTractive(dto);
+  throw new BadRequestException('Unsupported Autopilot provider');
+}

--- a/apps/api/src/care-events/care-event.types.ts
+++ b/apps/api/src/care-events/care-event.types.ts
@@ -23,7 +23,14 @@ export const QUEST_EVENT_TYPES = {
 } as const satisfies Record<WellbeingPathway, string>;
 
 export type EvidenceType =
-  'SELF_REPORT' | 'ACTIVITY' | 'COACH' | 'BEHAVIOR_VISION' | 'LOCATION' | 'MEDIA' | 'CLINIC';
+  | 'SELF_REPORT'
+  | 'ACTIVITY'
+  | 'COACH'
+  | 'BEHAVIOR_VISION'
+  | 'LOCATION'
+  | 'MEDIA'
+  | 'CLINIC'
+  | 'WEARABLE';
 
 export type CareEventInput = {
   userId: string;

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -18,6 +18,7 @@ const envSchema = z.object({
   S3_PUBLIC_URL: z.string().optional(),
   AWS_REGION: z.string().optional(),
   ENABLE_ADVENTURE_SYSTEM: z.enum(['true', 'false']).optional(),
+  ENABLE_DOGOS_AUTOPILOT: z.enum(['true', 'false']).optional(),
   MEDIA_LIBRARY_IMAGE_MAX_BYTES: z.coerce
     .number()
     .int()

--- a/apps/web/src/app/autopilot/page.tsx
+++ b/apps/web/src/app/autopilot/page.tsx
@@ -88,10 +88,7 @@ export default function AutopilotPage() {
     return [...byId.values()];
   }, [households.data]);
 
-  const petNames = useMemo(
-    () => new Map(pets.map((pet) => [pet.id, pet.name] as const)),
-    [pets],
-  );
+  const petNames = useMemo(() => new Map(pets.map((pet) => [pet.id, pet.name] as const)), [pets]);
 
   const createReminder = useMutation({
     mutationFn: (input: CreateCareReminderInput) => autopilotApi.createReminder(input),
@@ -166,8 +163,8 @@ export default function AutopilotPage() {
               </h1>
               <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
                 Autopilot keeps care reminders together and can surface conservative tracker
-                check-ins. It does not diagnose your dog, award wearable XP, or store tracker GPS
-                in this release.
+                check-ins. It does not diagnose your dog, award wearable XP, or store tracker GPS in
+                this release.
               </p>
             </div>
           </div>
@@ -187,7 +184,11 @@ export default function AutopilotPage() {
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <label className="space-y-1.5 text-xs font-semibold text-muted-foreground">
                   Dog
-                  <select className={inputClass} value={petId} onChange={(e) => setPetId(e.target.value)}>
+                  <select
+                    className={inputClass}
+                    value={petId}
+                    onChange={(e) => setPetId(e.target.value)}
+                  >
                     <option value="">Household / general</option>
                     {pets.map((pet) => (
                       <option key={pet.id} value={pet.id}>
@@ -275,7 +276,10 @@ export default function AutopilotPage() {
               )}
 
               <div className="flex gap-2">
-                <Button type="submit" disabled={createReminder.isPending || !title.trim() || !dueAt}>
+                <Button
+                  type="submit"
+                  disabled={createReminder.isPending || !title.trim() || !dueAt}
+                >
                   {createReminder.isPending && (
                     <Loader2 className="mr-1.5 h-4 w-4 animate-spin" aria-hidden="true" />
                   )}
@@ -340,7 +344,8 @@ export default function AutopilotPage() {
                               </span>
                             </div>
                             <p className="mt-1 text-xs text-muted-foreground">
-                              {petNames.get(signal.petId) ?? 'Your dog'} · {formatDate(signal.observedAt)}
+                              {petNames.get(signal.petId) ?? 'Your dog'} ·{' '}
+                              {formatDate(signal.observedAt)}
                             </p>
                             <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
                               {signal.body}
@@ -395,8 +400,10 @@ export default function AutopilotPage() {
                             <div>
                               <h3 className="font-semibold">{reminder.title}</h3>
                               <p className="mt-1 text-xs text-muted-foreground">
-                                {reminder.petId ? petNames.get(reminder.petId) ?? 'Dog' : 'Household'} ·{' '}
-                                {formatDate(reminder.dueAt)}
+                                {reminder.petId
+                                  ? (petNames.get(reminder.petId) ?? 'Dog')
+                                  : 'Household'}{' '}
+                                · {formatDate(reminder.dueAt)}
                               </p>
                             </div>
                             <Button

--- a/apps/web/src/app/autopilot/page.tsx
+++ b/apps/web/src/app/autopilot/page.tsx
@@ -1,0 +1,487 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  Activity,
+  BatteryLow,
+  BellRing,
+  CalendarClock,
+  Check,
+  Clock3,
+  Loader2,
+  PawPrint,
+  Plus,
+  Radio,
+  ShieldCheck,
+  Sparkles,
+  Trash2,
+} from 'lucide-react';
+import Link from 'next/link';
+import { FormEvent, useMemo, useState } from 'react';
+import { BottomNav } from '@/components/bottom-nav';
+import { Button } from '@/components/ui/button';
+import {
+  autopilotApi,
+  type AutopilotSignal,
+  type CareReminderKind,
+  type CreateCareReminderInput,
+} from '@/lib/api/autopilot';
+import { householdsApi } from '@/lib/api/households';
+
+const reminderKinds: Array<{ value: CareReminderKind; label: string }> = [
+  { value: 'VET_APPOINTMENT', label: 'Vet appointment' },
+  { value: 'MEDICATION', label: 'Medication' },
+  { value: 'GROOMING', label: 'Grooming' },
+  { value: 'GENERAL_CARE', label: 'General care' },
+];
+
+const inputClass =
+  'h-11 w-full rounded-xl border border-border bg-background px-3 text-sm outline-none transition focus:border-primary/60 focus:ring-2 focus:ring-primary/10';
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return 'Invalid date';
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function signalIcon(signal: AutopilotSignal) {
+  return signal.signalType === 'TRACKER_BATTERY_LOW' ? BatteryLow : Activity;
+}
+
+export default function AutopilotPage() {
+  const queryClient = useQueryClient();
+  const [showForm, setShowForm] = useState(false);
+  const [petId, setPetId] = useState('');
+  const [kind, setKind] = useState<CareReminderKind>('GENERAL_CARE');
+  const [title, setTitle] = useState('');
+  const [detail, setDetail] = useState('');
+  const [dueAt, setDueAt] = useState('');
+  const [repeatEveryDays, setRepeatEveryDays] = useState('');
+
+  const dashboard = useQuery({
+    queryKey: ['autopilot'],
+    queryFn: () => autopilotApi.getDashboard(),
+    retry: false,
+  });
+
+  const households = useQuery({
+    queryKey: ['households', 'me'],
+    queryFn: () => householdsApi.getMine(),
+    retry: false,
+  });
+
+  const pets = useMemo(() => {
+    const byId = new Map<
+      string,
+      { id: string; name: string; species: string; avatarUrl?: string | null }
+    >();
+    for (const household of households.data ?? []) {
+      for (const membership of household.pets) {
+        byId.set(membership.pet.id, membership.pet);
+      }
+    }
+    return [...byId.values()];
+  }, [households.data]);
+
+  const petNames = useMemo(
+    () => new Map(pets.map((pet) => [pet.id, pet.name] as const)),
+    [pets],
+  );
+
+  const createReminder = useMutation({
+    mutationFn: (input: CreateCareReminderInput) => autopilotApi.createReminder(input),
+    onSuccess: async () => {
+      setTitle('');
+      setDetail('');
+      setDueAt('');
+      setRepeatEveryDays('');
+      setShowForm(false);
+      await queryClient.invalidateQueries({ queryKey: ['autopilot'] });
+    },
+  });
+
+  const cancelReminder = useMutation({
+    mutationFn: (id: string) => autopilotApi.cancelReminder(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['autopilot'] }),
+  });
+
+  const acknowledgeSignal = useMutation({
+    mutationFn: (id: string) => autopilotApi.acknowledgeSignal(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['autopilot'] }),
+  });
+
+  const submitReminder = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const due = new Date(dueAt);
+    if (!title.trim() || !Number.isFinite(due.getTime())) return;
+
+    const repeat = repeatEveryDays ? Number(repeatEveryDays) : undefined;
+    createReminder.mutate({
+      ...(petId ? { petId } : {}),
+      kind,
+      title: title.trim(),
+      ...(detail.trim() ? { detail: detail.trim() } : {}),
+      dueAt: due.toISOString(),
+      ...(repeat && Number.isInteger(repeat) ? { repeatEveryDays: repeat } : {}),
+    });
+  };
+
+  return (
+    <div className="min-h-screen pb-24">
+      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/88 backdrop-blur-2xl">
+        <div className="mx-auto flex h-16 max-w-xl items-center justify-between px-4">
+          <Link href="/" className="flex items-center gap-3" aria-label="Back to Woof Today">
+            <span className="brand-mark flex h-9 w-9 items-center justify-center rounded-xl">
+              <Sparkles className="h-5 w-5 text-primary-foreground" aria-hidden="true" />
+            </span>
+            <span>
+              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                dogOS
+              </span>
+              <span className="block text-lg font-bold tracking-tight">Autopilot</span>
+            </span>
+          </Link>
+          <Button size="sm" onClick={() => setShowForm((value) => !value)}>
+            <Plus className="mr-1.5 h-4 w-4" aria-hidden="true" />
+            Reminder
+          </Button>
+        </div>
+      </header>
+
+      <main id="main-content" className="mx-auto max-w-xl px-4 pb-8 pt-5">
+        <section className="rounded-3xl border border-primary/15 bg-gradient-to-br from-primary/[0.1] via-card/90 to-secondary/[0.07] p-5 shadow-sm">
+          <div className="flex items-start gap-4">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <BellRing className="h-5 w-5" aria-hidden="true" />
+            </div>
+            <div>
+              <p className="eyebrow">Quietly proactive</p>
+              <h1 className="mt-1 text-2xl font-bold tracking-tight">
+                Useful context, without surrendering the wheel.
+              </h1>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                Autopilot keeps care reminders together and can surface conservative tracker
+                check-ins. It does not diagnose your dog, award wearable XP, or store tracker GPS
+                in this release.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {showForm && (
+          <section className="surface-soft mt-4 rounded-3xl p-5">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="eyebrow">Schedule care</p>
+                <h2 className="mt-1 text-lg font-bold">New reminder</h2>
+              </div>
+              <Clock3 className="h-5 w-5 text-primary" aria-hidden="true" />
+            </div>
+
+            <form className="mt-4 space-y-4" onSubmit={submitReminder}>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <label className="space-y-1.5 text-xs font-semibold text-muted-foreground">
+                  Dog
+                  <select className={inputClass} value={petId} onChange={(e) => setPetId(e.target.value)}>
+                    <option value="">Household / general</option>
+                    {pets.map((pet) => (
+                      <option key={pet.id} value={pet.id}>
+                        {pet.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="space-y-1.5 text-xs font-semibold text-muted-foreground">
+                  Type
+                  <select
+                    className={inputClass}
+                    value={kind}
+                    onChange={(e) => setKind(e.target.value as CareReminderKind)}
+                  >
+                    {reminderKinds.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              <label className="block space-y-1.5 text-xs font-semibold text-muted-foreground">
+                Reminder
+                <input
+                  className={inputClass}
+                  value={title}
+                  maxLength={120}
+                  required
+                  placeholder="e.g. Monthly heartworm medication"
+                  onChange={(e) => setTitle(e.target.value)}
+                />
+              </label>
+
+              <label className="block space-y-1.5 text-xs font-semibold text-muted-foreground">
+                Note <span className="font-normal">optional</span>
+                <input
+                  className={inputClass}
+                  value={detail}
+                  maxLength={500}
+                  placeholder="Context for your household"
+                  onChange={(e) => setDetail(e.target.value)}
+                />
+              </label>
+
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <label className="space-y-1.5 text-xs font-semibold text-muted-foreground">
+                  Due
+                  <input
+                    className={inputClass}
+                    type="datetime-local"
+                    required
+                    value={dueAt}
+                    onChange={(e) => setDueAt(e.target.value)}
+                  />
+                </label>
+                <label className="space-y-1.5 text-xs font-semibold text-muted-foreground">
+                  Repeat every <span className="font-normal">days, optional</span>
+                  <input
+                    className={inputClass}
+                    type="number"
+                    min={1}
+                    max={365}
+                    inputMode="numeric"
+                    value={repeatEveryDays}
+                    placeholder="30"
+                    onChange={(e) => setRepeatEveryDays(e.target.value)}
+                  />
+                </label>
+              </div>
+
+              {kind === 'MEDICATION' && (
+                <p className="rounded-2xl border border-border/70 bg-background/55 p-3 text-xs leading-relaxed text-muted-foreground">
+                  dogOS schedules the reminder only. Follow the dose and timing instructions from
+                  your veterinarian or medication label.
+                </p>
+              )}
+
+              {createReminder.isError && (
+                <p className="text-sm text-destructive" role="alert">
+                  That reminder could not be saved. Check the details and try again.
+                </p>
+              )}
+
+              <div className="flex gap-2">
+                <Button type="submit" disabled={createReminder.isPending || !title.trim() || !dueAt}>
+                  {createReminder.isPending && (
+                    <Loader2 className="mr-1.5 h-4 w-4 animate-spin" aria-hidden="true" />
+                  )}
+                  Save reminder
+                </Button>
+                <Button type="button" variant="ghost" onClick={() => setShowForm(false)}>
+                  Cancel
+                </Button>
+              </div>
+            </form>
+          </section>
+        )}
+
+        {dashboard.isLoading ? (
+          <div className="flex min-h-[35vh] items-center justify-center" role="status">
+            <div className="text-center">
+              <Loader2 className="mx-auto h-7 w-7 animate-spin text-primary" aria-hidden="true" />
+              <p className="mt-3 text-sm text-muted-foreground">Checking the household rhythm…</p>
+            </div>
+          </div>
+        ) : dashboard.isError || !dashboard.data ? (
+          <section className="surface-soft mt-4 rounded-3xl p-6 text-center">
+            <ShieldCheck className="mx-auto h-8 w-8 text-primary" aria-hidden="true" />
+            <h2 className="mt-3 text-lg font-bold">Autopilot is unavailable</h2>
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+              The feature may be paused for this environment. Your existing care, Adventure, and
+              household records are unchanged.
+            </p>
+          </section>
+        ) : (
+          <>
+            <section className="mt-6">
+              <div className="flex items-end justify-between gap-3">
+                <div>
+                  <p className="eyebrow">Needs your eyes</p>
+                  <h2 className="mt-1 text-xl font-bold tracking-tight">Check-ins</h2>
+                </div>
+                <span className="text-xs font-semibold text-muted-foreground">
+                  {dashboard.data.signals.length} open
+                </span>
+              </div>
+
+              <div className="mt-3 space-y-3">
+                {dashboard.data.signals.length === 0 ? (
+                  <div className="surface-soft rounded-2xl p-4 text-sm text-muted-foreground">
+                    Nothing needs a check-in right now.
+                  </div>
+                ) : (
+                  dashboard.data.signals.map((signal) => {
+                    const Icon = signalIcon(signal);
+                    return (
+                      <article key={signal.id} className="surface-soft rounded-2xl p-4">
+                        <div className="flex items-start gap-3">
+                          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                            <Icon className="h-4 w-4" aria-hidden="true" />
+                          </div>
+                          <div className="min-w-0 flex-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <h3 className="font-semibold">{signal.title}</h3>
+                              <span className="rounded-full border border-border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                                {signal.level === 'CHECK_IN' ? 'Check in' : 'Info'}
+                              </span>
+                            </div>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {petNames.get(signal.petId) ?? 'Your dog'} · {formatDate(signal.observedAt)}
+                            </p>
+                            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                              {signal.body}
+                            </p>
+                            <Button
+                              className="mt-3"
+                              variant="outline"
+                              size="sm"
+                              disabled={acknowledgeSignal.isPending}
+                              onClick={() => acknowledgeSignal.mutate(signal.id)}
+                            >
+                              <Check className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                              Got it
+                            </Button>
+                          </div>
+                        </div>
+                      </article>
+                    );
+                  })
+                )}
+              </div>
+            </section>
+
+            <section className="mt-7">
+              <div className="flex items-end justify-between gap-3">
+                <div>
+                  <p className="eyebrow">Coming up</p>
+                  <h2 className="mt-1 text-xl font-bold tracking-tight">Care reminders</h2>
+                </div>
+                <CalendarClock className="h-5 w-5 text-primary" aria-hidden="true" />
+              </div>
+
+              <div className="mt-3 space-y-3">
+                {dashboard.data.reminders.length === 0 ? (
+                  <button
+                    type="button"
+                    className="surface-soft w-full rounded-2xl p-4 text-left text-sm text-muted-foreground transition hover:border-primary/30"
+                    onClick={() => setShowForm(true)}
+                  >
+                    No reminders yet. Add one for appointments, medication, grooming, or ordinary
+                    care.
+                  </button>
+                ) : (
+                  dashboard.data.reminders.map((reminder) => (
+                    <article key={reminder.id} className="surface-soft rounded-2xl p-4">
+                      <div className="flex items-start gap-3">
+                        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-secondary/10 text-primary">
+                          <BellRing className="h-4 w-4" aria-hidden="true" />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-start justify-between gap-3">
+                            <div>
+                              <h3 className="font-semibold">{reminder.title}</h3>
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                {reminder.petId ? petNames.get(reminder.petId) ?? 'Dog' : 'Household'} ·{' '}
+                                {formatDate(reminder.dueAt)}
+                              </p>
+                            </div>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              aria-label={`Cancel ${reminder.title}`}
+                              disabled={cancelReminder.isPending}
+                              onClick={() => cancelReminder.mutate(reminder.id)}
+                            >
+                              <Trash2 className="h-4 w-4" aria-hidden="true" />
+                            </Button>
+                          </div>
+                          {reminder.detail && (
+                            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                              {reminder.detail}
+                            </p>
+                          )}
+                          {reminder.repeatEveryDays && (
+                            <p className="mt-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                              Repeats every {reminder.repeatEveryDays} days
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </article>
+                  ))
+                )}
+              </div>
+            </section>
+
+            <section className="mt-7">
+              <p className="eyebrow">Tracker adapters</p>
+              <h2 className="mt-1 text-xl font-bold tracking-tight">Ready for a real connector</h2>
+              <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                {dashboard.data.providers.map((provider) => (
+                  <article key={provider.provider} className="surface-soft rounded-2xl p-4">
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                        <Radio className="h-4 w-4" aria-hidden="true" />
+                      </div>
+                      <div>
+                        <h3 className="font-semibold">{provider.provider}</h3>
+                        <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                          Adapter ready
+                        </p>
+                      </div>
+                    </div>
+                    <p className="mt-3 text-xs leading-relaxed text-muted-foreground">
+                      Daily activity and device-health summaries are normalized. OAuth, webhooks,
+                      revocation, and location permissions arrive in Connectors.
+                    </p>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section className="mt-7 rounded-3xl border border-primary/15 bg-primary/[0.04] p-5">
+              <div className="flex items-center gap-2">
+                <ShieldCheck className="h-5 w-5 text-primary" aria-hidden="true" />
+                <h2 className="font-bold">Autopilot boundaries</h2>
+              </div>
+              <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <Boundary label="Tracker GPS stored" value="No" />
+                <Boundary label="Wearables award Bond XP" value="No" />
+                <Boundary label="Provider can edit dog records" value="No" />
+                <Boundary label="Signals are diagnoses" value="No" />
+              </div>
+            </section>
+          </>
+        )}
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+}
+
+function Boundary({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-2xl border border-border/60 bg-background/55 px-3 py-2.5">
+      <span className="flex items-center gap-2 text-xs text-muted-foreground">
+        <PawPrint className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+        {label}
+      </span>
+      <span className="text-xs font-bold text-primary">{value}</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/bottom-nav.tsx
+++ b/apps/web/src/components/bottom-nav.tsx
@@ -36,7 +36,7 @@ export function BottomNav() {
                 aria-current={isActive ? 'page' : undefined}
                 className={cn(
                   'group -mt-5 flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border brand-mark text-primary-foreground transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5',
-                  isActive ? 'border-primary/50 ring-4 ring-primary/10' : 'border-primary/20',
+                  isActive ? 'border-primary/50 ring-4 ring-primary/10' : 'border-primary/20'
                 )}
               >
                 <Icon
@@ -55,13 +55,13 @@ export function BottomNav() {
               aria-current={isActive ? 'page' : undefined}
               className={cn(
                 'group relative flex h-full min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-xl px-0.5 transition-colors',
-                isActive ? 'text-primary' : 'text-muted-foreground hover:text-foreground',
+                isActive ? 'text-primary' : 'text-muted-foreground hover:text-foreground'
               )}
             >
               <span
                 className={cn(
                   'absolute top-1.5 h-1 w-1 rounded-full bg-primary transition-opacity',
-                  isActive ? 'opacity-100' : 'opacity-0',
+                  isActive ? 'opacity-100' : 'opacity-0'
                 )}
                 aria-hidden="true"
               />

--- a/apps/web/src/components/bottom-nav.tsx
+++ b/apps/web/src/components/bottom-nav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Brain, Compass, Map, PawPrint, Users } from 'lucide-react';
+import { Brain, Compass, Map, PawPrint, Sparkles, Users } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
@@ -9,6 +9,7 @@ const navItems = [
   { href: '/', icon: PawPrint, label: 'Today' },
   { href: '/compass', icon: Compass, label: 'Compass' },
   { href: '/journey', icon: Map, label: 'Journey', isSpecial: true },
+  { href: '/autopilot', icon: Sparkles, label: 'Auto' },
   { href: '/coach', icon: Brain, label: 'Coach' },
   { href: '/pack', icon: Users, label: 'Pack' },
 ];
@@ -21,7 +22,7 @@ export function BottomNav() {
       aria-label="Primary navigation"
       className="fixed inset-x-0 bottom-0 z-50 border-t border-border/60 bg-background/92 pb-safe backdrop-blur-2xl"
     >
-      <div className="mx-auto flex h-[68px] max-w-xl items-center justify-around px-3">
+      <div className="mx-auto flex h-[68px] max-w-xl items-center justify-around px-2">
         {navItems.map((item) => {
           const isActive = item.href === '/' ? pathname === '/' : pathname.startsWith(item.href);
           const Icon = item.icon;
@@ -34,8 +35,8 @@ export function BottomNav() {
                 aria-label="Open Adventure Journey"
                 aria-current={isActive ? 'page' : undefined}
                 className={cn(
-                  'group -mt-5 flex h-14 w-14 items-center justify-center rounded-2xl border brand-mark text-primary-foreground transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5',
-                  isActive ? 'border-primary/50 ring-4 ring-primary/10' : 'border-primary/20'
+                  'group -mt-5 flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border brand-mark text-primary-foreground transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5',
+                  isActive ? 'border-primary/50 ring-4 ring-primary/10' : 'border-primary/20',
                 )}
               >
                 <Icon
@@ -53,19 +54,21 @@ export function BottomNav() {
               href={item.href}
               aria-current={isActive ? 'page' : undefined}
               className={cn(
-                'group relative flex h-full flex-1 flex-col items-center justify-center gap-1 rounded-xl px-1 transition-colors',
-                isActive ? 'text-primary' : 'text-muted-foreground hover:text-foreground'
+                'group relative flex h-full min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-xl px-0.5 transition-colors',
+                isActive ? 'text-primary' : 'text-muted-foreground hover:text-foreground',
               )}
             >
               <span
                 className={cn(
                   'absolute top-1.5 h-1 w-1 rounded-full bg-primary transition-opacity',
-                  isActive ? 'opacity-100' : 'opacity-0'
+                  isActive ? 'opacity-100' : 'opacity-0',
                 )}
                 aria-hidden="true"
               />
               <Icon className="h-5 w-5" aria-hidden="true" />
-              <span className="text-[11px] font-semibold tracking-wide">{item.label}</span>
+              <span className="text-[10px] font-semibold tracking-wide sm:text-[11px]">
+                {item.label}
+              </span>
             </Link>
           );
         })}

--- a/apps/web/src/lib/api/autopilot.spec.ts
+++ b/apps/web/src/lib/api/autopilot.spec.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const transport = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock('./client', () => ({
+  apiClient: transport,
+}));
+
+import { autopilotApi, type CreateCareReminderInput } from './autopilot';
+
+describe('autopilotApi', () => {
+  beforeEach(() => {
+    transport.get.mockReset();
+    transport.post.mockReset();
+    transport.delete.mockReset();
+  });
+
+  it('reads the authenticated Autopilot dashboard', async () => {
+    transport.get.mockResolvedValue({ reminders: [], signals: [] });
+
+    await autopilotApi.getDashboard();
+
+    expect(transport.get).toHaveBeenCalledWith('/autopilot');
+  });
+
+  it('preserves pet-scoped reminder input without adding autonomous care fields', async () => {
+    transport.post.mockResolvedValue({ id: 'reminder-1' });
+    const input: CreateCareReminderInput = {
+      petId: 'pet-1',
+      kind: 'MEDICATION',
+      title: 'Heartworm medication',
+      detail: 'Use the veterinarian-provided instructions.',
+      dueAt: '2026-08-24T18:00:00.000Z',
+      repeatEveryDays: 30,
+    };
+
+    await autopilotApi.createReminder(input);
+
+    expect(transport.post).toHaveBeenCalledWith('/autopilot/reminders', input);
+    const body = transport.post.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(body).not.toHaveProperty('dose');
+    expect(body).not.toHaveProperty('dosage');
+    expect(body).not.toHaveProperty('administerAutomatically');
+  });
+
+  it('cancels only the selected reminder route', async () => {
+    transport.delete.mockResolvedValue({ success: true });
+
+    await autopilotApi.cancelReminder('reminder-1');
+
+    expect(transport.delete).toHaveBeenCalledWith('/autopilot/reminders/reminder-1');
+  });
+
+  it('acknowledges signals without mutating the underlying observation', async () => {
+    transport.post.mockResolvedValue({ success: true });
+
+    await autopilotApi.acknowledgeSignal('signal-1');
+
+    expect(transport.post).toHaveBeenCalledWith('/autopilot/signals/signal-1/acknowledge');
+  });
+});

--- a/apps/web/src/lib/api/autopilot.ts
+++ b/apps/web/src/lib/api/autopilot.ts
@@ -1,0 +1,72 @@
+import { apiClient } from './client';
+
+export type AutopilotProviderCapability = {
+  provider: 'FI' | 'TRACTIVE';
+  status: 'STUB_READY';
+  accepts: Array<'DAILY_ACTIVITY' | 'DEVICE_STATUS'>;
+};
+
+export type CareReminderKind =
+  | 'VET_APPOINTMENT'
+  | 'MEDICATION'
+  | 'GROOMING'
+  | 'GENERAL_CARE';
+
+export type CareReminder = {
+  id: string;
+  schemaVersion: 'dogos-care-reminder-v1';
+  kind: CareReminderKind;
+  title: string;
+  detail?: string;
+  petId?: string;
+  dueAt: string;
+  repeatEveryDays?: number;
+  status: 'SCHEDULED' | 'COMPLETED' | 'CANCELLED';
+  lastAttemptAt?: string;
+  lastDeliveredAt?: string;
+};
+
+export type AutopilotSignal = {
+  id: string;
+  schemaVersion: 'dogos-autopilot-signal-v1';
+  petId: string;
+  sourceCareEventId: string;
+  signalType: 'ACTIVITY_BELOW_RECENT_BASELINE' | 'TRACKER_BATTERY_LOW';
+  level: 'CHECK_IN' | 'INFO';
+  title: string;
+  body: string;
+  observedAt: string;
+  evidence: Record<string, string | number | boolean>;
+  nonDiagnostic: true;
+};
+
+export type AutopilotDashboard = {
+  providers: AutopilotProviderCapability[];
+  reminders: CareReminder[];
+  signals: AutopilotSignal[];
+  boundaries: {
+    locationTelemetryStored: false;
+    canonicalPetMutationAllowed: false;
+    trackerObservationsRewardEligible: false;
+    signalsDiagnostic: false;
+  };
+};
+
+export type CreateCareReminderInput = {
+  petId?: string;
+  kind: CareReminderKind;
+  title: string;
+  detail?: string;
+  dueAt: string;
+  repeatEveryDays?: number;
+};
+
+export const autopilotApi = {
+  getDashboard: () => apiClient.get<AutopilotDashboard>('/autopilot'),
+  createReminder: (input: CreateCareReminderInput) =>
+    apiClient.post<CareReminder, CreateCareReminderInput>('/autopilot/reminders', input),
+  cancelReminder: (id: string) =>
+    apiClient.delete<{ success: boolean }>(`/autopilot/reminders/${id}`),
+  acknowledgeSignal: (id: string) =>
+    apiClient.post<{ success: boolean }>(`/autopilot/signals/${id}/acknowledge`),
+};

--- a/apps/web/src/lib/api/autopilot.ts
+++ b/apps/web/src/lib/api/autopilot.ts
@@ -6,11 +6,7 @@ export type AutopilotProviderCapability = {
   accepts: Array<'DAILY_ACTIVITY' | 'DEVICE_STATUS'>;
 };
 
-export type CareReminderKind =
-  | 'VET_APPOINTMENT'
-  | 'MEDICATION'
-  | 'GROOMING'
-  | 'GENERAL_CARE';
+export type CareReminderKind = 'VET_APPOINTMENT' | 'MEDICATION' | 'GROOMING' | 'GENERAL_CARE';
 
 export type CareReminder = {
   id: string;

--- a/apps/web/src/lib/api/households.ts
+++ b/apps/web/src/lib/api/households.ts
@@ -1,0 +1,27 @@
+import { apiClient } from './client';
+
+export type HouseholdPet = {
+  id: string;
+  status: string;
+  joinedAt: string;
+  pet: {
+    id: string;
+    name: string;
+    species: string;
+    breed?: string | null;
+    birthdate?: string | null;
+    avatarUrl?: string | null;
+  };
+};
+
+export type HouseholdSnapshot = {
+  id: string;
+  name: string;
+  timezone?: string | null;
+  viewerRole: string;
+  pets: HouseholdPet[];
+};
+
+export const householdsApi = {
+  getMine: () => apiClient.get<HouseholdSnapshot[]>('/households/me'),
+};

--- a/docs/DOGOS_AUTOPILOT.md
+++ b/docs/DOGOS_AUTOPILOT.md
@@ -1,0 +1,133 @@
+# dogOS Autopilot v1
+
+## Purpose
+
+Autopilot is the first proactive dogOS layer. It turns a small amount of trusted context into reminders and check-ins without turning Woof into a medical monitor or giving external vendors authority over canonical dog state.
+
+The pipeline is deliberately one-way:
+
+`provider payload -> adapter -> normalized summary -> immutable CareEvent -> dedupe -> bounded signal/reminder policy -> user suggestion`
+
+External providers never receive a code path that can directly mutate `Pet`, Activity, Health Lens, Adventure rewards, or household membership.
+
+## Phase A provider boundary
+
+The first adapters are Fi and Tractive stubs. They accept only:
+
+- `DAILY_ACTIVITY`
+  - activity minutes
+  - distance meters
+  - steps
+- `DEVICE_STATUS`
+  - battery percent
+  - online/offline/unknown state
+
+Autopilot v1 intentionally rejects location-shaped payloads, including nested latitude/longitude, coordinates, GPS traces, routes, and tracks. Continuous location ingestion belongs in the Connectors phase, where retention, revocation, export, and location-specific permissions can be explicit.
+
+Provider-specific fields that are not recognized by an adapter are discarded rather than copied into storage.
+
+## Observation integrity
+
+Normalized tracker summaries reuse the Adventure `CareEvent` ledger because it already provides:
+
+- immutable event identity
+- per-user dedupe keys
+- pet ownership checks
+- occurrence-time normalization
+- private visibility
+- provenance fields
+
+Wearable observations use `evidenceType=WEARABLE`, provider-specific `source`, and `safetyEligible=false`.
+
+That last invariant is critical: tracker data is context, not proof of virtuous care. It cannot award Bond XP. The normal Adventure reward ledger still records the zero-reward decision so the policy remains auditable.
+
+## Baseline-change signals
+
+Autopilot signals are suggestions stored as user notifications, not diagnoses or pet-health fields.
+
+### Lower activity check-in
+
+A lower-activity signal requires all of the following:
+
+1. a current daily tracker summary with activity minutes;
+2. at least six prior summaries in the preceding 28 days;
+3. a median recent baseline;
+4. current activity at or below 55% of that baseline; and
+5. an absolute drop of at least 20 minutes.
+
+The message explicitly names benign context such as rest days, weather, routine changes, and tracker wear. It does not infer illness, pain, fatigue, or another medical state.
+
+### Tracker battery
+
+Battery at or below 15% can create an informational device-maintenance signal. This is operational, not a wellbeing inference.
+
+Replayed provider events are deduped by the immutable CareEvent key and cannot create a second signal.
+
+## Care reminders
+
+Care reminders use the existing durable `Notification` store as scheduled notification envelopes. This keeps the first proactive layer additive without introducing another parallel notification database abstraction.
+
+Supported reminder kinds:
+
+- vet appointment
+- medication
+- grooming
+- general care
+
+A reminder may be one-time or repeat every 1-365 days. Household members who can access a pet may schedule its reminders.
+
+The scheduler runs every ten minutes. Before attempting delivery it claims a reminder with a PostgreSQL advisory transaction lock and records `lastAttemptAt`. This prevents multiple API replicas from immediately delivering the same reminder. Failed delivery leaves the reminder scheduled and eligible for a bounded retry after six hours. A one-time reminder is completed only after successful push delivery. Recurring reminders advance to the next future due time only after successful delivery.
+
+Medication reminder copy tells the user to follow veterinary instructions. The scheduler does not calculate or change medication dosage.
+
+## API
+
+All endpoints require JWT authentication and `ENABLE_DOGOS_AUTOPILOT`.
+
+- `GET /autopilot`
+  - active reminders
+  - unacknowledged signals
+  - provider capabilities
+  - explicit safety/privacy boundaries
+- `POST /autopilot/observations/:provider`
+  - authenticated owner-side Fi/Tractive stub ingestion
+- `POST /autopilot/reminders`
+  - schedule a care reminder
+- `DELETE /autopilot/reminders/:id`
+  - cancel a reminder owned by the authenticated user
+- `POST /autopilot/signals/:id/acknowledge`
+  - acknowledge a signal owned by the authenticated user
+
+Provider webhook authentication and OAuth/token lifecycle are intentionally deferred to the Connectors phase. Phase A does not expose an unauthenticated vendor webhook.
+
+## Rollout
+
+`ENABLE_DOGOS_AUTOPILOT` follows the Adventure rollout convention:
+
+- development/test: enabled unless explicitly false
+- production: disabled unless explicitly true
+
+A disabled experimental surface returns 404 rather than exposing rollout configuration.
+
+## Executable invariants
+
+`.github/workflows/dogos-autopilot-ci.yml` verifies the release surface and also rejects direct Prisma `Pet` create/update/delete/upsert calls anywhere inside `src/autopilot`.
+
+The focused contracts cover:
+
+- Fi normalization and field minimization
+- Tractive normalization
+- nested location rejection
+- unsupported provider rejection
+- invalid battery rejection
+- wearable CareEvents are private and zero-reward
+- provider replay does not duplicate signals
+- sparse baselines do not alert
+- large, well-supported activity drops create non-diagnostic check-ins
+- low battery creates only an informational signal
+- household-authorized reminder creation
+- failed push delivery does not complete a reminder
+
+## Next phases
+
+Autopilot v1 deliberately stops before provider OAuth/webhooks, continuous location retention, veterinary-record imports, retail actions, or autonomous purchasing. Those belong to the Connectors and Concierge phases where consent, provenance, revocation, and human approval can be designed as first-class contracts.


### PR DESCRIPTION
## Phase A: dogOS Autopilot

This PR starts the post-Foundation dogOS ecosystem on top of merged PR #8 (`216839af20408fe14dc8c90906e983e22540af58`).

### What it adds

- provider-neutral normalized tracker summary contract
- Fi and Tractive adapter stubs
- explicit rejection of location/GPS-shaped payloads in Phase A
- immutable private tracker observations through the existing CareEvent integrity ledger
- `WEARABLE` evidence type
- hard `safetyEligible=false` boundary so wearable summaries can never award Bond XP
- conservative recent-baseline activity check-ins
- low-tracker-battery informational signals
- one-time and recurring vet/medication/grooming/general-care reminders
- ten-minute reminder scheduler with PostgreSQL advisory claiming and six-hour failed-delivery backoff
- feature flag `ENABLE_DOGOS_AUTOPILOT`
- authenticated Autopilot API and `/autopilot` control center
- household-aware care reminder scheduling
- primary navigation entry without fake provider-connect affordances
- executable CI rule rejecting direct canonical `Pet` mutations from the Autopilot module

### Replay and integrity hardening

Autopilot signal creation is idempotent by immutable source CareEvent. A transaction-scoped PostgreSQL advisory lock prevents concurrent retries from duplicating a signal, and an existing signal is returned even if it has already been acknowledged.

More importantly, retry payloads are never trusted for signal derivation. After CareEvent dedupe, Autopilot reloads the persisted private observation and derives the signal from that snapshot. A focused adversarial contract proves that if a retry claims battery `80` but the already-committed event records battery `9`, the repaired signal still uses `9` and the original persisted timestamp.

### Privacy and safety

Autopilot v1 stores only recognized daily summary/device fields. Unknown provider fields are discarded. Continuous GPS/location telemetry is rejected and deferred to the Connectors phase, where retention and revocation can be explicit.

Signals are user-facing suggestions, not diagnoses. The lower-activity check requires at least six prior samples, a drop to <=55% of the median baseline, and an absolute decrease of at least 20 minutes. Reminder scheduling never calculates medication dosage.

The UI makes the boundaries visible:

- tracker GPS stored: no
- wearables award Bond XP: no
- provider can edit canonical dog records: no
- signals are diagnoses: no

### Focused contract coverage

- 5 provider adapter/privacy contracts
- 8 Autopilot service contracts, including altered-retry replay repair and acknowledged-signal dedupe
- 4 web API boundary contracts
- inherited Adventure reward-policy contracts
- full web test suite

### Exact-head qualification

**Qualified head:** `fb63a572f48ca6b7bfb45dd7e63185fa76700caa`

**dogOS Autopilot CI:** run `32604823708` / #21: green

- frozen lockfile install
- inherited migration deployment
- exact release-surface formatting
- zero-warning API and web lint
- direct canonical `Pet` mutation rejection
- API and web type-check
- provider privacy contracts
- Autopilot service/replay contracts
- Adventure reward-policy regression
- full web contracts
- API production build
- web production build

**dogOS Foundation CI:** run `32604823733` / #45: green on the same exact head.

**Adventure System CI:** run `32604823709` / #313: green on the same exact head.

**Root CI:** run `32604823707` / #302: green on the same exact head, including full static quality gates, ML compile/policy contracts, backend unit/API tests, Chromium smoke/accessibility/visual contracts, and API/Web production builds.

See `docs/DOGOS_AUTOPILOT.md` for the complete operating boundary and rollout contract.

### Next slice

Phase B, Our Story, should begin only from the exact merge commit of this PR. It will build the unified chronological dog/household life stream by referencing Activities, CareEvents, Media Library, milestones, and bounded wearable observations without duplicating source truth.