### PR TITLE
dogOS Connectors: verified transport, encrypted credentials, and provenance

### DIFF
--- a/.github/workflows/dogos-connectors-ci.yml
+++ b/.github/workflows/dogos-connectors-ci.yml
@@ -119,9 +119,10 @@ jobs:
           src/app.module.ts
           src/config/env.validation.ts
 
-      - name: Reject direct canonical mutations from Connectors
+      - name: Reject direct canonical mutations from production Connectors source
         run: |
-          if grep -REin '\.(pet|activity|careEvent|mediaAsset)\.(create|update|delete|upsert|createMany|updateMany|deleteMany)\b|\b(INSERT[[:space:]]+INTO|UPDATE|DELETE[[:space:]]+FROM)[[:space:]]+(public\.)?(pets|activities|care_events|media_assets)\b' apps/api/src/connectors; then
+          production_sources=$(find apps/api/src/connectors -type f -name '*.ts' ! -name '*.spec.ts' -print)
+          if grep -EIn '\.(pet|activity|careEvent|mediaAsset)\.(create|update|delete|upsert|createMany|updateMany|deleteMany)\b|\b(INSERT[[:space:]]+INTO|UPDATE|DELETE[[:space:]]+FROM)[[:space:]]+(public\.)?(pets|activities|care_events|media_assets)\b' $production_sources; then
             echo 'Connector transport must delegate canonical writes to domain importers.'
             exit 1
           fi

--- a/.github/workflows/dogos-connectors-ci.yml
+++ b/.github/workflows/dogos-connectors-ci.yml
@@ -8,6 +8,10 @@ on:
       - 'apps/api/src/app.module.ts'
       - 'apps/api/src/config/env.validation.ts'
       - 'apps/api/.env.example'
+      - 'apps/web/src/app/connectors/**'
+      - 'apps/web/src/app/settings/page.tsx'
+      - 'apps/web/src/components/settings/connected-services-settings.tsx'
+      - 'apps/web/src/lib/api/connectors*.ts'
       - 'packages/database/prisma/migrations/20260823004500_add_dogos_connectors_operational_schema/**'
       - '.github/workflows/dogos-connectors-ci.yml'
       - 'docs/DOGOS_CONNECTORS.md'
@@ -47,6 +51,7 @@ jobs:
       JWT_SECRET: ci-only-connectors-secret
       NODE_ENV: test
       ML_SERVICE_ENABLED: 'false'
+      NEXT_PUBLIC_API_URL: http://127.0.0.1:59999/api/v1
       ENABLE_ADVENTURE_SYSTEM: 'true'
       ENABLE_DOGOS_AUTOPILOT: 'true'
       ENABLE_DOGOS_OUR_STORY: 'true'
@@ -103,12 +108,22 @@ jobs:
             apps/api/src/connectors \
             apps/api/src/app.module.ts \
             apps/api/src/config/env.validation.ts \
+            apps/web/src/app/connectors \
+            apps/web/src/app/settings/page.tsx \
+            apps/web/src/components/settings/connected-services-settings.tsx \
+            apps/web/src/lib/api/connectors.ts \
+            apps/web/src/lib/api/connectors.spec.ts \
             .github/workflows/dogos-connectors-ci.yml \
             docs/DOGOS_CONNECTORS.md
           git diff --exit-code -- \
             apps/api/src/connectors \
             apps/api/src/app.module.ts \
             apps/api/src/config/env.validation.ts \
+            apps/web/src/app/connectors \
+            apps/web/src/app/settings/page.tsx \
+            apps/web/src/components/settings/connected-services-settings.tsx \
+            apps/web/src/lib/api/connectors.ts \
+            apps/web/src/lib/api/connectors.spec.ts \
             .github/workflows/dogos-connectors-ci.yml \
             docs/DOGOS_CONNECTORS.md
 
@@ -118,6 +133,15 @@ jobs:
           'src/connectors/**/*.ts'
           src/app.module.ts
           src/config/env.validation.ts
+
+      - name: Lint Connected Services web surface
+        run: >-
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/app/connectors/page.tsx
+          src/app/settings/page.tsx
+          src/components/settings/connected-services-settings.tsx
+          src/lib/api/connectors.ts
+          src/lib/api/connectors.spec.ts
 
       - name: Reject direct canonical mutations from production Connectors source
         run: |
@@ -145,6 +169,9 @@ jobs:
       - name: Type-check API
         run: pnpm --filter @woof/api type-check
 
+      - name: Type-check web app
+        run: pnpm --filter @woof/web type-check
+
       - name: Run connector crypto + lifecycle contracts
         run: pnpm --filter @woof/api exec jest src/connectors --runInBand --testPathIgnorePatterns=integration
 
@@ -160,5 +187,13 @@ jobs:
       - name: Run Our Story source contracts
         run: pnpm --filter @woof/api exec jest src/story --runInBand
 
+      - name: Run Connected Services web API contracts
+        run: pnpm --filter @woof/web exec vitest run src/lib/api/connectors.spec.ts
+
       - name: Build API
         run: pnpm --filter @woof/api build
+
+      - name: Build web app
+        env:
+          NEXT_PUBLIC_API_URL: https://api.example.com/api/v1
+        run: pnpm --filter @woof/web build

--- a/.github/workflows/dogos-connectors-ci.yml
+++ b/.github/workflows/dogos-connectors-ci.yml
@@ -1,0 +1,163 @@
+name: dogOS Connectors CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/connectors/**'
+      - 'apps/api/src/app.module.ts'
+      - 'apps/api/src/config/env.validation.ts'
+      - 'apps/api/.env.example'
+      - 'packages/database/prisma/migrations/20260823004500_add_dogos_connectors_operational_schema/**'
+      - '.github/workflows/dogos-connectors-ci.yml'
+      - 'docs/DOGOS_CONNECTORS.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-connectors-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  qualify:
+    name: Connectors transport + provenance qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+      SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_shadow
+      JWT_SECRET: ci-only-connectors-secret
+      NODE_ENV: test
+      ML_SERVICE_ENABLED: 'false'
+      ENABLE_ADVENTURE_SYSTEM: 'true'
+      ENABLE_DOGOS_AUTOPILOT: 'true'
+      ENABLE_DOGOS_OUR_STORY: 'true'
+      ENABLE_DOGOS_CONNECTORS: 'true'
+      CONNECTOR_CREDENTIALS_KEY: BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate Prisma schema
+        run: pnpm --filter @woof/database exec prisma validate
+
+      - name: Check Prisma schema formatting
+        run: |
+          pnpm --filter @woof/database exec prisma format
+          git diff --exit-code -- packages/database/prisma/schema.prisma
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject destructive connector migration operations
+        run: |
+          migration='packages/database/prisma/migrations/20260823004500_add_dogos_connectors_operational_schema/migration.sql'
+          if grep -EIn '\b(DROP|TRUNCATE)\b|ALTER[[:space:]]+TABLE[[:space:]]+(public\.)?(users|pets|activities|care_events|media_assets)\b' "$migration"; then
+            echo 'Connectors migration must remain additive and cannot alter canonical dogOS tables.'
+            exit 1
+          fi
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Verify canonical Prisma datamodel still has zero drift
+        run: >-
+          pnpm --filter @woof/database exec prisma migrate diff
+          --from-url "$DATABASE_URL"
+          --to-schema-datamodel prisma/schema.prisma
+          --exit-code
+
+      - name: Check Connectors formatting
+        run: |
+          pnpm exec prettier --write \
+            apps/api/src/connectors \
+            apps/api/src/app.module.ts \
+            apps/api/src/config/env.validation.ts \
+            .github/workflows/dogos-connectors-ci.yml \
+            docs/DOGOS_CONNECTORS.md
+          git diff --exit-code -- \
+            apps/api/src/connectors \
+            apps/api/src/app.module.ts \
+            apps/api/src/config/env.validation.ts \
+            .github/workflows/dogos-connectors-ci.yml \
+            docs/DOGOS_CONNECTORS.md
+
+      - name: Lint Connectors API surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          'src/connectors/**/*.ts'
+          src/app.module.ts
+          src/config/env.validation.ts
+
+      - name: Reject direct canonical mutations from Connectors
+        run: |
+          if grep -REin '\.(pet|activity|careEvent|mediaAsset)\.(create|update|delete|upsert|createMany|updateMany|deleteMany)\b|\b(INSERT[[:space:]]+INTO|UPDATE|DELETE[[:space:]]+FROM)[[:space:]]+(public\.)?(pets|activities|care_events|media_assets)\b' apps/api/src/connectors; then
+            echo 'Connector transport must delegate canonical writes to domain importers.'
+            exit 1
+          fi
+
+      - name: Reject browser provider impersonation routes
+        run: |
+          if grep -EIn 'import/wearable|@Body\(|importWearable' apps/api/src/connectors/connectors.controller.ts; then
+            echo 'Provider-originated payloads must not be accepted from the public browser API.'
+            exit 1
+          fi
+
+      - name: Reject raw provider payload persistence
+        run: |
+          migration='packages/database/prisma/migrations/20260823004500_add_dogos_connectors_operational_schema/migration.sql'
+          if grep -EIn '(raw_provider|raw_payload|provider_payload|payload_json)[[:space:]]' "$migration"; then
+            echo 'Operational connector persistence may store normalized hashes, not raw provider payloads.'
+            exit 1
+          fi
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Run connector crypto + lifecycle contracts
+        run: pnpm --filter @woof/api exec jest src/connectors --runInBand --testPathIgnorePatterns=integration
+
+      - name: Run connector operational integration contracts
+        run: >-
+          pnpm --filter @woof/api exec jest
+          src/connectors/connector-operational.store.integration.spec.ts
+          --runInBand
+
+      - name: Run Autopilot replay regression
+        run: pnpm --filter @woof/api exec jest src/autopilot/autopilot.service.spec.ts --runInBand
+
+      - name: Run Our Story source contracts
+        run: pnpm --filter @woof/api exec jest src/story --runInBand
+
+      - name: Build API
+        run: pnpm --filter @woof/api build

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -22,6 +22,13 @@ CORS_ORIGIN=http://localhost:3000,http://localhost:3001
 ENABLE_ADVENTURE_SYSTEM=true
 ENABLE_DOGOS_AUTOPILOT=true
 ENABLE_DOGOS_OUR_STORY=true
+ENABLE_DOGOS_CONNECTORS=true
+
+# dogOS connector credential vault.
+# Generate 32 random bytes and encode them as base64, for example:
+# openssl rand -base64 32
+# Required when ENABLE_DOGOS_CONNECTORS=true in production. Do not reuse JWT/VAPID keys.
+CONNECTOR_CREDENTIALS_KEY=
 
 # File Upload
 MAX_FILE_SIZE=10485760

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -17,6 +17,7 @@ import { CoActivityModule } from './co-activity/co-activity.module';
 import { CoachingModule } from './coaching/coaching.module';
 import { CompatibilityModule } from './compatibility/compatibility.module';
 import { validateEnvironment } from './config/env.validation';
+import { ConnectorsModule } from './connectors/connectors.module';
 import { EventsModule } from './events/events.module';
 import { GamificationModule } from './gamification/gamification.module';
 import { GoalsModule } from './goals/goals.module';
@@ -70,6 +71,7 @@ export const throttlerOptions: ThrottlerModuleOptions = {
     AdventureModule,
     AutopilotModule,
     StoryModule,
+    ConnectorsModule,
     SocialModule,
     MeetupsModule,
     CompatibilityModule,

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -20,6 +20,8 @@ const envSchema = z.object({
   ENABLE_ADVENTURE_SYSTEM: z.enum(['true', 'false']).optional(),
   ENABLE_DOGOS_AUTOPILOT: z.enum(['true', 'false']).optional(),
   ENABLE_DOGOS_OUR_STORY: z.enum(['true', 'false']).optional(),
+  ENABLE_DOGOS_CONNECTORS: z.enum(['true', 'false']).optional(),
+  CONNECTOR_CREDENTIALS_KEY: z.string().optional(),
   MEDIA_LIBRARY_IMAGE_MAX_BYTES: z.coerce
     .number()
     .int()
@@ -52,6 +54,11 @@ const envSchema = z.object({
   BEHAVIOR_VISION_TIMEOUT_MS: z.coerce.number().int().min(5000).max(90000).default(45000),
 });
 
+function connectorKeyIsValid(encoded: string | undefined) {
+  if (!encoded) return false;
+  return Buffer.from(encoded, 'base64').length === 32;
+}
+
 export function validateEnvironment(config: Record<string, unknown>) {
   const parsed = envSchema.safeParse(config);
 
@@ -63,6 +70,10 @@ export function validateEnvironment(config: Record<string, unknown>) {
   }
 
   const env = parsed.data;
+
+  if (env.CONNECTOR_CREDENTIALS_KEY && !connectorKeyIsValid(env.CONNECTOR_CREDENTIALS_KEY)) {
+    throw new Error('CONNECTOR_CREDENTIALS_KEY must decode to exactly 32 bytes');
+  }
 
   if (env.NODE_ENV === 'production') {
     const knownDevelopmentSecret = /^(dev-|change-this|your-)/i;
@@ -93,6 +104,15 @@ export function validateEnvironment(config: Record<string, unknown>) {
     ) {
       throw new Error(
         'Private object storage must be configured when MEDIA_DERIVATIVES_ENABLED=true'
+      );
+    }
+
+    if (
+      env.ENABLE_DOGOS_CONNECTORS === 'true' &&
+      !connectorKeyIsValid(env.CONNECTOR_CREDENTIALS_KEY)
+    ) {
+      throw new Error(
+        'CONNECTOR_CREDENTIALS_KEY is required and must decode to 32 bytes when connectors are enabled in production'
       );
     }
   }

--- a/apps/api/src/connectors/connector-credential.store.spec.ts
+++ b/apps/api/src/connectors/connector-credential.store.spec.ts
@@ -9,7 +9,6 @@ const key = Buffer.alloc(32, 9).toString('base64');
 function harness() {
   const integrationToken = {
     findMany: jest.fn().mockResolvedValue([]),
-    count: jest.fn().mockResolvedValue(0),
     upsert: jest.fn().mockResolvedValue({ id: 'token-1' }),
     findUnique: jest.fn().mockResolvedValue(null),
     deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
@@ -59,6 +58,22 @@ describe('ConnectorCredentialStore', () => {
       scopes: ['activity'],
       expiresAt: null,
     });
+    await expect(store.state(userId, 'TRACTIVE')).resolves.toBe('USABLE');
+  });
+
+  it('marks expired and malformed credentials unusable rather than connected', async () => {
+    const { store, integrationToken } = harness();
+    integrationToken.findUnique.mockResolvedValueOnce({
+      data: { v: 1, alg: 'A256GCM', iv: 'x', tag: 'y', ciphertext: 'z' },
+      expiresAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    await expect(store.state(userId, 'FI')).resolves.toBe('EXPIRED');
+
+    integrationToken.findUnique.mockResolvedValueOnce({
+      data: { plaintext: 'should-never-be-accepted' },
+      expiresAt: null,
+    });
+    await expect(store.state(userId, 'FI')).resolves.toBe('INVALID');
   });
 
   it('lists connection metadata without decrypting credential payloads', async () => {

--- a/apps/api/src/connectors/connector-credential.store.spec.ts
+++ b/apps/api/src/connectors/connector-credential.store.spec.ts
@@ -1,0 +1,94 @@
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../prisma/prisma.service';
+import { ConnectorCredentialStore } from './connector-credential.store';
+import { ConnectorCryptoService } from './connector-crypto.service';
+
+const userId = '11111111-1111-4111-8111-111111111111';
+const key = Buffer.alloc(32, 9).toString('base64');
+
+function harness() {
+  const integrationToken = {
+    findMany: jest.fn().mockResolvedValue([]),
+    count: jest.fn().mockResolvedValue(0),
+    upsert: jest.fn().mockResolvedValue({ id: 'token-1' }),
+    findUnique: jest.fn().mockResolvedValue(null),
+    deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
+  };
+  const prisma = { integrationToken } as unknown as PrismaService;
+  const crypto = new ConnectorCryptoService({
+    get: jest.fn((name: string) => (name === 'CONNECTOR_CREDENTIALS_KEY' ? key : undefined)),
+  } as unknown as ConfigService);
+  return {
+    integrationToken,
+    store: new ConnectorCredentialStore(prisma, crypto),
+  };
+}
+
+describe('ConnectorCredentialStore', () => {
+  it('stores only an encrypted envelope and normalized scopes', async () => {
+    const { store, integrationToken } = harness();
+
+    await store.put(
+      userId,
+      'FI',
+      { accessToken: 'access-secret', refreshToken: 'refresh-secret' },
+      ['activity', 'profile', 'activity'],
+      new Date('2026-09-01T00:00:00.000Z'),
+    );
+
+    const args = integrationToken.upsert.mock.calls[0]?.[0];
+    const stored = JSON.stringify(args.create.data);
+    expect(stored).not.toContain('access-secret');
+    expect(stored).not.toContain('refresh-secret');
+    expect(args.create.provider).toBe('dogos_connector:FI');
+    expect(args.create.scopes).toEqual(['activity', 'profile']);
+  });
+
+  it('decrypts a stored envelope only in its original user/provider context', async () => {
+    const { store, integrationToken } = harness();
+    await store.put(userId, 'TRACTIVE', { accessToken: 'secret' }, ['activity'], null);
+    const envelope = integrationToken.upsert.mock.calls[0]?.[0]?.create?.data;
+    integrationToken.findUnique.mockResolvedValue({
+      data: envelope,
+      scopes: ['activity'],
+      expiresAt: null,
+    });
+
+    await expect(store.get(userId, 'TRACTIVE')).resolves.toEqual({
+      credentials: { accessToken: 'secret' },
+      scopes: ['activity'],
+      expiresAt: null,
+    });
+  });
+
+  it('lists connection metadata without decrypting credential payloads', async () => {
+    const { store, integrationToken } = harness();
+    integrationToken.findMany.mockResolvedValue([
+      {
+        provider: 'dogos_connector:FI',
+        scopes: ['activity'],
+        expiresAt: new Date('2026-09-01T00:00:00.000Z'),
+        createdAt: new Date('2026-08-22T00:00:00.000Z'),
+      },
+    ]);
+
+    await expect(store.listMetadata(userId)).resolves.toEqual([
+      {
+        provider: 'FI',
+        scopes: ['activity'],
+        expiresAt: '2026-09-01T00:00:00.000Z',
+        createdAt: '2026-08-22T00:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('disconnects by deleting only the connector credential row', async () => {
+    const { store, integrationToken } = harness();
+
+    await store.remove(userId, 'CHEWY');
+
+    expect(integrationToken.deleteMany).toHaveBeenCalledWith({
+      where: { userId, provider: 'dogos_connector:CHEWY' },
+    });
+  });
+});

--- a/apps/api/src/connectors/connector-credential.store.spec.ts
+++ b/apps/api/src/connectors/connector-credential.store.spec.ts
@@ -32,7 +32,7 @@ describe('ConnectorCredentialStore', () => {
       'FI',
       { accessToken: 'access-secret', refreshToken: 'refresh-secret' },
       ['activity', 'profile', 'activity'],
-      new Date('2026-09-01T00:00:00.000Z'),
+      new Date('2026-09-01T00:00:00.000Z')
     );
 
     const args = integrationToken.upsert.mock.calls[0]?.[0];

--- a/apps/api/src/connectors/connector-credential.store.ts
+++ b/apps/api/src/connectors/connector-credential.store.ts
@@ -44,7 +44,7 @@ function readEnvelope(value: Prisma.JsonValue): ConnectorCredentialEnvelope | nu
 export class ConnectorCredentialStore {
   constructor(
     private readonly prisma: PrismaService,
-    private readonly crypto: ConnectorCryptoService,
+    private readonly crypto: ConnectorCryptoService
   ) {}
 
   encryptionConfigured() {
@@ -101,7 +101,7 @@ export class ConnectorCredentialStore {
     provider: ConnectorProvider,
     credentials: Record<string, unknown>,
     scopes: string[],
-    expiresAt: Date | null,
+    expiresAt: Date | null
   ) {
     const encrypted = this.crypto.encrypt(credentials, contextKey(userId, provider));
     await this.prisma.integrationToken.upsert({

--- a/apps/api/src/connectors/connector-credential.store.ts
+++ b/apps/api/src/connectors/connector-credential.store.ts
@@ -1,0 +1,130 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+import { ConnectorCryptoService } from './connector-crypto.service';
+import type { ConnectorCredentialEnvelope, ConnectorProvider } from './connectors.types';
+
+function providerKey(provider: ConnectorProvider) {
+  return `dogos_connector:${provider}`;
+}
+
+function contextKey(userId: string, provider: ConnectorProvider) {
+  return `dogos-connector-credential-v1:${userId}:${provider}`;
+}
+
+function toInputJson(envelope: ConnectorCredentialEnvelope): Prisma.InputJsonObject {
+  return envelope as unknown as Prisma.InputJsonObject;
+}
+
+function readEnvelope(value: Prisma.JsonValue): ConnectorCredentialEnvelope | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  if (
+    value.v !== 1 ||
+    value.alg !== 'A256GCM' ||
+    typeof value.iv !== 'string' ||
+    typeof value.tag !== 'string' ||
+    typeof value.ciphertext !== 'string'
+  ) {
+    return null;
+  }
+  return {
+    v: 1,
+    alg: 'A256GCM',
+    iv: value.iv,
+    tag: value.tag,
+    ciphertext: value.ciphertext,
+  };
+}
+
+@Injectable()
+export class ConnectorCredentialStore {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly crypto: ConnectorCryptoService,
+  ) {}
+
+  encryptionConfigured() {
+    return this.crypto.isConfigured();
+  }
+
+  async listMetadata(userId: string) {
+    const providers = ['FI', 'TRACTIVE', 'VET_PARTNER', 'CHEWY', 'PETCO'] as const;
+    const rows = await this.prisma.integrationToken.findMany({
+      where: {
+        userId,
+        provider: { in: providers.map((provider) => providerKey(provider)) },
+      },
+      select: { provider: true, scopes: true, expiresAt: true, createdAt: true },
+    });
+
+    return rows.map((row) => ({
+      provider: row.provider.slice('dogos_connector:'.length) as ConnectorProvider,
+      scopes: row.scopes,
+      expiresAt: row.expiresAt?.toISOString() ?? null,
+      createdAt: row.createdAt.toISOString(),
+    }));
+  }
+
+  async has(userId: string, provider: ConnectorProvider) {
+    const count = await this.prisma.integrationToken.count({
+      where: { userId, provider: providerKey(provider) },
+    });
+    return count > 0;
+  }
+
+  async put(
+    userId: string,
+    provider: ConnectorProvider,
+    credentials: Record<string, unknown>,
+    scopes: string[],
+    expiresAt: Date | null,
+  ) {
+    const encrypted = this.crypto.encrypt(credentials, contextKey(userId, provider));
+    await this.prisma.integrationToken.upsert({
+      where: {
+        userId_provider: {
+          userId,
+          provider: providerKey(provider),
+        },
+      },
+      create: {
+        userId,
+        provider: providerKey(provider),
+        scopes: [...new Set(scopes)].sort(),
+        expiresAt,
+        data: toInputJson(encrypted),
+      },
+      update: {
+        scopes: [...new Set(scopes)].sort(),
+        expiresAt,
+        data: toInputJson(encrypted),
+      },
+    });
+  }
+
+  async get(userId: string, provider: ConnectorProvider) {
+    const row = await this.prisma.integrationToken.findUnique({
+      where: {
+        userId_provider: {
+          userId,
+          provider: providerKey(provider),
+        },
+      },
+      select: { data: true, scopes: true, expiresAt: true },
+    });
+    if (!row) return null;
+    const envelope = readEnvelope(row.data);
+    if (!envelope) return null;
+    return {
+      credentials: this.crypto.decrypt(envelope, contextKey(userId, provider)),
+      scopes: row.scopes,
+      expiresAt: row.expiresAt,
+    };
+  }
+
+  async remove(userId: string, provider: ConnectorProvider) {
+    await this.prisma.integrationToken.deleteMany({
+      where: { userId, provider: providerKey(provider) },
+    });
+  }
+}

--- a/apps/api/src/connectors/connector-credential.store.ts
+++ b/apps/api/src/connectors/connector-credential.store.ts
@@ -2,7 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { Prisma } from '@woof/database';
 import { PrismaService } from '../prisma/prisma.service';
 import { ConnectorCryptoService } from './connector-crypto.service';
-import type { ConnectorCredentialEnvelope, ConnectorProvider } from './connectors.types';
+import type {
+  ConnectorCredentialEnvelope,
+  ConnectorCredentialState,
+  ConnectorProvider,
+} from './connectors.types';
 
 function providerKey(provider: ConnectorProvider) {
   return `dogos_connector:${provider}`;
@@ -65,11 +69,31 @@ export class ConnectorCredentialStore {
     }));
   }
 
-  async has(userId: string, provider: ConnectorProvider) {
-    const count = await this.prisma.integrationToken.count({
-      where: { userId, provider: providerKey(provider) },
+  async state(userId: string, provider: ConnectorProvider): Promise<ConnectorCredentialState> {
+    const row = await this.prisma.integrationToken.findUnique({
+      where: {
+        userId_provider: {
+          userId,
+          provider: providerKey(provider),
+        },
+      },
+      select: { data: true, expiresAt: true },
     });
-    return count > 0;
+    if (!row) return 'MISSING';
+    if (row.expiresAt && row.expiresAt.getTime() <= Date.now()) return 'EXPIRED';
+
+    const envelope = readEnvelope(row.data);
+    if (!envelope || !this.crypto.isConfigured()) return 'INVALID';
+    try {
+      this.crypto.decrypt(envelope, contextKey(userId, provider));
+      return 'USABLE';
+    } catch {
+      return 'INVALID';
+    }
+  }
+
+  async has(userId: string, provider: ConnectorProvider) {
+    return (await this.state(userId, provider)) === 'USABLE';
   }
 
   async put(
@@ -112,14 +136,18 @@ export class ConnectorCredentialStore {
       },
       select: { data: true, scopes: true, expiresAt: true },
     });
-    if (!row) return null;
+    if (!row || (row.expiresAt && row.expiresAt.getTime() <= Date.now())) return null;
     const envelope = readEnvelope(row.data);
     if (!envelope) return null;
-    return {
-      credentials: this.crypto.decrypt(envelope, contextKey(userId, provider)),
-      scopes: row.scopes,
-      expiresAt: row.expiresAt,
-    };
+    try {
+      return {
+        credentials: this.crypto.decrypt(envelope, contextKey(userId, provider)),
+        scopes: row.scopes,
+        expiresAt: row.expiresAt,
+      };
+    } catch {
+      return null;
+    }
   }
 
   async remove(userId: string, provider: ConnectorProvider) {

--- a/apps/api/src/connectors/connector-crypto.service.spec.ts
+++ b/apps/api/src/connectors/connector-crypto.service.spec.ts
@@ -1,0 +1,55 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ConnectorCryptoService } from './connector-crypto.service';
+
+const key = Buffer.alloc(32, 7).toString('base64');
+
+function service(configuredKey?: string) {
+  return new ConnectorCryptoService({
+    get: jest.fn((name: string) =>
+      name === 'CONNECTOR_CREDENTIALS_KEY' ? configuredKey : undefined,
+    ),
+  } as unknown as ConfigService);
+}
+
+describe('ConnectorCryptoService', () => {
+  it('round-trips connector credentials without exposing token plaintext', () => {
+    const crypto = service(key);
+    const envelope = crypto.encrypt(
+      { accessToken: 'secret-access-token', refreshToken: 'secret-refresh-token' },
+      'user-1:FI',
+    );
+
+    expect(JSON.stringify(envelope)).not.toContain('secret-access-token');
+    expect(JSON.stringify(envelope)).not.toContain('secret-refresh-token');
+    expect(crypto.decrypt(envelope, 'user-1:FI')).toEqual({
+      accessToken: 'secret-access-token',
+      refreshToken: 'secret-refresh-token',
+    });
+  });
+
+  it('binds ciphertext to its user/provider context with authenticated AAD', () => {
+    const crypto = service(key);
+    const envelope = crypto.encrypt({ accessToken: 'secret' }, 'user-1:FI');
+
+    expect(() => crypto.decrypt(envelope, 'user-2:FI')).toThrow(ServiceUnavailableException);
+    expect(() => crypto.decrypt(envelope, 'user-1:TRACTIVE')).toThrow(
+      ServiceUnavailableException,
+    );
+  });
+
+  it('fails closed when credential encryption is not configured', () => {
+    const crypto = service();
+
+    expect(crypto.isConfigured()).toBe(false);
+    expect(() => crypto.encrypt({ accessToken: 'secret' }, 'user-1:FI')).toThrow(
+      ServiceUnavailableException,
+    );
+  });
+
+  it('rejects a deployment key that does not decode to 32 bytes', () => {
+    expect(() => service(Buffer.alloc(16).toString('base64'))).toThrow(
+      'CONNECTOR_CREDENTIALS_KEY must decode to exactly 32 bytes',
+    );
+  });
+});

--- a/apps/api/src/connectors/connector-crypto.service.spec.ts
+++ b/apps/api/src/connectors/connector-crypto.service.spec.ts
@@ -7,7 +7,7 @@ const key = Buffer.alloc(32, 7).toString('base64');
 function service(configuredKey?: string) {
   return new ConnectorCryptoService({
     get: jest.fn((name: string) =>
-      name === 'CONNECTOR_CREDENTIALS_KEY' ? configuredKey : undefined,
+      name === 'CONNECTOR_CREDENTIALS_KEY' ? configuredKey : undefined
     ),
   } as unknown as ConfigService);
 }
@@ -17,7 +17,7 @@ describe('ConnectorCryptoService', () => {
     const crypto = service(key);
     const envelope = crypto.encrypt(
       { accessToken: 'secret-access-token', refreshToken: 'secret-refresh-token' },
-      'user-1:FI',
+      'user-1:FI'
     );
 
     expect(JSON.stringify(envelope)).not.toContain('secret-access-token');
@@ -33,9 +33,7 @@ describe('ConnectorCryptoService', () => {
     const envelope = crypto.encrypt({ accessToken: 'secret' }, 'user-1:FI');
 
     expect(() => crypto.decrypt(envelope, 'user-2:FI')).toThrow(ServiceUnavailableException);
-    expect(() => crypto.decrypt(envelope, 'user-1:TRACTIVE')).toThrow(
-      ServiceUnavailableException,
-    );
+    expect(() => crypto.decrypt(envelope, 'user-1:TRACTIVE')).toThrow(ServiceUnavailableException);
   });
 
   it('fails closed when credential encryption is not configured', () => {
@@ -43,13 +41,13 @@ describe('ConnectorCryptoService', () => {
 
     expect(crypto.isConfigured()).toBe(false);
     expect(() => crypto.encrypt({ accessToken: 'secret' }, 'user-1:FI')).toThrow(
-      ServiceUnavailableException,
+      ServiceUnavailableException
     );
   });
 
   it('rejects a deployment key that does not decode to 32 bytes', () => {
     expect(() => service(Buffer.alloc(16).toString('base64'))).toThrow(
-      'CONNECTOR_CREDENTIALS_KEY must decode to exactly 32 bytes',
+      'CONNECTOR_CREDENTIALS_KEY must decode to exactly 32 bytes'
     );
   });
 });

--- a/apps/api/src/connectors/connector-crypto.service.ts
+++ b/apps/api/src/connectors/connector-crypto.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, ServiceUnavailableException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+import type { ConnectorCredentialEnvelope } from './connectors.types';
+
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+
+@Injectable()
+export class ConnectorCryptoService {
+  private readonly key: Buffer | null;
+
+  constructor(private readonly config: ConfigService) {
+    const encoded = this.config.get<string>('CONNECTOR_CREDENTIALS_KEY');
+    this.key = encoded ? this.parseKey(encoded) : null;
+  }
+
+  isConfigured() {
+    return this.key !== null;
+  }
+
+  encrypt(value: Record<string, unknown>, context: string): ConnectorCredentialEnvelope {
+    const key = this.requireKey();
+    const iv = randomBytes(IV_BYTES);
+    const cipher = createCipheriv('aes-256-gcm', key, iv);
+    cipher.setAAD(Buffer.from(context, 'utf8'));
+    const ciphertext = Buffer.concat([
+      cipher.update(JSON.stringify(value), 'utf8'),
+      cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+
+    return {
+      v: 1,
+      alg: 'A256GCM',
+      iv: iv.toString('base64url'),
+      tag: tag.toString('base64url'),
+      ciphertext: ciphertext.toString('base64url'),
+    };
+  }
+
+  decrypt(envelope: ConnectorCredentialEnvelope, context: string): Record<string, unknown> {
+    const key = this.requireKey();
+    if (envelope.v !== 1 || envelope.alg !== 'A256GCM') {
+      throw new ServiceUnavailableException('Unsupported connector credential envelope');
+    }
+
+    try {
+      const decipher = createDecipheriv(
+        'aes-256-gcm',
+        key,
+        Buffer.from(envelope.iv, 'base64url'),
+      );
+      decipher.setAAD(Buffer.from(context, 'utf8'));
+      decipher.setAuthTag(Buffer.from(envelope.tag, 'base64url'));
+      const plaintext = Buffer.concat([
+        decipher.update(Buffer.from(envelope.ciphertext, 'base64url')),
+        decipher.final(),
+      ]).toString('utf8');
+      const parsed: unknown = JSON.parse(plaintext);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('credential payload is not an object');
+      }
+      return parsed as Record<string, unknown>;
+    } catch {
+      throw new ServiceUnavailableException('Connector credentials could not be decrypted');
+    }
+  }
+
+  private requireKey() {
+    if (!this.key) {
+      throw new ServiceUnavailableException(
+        'Connector credential encryption is not configured for this environment',
+      );
+    }
+    return this.key;
+  }
+
+  private parseKey(encoded: string) {
+    let key: Buffer;
+    try {
+      key = Buffer.from(encoded, 'base64');
+    } catch {
+      throw new Error('CONNECTOR_CREDENTIALS_KEY must be a base64-encoded 32-byte key');
+    }
+    if (key.length !== KEY_BYTES) {
+      throw new Error('CONNECTOR_CREDENTIALS_KEY must decode to exactly 32 bytes');
+    }
+    return key;
+  }
+}

--- a/apps/api/src/connectors/connector-crypto.service.ts
+++ b/apps/api/src/connectors/connector-crypto.service.ts
@@ -46,11 +46,7 @@ export class ConnectorCryptoService {
     }
 
     try {
-      const decipher = createDecipheriv(
-        'aes-256-gcm',
-        key,
-        Buffer.from(envelope.iv, 'base64url'),
-      );
+      const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(envelope.iv, 'base64url'));
       decipher.setAAD(Buffer.from(context, 'utf8'));
       decipher.setAuthTag(Buffer.from(envelope.tag, 'base64url'));
       const plaintext = Buffer.concat([
@@ -70,7 +66,7 @@ export class ConnectorCryptoService {
   private requireKey() {
     if (!this.key) {
       throw new ServiceUnavailableException(
-        'Connector credential encryption is not configured for this environment',
+        'Connector credential encryption is not configured for this environment'
       );
     }
     return this.key;

--- a/apps/api/src/connectors/connector-operational.store.integration.spec.ts
+++ b/apps/api/src/connectors/connector-operational.store.integration.spec.ts
@@ -98,7 +98,7 @@ describe('ConnectorOperationalStore integration', () => {
     const count = await prisma.$queryRaw<Array<{ count: number }>>(Prisma.sql`
       SELECT COUNT(*)::int AS count
       FROM dogos_connectors.import_receipts
-      WHERE connection_id = ${connection.id}
+      WHERE connection_id = CAST(${connection.id} AS uuid)
         AND resource_type = 'WEARABLE_DAILY_ACTIVITY'
         AND external_object_id = 'day-1'
     `);
@@ -147,7 +147,7 @@ describe('ConnectorOperationalStore integration', () => {
     >(Prisma.sql`
       SELECT mode, status, remote_receipt_ref
       FROM dogos_connectors.revocation_receipts
-      WHERE connection_id = ${connection.id}
+      WHERE connection_id = CAST(${connection.id} AS uuid)
       ORDER BY attempted_at DESC
       LIMIT 1
     `);

--- a/apps/api/src/connectors/connector-operational.store.integration.spec.ts
+++ b/apps/api/src/connectors/connector-operational.store.integration.spec.ts
@@ -57,7 +57,7 @@ describe('ConnectorOperationalStore integration', () => {
       externalPetLabel: 'Scout',
     });
     expect(identity).toEqual(
-      expect.objectContaining({ pet_id: petId, external_pet_id: 'fi-pet-1' }),
+      expect.objectContaining({ pet_id: petId, external_pet_id: 'fi-pet-1' })
     );
 
     await store.advanceSyncCursor({
@@ -122,7 +122,7 @@ describe('ConnectorOperationalStore integration', () => {
         provider: 'TRACTIVE',
         petId: other.petId,
         externalPetId: 'foreign-pet',
-      }),
+      })
     ).rejects.toThrow();
   });
 
@@ -139,7 +139,7 @@ describe('ConnectorOperationalStore integration', () => {
     const receiptId = await store.markLocallyRevoked(userId, 'PETCO');
     expect(receiptId).toEqual(expect.any(String));
     await expect(store.getConnection(userId, 'PETCO')).resolves.toEqual(
-      expect.objectContaining({ status: 'REVOKED', revokedAt: expect.any(String) }),
+      expect.objectContaining({ status: 'REVOKED', revokedAt: expect.any(String) })
     );
 
     const receipt = await prisma.$queryRaw<

--- a/apps/api/src/connectors/connector-operational.store.integration.spec.ts
+++ b/apps/api/src/connectors/connector-operational.store.integration.spec.ts
@@ -1,0 +1,160 @@
+import { randomUUID } from 'node:crypto';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+import { ConnectorOperationalStore } from './connector-operational.store';
+
+describe('ConnectorOperationalStore integration', () => {
+  const prisma = new PrismaService();
+  const store = new ConnectorOperationalStore(prisma);
+  const usersToDelete: string[] = [];
+
+  beforeAll(async () => {
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    if (usersToDelete.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: usersToDelete } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  async function fixture(label: string) {
+    const suffix = randomUUID().slice(0, 8);
+    const user = await prisma.user.create({
+      data: {
+        handle: `connector-${label}-${suffix}`,
+        email: `connector-${label}-${suffix}@example.test`,
+      },
+      select: { id: true },
+    });
+    usersToDelete.push(user.id);
+    const pet = await prisma.pet.create({
+      data: { ownerId: user.id, name: `Connector ${label}`, species: 'DOG' },
+      select: { id: true },
+    });
+    return { userId: user.id, petId: pet.id };
+  }
+
+  it('keeps connection metadata, identity, cursor, and receipt data relational', async () => {
+    const { userId, petId } = await fixture('relational');
+    const connection = await store.markConnected({
+      userId,
+      provider: 'FI',
+      externalAccountId: 'fi-account-1',
+      displayLabel: 'Home collar',
+      grantedScopes: ['activity', 'profile', 'activity'],
+    });
+
+    expect(connection.status).toBe('CONNECTED');
+    expect(connection.grantedScopes).toEqual(['activity', 'profile']);
+
+    const identity = await store.bindPetIdentity({
+      userId,
+      provider: 'FI',
+      petId,
+      externalPetId: 'fi-pet-1',
+      externalPetLabel: 'Scout',
+    });
+    expect(identity).toEqual(
+      expect.objectContaining({ pet_id: petId, external_pet_id: 'fi-pet-1' }),
+    );
+
+    await store.advanceSyncCursor({
+      userId,
+      provider: 'FI',
+      resourceType: 'DAILY_ACTIVITY',
+      cursor: 'cursor-2',
+      watermarkAt: new Date('2026-08-22T12:00:00.000Z'),
+    });
+    await expect(store.getSyncCursor(userId, 'FI', 'DAILY_ACTIVITY')).resolves.toEqual({
+      resourceType: 'DAILY_ACTIVITY',
+      cursor: 'cursor-2',
+      watermarkAt: '2026-08-22T12:00:00.000Z',
+      lastSuccessfulSyncAt: expect.any(String),
+    });
+
+    const payloadHash = 'a'.repeat(64);
+    const first = await store.recordImportReceipt({
+      connectionId: connection.id,
+      resourceType: 'WEARABLE_DAILY_ACTIVITY',
+      externalObjectId: 'day-1',
+      payloadHash,
+      disposition: 'IMPORTED',
+      canonicalRefType: 'CARE_EVENT',
+      canonicalRefId: 'care-event-1',
+      occurredAt: new Date('2026-08-22T12:00:00.000Z'),
+    });
+    const replay = await store.recordImportReceipt({
+      connectionId: connection.id,
+      resourceType: 'WEARABLE_DAILY_ACTIVITY',
+      externalObjectId: 'day-1',
+      payloadHash: 'b'.repeat(64),
+      disposition: 'FAILED',
+      detailCode: 'should_not_replace',
+    });
+
+    expect(replay).toEqual(first);
+    const count = await prisma.$queryRaw<Array<{ count: number }>>(Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM dogos_connectors.import_receipts
+      WHERE connection_id = ${connection.id}
+        AND resource_type = 'WEARABLE_DAILY_ACTIVITY'
+        AND external_object_id = 'day-1'
+    `);
+    expect(count[0]?.count).toBe(1);
+  });
+
+  it('rejects mapping a provider animal to a pet owned by someone else', async () => {
+    const owner = await fixture('owner');
+    const other = await fixture('other');
+    await store.markConnected({
+      userId: owner.userId,
+      provider: 'TRACTIVE',
+      externalAccountId: 'tractive-account-1',
+      displayLabel: null,
+      grantedScopes: ['activity'],
+    });
+
+    await expect(
+      store.bindPetIdentity({
+        userId: owner.userId,
+        provider: 'TRACTIVE',
+        petId: other.petId,
+        externalPetId: 'foreign-pet',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('records local revocation evidence while leaving provider revocation unclaimed', async () => {
+    const { userId } = await fixture('revoke');
+    const connection = await store.markConnected({
+      userId,
+      provider: 'PETCO',
+      externalAccountId: 'petco-account-1',
+      displayLabel: null,
+      grantedScopes: ['catalog'],
+    });
+
+    const receiptId = await store.markLocallyRevoked(userId, 'PETCO');
+    expect(receiptId).toEqual(expect.any(String));
+    await expect(store.getConnection(userId, 'PETCO')).resolves.toEqual(
+      expect.objectContaining({ status: 'REVOKED', revokedAt: expect.any(String) }),
+    );
+
+    const receipt = await prisma.$queryRaw<
+      Array<{ mode: string; status: string; remote_receipt_ref: string | null }>
+    >(Prisma.sql`
+      SELECT mode, status, remote_receipt_ref
+      FROM dogos_connectors.revocation_receipts
+      WHERE connection_id = ${connection.id}
+      ORDER BY attempted_at DESC
+      LIMIT 1
+    `);
+    expect(receipt[0]).toEqual({
+      mode: 'LOCAL_CREDENTIAL_DELETE',
+      status: 'SUCCEEDED',
+      remote_receipt_ref: null,
+    });
+  });
+});

--- a/apps/api/src/connectors/connector-operational.store.ts
+++ b/apps/api/src/connectors/connector-operational.store.ts
@@ -260,7 +260,7 @@ export class ConnectorOperationalStore {
              disposition, canonical_ref_type, canonical_ref_id, occurred_at,
              imported_at, detail_code
       FROM dogos_connectors.import_receipts
-      WHERE connection_id = ${connectionId}
+      WHERE connection_id = CAST(${connectionId} AS uuid)
         AND resource_type = ${resourceType}
         AND external_object_id = ${externalObjectId}
       LIMIT 1
@@ -284,7 +284,7 @@ export class ConnectorOperationalStore {
         connection_id, resource_type, external_object_id, payload_hash, disposition,
         canonical_ref_type, canonical_ref_id, occurred_at, detail_code
       ) VALUES (
-        ${input.connectionId}, ${input.resourceType}, ${input.externalObjectId},
+        CAST(${input.connectionId} AS uuid), ${input.resourceType}, ${input.externalObjectId},
         ${input.payloadHash}, ${input.disposition}, ${input.canonicalRefType ?? null},
         ${input.canonicalRefId ?? null}, ${input.occurredAt ?? null}, ${input.detailCode ?? null}
       )

--- a/apps/api/src/connectors/connector-operational.store.ts
+++ b/apps/api/src/connectors/connector-operational.store.ts
@@ -254,11 +254,7 @@ export class ConnectorOperationalStore {
     `);
   }
 
-  async getImportReceipt(
-    connectionId: string,
-    resourceType: string,
-    externalObjectId: string,
-  ) {
+  async getImportReceipt(connectionId: string, resourceType: string, externalObjectId: string) {
     const rows = await this.prisma.$queryRaw<ImportReceiptRow[]>(Prisma.sql`
       SELECT id, connection_id, resource_type, external_object_id, payload_hash,
              disposition, canonical_ref_type, canonical_ref_id, occurred_at,

--- a/apps/api/src/connectors/connector-operational.store.ts
+++ b/apps/api/src/connectors/connector-operational.store.ts
@@ -1,0 +1,321 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+import type { ConnectorProvider } from './connectors.types';
+
+type ConnectionRow = {
+  id: string;
+  provider: ConnectorProvider;
+  status: 'PARTNER_REQUIRED' | 'CONNECTED' | 'REAUTH_REQUIRED' | 'REVOKED';
+  external_account_id: string | null;
+  display_label: string | null;
+  granted_scopes: string[];
+  connected_at: Date | null;
+  last_sync_at: Date | null;
+  revoked_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+type PetIdentityRow = {
+  connection_id: string;
+  pet_id: string;
+  external_pet_id: string;
+  external_pet_label: string | null;
+  verified_at: Date | null;
+};
+
+type ImportReceiptRow = {
+  id: string;
+  connection_id: string;
+  resource_type: string;
+  external_object_id: string;
+  payload_hash: string;
+  disposition: 'IMPORTED' | 'SKIPPED' | 'FAILED';
+  canonical_ref_type: string | null;
+  canonical_ref_id: string | null;
+  occurred_at: Date | null;
+  imported_at: Date;
+  detail_code: string | null;
+};
+
+type SyncCursorRow = {
+  resource_type: string;
+  cursor_value: string | null;
+  watermark_at: Date | null;
+  last_successful_sync_at: Date | null;
+};
+
+function textArray(values: string[]) {
+  const unique = [...new Set(values)].sort();
+  return unique.length > 0
+    ? Prisma.sql`ARRAY[${Prisma.join(unique)}]::text[]`
+    : Prisma.sql`ARRAY[]::text[]`;
+}
+
+function toConnection(row: ConnectionRow) {
+  return {
+    id: row.id,
+    provider: row.provider,
+    status: row.status,
+    externalAccountId: row.external_account_id,
+    displayLabel: row.display_label,
+    grantedScopes: row.granted_scopes,
+    connectedAt: row.connected_at?.toISOString() ?? null,
+    lastSyncAt: row.last_sync_at?.toISOString() ?? null,
+    revokedAt: row.revoked_at?.toISOString() ?? null,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  };
+}
+
+function toReceipt(row: ImportReceiptRow) {
+  return {
+    id: row.id,
+    connectionId: row.connection_id,
+    resourceType: row.resource_type,
+    externalObjectId: row.external_object_id,
+    payloadHash: row.payload_hash,
+    disposition: row.disposition,
+    canonicalRefType: row.canonical_ref_type,
+    canonicalRefId: row.canonical_ref_id,
+    occurredAt: row.occurred_at?.toISOString() ?? null,
+    importedAt: row.imported_at.toISOString(),
+    detailCode: row.detail_code,
+  };
+}
+
+@Injectable()
+export class ConnectorOperationalStore {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async listConnections(userId: string) {
+    const rows = await this.prisma.$queryRaw<ConnectionRow[]>(Prisma.sql`
+      SELECT id, provider, status, external_account_id, display_label, granted_scopes,
+             connected_at, last_sync_at, revoked_at, created_at, updated_at
+      FROM dogos_connectors.connections
+      WHERE user_id = ${userId}
+      ORDER BY provider ASC
+    `);
+    return rows.map(toConnection);
+  }
+
+  async getConnection(userId: string, provider: ConnectorProvider) {
+    const rows = await this.prisma.$queryRaw<ConnectionRow[]>(Prisma.sql`
+      SELECT id, provider, status, external_account_id, display_label, granted_scopes,
+             connected_at, last_sync_at, revoked_at, created_at, updated_at
+      FROM dogos_connectors.connections
+      WHERE user_id = ${userId} AND provider = ${provider}
+      LIMIT 1
+    `);
+    return rows[0] ? toConnection(rows[0]) : null;
+  }
+
+  async markConnected(input: {
+    userId: string;
+    provider: ConnectorProvider;
+    externalAccountId: string | null;
+    displayLabel: string | null;
+    grantedScopes: string[];
+  }) {
+    const scopes = textArray(input.grantedScopes);
+    const rows = await this.prisma.$queryRaw<ConnectionRow[]>(Prisma.sql`
+      INSERT INTO dogos_connectors.connections (
+        user_id, provider, status, external_account_id, display_label, granted_scopes,
+        connected_at, revoked_at, updated_at
+      )
+      VALUES (
+        ${input.userId}, ${input.provider}, 'CONNECTED', ${input.externalAccountId},
+        ${input.displayLabel}, ${scopes}, NOW(), NULL, NOW()
+      )
+      ON CONFLICT (user_id, provider) DO UPDATE SET
+        status = 'CONNECTED',
+        external_account_id = EXCLUDED.external_account_id,
+        display_label = EXCLUDED.display_label,
+        granted_scopes = EXCLUDED.granted_scopes,
+        connected_at = COALESCE(dogos_connectors.connections.connected_at, NOW()),
+        revoked_at = NULL,
+        updated_at = NOW()
+      RETURNING id, provider, status, external_account_id, display_label, granted_scopes,
+                connected_at, last_sync_at, revoked_at, created_at, updated_at
+    `);
+    return toConnection(rows[0]!);
+  }
+
+  async markReauthRequired(userId: string, provider: ConnectorProvider) {
+    await this.prisma.$executeRaw(Prisma.sql`
+      UPDATE dogos_connectors.connections
+      SET status = 'REAUTH_REQUIRED', updated_at = NOW()
+      WHERE user_id = ${userId} AND provider = ${provider} AND status = 'CONNECTED'
+    `);
+  }
+
+  async bindPetIdentity(input: {
+    userId: string;
+    provider: ConnectorProvider;
+    petId: string;
+    externalPetId: string;
+    externalPetLabel?: string | null;
+  }) {
+    const rows = await this.prisma.$queryRaw<PetIdentityRow[]>(Prisma.sql`
+      INSERT INTO dogos_connectors.pet_identities (
+        connection_id, pet_id, external_pet_id, external_pet_label, verified_at, updated_at
+      )
+      SELECT id, ${input.petId}, ${input.externalPetId}, ${input.externalPetLabel ?? null}, NOW(), NOW()
+      FROM dogos_connectors.connections
+      WHERE user_id = ${input.userId}
+        AND provider = ${input.provider}
+        AND status = 'CONNECTED'
+      ON CONFLICT (connection_id, pet_id) DO UPDATE SET
+        external_pet_id = EXCLUDED.external_pet_id,
+        external_pet_label = EXCLUDED.external_pet_label,
+        verified_at = NOW(),
+        updated_at = NOW()
+      RETURNING connection_id, pet_id, external_pet_id, external_pet_label, verified_at
+    `);
+    return rows[0] ?? null;
+  }
+
+  async getPetIdentity(userId: string, provider: ConnectorProvider, externalPetId: string) {
+    const rows = await this.prisma.$queryRaw<PetIdentityRow[]>(Prisma.sql`
+      SELECT identity.connection_id, identity.pet_id, identity.external_pet_id,
+             identity.external_pet_label, identity.verified_at
+      FROM dogos_connectors.pet_identities AS identity
+      INNER JOIN dogos_connectors.connections AS connection
+        ON connection.id = identity.connection_id
+      WHERE connection.user_id = ${userId}
+        AND connection.provider = ${provider}
+        AND connection.status = 'CONNECTED'
+        AND identity.external_pet_id = ${externalPetId}
+      LIMIT 1
+    `);
+    const row = rows[0];
+    return row
+      ? {
+          connectionId: row.connection_id,
+          petId: row.pet_id,
+          externalPetId: row.external_pet_id,
+          externalPetLabel: row.external_pet_label,
+          verifiedAt: row.verified_at?.toISOString() ?? null,
+        }
+      : null;
+  }
+
+  async getSyncCursor(userId: string, provider: ConnectorProvider, resourceType: string) {
+    const rows = await this.prisma.$queryRaw<SyncCursorRow[]>(Prisma.sql`
+      SELECT cursor.resource_type, cursor.cursor_value, cursor.watermark_at,
+             cursor.last_successful_sync_at
+      FROM dogos_connectors.sync_cursors AS cursor
+      INNER JOIN dogos_connectors.connections AS connection
+        ON connection.id = cursor.connection_id
+      WHERE connection.user_id = ${userId}
+        AND connection.provider = ${provider}
+        AND cursor.resource_type = ${resourceType}
+      LIMIT 1
+    `);
+    const row = rows[0];
+    return row
+      ? {
+          resourceType: row.resource_type,
+          cursor: row.cursor_value,
+          watermarkAt: row.watermark_at?.toISOString() ?? null,
+          lastSuccessfulSyncAt: row.last_successful_sync_at?.toISOString() ?? null,
+        }
+      : null;
+  }
+
+  async advanceSyncCursor(input: {
+    userId: string;
+    provider: ConnectorProvider;
+    resourceType: string;
+    cursor: string | null;
+    watermarkAt: Date | null;
+  }) {
+    await this.prisma.$executeRaw(Prisma.sql`
+      INSERT INTO dogos_connectors.sync_cursors (
+        connection_id, resource_type, cursor_value, watermark_at,
+        last_successful_sync_at, updated_at
+      )
+      SELECT id, ${input.resourceType}, ${input.cursor}, ${input.watermarkAt}, NOW(), NOW()
+      FROM dogos_connectors.connections
+      WHERE user_id = ${input.userId}
+        AND provider = ${input.provider}
+        AND status = 'CONNECTED'
+      ON CONFLICT (connection_id, resource_type) DO UPDATE SET
+        cursor_value = EXCLUDED.cursor_value,
+        watermark_at = EXCLUDED.watermark_at,
+        last_successful_sync_at = NOW(),
+        updated_at = NOW()
+    `);
+    await this.prisma.$executeRaw(Prisma.sql`
+      UPDATE dogos_connectors.connections
+      SET last_sync_at = NOW(), updated_at = NOW()
+      WHERE user_id = ${input.userId} AND provider = ${input.provider}
+    `);
+  }
+
+  async getImportReceipt(
+    connectionId: string,
+    resourceType: string,
+    externalObjectId: string,
+  ) {
+    const rows = await this.prisma.$queryRaw<ImportReceiptRow[]>(Prisma.sql`
+      SELECT id, connection_id, resource_type, external_object_id, payload_hash,
+             disposition, canonical_ref_type, canonical_ref_id, occurred_at,
+             imported_at, detail_code
+      FROM dogos_connectors.import_receipts
+      WHERE connection_id = ${connectionId}
+        AND resource_type = ${resourceType}
+        AND external_object_id = ${externalObjectId}
+      LIMIT 1
+    `);
+    return rows[0] ? toReceipt(rows[0]) : null;
+  }
+
+  async recordImportReceipt(input: {
+    connectionId: string;
+    resourceType: string;
+    externalObjectId: string;
+    payloadHash: string;
+    disposition: 'IMPORTED' | 'SKIPPED' | 'FAILED';
+    canonicalRefType?: string | null;
+    canonicalRefId?: string | null;
+    occurredAt?: Date | null;
+    detailCode?: string | null;
+  }) {
+    const rows = await this.prisma.$queryRaw<ImportReceiptRow[]>(Prisma.sql`
+      INSERT INTO dogos_connectors.import_receipts (
+        connection_id, resource_type, external_object_id, payload_hash, disposition,
+        canonical_ref_type, canonical_ref_id, occurred_at, detail_code
+      ) VALUES (
+        ${input.connectionId}, ${input.resourceType}, ${input.externalObjectId},
+        ${input.payloadHash}, ${input.disposition}, ${input.canonicalRefType ?? null},
+        ${input.canonicalRefId ?? null}, ${input.occurredAt ?? null}, ${input.detailCode ?? null}
+      )
+      ON CONFLICT (connection_id, resource_type, external_object_id) DO NOTHING
+      RETURNING id, connection_id, resource_type, external_object_id, payload_hash,
+                disposition, canonical_ref_type, canonical_ref_id, occurred_at,
+                imported_at, detail_code
+    `);
+    if (rows[0]) return toReceipt(rows[0]);
+    return this.getImportReceipt(input.connectionId, input.resourceType, input.externalObjectId);
+  }
+
+  async markLocallyRevoked(userId: string, provider: ConnectorProvider) {
+    const rows = await this.prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+      WITH revoked AS (
+        UPDATE dogos_connectors.connections
+        SET status = 'REVOKED', revoked_at = NOW(), updated_at = NOW()
+        WHERE user_id = ${userId} AND provider = ${provider}
+        RETURNING id
+      )
+      INSERT INTO dogos_connectors.revocation_receipts (
+        connection_id, mode, status, detail_code, completed_at
+      )
+      SELECT id, 'LOCAL_CREDENTIAL_DELETE', 'SUCCEEDED', 'local_credentials_removed', NOW()
+      FROM revoked
+      RETURNING id
+    `);
+    return rows[0]?.id ?? null;
+  }
+}

--- a/apps/api/src/connectors/connectors-enabled.guard.ts
+++ b/apps/api/src/connectors/connectors-enabled.guard.ts
@@ -1,0 +1,17 @@
+import { CanActivate, Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class ConnectorsEnabledGuard implements CanActivate {
+  constructor(private readonly config: ConfigService) {}
+
+  canActivate(): boolean {
+    const configured = this.config.get<string>('ENABLE_DOGOS_CONNECTORS');
+    const enabled =
+      configured === 'true' ||
+      (configured !== 'false' && this.config.get<string>('NODE_ENV') !== 'production');
+
+    if (!enabled) throw new NotFoundException();
+    return true;
+  }
+}

--- a/apps/api/src/connectors/connectors.controller.ts
+++ b/apps/api/src/connectors/connectors.controller.ts
@@ -1,0 +1,45 @@
+import { Body, Controller, Delete, Get, Param, Post, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { AuthenticatedRequest } from '../auth/authenticated-request';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { IngestTrackerObservationDto } from '../autopilot/dto/autopilot.dto';
+import { ConnectorsEnabledGuard } from './connectors-enabled.guard';
+import { ConnectorsService } from './connectors.service';
+
+@ApiTags('connectors')
+@ApiBearerAuth()
+@Controller('connectors')
+@UseGuards(JwtAuthGuard, ConnectorsEnabledGuard)
+export class ConnectorsController {
+  constructor(private readonly connectors: ConnectorsService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List dogOS connector capabilities and verified connection state' })
+  getDashboard(@Request() req: AuthenticatedRequest) {
+    return this.connectors.getDashboard(req.user.sub);
+  }
+
+  @Post(':provider/oauth/start')
+  @ApiOperation({ summary: 'Start OAuth only when an official provider transport is configured' })
+  startOAuth(@Param('provider') provider: string) {
+    return this.connectors.startOAuth(provider);
+  }
+
+  @Delete(':provider')
+  @ApiOperation({ summary: 'Remove locally stored connector credentials' })
+  disconnect(@Request() req: AuthenticatedRequest, @Param('provider') provider: string) {
+    return this.connectors.disconnect(req.user.sub, provider);
+  }
+
+  @Post(':provider/import/wearable')
+  @ApiOperation({
+    summary: 'Import a verified wearable summary through the existing zero-reward Autopilot path',
+  })
+  importWearable(
+    @Request() req: AuthenticatedRequest,
+    @Param('provider') provider: string,
+    @Body() dto: IngestTrackerObservationDto,
+  ) {
+    return this.connectors.importWearableObservation(req.user.sub, provider, dto);
+  }
+}

--- a/apps/api/src/connectors/connectors.controller.ts
+++ b/apps/api/src/connectors/connectors.controller.ts
@@ -1,8 +1,7 @@
-import { Body, Controller, Delete, Get, Param, Post, Request, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Get, Param, Post, Request, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import type { AuthenticatedRequest } from '../auth/authenticated-request';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { IngestTrackerObservationDto } from '../autopilot/dto/autopilot.dto';
 import { ConnectorsEnabledGuard } from './connectors-enabled.guard';
 import { ConnectorsService } from './connectors.service';
 
@@ -26,20 +25,8 @@ export class ConnectorsController {
   }
 
   @Delete(':provider')
-  @ApiOperation({ summary: 'Remove locally stored connector credentials' })
+  @ApiOperation({ summary: 'Disconnect a provider and remove locally stored credentials' })
   disconnect(@Request() req: AuthenticatedRequest, @Param('provider') provider: string) {
     return this.connectors.disconnect(req.user.sub, provider);
-  }
-
-  @Post(':provider/import/wearable')
-  @ApiOperation({
-    summary: 'Import a verified wearable summary through the existing zero-reward Autopilot path',
-  })
-  importWearable(
-    @Request() req: AuthenticatedRequest,
-    @Param('provider') provider: string,
-    @Body() dto: IngestTrackerObservationDto,
-  ) {
-    return this.connectors.importWearableObservation(req.user.sub, provider, dto);
   }
 }

--- a/apps/api/src/connectors/connectors.module.ts
+++ b/apps/api/src/connectors/connectors.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { AutopilotModule } from '../autopilot/autopilot.module';
 import { ConnectorCredentialStore } from './connector-credential.store';
 import { ConnectorCryptoService } from './connector-crypto.service';
+import { ConnectorOperationalStore } from './connector-operational.store';
 import { ConnectorsController } from './connectors.controller';
 import { ConnectorsEnabledGuard } from './connectors-enabled.guard';
 import { ConnectorsService } from './connectors.service';
@@ -12,9 +13,10 @@ import { ConnectorsService } from './connectors.service';
   providers: [
     ConnectorCryptoService,
     ConnectorCredentialStore,
+    ConnectorOperationalStore,
     ConnectorsEnabledGuard,
     ConnectorsService,
   ],
-  exports: [ConnectorCredentialStore, ConnectorsService],
+  exports: [ConnectorCredentialStore, ConnectorOperationalStore, ConnectorsService],
 })
 export class ConnectorsModule {}

--- a/apps/api/src/connectors/connectors.module.ts
+++ b/apps/api/src/connectors/connectors.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { AutopilotModule } from '../autopilot/autopilot.module';
+import { ConnectorCredentialStore } from './connector-credential.store';
+import { ConnectorCryptoService } from './connector-crypto.service';
+import { ConnectorsController } from './connectors.controller';
+import { ConnectorsEnabledGuard } from './connectors-enabled.guard';
+import { ConnectorsService } from './connectors.service';
+
+@Module({
+  imports: [AutopilotModule],
+  controllers: [ConnectorsController],
+  providers: [
+    ConnectorCryptoService,
+    ConnectorCredentialStore,
+    ConnectorsEnabledGuard,
+    ConnectorsService,
+  ],
+  exports: [ConnectorCredentialStore, ConnectorsService],
+})
+export class ConnectorsModule {}

--- a/apps/api/src/connectors/connectors.service.spec.ts
+++ b/apps/api/src/connectors/connectors.service.spec.ts
@@ -64,7 +64,7 @@ function harness() {
     service: new ConnectorsService(
       credentials as unknown as ConnectorCredentialStore,
       operational as unknown as ConnectorOperationalStore,
-      autopilot as unknown as AutopilotService,
+      autopilot as unknown as AutopilotService
     ),
   };
 }
@@ -87,7 +87,7 @@ describe('ConnectorsService', () => {
           availability: 'PARTNER_REQUIRED',
           autonomousPurchaseAllowed: false,
         }),
-      ]),
+      ])
     );
     expect(dashboard.boundaries).toEqual(
       expect.objectContaining({
@@ -96,7 +96,7 @@ describe('ConnectorsService', () => {
         canonicalPetMutationAllowed: false,
         autonomousRetailPurchaseAllowed: false,
         rawProviderPayloadStored: false,
-      }),
+      })
     );
   });
 
@@ -120,7 +120,7 @@ describe('ConnectorsService', () => {
         availability: 'CONNECTED',
         credentialState: 'USABLE',
         connection: expect.objectContaining({ id: connection.id }),
-      }),
+      })
     );
   });
 
@@ -136,7 +136,7 @@ describe('ConnectorsService', () => {
       expect.objectContaining({
         availability: 'REAUTH_REQUIRED',
         credentialState: 'EXPIRED',
-      }),
+      })
     );
     expect(operational.markReauthRequired).toHaveBeenCalledWith(userId, 'TRACTIVE');
   });
@@ -156,10 +156,10 @@ describe('ConnectorsService', () => {
 
     expect(credentials.put).toHaveBeenCalled();
     expect(operational.markConnected).toHaveBeenCalledWith(
-      expect.objectContaining({ userId, provider: 'FI', externalAccountId: 'fi-account-1' }),
+      expect.objectContaining({ userId, provider: 'FI', externalAccountId: 'fi-account-1' })
     );
     expect(credentials.put.mock.invocationCallOrder[0]).toBeLessThan(
-      operational.markConnected.mock.invocationCallOrder[0]!,
+      operational.markConnected.mock.invocationCallOrder[0]!
     );
   });
 
@@ -173,7 +173,7 @@ describe('ConnectorsService', () => {
         kind: 'DAILY_ACTIVITY',
         observedAt: '2026-08-22T08:00:00.000Z',
         payload: { activityMinutes: 45 },
-      }),
+      })
     ).rejects.toBeInstanceOf(UnauthorizedException);
 
     operational.getConnection.mockResolvedValue({ ...connection, provider: 'FI' });
@@ -185,7 +185,7 @@ describe('ConnectorsService', () => {
         kind: 'DAILY_ACTIVITY',
         observedAt: '2026-08-22T08:00:00.000Z',
         payload: { activityMinutes: 45 },
-      }),
+      })
     ).rejects.toBeInstanceOf(UnauthorizedException);
   });
 
@@ -208,15 +208,13 @@ describe('ConnectorsService', () => {
         kind: 'DAILY_ACTIVITY',
         observedAt: '2026-08-22T08:00:00.000Z',
         payload: { activityMinutes: 51 },
-      }),
-    ).resolves.toEqual(
-      expect.objectContaining({ careEventId: 'care-event-1', bondXp: 0 }),
-    );
+      })
+    ).resolves.toEqual(expect.objectContaining({ careEventId: 'care-event-1', bondXp: 0 }));
 
     expect(autopilot.ingestProviderObservation).toHaveBeenCalledWith(
       userId,
       'TRACTIVE',
-      expect.objectContaining({ petId, externalEventId: 'day-1' }),
+      expect.objectContaining({ petId, externalEventId: 'day-1' })
     );
     expect(operational.recordImportReceipt).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -225,7 +223,7 @@ describe('ConnectorsService', () => {
         canonicalRefType: 'CARE_EVENT',
         canonicalRefId: 'care-event-1',
         payloadHash: expect.stringMatching(/^[0-9a-f]{64}$/),
-      }),
+      })
     );
   });
 
@@ -261,11 +259,11 @@ describe('ConnectorsService', () => {
         kind: 'DAILY_ACTIVITY',
         observedAt: '2026-08-22T08:00:00.000Z',
         payload: { activityMinutes: 99 },
-      }),
+      })
     ).rejects.toBeInstanceOf(ConflictException);
 
     expect(operational.recordImportReceipt).toHaveBeenCalledWith(
-      expect.objectContaining({ canonicalRefId: 'care-event-1', disposition: 'IMPORTED' }),
+      expect.objectContaining({ canonicalRefId: 'care-event-1', disposition: 'IMPORTED' })
     );
   });
 
@@ -294,7 +292,7 @@ describe('ConnectorsService', () => {
         kind: 'DEVICE_STATUS',
         observedAt: '2026-08-22T08:00:00.000Z',
         payload: { batteryPercent: 50 },
-      }),
+      })
     ).rejects.toBeInstanceOf(ConflictException);
   });
 });

--- a/apps/api/src/connectors/connectors.service.spec.ts
+++ b/apps/api/src/connectors/connectors.service.spec.ts
@@ -1,0 +1,131 @@
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
+import { AutopilotService } from '../autopilot/autopilot.service';
+import { ConnectorCredentialStore } from './connector-credential.store';
+import { ConnectorsService } from './connectors.service';
+
+const userId = '11111111-1111-4111-8111-111111111111';
+
+function harness() {
+  const credentials = {
+    listMetadata: jest.fn().mockResolvedValue([]),
+    encryptionConfigured: jest.fn().mockReturnValue(true),
+    remove: jest.fn().mockResolvedValue(undefined),
+    has: jest.fn().mockResolvedValue(false),
+  };
+  const autopilot = {
+    ingestProviderObservation: jest.fn().mockResolvedValue({ duplicate: false }),
+  };
+  return {
+    credentials,
+    autopilot,
+    service: new ConnectorsService(
+      credentials as unknown as ConnectorCredentialStore,
+      autopilot as unknown as AutopilotService,
+    ),
+  };
+}
+
+describe('ConnectorsService', () => {
+  it('reports partner-gated providers without fake connected states', async () => {
+    const { service } = harness();
+
+    const dashboard = await service.getDashboard(userId);
+
+    expect(dashboard.providers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider: 'FI',
+          availability: 'PARTNER_REQUIRED',
+          preciseLocationEnabled: false,
+        }),
+        expect.objectContaining({
+          provider: 'CHEWY',
+          availability: 'PARTNER_REQUIRED',
+          autonomousPurchaseAllowed: false,
+        }),
+      ]),
+    );
+    expect(dashboard.boundaries).toEqual(
+      expect.objectContaining({
+        undocumentedOAuthAllowed: false,
+        canonicalPetMutationAllowed: false,
+        autonomousRetailPurchaseAllowed: false,
+      }),
+    );
+  });
+
+  it('refuses to invent OAuth authorization URLs for partner-gated providers', () => {
+    const { service } = harness();
+
+    expect(() => service.startOAuth('fi')).toThrow(ConflictException);
+    expect(() => service.startOAuth('chewy')).toThrow(ConflictException);
+  });
+
+  it('shows connected only when an encrypted credential row actually exists', async () => {
+    const { service, credentials } = harness();
+    credentials.listMetadata.mockResolvedValue([
+      {
+        provider: 'TRACTIVE',
+        scopes: ['activity'],
+        expiresAt: null,
+        createdAt: '2026-08-22T00:00:00.000Z',
+      },
+    ]);
+
+    const dashboard = await service.getDashboard(userId);
+    const tractive = dashboard.providers.find((provider) => provider.provider === 'TRACTIVE');
+
+    expect(tractive).toEqual(
+      expect.objectContaining({
+        availability: 'CONNECTED',
+        connection: expect.objectContaining({ scopes: ['activity'] }),
+      }),
+    );
+  });
+
+  it('requires a verified wearable credential before routing an import to Autopilot', async () => {
+    const { service } = harness();
+
+    await expect(
+      service.importWearableObservation(userId, 'FI', {
+        petId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+        externalEventId: 'fi-day-1',
+        kind: 'DAILY_ACTIVITY',
+        observedAt: '2026-08-22T08:00:00.000Z',
+        payload: { activityMinutes: 45 },
+      }),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('reuses the Autopilot normalization and zero-reward path after connection verification', async () => {
+    const { service, credentials, autopilot } = harness();
+    credentials.has.mockResolvedValue(true);
+    const dto = {
+      petId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      externalEventId: 'tractive-day-1',
+      kind: 'DAILY_ACTIVITY' as const,
+      observedAt: '2026-08-22T08:00:00.000Z',
+      payload: { activityMinutes: 51 },
+    };
+
+    await service.importWearableObservation(userId, 'tractive', dto);
+
+    expect(autopilot.ingestProviderObservation).toHaveBeenCalledWith(
+      userId,
+      'TRACTIVE',
+      dto,
+    );
+  });
+
+  it('disconnects local connector credentials without claiming remote revocation', async () => {
+    const { service, credentials } = harness();
+
+    await expect(service.disconnect(userId, 'PETCO')).resolves.toEqual({
+      success: true,
+      provider: 'PETCO',
+      localCredentialsRemoved: true,
+      remoteRevocation: 'NOT_CONFIGURED',
+    });
+    expect(credentials.remove).toHaveBeenCalledWith(userId, 'PETCO');
+  });
+});

--- a/apps/api/src/connectors/connectors.service.spec.ts
+++ b/apps/api/src/connectors/connectors.service.spec.ts
@@ -1,25 +1,69 @@
 import { ConflictException, UnauthorizedException } from '@nestjs/common';
 import { AutopilotService } from '../autopilot/autopilot.service';
 import { ConnectorCredentialStore } from './connector-credential.store';
+import { ConnectorOperationalStore } from './connector-operational.store';
 import { ConnectorsService } from './connectors.service';
 
 const userId = '11111111-1111-4111-8111-111111111111';
+const petId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const connection = {
+  id: '22222222-2222-4222-8222-222222222222',
+  provider: 'TRACTIVE' as const,
+  status: 'CONNECTED' as const,
+  externalAccountId: 'account-1',
+  displayLabel: null,
+  grantedScopes: ['activity'],
+  connectedAt: '2026-08-22T00:00:00.000Z',
+  lastSyncAt: null,
+  revokedAt: null,
+  createdAt: '2026-08-22T00:00:00.000Z',
+  updatedAt: '2026-08-22T00:00:00.000Z',
+};
 
 function harness() {
   const credentials = {
-    listMetadata: jest.fn().mockResolvedValue([]),
     encryptionConfigured: jest.fn().mockReturnValue(true),
+    state: jest.fn().mockResolvedValue('MISSING'),
+    put: jest.fn().mockResolvedValue(undefined),
     remove: jest.fn().mockResolvedValue(undefined),
-    has: jest.fn().mockResolvedValue(false),
+  };
+  const operational = {
+    listConnections: jest.fn().mockResolvedValue([]),
+    getConnection: jest.fn().mockResolvedValue(null),
+    markConnected: jest.fn().mockResolvedValue(connection),
+    markReauthRequired: jest.fn().mockResolvedValue(undefined),
+    bindPetIdentity: jest.fn().mockResolvedValue(null),
+    getPetIdentity: jest.fn().mockResolvedValue(null),
+    getImportReceipt: jest.fn().mockResolvedValue(null),
+    recordImportReceipt: jest.fn().mockImplementation(async (input) => ({
+      id: 'receipt-1',
+      ...input,
+      importedAt: '2026-08-22T08:00:00.000Z',
+    })),
+    markLocallyRevoked: jest.fn().mockResolvedValue('revocation-1'),
   };
   const autopilot = {
-    ingestProviderObservation: jest.fn().mockResolvedValue({ duplicate: false }),
+    ingestProviderObservation: jest.fn().mockResolvedValue({
+      careEventId: 'care-event-1',
+      duplicate: false,
+      bondXp: 0,
+      observation: {
+        provider: 'TRACTIVE',
+        externalEventId: 'day-1',
+        kind: 'DAILY_ACTIVITY',
+        observedAt: new Date('2026-08-22T08:00:00.000Z'),
+        metrics: { activityMinutes: 51 },
+      },
+      signal: null,
+    }),
   };
   return {
     credentials,
+    operational,
     autopilot,
     service: new ConnectorsService(
       credentials as unknown as ConnectorCredentialStore,
+      operational as unknown as ConnectorOperationalStore,
       autopilot as unknown as AutopilotService,
     ),
   };
@@ -48,8 +92,10 @@ describe('ConnectorsService', () => {
     expect(dashboard.boundaries).toEqual(
       expect.objectContaining({
         undocumentedOAuthAllowed: false,
+        browserProviderImpersonationAllowed: false,
         canonicalPetMutationAllowed: false,
         autonomousRetailPurchaseAllowed: false,
+        rawProviderPayloadStored: false,
       }),
     );
   });
@@ -61,16 +107,10 @@ describe('ConnectorsService', () => {
     expect(() => service.startOAuth('chewy')).toThrow(ConflictException);
   });
 
-  it('shows connected only when an encrypted credential row actually exists', async () => {
-    const { service, credentials } = harness();
-    credentials.listMetadata.mockResolvedValue([
-      {
-        provider: 'TRACTIVE',
-        scopes: ['activity'],
-        expiresAt: null,
-        createdAt: '2026-08-22T00:00:00.000Z',
-      },
-    ]);
+  it('shows connected only when operational state and credential authentication both pass', async () => {
+    const { service, operational, credentials } = harness();
+    operational.listConnections.mockResolvedValue([connection]);
+    credentials.state.mockResolvedValue('USABLE');
 
     const dashboard = await service.getDashboard(userId);
     const tractive = dashboard.providers.find((provider) => provider.provider === 'TRACTIVE');
@@ -78,18 +118,70 @@ describe('ConnectorsService', () => {
     expect(tractive).toEqual(
       expect.objectContaining({
         availability: 'CONNECTED',
-        connection: expect.objectContaining({ scopes: ['activity'] }),
+        credentialState: 'USABLE',
+        connection: expect.objectContaining({ id: connection.id }),
       }),
     );
   });
 
-  it('requires a verified wearable credential before routing an import to Autopilot', async () => {
-    const { service } = harness();
+  it('degrades expired connected credentials to reauthorization', async () => {
+    const { service, operational, credentials } = harness();
+    operational.listConnections.mockResolvedValue([connection]);
+    credentials.state.mockResolvedValue('EXPIRED');
+
+    const dashboard = await service.getDashboard(userId);
+    const tractive = dashboard.providers.find((provider) => provider.provider === 'TRACTIVE');
+
+    expect(tractive).toEqual(
+      expect.objectContaining({
+        availability: 'REAUTH_REQUIRED',
+        credentialState: 'EXPIRED',
+      }),
+    );
+    expect(operational.markReauthRequired).toHaveBeenCalledWith(userId, 'TRACTIVE');
+  });
+
+  it('registers credentials before declaring a transport-verified connection', async () => {
+    const { service, credentials, operational } = harness();
+
+    await service.registerVerifiedConnectionFromTransport({
+      userId,
+      provider: 'FI',
+      externalAccountId: 'fi-account-1',
+      displayLabel: 'Collar',
+      grantedScopes: ['activity'],
+      credentials: { accessToken: 'secret' },
+      expiresAt: null,
+    });
+
+    expect(credentials.put).toHaveBeenCalled();
+    expect(operational.markConnected).toHaveBeenCalledWith(
+      expect.objectContaining({ userId, provider: 'FI', externalAccountId: 'fi-account-1' }),
+    );
+    expect(credentials.put.mock.invocationCallOrder[0]).toBeLessThan(
+      operational.markConnected.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it('requires a connected account, usable credential, and mapped provider pet before import', async () => {
+    const { service, operational, credentials } = harness();
 
     await expect(
-      service.importWearableObservation(userId, 'FI', {
-        petId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
-        externalEventId: 'fi-day-1',
+      service.ingestWearableFromTransport(userId, 'FI', {
+        externalPetId: 'fi-pet-1',
+        externalObjectId: 'fi-day-1',
+        kind: 'DAILY_ACTIVITY',
+        observedAt: '2026-08-22T08:00:00.000Z',
+        payload: { activityMinutes: 45 },
+      }),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+
+    operational.getConnection.mockResolvedValue({ ...connection, provider: 'FI' });
+    credentials.state.mockResolvedValue('USABLE');
+    await expect(
+      service.ingestWearableFromTransport(userId, 'FI', {
+        externalPetId: 'fi-pet-1',
+        externalObjectId: 'fi-day-1',
         kind: 'DAILY_ACTIVITY',
         observedAt: '2026-08-22T08:00:00.000Z',
         payload: { activityMinutes: 45 },
@@ -97,35 +189,112 @@ describe('ConnectorsService', () => {
     ).rejects.toBeInstanceOf(UnauthorizedException);
   });
 
-  it('reuses the Autopilot normalization and zero-reward path after connection verification', async () => {
-    const { service, credentials, autopilot } = harness();
-    credentials.has.mockResolvedValue(true);
-    const dto = {
-      petId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
-      externalEventId: 'tractive-day-1',
-      kind: 'DAILY_ACTIVITY' as const,
-      observedAt: '2026-08-22T08:00:00.000Z',
-      payload: { activityMinutes: 51 },
-    };
+  it('reuses Autopilot source truth and records hash-only provenance after verified import', async () => {
+    const { service, operational, credentials, autopilot } = harness();
+    operational.getConnection.mockResolvedValue(connection);
+    credentials.state.mockResolvedValue('USABLE');
+    operational.getPetIdentity.mockResolvedValue({
+      connectionId: connection.id,
+      petId,
+      externalPetId: 'tractive-pet-1',
+      externalPetLabel: 'Scout',
+      verifiedAt: '2026-08-22T00:00:00.000Z',
+    });
 
-    await service.importWearableObservation(userId, 'tractive', dto);
+    await expect(
+      service.ingestWearableFromTransport(userId, 'tractive', {
+        externalPetId: 'tractive-pet-1',
+        externalObjectId: 'day-1',
+        kind: 'DAILY_ACTIVITY',
+        observedAt: '2026-08-22T08:00:00.000Z',
+        payload: { activityMinutes: 51 },
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({ careEventId: 'care-event-1', bondXp: 0 }),
+    );
 
     expect(autopilot.ingestProviderObservation).toHaveBeenCalledWith(
       userId,
       'TRACTIVE',
-      dto,
+      expect.objectContaining({ petId, externalEventId: 'day-1' }),
+    );
+    expect(operational.recordImportReceipt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: connection.id,
+        disposition: 'IMPORTED',
+        canonicalRefType: 'CARE_EVENT',
+        canonicalRefId: 'care-event-1',
+        payloadHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      }),
     );
   });
 
-  it('disconnects local connector credentials without claiming remote revocation', async () => {
-    const { service, credentials } = harness();
+  it('repairs a missing receipt from canonical truth and rejects an altered replay payload', async () => {
+    const { service, operational, credentials, autopilot } = harness();
+    operational.getConnection.mockResolvedValue(connection);
+    credentials.state.mockResolvedValue('USABLE');
+    operational.getPetIdentity.mockResolvedValue({
+      connectionId: connection.id,
+      petId,
+      externalPetId: 'tractive-pet-1',
+      externalPetLabel: null,
+      verifiedAt: '2026-08-22T00:00:00.000Z',
+    });
+    autopilot.ingestProviderObservation.mockResolvedValue({
+      careEventId: 'care-event-1',
+      duplicate: true,
+      bondXp: 0,
+      observation: {
+        provider: 'TRACTIVE',
+        externalEventId: 'day-1',
+        kind: 'DAILY_ACTIVITY',
+        observedAt: new Date('2026-08-22T08:00:00.000Z'),
+        metrics: { activityMinutes: 51 },
+      },
+      signal: null,
+    });
+
+    await expect(
+      service.ingestWearableFromTransport(userId, 'TRACTIVE', {
+        externalPetId: 'tractive-pet-1',
+        externalObjectId: 'day-1',
+        kind: 'DAILY_ACTIVITY',
+        observedAt: '2026-08-22T08:00:00.000Z',
+        payload: { activityMinutes: 99 },
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(operational.recordImportReceipt).toHaveBeenCalledWith(
+      expect.objectContaining({ canonicalRefId: 'care-event-1', disposition: 'IMPORTED' }),
+    );
+  });
+
+  it('disconnects local credentials and records local-only revocation evidence', async () => {
+    const { service, credentials, operational } = harness();
+    operational.getConnection.mockResolvedValue({ ...connection, provider: 'PETCO' });
 
     await expect(service.disconnect(userId, 'PETCO')).resolves.toEqual({
       success: true,
       provider: 'PETCO',
       localCredentialsRemoved: true,
+      localRevocationReceiptId: 'revocation-1',
       remoteRevocation: 'NOT_CONFIGURED',
     });
     expect(credentials.remove).toHaveBeenCalledWith(userId, 'PETCO');
+    expect(operational.markLocallyRevoked).toHaveBeenCalledWith(userId, 'PETCO');
+  });
+
+  it('never routes retail connectors through wearable ingestion', async () => {
+    const { service } = harness();
+
+    await expect(
+      service.ingestWearableFromTransport(userId, 'CHEWY', {
+        externalPetId: 'retail-pet',
+        externalObjectId: 'item-1',
+        kind: 'DEVICE_STATUS',
+        observedAt: '2026-08-22T08:00:00.000Z',
+        payload: { batteryPercent: 50 },
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
   });
 });

--- a/apps/api/src/connectors/connectors.service.ts
+++ b/apps/api/src/connectors/connectors.service.ts
@@ -1,38 +1,110 @@
+import { createHash } from 'node:crypto';
 import { ConflictException, Injectable, UnauthorizedException } from '@nestjs/common';
 import type { IngestTrackerObservationDto } from '../autopilot/dto/autopilot.dto';
+import { normalizeProviderObservation } from '../autopilot/provider-adapters';
 import { AutopilotService } from '../autopilot/autopilot.service';
+import type { NormalizedTrackerObservation } from '../autopilot/autopilot.types';
 import { ConnectorCredentialStore } from './connector-credential.store';
-import type { ConnectorProvider } from './connectors.types';
+import { ConnectorOperationalStore } from './connector-operational.store';
+import type {
+  ConnectorProvider,
+  VerifiedWearableTransportEvent,
+} from './connectors.types';
 import { CONNECTOR_PROVIDER_REGISTRY, parseConnectorProvider } from './provider-registry';
+
+function hashObservation(observation: NormalizedTrackerObservation) {
+  const metrics = Object.fromEntries(
+    Object.entries(observation.metrics)
+      .filter(([, value]) => value !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+  const canonical = JSON.stringify({
+    provider: observation.provider,
+    externalEventId: observation.externalEventId,
+    kind: observation.kind,
+    observedAt: observation.observedAt.toISOString(),
+    metrics,
+  });
+  return createHash('sha256').update(canonical).digest('hex');
+}
 
 @Injectable()
 export class ConnectorsService {
   constructor(
     private readonly credentials: ConnectorCredentialStore,
+    private readonly operational: ConnectorOperationalStore,
     private readonly autopilot: AutopilotService,
   ) {}
 
   async getDashboard(userId: string) {
-    const connected = new Map(
-      (await this.credentials.listMetadata(userId)).map((metadata) => [metadata.provider, metadata]),
+    const connections = new Map(
+      (await this.operational.listConnections(userId)).map((connection) => [
+        connection.provider,
+        connection,
+      ]),
+    );
+
+    const providers = await Promise.all(
+      Object.values(CONNECTOR_PROVIDER_REGISTRY).map(async (definition) => {
+        const connection = connections.get(definition.provider) ?? null;
+        if (!connection) {
+          return {
+            ...definition,
+            availability: definition.availability,
+            connection: null,
+            credentialState: 'MISSING' as const,
+          };
+        }
+
+        if (connection.status === 'REVOKED') {
+          return {
+            ...definition,
+            availability: 'REVOKED' as const,
+            connection,
+            credentialState: 'MISSING' as const,
+          };
+        }
+
+        if (connection.status !== 'CONNECTED') {
+          return {
+            ...definition,
+            availability: connection.status,
+            connection,
+            credentialState: 'MISSING' as const,
+          };
+        }
+
+        const credentialState = await this.credentials.state(userId, definition.provider);
+        if (credentialState !== 'USABLE') {
+          await this.operational.markReauthRequired(userId, definition.provider);
+          return {
+            ...definition,
+            availability: 'REAUTH_REQUIRED' as const,
+            connection: { ...connection, status: 'REAUTH_REQUIRED' as const },
+            credentialState,
+          };
+        }
+
+        return {
+          ...definition,
+          availability: 'CONNECTED' as const,
+          connection,
+          credentialState,
+        };
+      }),
     );
 
     return {
-      providers: Object.values(CONNECTOR_PROVIDER_REGISTRY).map((definition) => {
-        const metadata = connected.get(definition.provider);
-        return {
-          ...definition,
-          availability: metadata ? ('CONNECTED' as const) : definition.availability,
-          connection: metadata ?? null,
-        };
-      }),
+      providers,
       credentialEncryptionConfigured: this.credentials.encryptionConfigured(),
       boundaries: {
         undocumentedOAuthAllowed: false,
+        browserProviderImpersonationAllowed: false,
         preciseLocationImportEnabled: false,
         canonicalPetMutationAllowed: false,
         autonomousRetailPurchaseAllowed: false,
         importedWearablesRewardEligible: false,
+        rawProviderPayloadStored: false,
       },
     };
   }
@@ -50,27 +122,150 @@ export class ConnectorsService {
 
   async disconnect(userId: string, providerValue: string) {
     const provider = parseConnectorProvider(providerValue);
+    const connection = await this.operational.getConnection(userId, provider);
     await this.credentials.remove(userId, provider);
+    const revocationReceiptId = connection
+      ? await this.operational.markLocallyRevoked(userId, provider)
+      : null;
+
     return {
       success: true,
       provider,
       localCredentialsRemoved: true,
+      localRevocationReceiptId: revocationReceiptId,
       remoteRevocation: 'NOT_CONFIGURED' as const,
     };
   }
 
-  async importWearableObservation(
+  /**
+   * Internal transport seam. Future verified OAuth callbacks call this only after
+   * validating the provider response. It is intentionally not exposed by the
+   * public ConnectorsController.
+   */
+  async registerVerifiedConnectionFromTransport(input: {
+    userId: string;
+    provider: ConnectorProvider;
+    externalAccountId: string | null;
+    displayLabel: string | null;
+    grantedScopes: string[];
+    credentials: Record<string, unknown>;
+    expiresAt: Date | null;
+  }) {
+    await this.credentials.put(
+      input.userId,
+      input.provider,
+      input.credentials,
+      input.grantedScopes,
+      input.expiresAt,
+    );
+    return this.operational.markConnected({
+      userId: input.userId,
+      provider: input.provider,
+      externalAccountId: input.externalAccountId,
+      displayLabel: input.displayLabel,
+      grantedScopes: input.grantedScopes,
+    });
+  }
+
+  /** Map a provider-owned pet identity to an owned dogOS pet after provider discovery. */
+  async bindPetIdentityFromTransport(input: {
+    userId: string;
+    provider: ConnectorProvider;
+    petId: string;
+    externalPetId: string;
+    externalPetLabel?: string | null;
+  }) {
+    const identity = await this.operational.bindPetIdentity(input);
+    if (!identity) {
+      throw new ConflictException('A connected provider and owned pet are required for identity mapping');
+    }
+    return identity;
+  }
+
+  /**
+   * Internal provider-ingestion seam. Browser callers cannot supply provider data.
+   * The external pet identity is resolved through connector metadata before the
+   * normalized summary is delegated to Autopilot/CareEvent source truth.
+   */
+  async ingestWearableFromTransport(
     userId: string,
     providerValue: string,
-    dto: IngestTrackerObservationDto,
+    event: VerifiedWearableTransportEvent,
   ) {
     const provider = parseConnectorProvider(providerValue);
     this.assertWearable(provider);
-    if (!(await this.credentials.has(userId, provider))) {
-      throw new UnauthorizedException('A verified connector credential is required before import');
+
+    const connection = await this.operational.getConnection(userId, provider);
+    if (!connection || connection.status !== 'CONNECTED') {
+      throw new UnauthorizedException('A connected provider account is required before import');
     }
 
-    return this.autopilot.ingestProviderObservation(userId, provider, dto);
+    const credentialState = await this.credentials.state(userId, provider);
+    if (credentialState !== 'USABLE') {
+      await this.operational.markReauthRequired(userId, provider);
+      throw new UnauthorizedException('The connector credential requires reauthorization');
+    }
+
+    const identity = await this.operational.getPetIdentity(userId, provider, event.externalPetId);
+    if (!identity) {
+      throw new UnauthorizedException('The provider pet is not mapped to an owned dogOS pet');
+    }
+
+    const dto: IngestTrackerObservationDto = {
+      petId: identity.petId,
+      externalEventId: event.externalObjectId,
+      kind: event.kind,
+      observedAt: event.observedAt,
+      payload: event.payload,
+    };
+    const requestedObservation = normalizeProviderObservation(provider, dto);
+    const requestedHash = hashObservation(requestedObservation);
+    const resourceType = `WEARABLE_${event.kind}`;
+
+    const existing = await this.operational.getImportReceipt(
+      identity.connectionId,
+      resourceType,
+      event.externalObjectId,
+    );
+    if (existing) {
+      if (existing.payloadHash !== requestedHash) {
+        throw new ConflictException({
+          code: 'external_object_changed_after_import',
+          provider,
+          externalObjectId: event.externalObjectId,
+        });
+      }
+      return { duplicate: true, receipt: existing };
+    }
+
+    const result = await this.autopilot.ingestProviderObservation(userId, provider, dto);
+    const canonicalHash = hashObservation(result.observation);
+    const receipt = await this.operational.recordImportReceipt({
+      connectionId: identity.connectionId,
+      resourceType,
+      externalObjectId: event.externalObjectId,
+      payloadHash: canonicalHash,
+      disposition: 'IMPORTED',
+      canonicalRefType: 'CARE_EVENT',
+      canonicalRefId: result.careEventId,
+      occurredAt: result.observation.observedAt,
+    });
+
+    if (!receipt) throw new ConflictException('Connector import receipt could not be persisted');
+    if (receipt.payloadHash !== requestedHash || canonicalHash !== requestedHash) {
+      throw new ConflictException({
+        code: 'external_object_changed_after_import',
+        provider,
+        externalObjectId: event.externalObjectId,
+      });
+    }
+
+    return {
+      duplicate: result.duplicate,
+      careEventId: result.careEventId,
+      bondXp: result.bondXp,
+      receipt,
+    };
   }
 
   private assertWearable(provider: ConnectorProvider) {

--- a/apps/api/src/connectors/connectors.service.ts
+++ b/apps/api/src/connectors/connectors.service.ts
@@ -1,0 +1,81 @@
+import { ConflictException, Injectable, UnauthorizedException } from '@nestjs/common';
+import type { IngestTrackerObservationDto } from '../autopilot/dto/autopilot.dto';
+import { AutopilotService } from '../autopilot/autopilot.service';
+import { ConnectorCredentialStore } from './connector-credential.store';
+import type { ConnectorProvider } from './connectors.types';
+import { CONNECTOR_PROVIDER_REGISTRY, parseConnectorProvider } from './provider-registry';
+
+@Injectable()
+export class ConnectorsService {
+  constructor(
+    private readonly credentials: ConnectorCredentialStore,
+    private readonly autopilot: AutopilotService,
+  ) {}
+
+  async getDashboard(userId: string) {
+    const connected = new Map(
+      (await this.credentials.listMetadata(userId)).map((metadata) => [metadata.provider, metadata]),
+    );
+
+    return {
+      providers: Object.values(CONNECTOR_PROVIDER_REGISTRY).map((definition) => {
+        const metadata = connected.get(definition.provider);
+        return {
+          ...definition,
+          availability: metadata ? ('CONNECTED' as const) : definition.availability,
+          connection: metadata ?? null,
+        };
+      }),
+      credentialEncryptionConfigured: this.credentials.encryptionConfigured(),
+      boundaries: {
+        undocumentedOAuthAllowed: false,
+        preciseLocationImportEnabled: false,
+        canonicalPetMutationAllowed: false,
+        autonomousRetailPurchaseAllowed: false,
+        importedWearablesRewardEligible: false,
+      },
+    };
+  }
+
+  startOAuth(providerValue: string) {
+    const provider = parseConnectorProvider(providerValue);
+    const definition = CONNECTOR_PROVIDER_REGISTRY[provider];
+
+    throw new ConflictException({
+      code: 'partner_required',
+      provider,
+      message: `${definition.label} does not have a verified OAuth transport configured in this dogOS release.`,
+    });
+  }
+
+  async disconnect(userId: string, providerValue: string) {
+    const provider = parseConnectorProvider(providerValue);
+    await this.credentials.remove(userId, provider);
+    return {
+      success: true,
+      provider,
+      localCredentialsRemoved: true,
+      remoteRevocation: 'NOT_CONFIGURED' as const,
+    };
+  }
+
+  async importWearableObservation(
+    userId: string,
+    providerValue: string,
+    dto: IngestTrackerObservationDto,
+  ) {
+    const provider = parseConnectorProvider(providerValue);
+    this.assertWearable(provider);
+    if (!(await this.credentials.has(userId, provider))) {
+      throw new UnauthorizedException('A verified connector credential is required before import');
+    }
+
+    return this.autopilot.ingestProviderObservation(userId, provider, dto);
+  }
+
+  private assertWearable(provider: ConnectorProvider) {
+    if (CONNECTOR_PROVIDER_REGISTRY[provider].domain !== 'WEARABLE') {
+      throw new ConflictException('This connector does not import wearable observations');
+    }
+  }
+}

--- a/apps/api/src/connectors/connectors.service.ts
+++ b/apps/api/src/connectors/connectors.service.ts
@@ -6,17 +6,14 @@ import { AutopilotService } from '../autopilot/autopilot.service';
 import type { NormalizedTrackerObservation } from '../autopilot/autopilot.types';
 import { ConnectorCredentialStore } from './connector-credential.store';
 import { ConnectorOperationalStore } from './connector-operational.store';
-import type {
-  ConnectorProvider,
-  VerifiedWearableTransportEvent,
-} from './connectors.types';
+import type { ConnectorProvider, VerifiedWearableTransportEvent } from './connectors.types';
 import { CONNECTOR_PROVIDER_REGISTRY, parseConnectorProvider } from './provider-registry';
 
 function hashObservation(observation: NormalizedTrackerObservation) {
   const metrics = Object.fromEntries(
     Object.entries(observation.metrics)
       .filter(([, value]) => value !== undefined)
-      .sort(([left], [right]) => left.localeCompare(right)),
+      .sort(([left], [right]) => left.localeCompare(right))
   );
   const canonical = JSON.stringify({
     provider: observation.provider,
@@ -33,7 +30,7 @@ export class ConnectorsService {
   constructor(
     private readonly credentials: ConnectorCredentialStore,
     private readonly operational: ConnectorOperationalStore,
-    private readonly autopilot: AutopilotService,
+    private readonly autopilot: AutopilotService
   ) {}
 
   async getDashboard(userId: string) {
@@ -41,7 +38,7 @@ export class ConnectorsService {
       (await this.operational.listConnections(userId)).map((connection) => [
         connection.provider,
         connection,
-      ]),
+      ])
     );
 
     const providers = await Promise.all(
@@ -91,7 +88,7 @@ export class ConnectorsService {
           connection,
           credentialState,
         };
-      }),
+      })
     );
 
     return {
@@ -156,7 +153,7 @@ export class ConnectorsService {
       input.provider,
       input.credentials,
       input.grantedScopes,
-      input.expiresAt,
+      input.expiresAt
     );
     return this.operational.markConnected({
       userId: input.userId,
@@ -177,7 +174,9 @@ export class ConnectorsService {
   }) {
     const identity = await this.operational.bindPetIdentity(input);
     if (!identity) {
-      throw new ConflictException('A connected provider and owned pet are required for identity mapping');
+      throw new ConflictException(
+        'A connected provider and owned pet are required for identity mapping'
+      );
     }
     return identity;
   }
@@ -190,7 +189,7 @@ export class ConnectorsService {
   async ingestWearableFromTransport(
     userId: string,
     providerValue: string,
-    event: VerifiedWearableTransportEvent,
+    event: VerifiedWearableTransportEvent
   ) {
     const provider = parseConnectorProvider(providerValue);
     this.assertWearable(provider);
@@ -225,7 +224,7 @@ export class ConnectorsService {
     const existing = await this.operational.getImportReceipt(
       identity.connectionId,
       resourceType,
-      event.externalObjectId,
+      event.externalObjectId
     );
     if (existing) {
       if (existing.payloadHash !== requestedHash) {

--- a/apps/api/src/connectors/connectors.types.ts
+++ b/apps/api/src/connectors/connectors.types.ts
@@ -2,11 +2,7 @@ export const CONNECTOR_PROVIDERS = ['FI', 'TRACTIVE', 'VET_PARTNER', 'CHEWY', 'P
 export type ConnectorProvider = (typeof CONNECTOR_PROVIDERS)[number];
 
 export type ConnectorDomain = 'WEARABLE' | 'VET' | 'RETAIL';
-export type ConnectorAvailability =
-  | 'PARTNER_REQUIRED'
-  | 'CONNECTED'
-  | 'REAUTH_REQUIRED'
-  | 'REVOKED';
+export type ConnectorAvailability = 'PARTNER_REQUIRED' | 'CONNECTED' | 'REAUTH_REQUIRED' | 'REVOKED';
 export type ConnectorCredentialState = 'MISSING' | 'USABLE' | 'EXPIRED' | 'INVALID';
 
 export type ConnectorCapability =

--- a/apps/api/src/connectors/connectors.types.ts
+++ b/apps/api/src/connectors/connectors.types.ts
@@ -2,7 +2,8 @@ export const CONNECTOR_PROVIDERS = ['FI', 'TRACTIVE', 'VET_PARTNER', 'CHEWY', 'P
 export type ConnectorProvider = (typeof CONNECTOR_PROVIDERS)[number];
 
 export type ConnectorDomain = 'WEARABLE' | 'VET' | 'RETAIL';
-export type ConnectorAvailability = 'PARTNER_REQUIRED' | 'CONNECTED' | 'REAUTH_REQUIRED' | 'REVOKED';
+export type ConnectorAvailability =
+  'PARTNER_REQUIRED' | 'CONNECTED' | 'REAUTH_REQUIRED' | 'REVOKED';
 export type ConnectorCredentialState = 'MISSING' | 'USABLE' | 'EXPIRED' | 'INVALID';
 
 export type ConnectorCapability =

--- a/apps/api/src/connectors/connectors.types.ts
+++ b/apps/api/src/connectors/connectors.types.ts
@@ -1,0 +1,35 @@
+export const CONNECTOR_PROVIDERS = ['FI', 'TRACTIVE', 'VET_PARTNER', 'CHEWY', 'PETCO'] as const;
+export type ConnectorProvider = (typeof CONNECTOR_PROVIDERS)[number];
+
+export type ConnectorDomain = 'WEARABLE' | 'VET' | 'RETAIL';
+export type ConnectorAvailability = 'PARTNER_REQUIRED' | 'CONNECTED';
+
+export type ConnectorCapability =
+  | 'DAILY_ACTIVITY'
+  | 'DEVICE_STATUS'
+  | 'APPOINTMENT_IMPORT'
+  | 'VACCINATION_IMPORT'
+  | 'MEDICATION_REFERENCE'
+  | 'DOCUMENT_REFERENCE'
+  | 'CATALOG_REFERENCE'
+  | 'USER_APPROVED_HANDOFF';
+
+export type ConnectorProviderDefinition = {
+  provider: ConnectorProvider;
+  label: string;
+  domain: ConnectorDomain;
+  availability: 'PARTNER_REQUIRED';
+  capabilities: ConnectorCapability[];
+  preciseLocationEnabled: false;
+  canonicalPetMutationAllowed: false;
+  autonomousPurchaseAllowed: false;
+  notes: string;
+};
+
+export type ConnectorCredentialEnvelope = {
+  v: 1;
+  alg: 'A256GCM';
+  iv: string;
+  tag: string;
+  ciphertext: string;
+};

--- a/apps/api/src/connectors/connectors.types.ts
+++ b/apps/api/src/connectors/connectors.types.ts
@@ -2,7 +2,12 @@ export const CONNECTOR_PROVIDERS = ['FI', 'TRACTIVE', 'VET_PARTNER', 'CHEWY', 'P
 export type ConnectorProvider = (typeof CONNECTOR_PROVIDERS)[number];
 
 export type ConnectorDomain = 'WEARABLE' | 'VET' | 'RETAIL';
-export type ConnectorAvailability = 'PARTNER_REQUIRED' | 'CONNECTED';
+export type ConnectorAvailability =
+  | 'PARTNER_REQUIRED'
+  | 'CONNECTED'
+  | 'REAUTH_REQUIRED'
+  | 'REVOKED';
+export type ConnectorCredentialState = 'MISSING' | 'USABLE' | 'EXPIRED' | 'INVALID';
 
 export type ConnectorCapability =
   | 'DAILY_ACTIVITY'
@@ -32,4 +37,12 @@ export type ConnectorCredentialEnvelope = {
   iv: string;
   tag: string;
   ciphertext: string;
+};
+
+export type VerifiedWearableTransportEvent = {
+  externalPetId: string;
+  externalObjectId: string;
+  kind: 'DAILY_ACTIVITY' | 'DEVICE_STATUS';
+  observedAt: string;
+  payload: Record<string, unknown>;
 };

--- a/apps/api/src/connectors/provider-registry.ts
+++ b/apps/api/src/connectors/provider-registry.ts
@@ -1,0 +1,82 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  CONNECTOR_PROVIDERS,
+  type ConnectorProvider,
+  type ConnectorProviderDefinition,
+} from './connectors.types';
+
+export const CONNECTOR_PROVIDER_REGISTRY: Record<ConnectorProvider, ConnectorProviderDefinition> = {
+  FI: {
+    provider: 'FI',
+    label: 'Fi',
+    domain: 'WEARABLE',
+    availability: 'PARTNER_REQUIRED',
+    capabilities: ['DAILY_ACTIVITY', 'DEVICE_STATUS'],
+    preciseLocationEnabled: false,
+    canonicalPetMutationAllowed: false,
+    autonomousPurchaseAllowed: false,
+    notes:
+      'Wearable normalization is implemented, but dogOS does not claim a supported public Fi OAuth/API contract without verified partner documentation.',
+  },
+  TRACTIVE: {
+    provider: 'TRACTIVE',
+    label: 'Tractive',
+    domain: 'WEARABLE',
+    availability: 'PARTNER_REQUIRED',
+    capabilities: ['DAILY_ACTIVITY', 'DEVICE_STATUS'],
+    preciseLocationEnabled: false,
+    canonicalPetMutationAllowed: false,
+    autonomousPurchaseAllowed: false,
+    notes:
+      'Wearable normalization is implemented, but dogOS does not claim a supported public Tractive OAuth/API contract without verified partner documentation.',
+  },
+  VET_PARTNER: {
+    provider: 'VET_PARTNER',
+    label: 'Veterinary partner',
+    domain: 'VET',
+    availability: 'PARTNER_REQUIRED',
+    capabilities: [
+      'APPOINTMENT_IMPORT',
+      'VACCINATION_IMPORT',
+      'MEDICATION_REFERENCE',
+      'DOCUMENT_REFERENCE',
+    ],
+    preciseLocationEnabled: false,
+    canonicalPetMutationAllowed: false,
+    autonomousPurchaseAllowed: false,
+    notes:
+      'Veterinary transport is provider-specific. Records must retain source provenance and remain references/imported observations unless an explicit domain workflow promotes them.',
+  },
+  CHEWY: {
+    provider: 'CHEWY',
+    label: 'Chewy',
+    domain: 'RETAIL',
+    availability: 'PARTNER_REQUIRED',
+    capabilities: ['CATALOG_REFERENCE', 'USER_APPROVED_HANDOFF'],
+    preciseLocationEnabled: false,
+    canonicalPetMutationAllowed: false,
+    autonomousPurchaseAllowed: false,
+    notes:
+      'Retail integration is approval-first. dogOS does not autonomously add to cart, place orders, or charge payment methods.',
+  },
+  PETCO: {
+    provider: 'PETCO',
+    label: 'Petco',
+    domain: 'RETAIL',
+    availability: 'PARTNER_REQUIRED',
+    capabilities: ['CATALOG_REFERENCE', 'USER_APPROVED_HANDOFF'],
+    preciseLocationEnabled: false,
+    canonicalPetMutationAllowed: false,
+    autonomousPurchaseAllowed: false,
+    notes:
+      'Retail integration is approval-first. dogOS does not autonomously add to cart, place orders, or charge payment methods.',
+  },
+};
+
+export function parseConnectorProvider(value: string): ConnectorProvider {
+  const provider = value.toUpperCase() as ConnectorProvider;
+  if (!CONNECTOR_PROVIDERS.includes(provider)) {
+    throw new BadRequestException('Unsupported dogOS connector provider');
+  }
+  return provider;
+}

--- a/apps/web/src/app/connectors/page.tsx
+++ b/apps/web/src/app/connectors/page.tsx
@@ -1,0 +1,316 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  ChevronLeft,
+  Loader2,
+  LockKeyhole,
+  MapPinned,
+  PlugZap,
+  ShieldCheck,
+  ShoppingBag,
+  Stethoscope,
+  Watch,
+} from 'lucide-react';
+import Link from 'next/link';
+import { toast } from 'sonner';
+import { BottomNav } from '@/components/bottom-nav';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  connectorsApi,
+  type ConnectorDomain,
+  type ConnectorProvider,
+  type ConnectorProviderState,
+} from '@/lib/api/connectors';
+
+const capabilityLabels: Record<string, string> = {
+  DAILY_ACTIVITY: 'Daily activity',
+  DEVICE_STATUS: 'Device status',
+  APPOINTMENT_IMPORT: 'Appointments',
+  VACCINATION_IMPORT: 'Vaccinations',
+  MEDICATION_REFERENCE: 'Medication instructions',
+  DOCUMENT_REFERENCE: 'Source documents',
+  CATALOG_REFERENCE: 'Product catalog',
+  USER_APPROVED_HANDOFF: 'User-approved handoff',
+};
+
+const statusLabels = {
+  PARTNER_REQUIRED: 'Partner access required',
+  CONNECTED: 'Connected',
+  REAUTH_REQUIRED: 'Reconnect required',
+  REVOKED: 'Disconnected',
+} as const;
+
+function domainIcon(domain: ConnectorDomain) {
+  if (domain === 'WEARABLE') return Watch;
+  if (domain === 'VET') return Stethoscope;
+  return ShoppingBag;
+}
+
+function providerNote(provider: ConnectorProvider) {
+  if (provider === 'FI' || provider === 'TRACTIVE') {
+    return 'Summary-only wearable context. Precise tracker location remains off.';
+  }
+  if (provider === 'VET_PARTNER') {
+    return 'Imported records keep provider provenance. dogOS never computes a prescription or dose.';
+  }
+  return 'Catalog context can support a suggestion, but purchases always require your action.';
+}
+
+function providerStatusClass(provider: ConnectorProviderState) {
+  if (provider.availability === 'CONNECTED') return 'bg-primary/10 text-primary';
+  if (provider.availability === 'REAUTH_REQUIRED') return 'bg-amber-500/10 text-amber-700';
+  return 'border border-border text-muted-foreground';
+}
+
+export default function ConnectorsPage() {
+  const queryClient = useQueryClient();
+  const dashboard = useQuery({
+    queryKey: ['connectors'],
+    queryFn: connectorsApi.getDashboard,
+    retry: false,
+  });
+
+  const disconnect = useMutation({
+    mutationFn: connectorsApi.disconnect,
+    onSuccess: async (result) => {
+      await queryClient.invalidateQueries({ queryKey: ['connectors'] });
+      toast.success(`${result.provider} disconnected from dogOS`);
+    },
+    onError: () => toast.error('That service could not be disconnected. Please try again.'),
+  });
+
+  return (
+    <div className="min-h-screen pb-24">
+      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/88 backdrop-blur-2xl">
+        <div className="mx-auto flex h-16 max-w-xl items-center gap-3 px-4">
+          <Button variant="ghost" size="icon" asChild className="rounded-xl">
+            <Link href="/settings" aria-label="Back to settings">
+              <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+            </Link>
+          </Button>
+          <span className="brand-mark flex h-9 w-9 items-center justify-center rounded-xl">
+            <PlugZap className="h-5 w-5 text-primary-foreground" aria-hidden="true" />
+          </span>
+          <div>
+            <p className="eyebrow">dogOS Connectors</p>
+            <h1 className="mt-0.5 text-xl font-bold tracking-tight">Connected services</h1>
+          </div>
+        </div>
+      </header>
+
+      <main id="main-content" className="mx-auto max-w-xl space-y-6 px-4 py-5">
+        <section className="rounded-3xl border border-primary/15 bg-gradient-to-br from-primary/[0.1] via-card/90 to-secondary/[0.07] p-5 shadow-sm">
+          <div className="flex items-start gap-4">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <ShieldCheck className="h-5 w-5" aria-hidden="true" />
+            </div>
+            <div>
+              <p className="eyebrow">Bring context, not control</p>
+              <h2 className="mt-1 text-2xl font-bold tracking-tight">
+                External services stay outside your dog&apos;s source of truth.
+              </h2>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                Connectors can import bounded, sourced context through verified provider transports.
+                They cannot silently rewrite your dog, activities, private memories, or Story.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {dashboard.isLoading ? (
+          <div className="flex min-h-[35vh] items-center justify-center" role="status">
+            <Loader2 className="h-7 w-7 animate-spin text-primary" aria-hidden="true" />
+            <span className="sr-only">Loading connected services</span>
+          </div>
+        ) : dashboard.isError || !dashboard.data ? (
+          <Card className="surface-soft rounded-3xl p-6 text-center">
+            <PlugZap className="mx-auto h-8 w-8 text-primary" aria-hidden="true" />
+            <h2 className="mt-3 text-lg font-bold">Connected services are unavailable</h2>
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+              The feature may be paused in this environment. Existing dogOS records are unchanged.
+            </p>
+            <Button className="mt-4" variant="outline" onClick={() => dashboard.refetch()}>
+              Try again
+            </Button>
+          </Card>
+        ) : (
+          <>
+            <section className="space-y-3" aria-labelledby="services-heading">
+              <div>
+                <p className="eyebrow">Provider access</p>
+                <h2 id="services-heading" className="mt-1 text-xl font-bold tracking-tight">
+                  Services
+                </h2>
+                <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                  A service only says Connected when dogOS has both verified connection metadata and
+                  a usable authenticated credential. Partner-gated services stay visibly gated.
+                </p>
+              </div>
+
+              <div className="space-y-3">
+                {dashboard.data.providers.map((provider) => {
+                  const Icon = domainIcon(provider.domain);
+                  const canDisconnect =
+                    provider.availability === 'CONNECTED' ||
+                    provider.availability === 'REAUTH_REQUIRED';
+                  return (
+                    <Card key={provider.provider} className="surface-soft rounded-3xl p-4">
+                      <div className="flex items-start gap-3">
+                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                          <Icon className="h-5 w-5" aria-hidden="true" />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div>
+                              <h3 className="font-semibold">{provider.label}</h3>
+                              <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                                {provider.domain === 'WEARABLE'
+                                  ? 'Wearable'
+                                  : provider.domain === 'VET'
+                                    ? 'Veterinary'
+                                    : 'Retail'}
+                              </p>
+                            </div>
+                            <span
+                              className={`rounded-full px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide ${providerStatusClass(provider)}`}
+                            >
+                              {statusLabels[provider.availability]}
+                            </span>
+                          </div>
+
+                          <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                            {providerNote(provider.provider)}
+                          </p>
+
+                          <div className="mt-3 flex flex-wrap gap-1.5">
+                            {provider.capabilities.map((capability) => (
+                              <span
+                                key={capability}
+                                className="rounded-full border border-border/70 bg-background/50 px-2 py-1 text-[10px] font-medium text-muted-foreground"
+                              >
+                                {capabilityLabels[capability] ?? capability}
+                              </span>
+                            ))}
+                          </div>
+
+                          {provider.availability === 'PARTNER_REQUIRED' && (
+                            <p className="mt-3 rounded-2xl border border-border/70 bg-background/55 p-3 text-xs leading-relaxed text-muted-foreground">
+                              No supported provider authorization flow is configured yet, so dogOS
+                              will not offer a pretend Connect button.
+                            </p>
+                          )}
+
+                          {provider.availability === 'REAUTH_REQUIRED' && (
+                            <p className="mt-3 rounded-2xl border border-border/70 bg-background/55 p-3 text-xs leading-relaxed text-muted-foreground">
+                              The stored provider credential is expired or could not be authenticated.
+                              No new provider data will import until a verified reauthorization flow
+                              becomes available.
+                            </p>
+                          )}
+
+                          {canDisconnect && (
+                            <Button
+                              className="mt-3"
+                              size="sm"
+                              variant="outline"
+                              disabled={disconnect.isPending}
+                              onClick={() => disconnect.mutate(provider.provider)}
+                            >
+                              {disconnect.isPending && (
+                                <Loader2
+                                  className="mr-1.5 h-4 w-4 animate-spin"
+                                  aria-hidden="true"
+                                />
+                              )}
+                              Disconnect
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+                    </Card>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="space-y-3" aria-labelledby="connector-boundaries-heading">
+              <div>
+                <p className="eyebrow">Trust boundary</p>
+                <h2 id="connector-boundaries-heading" className="mt-1 text-xl font-bold">
+                  What Connectors cannot do
+                </h2>
+              </div>
+              <Card className="surface-soft grid grid-cols-1 gap-3 rounded-3xl p-4 sm:grid-cols-2">
+                <Boundary
+                  icon={MapPinned}
+                  title="Import precise tracker GPS"
+                  value="No"
+                  detail="Location needs a separate explicit scope, retention policy, and deletion contract."
+                />
+                <Boundary
+                  icon={ShieldCheck}
+                  title="Rewrite canonical dog records"
+                  value="No"
+                  detail="Provider transport delegates to domain importers instead."
+                />
+                <Boundary
+                  icon={ShoppingBag}
+                  title="Place retail orders"
+                  value="No"
+                  detail="Retail connectors stop at user-approved handoff."
+                />
+                <Boundary
+                  icon={LockKeyhole}
+                  title="Store raw provider payloads"
+                  value="No"
+                  detail="Operational provenance stores normalized hashes and references only."
+                />
+              </Card>
+            </section>
+
+            <Card className="rounded-3xl border-primary/15 bg-primary/[0.04] p-4">
+              <div className="flex items-start gap-3">
+                <LockKeyhole className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+                <div>
+                  <p className="font-semibold">Credential vault</p>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                    {dashboard.data.credentialEncryptionConfigured
+                      ? 'Connector credentials use authenticated encryption before persistence.'
+                      : 'Credential encryption is not configured in this environment, so credential operations fail closed.'}
+                  </p>
+                </div>
+              </div>
+            </Card>
+          </>
+        )}
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+}
+
+function Boundary({
+  icon: Icon,
+  title,
+  value,
+  detail,
+}: {
+  icon: typeof ShieldCheck;
+  title: string;
+  value: 'No';
+  detail: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-border/70 bg-background/55 p-3">
+      <div className="flex items-center gap-2">
+        <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
+        <p className="text-xs font-semibold">{title}</p>
+        <span className="ml-auto text-xs font-bold text-primary">{value}</span>
+      </div>
+      <p className="mt-2 text-xs leading-relaxed text-muted-foreground">{detail}</p>
+    </div>
+  );
+}

--- a/apps/web/src/app/connectors/page.tsx
+++ b/apps/web/src/app/connectors/page.tsx
@@ -204,9 +204,9 @@ export default function ConnectorsPage() {
 
                           {provider.availability === 'REAUTH_REQUIRED' && (
                             <p className="mt-3 rounded-2xl border border-border/70 bg-background/55 p-3 text-xs leading-relaxed text-muted-foreground">
-                              The stored provider credential is expired or could not be authenticated.
-                              No new provider data will import until a verified reauthorization flow
-                              becomes available.
+                              The stored provider credential is expired or could not be
+                              authenticated. No new provider data will import until a verified
+                              reauthorization flow becomes available.
                             </p>
                           )}
 

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -26,11 +26,7 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { authApi } from '@/lib/api';
-import {
-  type MeetupLocationSharing,
-  privacyApi,
-  type PrivacyPreferences,
-} from '@/lib/api/privacy';
+import { type MeetupLocationSharing, privacyApi, type PrivacyPreferences } from '@/lib/api/privacy';
 import type { AuthUser } from '@/lib/stores/auth-store';
 
 const retentionOptions = [1, 6, 12, 24] as const;
@@ -90,7 +86,7 @@ export default function SettingsPage() {
       toast.success(
         result.deleted > 0
           ? `Deleted ${result.deleted} stored location point${result.deleted === 1 ? '' : 's'}`
-          : 'No stored location history remained',
+          : 'No stored location history remained'
       );
     },
     onError: (error) => {
@@ -137,7 +133,8 @@ export default function SettingsPage() {
         <ShieldCheck className="h-8 w-8 text-primary" aria-hidden="true" />
         <h1 className="mt-4 text-xl font-semibold">Privacy settings unavailable</h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          Woof could not load your consent state, so location controls remain unavailable rather than guessing.
+          Woof could not load your consent state, so location controls remain unavailable rather
+          than guessing.
         </p>
         <Button className="mt-5" onClick={() => privacyQuery.refetch()}>
           Try again
@@ -168,7 +165,11 @@ export default function SettingsPage() {
             <Avatar className="h-14 w-14 border border-border">
               <AvatarImage src={profile?.avatarUrl || '/placeholder.svg'} alt="" />
               <AvatarFallback>
-                {profile?.handle ? profile.handle.slice(0, 1).toUpperCase() : <PawPrint className="h-5 w-5" />}
+                {profile?.handle ? (
+                  profile.handle.slice(0, 1).toUpperCase()
+                ) : (
+                  <PawPrint className="h-5 w-5" />
+                )}
               </AvatarFallback>
             </Avatar>
             <div className="min-w-0 flex-1">
@@ -193,8 +194,8 @@ export default function SettingsPage() {
               Precise location is opt-in
             </h2>
             <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              Woof does not need precise location for matching. When you choose to enable it for proximity features,
-              retained points automatically expire within 24 hours.
+              Woof does not need precise location for matching. When you choose to enable it for
+              proximity features, retained points automatically expire within 24 hours.
             </p>
           </div>
 
@@ -209,8 +210,8 @@ export default function SettingsPage() {
                     Precise location
                   </label>
                   <p className="mt-1 text-sm leading-5 text-muted-foreground">
-                    Allows temporary location pings for features you explicitly use. Turning this off also deletes
-                    retained pings.
+                    Allows temporary location pings for features you explicitly use. Turning this
+                    off also deletes retained pings.
                   </p>
                 </div>
               </div>
@@ -233,7 +234,8 @@ export default function SettingsPage() {
                     Mutual proximity suggestions
                   </label>
                   <p className="mt-1 text-sm leading-5 text-muted-foreground">
-                    Only works when both members opt in. Other members never receive your historical coordinates.
+                    Only works when both members opt in. Other members never receive your historical
+                    coordinates.
                   </p>
                 </div>
               </div>
@@ -256,7 +258,8 @@ export default function SettingsPage() {
                     Share activity routes
                   </label>
                   <p className="mt-1 text-sm leading-5 text-muted-foreground">
-                    Off keeps detailed walk and activity geometry private even when you share an activity summary.
+                    Off keeps detailed walk and activity geometry private even when you share an
+                    activity summary.
                   </p>
                 </div>
               </div>
@@ -286,7 +289,8 @@ export default function SettingsPage() {
                 Location retention
               </label>
               <p className="mt-1 text-sm text-muted-foreground">
-                Older location pings are pruned automatically. The server enforces a hard 24-hour maximum.
+                Older location pings are pruned automatically. The server enforces a hard 24-hour
+                maximum.
               </p>
               <select
                 id="retention-hours"
@@ -308,8 +312,8 @@ export default function SettingsPage() {
                 Meetup location sharing
               </label>
               <p className="mt-1 text-sm text-muted-foreground">
-                Proposals contain only a coarse venue area. Choose whether more specific coordination is permitted
-                after both people confirm.
+                Proposals contain only a coarse venue area. Choose whether more specific
+                coordination is permitted after both people confirm.
               </p>
               <select
                 id="meetup-location-sharing"
@@ -347,28 +351,39 @@ export default function SettingsPage() {
             ) : (
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
                 <div>
-                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Points stored</p>
-                  <p className="mt-1 text-xl font-bold">{locationSummary?.storedLocationPings ?? 0}</p>
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                    Points stored
+                  </p>
+                  <p className="mt-1 text-xl font-bold">
+                    {locationSummary?.storedLocationPings ?? 0}
+                  </p>
                 </div>
                 <div>
                   <p className="text-xs uppercase tracking-wide text-muted-foreground">Oldest</p>
-                  <p className="mt-1 text-sm font-medium">{formatStoredDate(locationSummary?.oldestStoredAt ?? null)}</p>
+                  <p className="mt-1 text-sm font-medium">
+                    {formatStoredDate(locationSummary?.oldestStoredAt ?? null)}
+                  </p>
                 </div>
                 <div>
                   <p className="text-xs uppercase tracking-wide text-muted-foreground">Newest</p>
-                  <p className="mt-1 text-sm font-medium">{formatStoredDate(locationSummary?.newestStoredAt ?? null)}</p>
+                  <p className="mt-1 text-sm font-medium">
+                    {formatStoredDate(locationSummary?.newestStoredAt ?? null)}
+                  </p>
                 </div>
               </div>
             )}
 
             <div className="mt-4 rounded-xl border border-border/70 bg-background/50 p-3 text-xs leading-5 text-muted-foreground">
-              This screen intentionally reports counts and timestamps only. It never retrieves your stored coordinates.
+              This screen intentionally reports counts and timestamps only. It never retrieves your
+              stored coordinates.
             </div>
 
             <Button
               variant="outline"
               className="mt-4 w-full gap-2 border-destructive/30 text-destructive hover:bg-destructive/10 hover:text-destructive"
-              disabled={clearLocation.isPending || (locationSummary?.storedLocationPings ?? 0) === 0}
+              disabled={
+                clearLocation.isPending || (locationSummary?.storedLocationPings ?? 0) === 0
+              }
               onClick={() => clearLocation.mutate()}
             >
               {clearLocation.isPending ? (

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -18,6 +18,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { BottomNav } from '@/components/bottom-nav';
+import { ConnectedServicesSettings } from '@/components/settings/connected-services-settings';
 import { NotificationSettings } from '@/components/settings/notification-settings';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
@@ -379,6 +380,8 @@ export default function SettingsPage() {
             </Button>
           </Card>
         </section>
+
+        <ConnectedServicesSettings />
 
         <NotificationSettings />
 

--- a/apps/web/src/components/settings/connected-services-settings.tsx
+++ b/apps/web/src/components/settings/connected-services-settings.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { ChevronRight, Loader2, PlugZap, ShieldCheck } from 'lucide-react';
+import Link from 'next/link';
+import { Card } from '@/components/ui/card';
+import { connectorsApi } from '@/lib/api/connectors';
+
+export function ConnectedServicesSettings() {
+  const dashboard = useQuery({
+    queryKey: ['connectors'],
+    queryFn: connectorsApi.getDashboard,
+    retry: false,
+    staleTime: 15_000,
+  });
+
+  const connected =
+    dashboard.data?.providers.filter((provider) => provider.availability === 'CONNECTED').length ?? 0;
+  const needsAttention =
+    dashboard.data?.providers.filter((provider) => provider.availability === 'REAUTH_REQUIRED')
+      .length ?? 0;
+
+  return (
+    <section className="space-y-3" aria-labelledby="connected-services-heading">
+      <div>
+        <p className="eyebrow">External context</p>
+        <h2 id="connected-services-heading" className="mt-1 text-lg font-bold">
+          Connected services
+        </h2>
+        <p className="mt-1 text-sm leading-6 text-muted-foreground">
+          See which outside services can contribute sourced context without becoming a second dogOS
+          source of truth.
+        </p>
+      </div>
+
+      <Link href="/connectors" className="block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+        <Card className="surface-soft flex items-center gap-3 rounded-2xl p-4 transition hover:border-primary/30">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+            <PlugZap className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="font-semibold">Manage connected services</p>
+            {dashboard.isLoading ? (
+              <p className="mt-1 flex items-center gap-1.5 text-sm text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                Checking provider state
+              </p>
+            ) : dashboard.isError ? (
+              <p className="mt-1 flex items-center gap-1.5 text-sm text-muted-foreground">
+                <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+                Connector state unavailable
+              </p>
+            ) : needsAttention > 0 ? (
+              <p className="mt-1 text-sm text-muted-foreground">
+                {needsAttention} service{needsAttention === 1 ? '' : 's'} need reauthorization
+              </p>
+            ) : connected > 0 ? (
+              <p className="mt-1 text-sm text-muted-foreground">
+                {connected} verified service{connected === 1 ? '' : 's'} connected
+              </p>
+            ) : (
+              <p className="mt-1 text-sm text-muted-foreground">
+                Available integrations are currently partner-gated
+              </p>
+            )}
+          </div>
+          <ChevronRight className="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden="true" />
+        </Card>
+      </Link>
+    </section>
+  );
+}

--- a/apps/web/src/components/settings/connected-services-settings.tsx
+++ b/apps/web/src/components/settings/connected-services-settings.tsx
@@ -15,7 +15,8 @@ export function ConnectedServicesSettings() {
   });
 
   const connected =
-    dashboard.data?.providers.filter((provider) => provider.availability === 'CONNECTED').length ?? 0;
+    dashboard.data?.providers.filter((provider) => provider.availability === 'CONNECTED').length ??
+    0;
   const needsAttention =
     dashboard.data?.providers.filter((provider) => provider.availability === 'REAUTH_REQUIRED')
       .length ?? 0;
@@ -33,7 +34,10 @@ export function ConnectedServicesSettings() {
         </p>
       </div>
 
-      <Link href="/connectors" className="block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+      <Link
+        href="/connectors"
+        className="block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
         <Card className="surface-soft flex items-center gap-3 rounded-2xl p-4 transition hover:border-primary/30">
           <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
             <PlugZap className="h-5 w-5" aria-hidden="true" />

--- a/apps/web/src/lib/api/connectors.spec.ts
+++ b/apps/web/src/lib/api/connectors.spec.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const transport = vi.hoisted(() => ({
+  get: vi.fn(),
+  delete: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.mock('./client', () => ({
+  apiClient: transport,
+}));
+
+import { connectorsApi } from './connectors';
+
+describe('connectorsApi', () => {
+  beforeEach(() => {
+    transport.get.mockReset();
+    transport.delete.mockReset();
+    transport.post.mockReset();
+  });
+
+  it('reads provider capabilities and truthful connection state', async () => {
+    transport.get.mockResolvedValue({ providers: [] });
+
+    await connectorsApi.getDashboard();
+
+    expect(transport.get).toHaveBeenCalledWith('/connectors');
+  });
+
+  it('disconnects a named provider without sending provider credentials or payload data', async () => {
+    transport.delete.mockResolvedValue({ success: true });
+
+    await connectorsApi.disconnect('TRACTIVE');
+
+    expect(transport.delete).toHaveBeenCalledWith('/connectors/TRACTIVE');
+    expect(transport.post).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/api/connectors.ts
+++ b/apps/web/src/lib/api/connectors.ts
@@ -3,10 +3,7 @@ import { apiClient } from './client';
 export type ConnectorProvider = 'FI' | 'TRACTIVE' | 'VET_PARTNER' | 'CHEWY' | 'PETCO';
 export type ConnectorDomain = 'WEARABLE' | 'VET' | 'RETAIL';
 export type ConnectorAvailability =
-  | 'PARTNER_REQUIRED'
-  | 'CONNECTED'
-  | 'REAUTH_REQUIRED'
-  | 'REVOKED';
+  'PARTNER_REQUIRED' | 'CONNECTED' | 'REAUTH_REQUIRED' | 'REVOKED';
 export type ConnectorCredentialState = 'MISSING' | 'USABLE' | 'EXPIRED' | 'INVALID';
 
 export type ConnectorConnection = {

--- a/apps/web/src/lib/api/connectors.ts
+++ b/apps/web/src/lib/api/connectors.ts
@@ -1,0 +1,66 @@
+import { apiClient } from './client';
+
+export type ConnectorProvider = 'FI' | 'TRACTIVE' | 'VET_PARTNER' | 'CHEWY' | 'PETCO';
+export type ConnectorDomain = 'WEARABLE' | 'VET' | 'RETAIL';
+export type ConnectorAvailability =
+  | 'PARTNER_REQUIRED'
+  | 'CONNECTED'
+  | 'REAUTH_REQUIRED'
+  | 'REVOKED';
+export type ConnectorCredentialState = 'MISSING' | 'USABLE' | 'EXPIRED' | 'INVALID';
+
+export type ConnectorConnection = {
+  id: string;
+  provider: ConnectorProvider;
+  status: ConnectorAvailability;
+  externalAccountId: string | null;
+  displayLabel: string | null;
+  grantedScopes: string[];
+  connectedAt: string | null;
+  lastSyncAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ConnectorProviderState = {
+  provider: ConnectorProvider;
+  label: string;
+  domain: ConnectorDomain;
+  availability: ConnectorAvailability;
+  capabilities: string[];
+  preciseLocationEnabled: false;
+  canonicalPetMutationAllowed: false;
+  autonomousPurchaseAllowed: false;
+  notes: string;
+  connection: ConnectorConnection | null;
+  credentialState: ConnectorCredentialState;
+};
+
+export type ConnectorsDashboard = {
+  providers: ConnectorProviderState[];
+  credentialEncryptionConfigured: boolean;
+  boundaries: {
+    undocumentedOAuthAllowed: false;
+    browserProviderImpersonationAllowed: false;
+    preciseLocationImportEnabled: false;
+    canonicalPetMutationAllowed: false;
+    autonomousRetailPurchaseAllowed: false;
+    importedWearablesRewardEligible: false;
+    rawProviderPayloadStored: false;
+  };
+};
+
+export type DisconnectConnectorResult = {
+  success: true;
+  provider: ConnectorProvider;
+  localCredentialsRemoved: true;
+  localRevocationReceiptId: string | null;
+  remoteRevocation: 'NOT_CONFIGURED';
+};
+
+export const connectorsApi = {
+  getDashboard: () => apiClient.get<ConnectorsDashboard>('/connectors'),
+  disconnect: (provider: ConnectorProvider) =>
+    apiClient.delete<DisconnectConnectorResult>(`/connectors/${provider}`),
+};

--- a/docs/DOGOS_CONNECTORS.md
+++ b/docs/DOGOS_CONNECTORS.md
@@ -26,13 +26,13 @@ This prevents provider bookkeeping from becoming a parallel dog database while k
 
 Phase C begins with these provider classes:
 
-| Provider | Domain | v1 availability | Permitted capability |
-| --- | --- | --- | --- |
-| Fi | Wearable | `PARTNER_REQUIRED` | Daily activity, device status |
-| Tractive | Wearable | `PARTNER_REQUIRED` | Daily activity, device status |
-| Veterinary partner | Vet | `PARTNER_REQUIRED` | Appointment/vaccination import, medication/document references |
-| Chewy | Retail | `PARTNER_REQUIRED` | Catalog references, user-approved handoff |
-| Petco | Retail | `PARTNER_REQUIRED` | Catalog references, user-approved handoff |
+| Provider           | Domain   | v1 availability    | Permitted capability                                           |
+| ------------------ | -------- | ------------------ | -------------------------------------------------------------- |
+| Fi                 | Wearable | `PARTNER_REQUIRED` | Daily activity, device status                                  |
+| Tractive           | Wearable | `PARTNER_REQUIRED` | Daily activity, device status                                  |
+| Veterinary partner | Vet      | `PARTNER_REQUIRED` | Appointment/vaccination import, medication/document references |
+| Chewy              | Retail   | `PARTNER_REQUIRED` | Catalog references, user-approved handoff                      |
+| Petco              | Retail   | `PARTNER_REQUIRED` | Catalog references, user-approved handoff                      |
 
 `PARTNER_REQUIRED` is intentional. dogOS does not turn a consumer login page, reverse-engineered endpoint, or undocumented mobile API into a claimed OAuth integration.
 

--- a/docs/DOGOS_CONNECTORS.md
+++ b/docs/DOGOS_CONNECTORS.md
@@ -12,6 +12,16 @@ The intended pipeline is:
 
 For wearables, the domain importer already exists: Fi/Tractive summaries pass through Autopilot's adapter and immutable zero-reward CareEvent path.
 
+## Three persistence zones
+
+Phase C intentionally separates three different kinds of state:
+
+1. **Canonical dogOS truth** remains in the existing `public` schema. `Pet`, `Activity`, `CareEvent`, `MediaAsset`, Story, Adventure, and household records retain their existing owners and mutation rules.
+2. **Connector operational metadata** lives in the isolated PostgreSQL schema `dogos_connectors`. It stores only queryable transport metadata: connection lifecycle, provider-to-pet identity mapping, cursors, hash-only import receipts, and revocation receipts.
+3. **Provider secrets** remain in `IntegrationToken`, but only after authenticated encryption. No OAuth access/refresh token is stored in the operational schema.
+
+This prevents provider bookkeeping from becoming a parallel dog database while keeping sync state relational and auditable.
+
 ## Provider registry
 
 Phase C begins with these provider classes:
@@ -43,7 +53,40 @@ Phase C therefore wraps connector credential payloads in an authenticated encryp
 
 `CONNECTOR_CREDENTIALS_KEY` must decode to exactly 32 bytes. Production startup fails when Connectors is enabled without a valid key.
 
-For this first scaffold, `IntegrationToken` is used only as the encrypted **credential vault**. It is not the future home for sync cursors, provider-pet identity mapping, import receipts, or provenance history. Those require explicit relational persistence in the next Phase C slice.
+A connection is not considered healthy merely because a credential row exists. `CONNECTED` requires both:
+
+- an operational connection in `dogos_connectors.connections` with `status=CONNECTED`
+- a decryptable, unexpired authenticated credential envelope
+
+Expired, malformed, or authentication-failing credentials degrade the operational connection to `REAUTH_REQUIRED`.
+
+## Operational relational schema
+
+The additive migration creates five tables under `dogos_connectors`:
+
+- `connections`
+  - user/provider lifecycle
+  - external account ID/display label
+  - granted scopes
+  - connected, sync, and revoked timestamps
+- `pet_identities`
+  - provider animal ID ↔ dogOS pet ID
+  - unique per connection
+  - a database trigger rejects any mapping where the pet is not owned by the connection user
+- `sync_cursors`
+  - per-connection, per-resource cursor and watermark
+- `import_receipts`
+  - provider external object ID
+  - SHA-256 of the normalized canonical observation
+  - imported/skipped/failed disposition
+  - optional canonical reference ID/type
+  - no raw provider payload
+- `revocation_receipts`
+  - local credential deletion vs future remote revocation
+  - success/unavailable/failure evidence
+  - no raw provider response body
+
+The migration is additive. It does not alter canonical dogOS tables.
 
 ## Wearables
 
@@ -56,7 +99,23 @@ Fi and Tractive retain the Phase A normalization policy:
 - wearable observations cannot earn Bond XP
 - connector transport cannot mutate `Pet` or `Activity`
 
-A connector wearable import requires a verified encrypted credential row before it can reach Autopilot.
+There is intentionally **no public browser wearable-ingestion endpoint**. A browser must not be able to impersonate Fi or Tractive by posting a provider-shaped JSON body.
+
+The internal verified-transport seam requires all of the following before delegation to Autopilot:
+
+1. operational connection status is `CONNECTED`
+2. encrypted provider credential authenticates and is not expired
+3. external provider pet ID maps to an owned dogOS pet
+4. provider is a wearable provider
+5. provider payload passes the existing Autopilot summary/location normalization rules
+
+The connector then records a hash-only import receipt referencing the resulting immutable CareEvent.
+
+### Lost-response repair
+
+Autopilot/CareEvent remains the exactly-once source boundary. The connector receipt is downstream evidence, not a second dedupe authority.
+
+If a process dies after CareEvent persistence but before the connector receipt is written, replay re-enters Autopilot, receives the existing canonical observation, and repairs the missing receipt from that persisted observation. If the retry payload differs from the canonical observation, the canonical receipt is repaired first and the altered retry is rejected.
 
 ## Veterinary records
 
@@ -70,7 +129,7 @@ The registry defines the allowed v1 intent:
 - documents remain source references
 - no connector computes dosage, prescribes treatment, or directly rewrites canonical pet health fields
 
-Provider-specific identity mapping and immutable import receipts are required before a real vet transport can be enabled.
+A real vet transport must use the same connection, identity, cursor, and import-receipt boundary before it can be enabled.
 
 ## Retail
 
@@ -90,13 +149,13 @@ Precise tracker location import is disabled in this slice. Provider definitions 
 
 Before location can be enabled, Connectors must add an explicit scope, retention duration, deletion/revocation behavior, and user-visible permission surface. Phase A's location-rejection behavior remains the default.
 
-## Current API
+## Current public API
 
 All routes are JWT-protected and feature-gated by `ENABLE_DOGOS_CONNECTORS`.
 
 - `GET /connectors`
   - provider capabilities
-  - truthful connection state
+  - truthful operational + credential connection state
   - credential-vault readiness
   - global safety boundaries
 - `POST /connectors/:provider/oauth/start`
@@ -104,23 +163,10 @@ All routes are JWT-protected and feature-gated by `ENABLE_DOGOS_CONNECTORS`.
   - never invents an undocumented authorization URL
 - `DELETE /connectors/:provider`
   - deletes local encrypted credentials
+  - records local revocation evidence when an operational connection exists
   - does not falsely claim remote revocation when no official revocation transport is configured
-- `POST /connectors/:provider/import/wearable`
-  - Fi/Tractive only
-  - requires a verified connector credential
-  - delegates to Autopilot normalization and reward policy
 
-## Next persistence slice
-
-Before enabling a real external sync, add explicit relational models for:
-
-1. connector connection metadata and lifecycle
-2. provider ↔ Woof pet identity mapping
-3. per-resource sync cursors
-4. immutable import receipts with provider external ID/hash, timestamps, source kind, status, and dedupe uniqueness
-5. revocation/deletion receipts
-
-Secrets should remain in the encrypted credential vault, separate from these queryable metadata models.
+Provider ingestion, connection registration, identity binding, and cursor advancement are internal transport seams, not browser APIs.
 
 ## CI invariants
 
@@ -129,12 +175,17 @@ The dedicated Connectors lane must prove:
 - credential plaintext is absent from persisted envelopes
 - ciphertext is bound to user/provider AAD
 - missing/malformed encryption key fails closed
+- expired/corrupt credentials cannot remain `CONNECTED`
 - unsupported/partner-gated providers cannot manufacture OAuth state
-- a connection state requires an actual encrypted credential row
-- wearable import requires connection verification
-- wearable import reuses Autopilot
+- browser provider impersonation is not exposed
+- cross-user provider-pet mapping is rejected by the database
+- sync cursors persist independently from canonical records
+- import receipt uniqueness prevents provenance duplication
+- lost receipt repair derives from immutable Autopilot/CareEvent truth
+- altered external-object replays are rejected
 - retail definitions prohibit autonomous purchase
 - precise location remains disabled
+- operational tables contain no raw provider payload column
 - connector source contains no direct canonical `Pet`, `Activity`, `CareEvent`, or `MediaAsset` mutation calls
 - strict lint/type-check and API build remain green
 - inherited Autopilot, Our Story, Foundation, Adventure, and root CI remain green on the same exact head

--- a/docs/DOGOS_CONNECTORS.md
+++ b/docs/DOGOS_CONNECTORS.md
@@ -1,0 +1,140 @@
+# dogOS Connectors
+
+Connectors is the external-system boundary for dogOS. It is deliberately split from the canonical dog, activity, care, media, Story, and Autopilot domains so vendor APIs cannot become hidden sources of truth.
+
+## Phase C v1 rule
+
+**A provider transport may authenticate, fetch, normalize, deduplicate, and prove provenance. It may not directly rewrite canonical dogOS records.**
+
+The intended pipeline is:
+
+`provider transport → verified connector identity → normalized import envelope → domain importer → canonical source or immutable observation`
+
+For wearables, the domain importer already exists: Fi/Tractive summaries pass through Autopilot's adapter and immutable zero-reward CareEvent path.
+
+## Provider registry
+
+Phase C begins with these provider classes:
+
+| Provider | Domain | v1 availability | Permitted capability |
+| --- | --- | --- | --- |
+| Fi | Wearable | `PARTNER_REQUIRED` | Daily activity, device status |
+| Tractive | Wearable | `PARTNER_REQUIRED` | Daily activity, device status |
+| Veterinary partner | Vet | `PARTNER_REQUIRED` | Appointment/vaccination import, medication/document references |
+| Chewy | Retail | `PARTNER_REQUIRED` | Catalog references, user-approved handoff |
+| Petco | Retail | `PARTNER_REQUIRED` | Catalog references, user-approved handoff |
+
+`PARTNER_REQUIRED` is intentional. dogOS does not turn a consumer login page, reverse-engineered endpoint, or undocumented mobile API into a claimed OAuth integration.
+
+A future provider can move out of this state only after its supported API contract, credentials, scopes, callback policy, revocation behavior, and signing requirements are verified.
+
+## Credential storage
+
+The pre-existing `IntegrationToken.data` column is ordinary JSON. Existing push-subscription usage demonstrates that the field itself does not provide encryption.
+
+Phase C therefore wraps connector credential payloads in an authenticated encryption envelope before persistence:
+
+- AES-256-GCM
+- fresh 96-bit IV for every write
+- authenticated tag
+- user + provider binding through additional authenticated data (AAD)
+- versioned envelope (`v=1`, `alg=A256GCM`)
+- no plaintext access or refresh token in the database JSON
+
+`CONNECTOR_CREDENTIALS_KEY` must decode to exactly 32 bytes. Production startup fails when Connectors is enabled without a valid key.
+
+For this first scaffold, `IntegrationToken` is used only as the encrypted **credential vault**. It is not the future home for sync cursors, provider-pet identity mapping, import receipts, or provenance history. Those require explicit relational persistence in the next Phase C slice.
+
+## Wearables
+
+Fi and Tractive retain the Phase A normalization policy:
+
+- daily activity and device-status summaries only
+- unrecognized vendor fields are discarded
+- location/GPS-shaped payloads are rejected by Autopilot
+- imported wearable observations are private and `safetyEligible=false`
+- wearable observations cannot earn Bond XP
+- connector transport cannot mutate `Pet` or `Activity`
+
+A connector wearable import requires a verified encrypted credential row before it can reach Autopilot.
+
+## Veterinary records
+
+Veterinary transport is provider-specific. Phase C does not pretend generic human FHIR support is equivalent to a veterinary EHR integration.
+
+The registry defines the allowed v1 intent:
+
+- appointments may be imported as sourced records/observations
+- vaccination data may be imported with provenance
+- medication information is a reference to veterinarian-provided instructions
+- documents remain source references
+- no connector computes dosage, prescribes treatment, or directly rewrites canonical pet health fields
+
+Provider-specific identity mapping and immutable import receipts are required before a real vet transport can be enabled.
+
+## Retail
+
+Retail is approval-first:
+
+- catalog/product references may inform suggestions
+- handoff may occur only after the user chooses to proceed
+- no autonomous cart additions
+- no autonomous order placement
+- no autonomous payment or charge
+
+Chewy and Petco remain partner-gated until a supported integration contract is available.
+
+## Location
+
+Precise tracker location import is disabled in this slice. Provider definitions explicitly report `preciseLocationEnabled=false`.
+
+Before location can be enabled, Connectors must add an explicit scope, retention duration, deletion/revocation behavior, and user-visible permission surface. Phase A's location-rejection behavior remains the default.
+
+## Current API
+
+All routes are JWT-protected and feature-gated by `ENABLE_DOGOS_CONNECTORS`.
+
+- `GET /connectors`
+  - provider capabilities
+  - truthful connection state
+  - credential-vault readiness
+  - global safety boundaries
+- `POST /connectors/:provider/oauth/start`
+  - currently returns an explicit `partner_required` conflict for registry providers
+  - never invents an undocumented authorization URL
+- `DELETE /connectors/:provider`
+  - deletes local encrypted credentials
+  - does not falsely claim remote revocation when no official revocation transport is configured
+- `POST /connectors/:provider/import/wearable`
+  - Fi/Tractive only
+  - requires a verified connector credential
+  - delegates to Autopilot normalization and reward policy
+
+## Next persistence slice
+
+Before enabling a real external sync, add explicit relational models for:
+
+1. connector connection metadata and lifecycle
+2. provider ↔ Woof pet identity mapping
+3. per-resource sync cursors
+4. immutable import receipts with provider external ID/hash, timestamps, source kind, status, and dedupe uniqueness
+5. revocation/deletion receipts
+
+Secrets should remain in the encrypted credential vault, separate from these queryable metadata models.
+
+## CI invariants
+
+The dedicated Connectors lane must prove:
+
+- credential plaintext is absent from persisted envelopes
+- ciphertext is bound to user/provider AAD
+- missing/malformed encryption key fails closed
+- unsupported/partner-gated providers cannot manufacture OAuth state
+- a connection state requires an actual encrypted credential row
+- wearable import requires connection verification
+- wearable import reuses Autopilot
+- retail definitions prohibit autonomous purchase
+- precise location remains disabled
+- connector source contains no direct canonical `Pet`, `Activity`, `CareEvent`, or `MediaAsset` mutation calls
+- strict lint/type-check and API build remain green
+- inherited Autopilot, Our Story, Foundation, Adventure, and root CI remain green on the same exact head

--- a/packages/database/prisma/migrations/20260823004500_add_dogos_connectors_operational_schema/migration.sql
+++ b/packages/database/prisma/migrations/20260823004500_add_dogos_connectors_operational_schema/migration.sql
@@ -1,0 +1,102 @@
+-- dogOS Connectors operational metadata lives outside the canonical public schema.
+-- No raw provider payloads or OAuth secrets are stored here.
+CREATE SCHEMA IF NOT EXISTS dogos_connectors;
+
+CREATE TABLE dogos_connectors.connections (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id TEXT NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'PARTNER_REQUIRED',
+  external_account_id TEXT,
+  display_label TEXT,
+  granted_scopes TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  connected_at TIMESTAMPTZ,
+  last_sync_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT connector_connections_user_provider_key UNIQUE (user_id, provider),
+  CONSTRAINT connector_connections_provider_check CHECK (
+    provider IN ('FI', 'TRACTIVE', 'VET_PARTNER', 'CHEWY', 'PETCO')
+  ),
+  CONSTRAINT connector_connections_status_check CHECK (
+    status IN ('PARTNER_REQUIRED', 'CONNECTED', 'REAUTH_REQUIRED', 'REVOKED')
+  )
+);
+
+CREATE INDEX connector_connections_user_status_idx
+  ON dogos_connectors.connections(user_id, status);
+
+CREATE TABLE dogos_connectors.pet_identities (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  connection_id UUID NOT NULL REFERENCES dogos_connectors.connections(id) ON DELETE CASCADE,
+  pet_id TEXT NOT NULL REFERENCES public.pets(id) ON DELETE CASCADE,
+  external_pet_id TEXT NOT NULL,
+  external_pet_label TEXT,
+  verified_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT connector_pet_identity_external_key UNIQUE (connection_id, external_pet_id),
+  CONSTRAINT connector_pet_identity_pet_key UNIQUE (connection_id, pet_id)
+);
+
+CREATE INDEX connector_pet_identities_pet_idx
+  ON dogos_connectors.pet_identities(pet_id);
+
+CREATE TABLE dogos_connectors.sync_cursors (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  connection_id UUID NOT NULL REFERENCES dogos_connectors.connections(id) ON DELETE CASCADE,
+  resource_type TEXT NOT NULL,
+  cursor_value TEXT,
+  watermark_at TIMESTAMPTZ,
+  last_successful_sync_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT connector_sync_cursor_resource_key UNIQUE (connection_id, resource_type)
+);
+
+CREATE TABLE dogos_connectors.import_receipts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  connection_id UUID NOT NULL REFERENCES dogos_connectors.connections(id) ON DELETE CASCADE,
+  resource_type TEXT NOT NULL,
+  external_object_id TEXT NOT NULL,
+  payload_hash TEXT NOT NULL,
+  disposition TEXT NOT NULL,
+  canonical_ref_type TEXT,
+  canonical_ref_id TEXT,
+  occurred_at TIMESTAMPTZ,
+  imported_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  detail_code TEXT,
+  CONSTRAINT connector_import_receipt_object_key UNIQUE (
+    connection_id,
+    resource_type,
+    external_object_id
+  ),
+  CONSTRAINT connector_import_receipt_hash_check CHECK (payload_hash ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT connector_import_receipt_disposition_check CHECK (
+    disposition IN ('IMPORTED', 'SKIPPED', 'FAILED')
+  )
+);
+
+CREATE INDEX connector_import_receipts_connection_time_idx
+  ON dogos_connectors.import_receipts(connection_id, imported_at DESC);
+
+CREATE TABLE dogos_connectors.revocation_receipts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  connection_id UUID NOT NULL REFERENCES dogos_connectors.connections(id) ON DELETE CASCADE,
+  mode TEXT NOT NULL,
+  status TEXT NOT NULL,
+  remote_receipt_ref TEXT,
+  detail_code TEXT,
+  attempted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  CONSTRAINT connector_revocation_mode_check CHECK (
+    mode IN ('LOCAL_CREDENTIAL_DELETE', 'REMOTE_REVOKE')
+  ),
+  CONSTRAINT connector_revocation_status_check CHECK (
+    status IN ('SUCCEEDED', 'UNAVAILABLE', 'FAILED')
+  )
+);
+
+CREATE INDEX connector_revocations_connection_time_idx
+  ON dogos_connectors.revocation_receipts(connection_id, attempted_at DESC);

--- a/packages/database/prisma/migrations/20260823004500_add_dogos_connectors_operational_schema/migration.sql
+++ b/packages/database/prisma/migrations/20260823004500_add_dogos_connectors_operational_schema/migration.sql
@@ -43,6 +43,29 @@ CREATE TABLE dogos_connectors.pet_identities (
 CREATE INDEX connector_pet_identities_pet_idx
   ON dogos_connectors.pet_identities(pet_id);
 
+CREATE FUNCTION dogos_connectors.enforce_pet_identity_owner()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM dogos_connectors.connections AS connection
+    INNER JOIN public.pets AS pet ON pet.id = NEW.pet_id
+    WHERE connection.id = NEW.connection_id
+      AND pet.owner_id = connection.user_id
+  ) THEN
+    RAISE EXCEPTION 'connector pet identity must belong to the connection owner';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER connector_pet_identity_owner_guard
+BEFORE INSERT OR UPDATE ON dogos_connectors.pet_identities
+FOR EACH ROW
+EXECUTE FUNCTION dogos_connectors.enforce_pet_identity_owner();
+
 CREATE TABLE dogos_connectors.sync_cursors (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   connection_id UUID NOT NULL REFERENCES dogos_connectors.connections(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Phase C: dogOS Connectors

This PR starts from the exact merged Our Story release `94cec12703ff6de8ee6491410c19e57cceebf0e4`.

### Product thesis

Connectors is an external-system boundary, not a second dog database. Provider transports may authenticate, normalize, deduplicate, prove provenance, and hand data to existing domain importers. They may not directly rewrite canonical dogOS source records.

### Provider registry

- Fi — wearable, partner-gated
- Tractive — wearable, partner-gated
- veterinary partner — provider-specific vet transport, partner-gated
- Chewy — retail handoff/catalog intent, partner-gated
- Petco — retail handoff/catalog intent, partner-gated

No consumer login page, reverse-engineered endpoint, undocumented mobile API, or unsupported OAuth flow is represented as working integration functionality.

### Persistence boundary

Connector state is deliberately split into three zones:

1. canonical dogOS source truth remains in the existing `public` schema
2. queryable connector lifecycle/provenance lives in isolated `dogos_connectors`
3. provider secrets use `IntegrationToken` only as an AES-256-GCM encrypted credential vault

The operational schema stores connection metadata, external-pet identity mappings, sync cursors/watermarks, hash-only import receipts, and revocation receipts. It does not store raw provider payloads.

The connector migration is additive, leaves the canonical Prisma datamodel at zero drift, and database-enforces that an external provider animal cannot be mapped to a dog owned by another user.

### Credential boundary

The pre-existing `IntegrationToken.data` field is ordinary JSON, so Phase C does not rely on its historical "encrypted" comment.

Connector credentials are wrapped before persistence using:

- AES-256-GCM
- fresh IV per write
- authenticated tag
- user/provider AAD binding
- versioned envelope
- production-required 32-byte `CONNECTOR_CREDENTIALS_KEY`

A provider is `CONNECTED` only when operational connection state is connected and the credential envelope authenticates and is unexpired. Expired or invalid credentials degrade to `REAUTH_REQUIRED`.

### Wearable import boundary

There is intentionally no browser endpoint that accepts Fi/Tractive-shaped provider payloads.

The internal verified transport seam requires:

- connected operational provider account
- usable authenticated credential
- verified external provider pet → owned dogOS pet mapping
- wearable provider capability
- existing Autopilot normalization/privacy checks

Autopilot/CareEvent remains the exactly-once canonical source boundary. Connector receipts reference the resulting immutable CareEvent and contain only a SHA-256 hash of the persisted normalized observation.

If the process dies after CareEvent persistence but before the connector receipt, replay repairs the receipt from persisted canonical truth. An altered retry for the same provider external object is rejected.

### User-facing Connected Services

Phase C includes a real, deliberately bounded product surface:

- Settings contains one `Connected services` entry rather than adding another bottom-navigation destination
- `/connectors` shows provider domain, capabilities, verified connection state, and safety boundaries
- `PARTNER_REQUIRED` providers do not receive a pretend Connect button
- `REAUTH_REQUIRED` explains that imports are paused until a verified authorization path exists
- connected or reauth-required providers can remove local credentials through Disconnect
- the UI explicitly states that tracker GPS import, canonical dog mutation, autonomous retail purchasing, and raw provider payload persistence are not enabled

### Safety boundaries

- no direct Pet/Activity/CareEvent/MediaAsset mutations in connector transport
- no precise tracker-location import in this release
- no wearable Bond XP
- no autonomous retail cart/order/payment behavior
- no veterinary dosage computation or prescription logic
- no false claim of remote revocation when no partner revocation endpoint exists
- cross-user provider-pet mapping rejected by PostgreSQL
- public browser routes cannot impersonate provider ingestion

### Public API

- `GET /connectors`
- `POST /connectors/:provider/oauth/start` — explicit `partner_required` while no verified partner authorization path is configured
- `DELETE /connectors/:provider` — local credential deletion plus local revocation receipt when applicable

Provider ingestion, external-pet identity mapping, cursor advancement, and receipt persistence remain internal transport seams.

### Exact-head qualification

Release candidate: `7c81f75635e758ae7fc17ae8831759a168057294`

All required lanes are green on that exact SHA:

- dogOS Connectors CI #25 — run `32619470603`
- dogOS Our Story CI #40 — run `32619470607`
- dogOS Autopilot CI #61 — run `32619470606`
- dogOS Foundation CI #85 — run `32619470637`
- Adventure System CI #353 — run `32619470605`
- root CI #344 — run `32619470608`

The dedicated Connectors lane passed migration + zero Prisma drift, canonical formatting, strict API and web lint, API and web type-check, canonical-mutation/browser-impersonation/raw-payload tripwires, credential crypto/lifecycle contracts, real PostgreSQL operational contracts, Autopilot replay regression, Story source contracts, Connected Services web API contracts, and API/web production builds.

Root CI independently passed release-critical formatting, full lint/type-check, ML policy checks, backend tests, Chromium smoke/accessibility/visual contracts, and API/web production builds.

See `docs/DOGOS_CONNECTORS.md` for the complete boundary contract.