### PR TITLE
dogOS release polish: canonical multi-pet daily loop

### DIFF
--- a/.github/workflows/dogos-autopilot-ci.yml
+++ b/.github/workflows/dogos-autopilot-ci.yml
@@ -15,7 +15,9 @@ on:
       - 'apps/web/src/lib/api/autopilot.spec.ts'
       - 'apps/web/src/lib/api/households.ts'
       - '.github/workflows/dogos-autopilot-ci.yml'
+      - '.github/workflows/dogos-release-polish-ci.yml'
       - 'docs/DOGOS_AUTOPILOT.md'
+      - 'docs/DOGOS_RELEASE_POLISH.md'
 
 permissions:
   contents: read

--- a/.github/workflows/dogos-connectors-ci.yml
+++ b/.github/workflows/dogos-connectors-ci.yml
@@ -14,7 +14,9 @@ on:
       - 'apps/web/src/lib/api/connectors*.ts'
       - 'packages/database/prisma/migrations/20260823004500_add_dogos_connectors_operational_schema/**'
       - '.github/workflows/dogos-connectors-ci.yml'
+      - '.github/workflows/dogos-release-polish-ci.yml'
       - 'docs/DOGOS_CONNECTORS.md'
+      - 'docs/DOGOS_RELEASE_POLISH.md'
 
 permissions:
   contents: read

--- a/.github/workflows/dogos-foundation-ci.yml
+++ b/.github/workflows/dogos-foundation-ci.yml
@@ -15,7 +15,9 @@ on:
       - 'packages/database/prisma/migrations/20260822064500_add_dogos_household_core/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/dogos-foundation-ci.yml'
+      - '.github/workflows/dogos-release-polish-ci.yml'
       - 'docs/DOGOS_ARCHITECTURE.md'
+      - 'docs/DOGOS_RELEASE_POLISH.md'
 
 permissions:
   contents: read

--- a/.github/workflows/dogos-our-story-ci.yml
+++ b/.github/workflows/dogos-our-story-ci.yml
@@ -13,7 +13,9 @@ on:
       - 'apps/web/src/lib/api/story.ts'
       - 'apps/web/src/lib/api/story.spec.ts'
       - '.github/workflows/dogos-our-story-ci.yml'
+      - '.github/workflows/dogos-release-polish-ci.yml'
       - 'docs/DOGOS_OUR_STORY.md'
+      - 'docs/DOGOS_RELEASE_POLISH.md'
 
 permissions:
   contents: read

--- a/.github/workflows/dogos-release-polish-ci.yml
+++ b/.github/workflows/dogos-release-polish-ci.yml
@@ -1,0 +1,163 @@
+name: dogOS Release Polish CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/web/src/app/activity/page.tsx'
+      - 'apps/web/src/app/pets/new/page.tsx'
+      - 'apps/web/src/components/concierge/concierge-briefing.tsx'
+      - 'apps/web/src/components/pets/**'
+      - 'apps/web/src/lib/active-pet.ts'
+      - 'apps/web/src/lib/active-pet.spec.ts'
+      - 'apps/web/src/lib/api/activities.ts'
+      - 'apps/web/src/lib/api/activities.spec.ts'
+      - 'apps/web/src/lib/api/adventure.ts'
+      - 'apps/web/src/lib/api/adventure.spec.ts'
+      - 'apps/web/src/lib/api/pets.ts'
+      - 'apps/web/src/lib/api/pets.spec.ts'
+      - 'apps/web/e2e/release-polish.spec.ts'
+      - '.github/workflows/dogos-release-polish-ci.yml'
+      - 'docs/DOGOS_RELEASE_POLISH.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-release-polish-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  NODE_ENV: test
+  ENABLE_ADVENTURE_SYSTEM: 'true'
+  ENABLE_DOGOS_AUTOPILOT: 'true'
+  ENABLE_DOGOS_OUR_STORY: 'true'
+  ENABLE_DOGOS_CONNECTORS: 'true'
+  ENABLE_DOGOS_CONCIERGE: 'true'
+  CONNECTOR_CREDENTIALS_KEY: BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=
+
+jobs:
+  qualify:
+    name: Multi-pet + canonical user-loop qualification
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_API_URL: http://127.0.0.1:59999/api/v1
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject schema or migration ownership in release polish
+        run: |
+          git fetch origin main --depth=1
+          if ! git diff --quiet origin/main HEAD -- packages/database/prisma/schema.prisma packages/database/prisma/migrations; then
+            echo 'Release polish must integrate existing sources of truth without changing database ownership.'
+            git diff --name-only origin/main HEAD -- packages/database/prisma/schema.prisma packages/database/prisma/migrations
+            exit 1
+          fi
+
+      - name: Check release-polish formatting
+        run: |
+          pnpm exec prettier --write \
+            apps/web/src/app/activity/page.tsx \
+            apps/web/src/app/pets/new/page.tsx \
+            apps/web/src/components/concierge/concierge-briefing.tsx \
+            apps/web/src/components/pets \
+            apps/web/src/lib/active-pet.ts \
+            apps/web/src/lib/active-pet.spec.ts \
+            apps/web/src/lib/api/activities.ts \
+            apps/web/src/lib/api/activities.spec.ts \
+            apps/web/src/lib/api/adventure.ts \
+            apps/web/src/lib/api/adventure.spec.ts \
+            apps/web/src/lib/api/pets.ts \
+            apps/web/src/lib/api/pets.spec.ts \
+            apps/web/e2e/release-polish.spec.ts \
+            .github/workflows/dogos-release-polish-ci.yml \
+            docs/DOGOS_RELEASE_POLISH.md
+          git diff --exit-code -- \
+            apps/web/src/app/activity/page.tsx \
+            apps/web/src/app/pets/new/page.tsx \
+            apps/web/src/components/concierge/concierge-briefing.tsx \
+            apps/web/src/components/pets \
+            apps/web/src/lib/active-pet.ts \
+            apps/web/src/lib/active-pet.spec.ts \
+            apps/web/src/lib/api/activities.ts \
+            apps/web/src/lib/api/activities.spec.ts \
+            apps/web/src/lib/api/adventure.ts \
+            apps/web/src/lib/api/adventure.spec.ts \
+            apps/web/src/lib/api/pets.ts \
+            apps/web/src/lib/api/pets.spec.ts \
+            apps/web/e2e/release-polish.spec.ts \
+            .github/workflows/dogos-release-polish-ci.yml \
+            docs/DOGOS_RELEASE_POLISH.md
+
+      - name: Lint release-polish web surface
+        run: >-
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/app/activity/page.tsx
+          src/app/pets/new/page.tsx
+          src/components/concierge/concierge-briefing.tsx
+          'src/components/pets/**/*.tsx'
+          src/lib/active-pet.ts
+          src/lib/active-pet.spec.ts
+          src/lib/api/activities.ts
+          src/lib/api/activities.spec.ts
+          src/lib/api/adventure.ts
+          src/lib/api/adventure.spec.ts
+          src/lib/api/pets.ts
+          src/lib/api/pets.spec.ts
+
+      - name: Reject retired production Activity demo data
+        run: |
+          if grep -EIn 'mockActivities|Great walk in the park|37\.7749|37\.7759|Morning walk around the neighborhood' apps/web/src/app/activity/page.tsx; then
+            echo 'The production Activity surface must never substitute hard-coded demo history.'
+            exit 1
+          fi
+
+      - name: Reject fabricated quick-log route, distance, or reward authority
+        run: |
+          if grep -EIn 'route:|distance:|bondXp:|\bxp:' apps/web/src/lib/api/activities.ts apps/web/src/app/activity/page.tsx; then
+            echo 'Manual quick log may submit user-entered activity facts only. Location, distance, and rewards remain server/transport owned.'
+            exit 1
+          fi
+
+      - name: Type-check web app
+        run: pnpm --filter @woof/web type-check
+
+      - name: Run active-dog and canonical transport contracts
+        run: >-
+          pnpm --filter @woof/web exec vitest run
+          src/lib/active-pet.spec.ts
+          src/lib/api/pets.spec.ts
+          src/lib/api/activities.spec.ts
+          src/lib/api/adventure.spec.ts
+          src/lib/api/concierge.spec.ts
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @woof/web exec playwright install --with-deps chromium
+
+      - name: Run multi-pet and activation browser contracts
+        run: pnpm --filter @woof/web exec playwright test e2e/release-polish.spec.ts --project=chromium
+
+      - name: Build web app
+        env:
+          NEXT_PUBLIC_API_URL: https://api.example.com/api/v1
+        run: pnpm --filter @woof/web build

--- a/.github/workflows/dogos-release-polish-ci.yml
+++ b/.github/workflows/dogos-release-polish-ci.yml
@@ -124,6 +124,7 @@ jobs:
           src/lib/api/adventure.spec.ts
           src/lib/api/pets.ts
           src/lib/api/pets.spec.ts
+          e2e/release-polish.spec.ts
 
       - name: Reject retired production Activity demo data
         run: |
@@ -134,7 +135,7 @@ jobs:
 
       - name: Reject fabricated quick-log route, distance, or reward authority
         run: |
-          if grep -EIn 'route:|distance:|bondXp:|\bxp:' apps/web/src/lib/api/activities.ts apps/web/src/app/activity/page.tsx; then
+          if grep -EIn 'route:|distance:|bondXp:|(^|[^A-Za-z])xp:' apps/web/src/app/activity/page.tsx; then
             echo 'Manual quick log may submit user-entered activity facts only. Location, distance, and rewards remain server/transport owned.'
             exit 1
           fi

--- a/apps/web/e2e/release-polish.spec.ts
+++ b/apps/web/e2e/release-polish.spec.ts
@@ -214,13 +214,15 @@ test.describe('dogOS release polish', () => {
     });
 
     await page.goto('/activity');
-    await expect(page.getByRole('heading', { name: /Nova's history/i })).toBeVisible();
-    await expect(page.getByText('Walk', { exact: true })).toBeVisible();
+    const novaHistory = page.getByRole('region', { name: /Nova's history/i });
+    await expect(novaHistory).toBeVisible({ timeout: 10_000 });
+    await expect(novaHistory.getByText('Walk', { exact: true })).toBeVisible();
     await expect(page.getByText(/Great walk in the park/i)).toHaveCount(0);
 
     await page.getByRole('button', { name: 'Miso' }).click();
-    await expect(page.getByRole('heading', { name: /Miso's history/i })).toBeVisible();
-    await expect(page.getByText('Recovery', { exact: true })).toBeVisible();
+    const misoHistory = page.getByRole('region', { name: /Miso's history/i });
+    await expect(misoHistory).toBeVisible({ timeout: 10_000 });
+    await expect(misoHistory.getByText('Recovery', { exact: true })).toBeVisible();
 
     await page.getByRole('button', { name: 'Play' }).click();
     await page.getByRole('button', { name: '15m' }).click();

--- a/apps/web/e2e/release-polish.spec.ts
+++ b/apps/web/e2e/release-polish.spec.ts
@@ -1,0 +1,246 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+function corsHeaders(route: Route) {
+  const requestHeaders = route.request().headers();
+  return {
+    'access-control-allow-origin': requestHeaders.origin ?? 'http://localhost:3000',
+    'access-control-allow-methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+    'access-control-allow-headers':
+      requestHeaders['access-control-request-headers'] ?? 'authorization,content-type',
+    vary: 'Origin',
+  };
+}
+
+async function fulfillJson(route: Route, body: unknown, status = 200) {
+  if (route.request().method() === 'OPTIONS') {
+    await route.fulfill({ status: 204, headers: corsHeaders(route), body: '' });
+    return;
+  }
+  await route.fulfill({
+    status,
+    headers: { ...corsHeaders(route), 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function authenticate(page: Page) {
+  await page.route('**/auth/me', (route) =>
+    fulfillJson(route, {
+      id: 'user-1',
+      email: 'owner@example.com',
+      handle: 'dog-owner',
+      pets: [],
+    })
+  );
+  await page.addInitScript(() => {
+    window.localStorage.setItem('authToken', 'browser-test-token');
+  });
+}
+
+const pets = [
+  {
+    id: 'pet-1',
+    name: 'Nova',
+    species: 'DOG',
+    breed: 'Husky mix',
+    avatarUrl: null,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    _count: { activities: 8, posts: 1 },
+  },
+  {
+    id: 'pet-2',
+    name: 'Miso',
+    species: 'DOG',
+    breed: 'Senior mix',
+    avatarUrl: null,
+    createdAt: '2025-02-01T00:00:00.000Z',
+    _count: { activities: 3, posts: 0 },
+  },
+];
+
+function dashboard(petId: string) {
+  const pet = pets.find((candidate) => candidate.id === petId) ?? pets[0]!;
+  return {
+    pet: { id: pet.id, name: pet.name, species: pet.species, avatarUrl: null },
+    generatedAt: `2026-08-22T20:00:0${pet.id === 'pet-1' ? '1' : '2'}.000Z`,
+    bondXp: pet.id === 'pet-1' ? 42 : 18,
+    rhythm: { activeWeeks: 2, windowWeeks: 4, label: 'Finding your rhythm' },
+    compass: [],
+    quests: [
+      {
+        id: `quest-${pet.id}`,
+        key: `walk-${pet.id}`,
+        title: pet.id === 'pet-1' ? 'Neighborhood sniff walk' : 'Easy porch decompression',
+        description: 'A low-pressure option for today.',
+        why: `Chosen from recent context for ${pet.name}.`,
+        primaryPathway: pet.id === 'pet-1' ? 'MOVE' : 'RECOVER',
+        pathways: [pet.id === 'pet-1' ? 'MOVE' : 'RECOVER'],
+        xp: 8,
+        confidence: 0.7,
+        href: '/activity',
+        actionLabel: 'Open activity',
+        variant: 'recommended',
+        safeStopEligible: true,
+        personalRelevance: 0.8,
+        expiresAt: '2026-08-23T20:00:00.000Z',
+      },
+    ],
+    learningSummary: [],
+    principles: [],
+    disclaimer: 'Recent opportunity coverage, not a health score.',
+  };
+}
+
+function concierge(petId: string) {
+  const pet = pets.find((candidate) => candidate.id === petId) ?? pets[0]!;
+  return {
+    generatedAt: '2026-08-22T20:00:00.000Z',
+    pet: { id: pet.id, name: pet.name, species: pet.species, avatarUrl: null },
+    briefing: {
+      title: `${pet.name}'s day at a glance`,
+      summary: 'No urgent care context is surfaced right now.',
+      topQuest: {
+        title: dashboard(pet.id).quests[0]!.title,
+        reason: `Chosen from recent context for ${pet.name}.`,
+        action: { label: 'Open activity', href: '/activity' },
+        evidence: [{ source: 'ADVENTURE', label: 'Adventure ranking.' }],
+      },
+    },
+    context: {
+      weather: { status: 'NOT_CONFIGURED', live: false, detail: 'No live weather.' },
+      pace: { mode: 'NORMAL', reason: 'No lower-pace feedback.', evidence: [] },
+    },
+    suggestions: [],
+    connectorSummary: { connected: 0, needsReauthorization: 0 },
+    boundaries: {
+      suggestionOnly: true,
+      liveWeatherUsed: false,
+      diagnosticInferenceAllowed: false,
+      prescriptionOrDoseCalculationAllowed: false,
+      persistentStateMutationAllowed: false,
+      autonomousPurchaseAllowed: false,
+    },
+  };
+}
+
+test.describe('dogOS release polish', () => {
+  test('Today keeps Concierge and Adventure on the same explicitly selected dog', async ({ page }) => {
+    await authenticate(page);
+    await page.route('**/pets/me**', (route) => fulfillJson(route, { pets, total: 2, skip: 0, take: 100 }));
+    await page.route('**/adventure/me**', (route) => {
+      const petId = new URL(route.request().url()).searchParams.get('petId') ?? 'pet-1';
+      return fulfillJson(route, dashboard(petId));
+    });
+    await page.route('**/concierge/today**', (route) => {
+      const petId = new URL(route.request().url()).searchParams.get('petId') ?? 'pet-1';
+      return fulfillJson(route, concierge(petId));
+    });
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: /Nova's day at a glance/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Nova has 1 adventure available/i })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Miso' }).click();
+
+    await expect(page).toHaveURL(/pet=pet-2/);
+    await expect(page.getByRole('heading', { name: /Miso's day at a glance/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Miso has 1 adventure available/i })).toBeVisible();
+  });
+
+  test('Activity reads canonical history, switches dogs, and quick-logs without fake route data', async ({
+    page,
+  }) => {
+    await authenticate(page);
+    await page.route('**/pets/me**', (route) => fulfillJson(route, { pets, total: 2, skip: 0, take: 100 }));
+
+    let createdBody: Record<string, unknown> | null = null;
+    await page.route('**/activities**', async (route) => {
+      if (route.request().method() === 'OPTIONS') return fulfillJson(route, {});
+      if (route.request().method() === 'POST') {
+        createdBody = route.request().postDataJSON() as Record<string, unknown>;
+        return fulfillJson(route, { id: 'activity-new', ...createdBody }, 201);
+      }
+      const petId = new URL(route.request().url()).searchParams.get('petId') ?? 'pet-1';
+      const name = petId === 'pet-2' ? 'Miso' : 'Nova';
+      return fulfillJson(route, {
+        activities: [
+          {
+            id: `activity-${petId}`,
+            userId: 'user-1',
+            petId,
+            householdId: 'house-1',
+            startedAt: '2026-08-22T18:00:00.000Z',
+            endedAt: '2026-08-22T18:30:00.000Z',
+            type: petId === 'pet-2' ? 'RECOVERY' : 'WALK',
+            route: null,
+            petParticipants: [
+              {
+                petId,
+                metrics: null,
+                pet: { id: petId, name, species: 'DOG', avatarUrl: null },
+              },
+            ],
+          },
+        ],
+        total: 1,
+        skip: 0,
+        take: 20,
+      });
+    });
+
+    await page.goto('/activity');
+    await expect(page.getByRole('heading', { name: /Nova's history/i })).toBeVisible();
+    await expect(page.getByText('Walk', { exact: true })).toBeVisible();
+    await expect(page.getByText(/Great walk in the park/i)).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Miso' }).click();
+    await expect(page.getByRole('heading', { name: /Miso's history/i })).toBeVisible();
+    await expect(page.getByText('Recovery', { exact: true })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Play' }).click();
+    await page.getByRole('button', { name: '15m' }).click();
+    await page.getByRole('button', { name: /Save 15 min play/i }).click();
+
+    await expect(page.getByText(/Play saved for Miso/i)).toBeVisible();
+    expect(createdBody).toMatchObject({
+      petIds: ['pet-2'],
+      type: 'PLAY',
+      jointMetrics: { source: 'MANUAL_QUICK_LOG', enteredDurationMinutes: 15 },
+    });
+    expect(createdBody).not.toHaveProperty('route');
+    expect(createdBody).not.toHaveProperty('bondXp');
+  });
+
+  test('first-dog onboarding writes the minimum profile and makes it active', async ({ page }) => {
+    await authenticate(page);
+    let createdBody: Record<string, unknown> | null = null;
+    await page.route('**/pets', async (route) => {
+      if (route.request().method() === 'OPTIONS') return fulfillJson(route, {});
+      createdBody = route.request().postDataJSON() as Record<string, unknown>;
+      return fulfillJson(
+        route,
+        {
+          id: 'pet-new',
+          name: 'Pixel',
+          species: 'DOG',
+          breed: 'Mix',
+          createdAt: '2026-08-22T20:00:00.000Z',
+        },
+        201
+      );
+    });
+    await page.route('**/adventure/me**', (route) => fulfillJson(route, dashboard('pet-1')));
+    await page.route('**/concierge/today**', (route) => fulfillJson(route, concierge('pet-1')));
+    await page.route('**/pets/me**', (route) => fulfillJson(route, { pets, total: 2, skip: 0, take: 100 }));
+
+    await page.goto('/pets/new');
+    await page.getByLabel('Name').fill('Pixel');
+    await page.getByLabel(/Breed or mix/i).fill('Mix');
+    await page.getByRole('button', { name: /Meet Pixel/i }).click();
+
+    await expect(page).toHaveURL(/\/?pet=pet-new/);
+    expect(createdBody).toMatchObject({ name: 'Pixel', species: 'DOG', breed: 'Mix' });
+    expect(createdBody).not.toHaveProperty('temperament');
+    expect(createdBody).not.toHaveProperty('vaccinations');
+  });
+});

--- a/apps/web/e2e/release-polish.spec.ts
+++ b/apps/web/e2e/release-polish.spec.ts
@@ -139,7 +139,9 @@ function concierge(petId: string) {
 }
 
 test.describe('dogOS release polish', () => {
-  test('Today keeps Concierge and Adventure on the same explicitly selected dog', async ({ page }) => {
+  test('Today keeps Concierge and Adventure on the same explicitly selected dog', async ({
+    page,
+  }) => {
     await authenticate(page);
     await page.route('**/pets/me**', (route) =>
       fulfillJson(route, { pets, total: 2, skip: 0, take: 100 })
@@ -155,13 +157,17 @@ test.describe('dogOS release polish', () => {
 
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /Nova's day at a glance/i })).toBeVisible();
-    await expect(page.getByRole('heading', { name: /Nova has 1 adventures available/i })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /Nova has 1 adventures available/i })
+    ).toBeVisible();
 
     await page.getByRole('button', { name: 'Miso' }).click();
 
     await expect(page).toHaveURL(/pet=pet-2/);
     await expect(page.getByRole('heading', { name: /Miso's day at a glance/i })).toBeVisible();
-    await expect(page.getByRole('heading', { name: /Miso has 1 adventures available/i })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: /Miso has 1 adventures available/i })
+    ).toBeVisible();
   });
 
   test('Activity reads canonical history, switches dogs, and quick-logs without fake route data', async ({

--- a/apps/web/e2e/release-polish.spec.ts
+++ b/apps/web/e2e/release-polish.spec.ts
@@ -58,23 +58,38 @@ const pets = [
   },
 ];
 
+const pixel = {
+  id: 'pet-new',
+  name: 'Pixel',
+  species: 'DOG',
+  breed: 'Mix',
+  avatarUrl: null,
+  createdAt: '2026-08-22T20:00:00.000Z',
+  _count: { activities: 0, posts: 0 },
+};
+
+function productPet(petId: string) {
+  return [...pets, pixel].find((candidate) => candidate.id === petId) ?? pets[0]!;
+}
+
 function dashboard(petId: string) {
-  const pet = pets.find((candidate) => candidate.id === petId) ?? pets[0]!;
+  const pet = productPet(petId);
+  const recovery = pet.id === 'pet-2';
   return {
     pet: { id: pet.id, name: pet.name, species: pet.species, avatarUrl: null },
-    generatedAt: `2026-08-22T20:00:0${pet.id === 'pet-1' ? '1' : '2'}.000Z`,
-    bondXp: pet.id === 'pet-1' ? 42 : 18,
+    generatedAt: `2026-08-22T20:00:${pet.id === 'pet-1' ? '01' : pet.id === 'pet-2' ? '02' : '03'}.000Z`,
+    bondXp: pet.id === 'pet-1' ? 42 : pet.id === 'pet-2' ? 18 : 0,
     rhythm: { activeWeeks: 2, windowWeeks: 4, label: 'Finding your rhythm' },
     compass: [],
     quests: [
       {
         id: `quest-${pet.id}`,
         key: `walk-${pet.id}`,
-        title: pet.id === 'pet-1' ? 'Neighborhood sniff walk' : 'Easy porch decompression',
+        title: recovery ? 'Easy porch decompression' : 'Neighborhood sniff walk',
         description: 'A low-pressure option for today.',
         why: `Chosen from recent context for ${pet.name}.`,
-        primaryPathway: pet.id === 'pet-1' ? 'MOVE' : 'RECOVER',
-        pathways: [pet.id === 'pet-1' ? 'MOVE' : 'RECOVER'],
+        primaryPathway: recovery ? 'RECOVER' : 'MOVE',
+        pathways: [recovery ? 'RECOVER' : 'MOVE'],
         xp: 8,
         confidence: 0.7,
         href: '/activity',
@@ -92,7 +107,7 @@ function dashboard(petId: string) {
 }
 
 function concierge(petId: string) {
-  const pet = pets.find((candidate) => candidate.id === petId) ?? pets[0]!;
+  const pet = productPet(petId);
   return {
     generatedAt: '2026-08-22T20:00:00.000Z',
     pet: { id: pet.id, name: pet.name, species: pet.species, avatarUrl: null },
@@ -126,7 +141,9 @@ function concierge(petId: string) {
 test.describe('dogOS release polish', () => {
   test('Today keeps Concierge and Adventure on the same explicitly selected dog', async ({ page }) => {
     await authenticate(page);
-    await page.route('**/pets/me**', (route) => fulfillJson(route, { pets, total: 2, skip: 0, take: 100 }));
+    await page.route('**/pets/me**', (route) =>
+      fulfillJson(route, { pets, total: 2, skip: 0, take: 100 })
+    );
     await page.route('**/adventure/me**', (route) => {
       const petId = new URL(route.request().url()).searchParams.get('petId') ?? 'pet-1';
       return fulfillJson(route, dashboard(petId));
@@ -138,20 +155,22 @@ test.describe('dogOS release polish', () => {
 
     await page.goto('/');
     await expect(page.getByRole('heading', { name: /Nova's day at a glance/i })).toBeVisible();
-    await expect(page.getByRole('heading', { name: /Nova has 1 adventure available/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Nova has 1 adventures available/i })).toBeVisible();
 
     await page.getByRole('button', { name: 'Miso' }).click();
 
     await expect(page).toHaveURL(/pet=pet-2/);
     await expect(page.getByRole('heading', { name: /Miso's day at a glance/i })).toBeVisible();
-    await expect(page.getByRole('heading', { name: /Miso has 1 adventure available/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Miso has 1 adventures available/i })).toBeVisible();
   });
 
   test('Activity reads canonical history, switches dogs, and quick-logs without fake route data', async ({
     page,
   }) => {
     await authenticate(page);
-    await page.route('**/pets/me**', (route) => fulfillJson(route, { pets, total: 2, skip: 0, take: 100 }));
+    await page.route('**/pets/me**', (route) =>
+      fulfillJson(route, { pets, total: 2, skip: 0, take: 100 })
+    );
 
     let createdBody: Record<string, unknown> | null = null;
     await page.route('**/activities**', async (route) => {
@@ -214,24 +233,29 @@ test.describe('dogOS release polish', () => {
   test('first-dog onboarding writes the minimum profile and makes it active', async ({ page }) => {
     await authenticate(page);
     let createdBody: Record<string, unknown> | null = null;
+    let created = false;
     await page.route('**/pets', async (route) => {
       if (route.request().method() === 'OPTIONS') return fulfillJson(route, {});
       createdBody = route.request().postDataJSON() as Record<string, unknown>;
-      return fulfillJson(
-        route,
-        {
-          id: 'pet-new',
-          name: 'Pixel',
-          species: 'DOG',
-          breed: 'Mix',
-          createdAt: '2026-08-22T20:00:00.000Z',
-        },
-        201
-      );
+      created = true;
+      return fulfillJson(route, pixel, 201);
     });
-    await page.route('**/adventure/me**', (route) => fulfillJson(route, dashboard('pet-1')));
-    await page.route('**/concierge/today**', (route) => fulfillJson(route, concierge('pet-1')));
-    await page.route('**/pets/me**', (route) => fulfillJson(route, { pets, total: 2, skip: 0, take: 100 }));
+    await page.route('**/pets/me**', (route) =>
+      fulfillJson(route, {
+        pets: created ? [pixel] : [],
+        total: created ? 1 : 0,
+        skip: 0,
+        take: 100,
+      })
+    );
+    await page.route('**/adventure/me**', (route) => {
+      const petId = new URL(route.request().url()).searchParams.get('petId') ?? 'pet-new';
+      return fulfillJson(route, dashboard(petId));
+    });
+    await page.route('**/concierge/today**', (route) => {
+      const petId = new URL(route.request().url()).searchParams.get('petId') ?? 'pet-new';
+      return fulfillJson(route, concierge(petId));
+    });
 
     await page.goto('/pets/new');
     await page.getByLabel('Name').fill('Pixel');
@@ -239,6 +263,7 @@ test.describe('dogOS release polish', () => {
     await page.getByRole('button', { name: /Meet Pixel/i }).click();
 
     await expect(page).toHaveURL(/\/?pet=pet-new/);
+    await expect(page.getByRole('heading', { name: /Pixel's day at a glance/i })).toBeVisible();
     expect(createdBody).toMatchObject({ name: 'Pixel', species: 'DOG', breed: 'Mix' });
     expect(createdBody).not.toHaveProperty('temperament');
     expect(createdBody).not.toHaveProperty('vaccinations');

--- a/apps/web/src/app/activity/page.tsx
+++ b/apps/web/src/app/activity/page.tsx
@@ -172,7 +172,7 @@ export default function ActivityPage() {
               anonymous bucket.
             </p>
             <Button className="mt-5" asChild>
-              <Link href="/profile">Open your pack</Link>
+              <Link href="/pets/new">Add your dog</Link>
             </Button>
           </Card>
         ) : selectedPet ? (
@@ -186,8 +186,8 @@ export default function ActivityPage() {
                   <p className="eyebrow">Quick log</p>
                   <h2 className="mt-1 text-lg font-bold">Save what just happened</h2>
                   <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-                    One tap creates a real completed Activity. No fake routes, no inferred distance,
-                    and no background claim about where you went.
+                    A few taps create a real completed Activity. No fake routes, no inferred
+                    distance, and no background claim about where you went.
                   </p>
                 </div>
               </div>

--- a/apps/web/src/app/activity/page.tsx
+++ b/apps/web/src/app/activity/page.tsx
@@ -224,7 +224,11 @@ export default function ActivityPage() {
 
               <div className="mt-4">
                 <p className="text-xs font-semibold text-muted-foreground">About how long?</p>
-                <div className="mt-2 grid grid-cols-4 gap-2" role="group" aria-label="Activity duration">
+                <div
+                  className="mt-2 grid grid-cols-4 gap-2"
+                  role="group"
+                  aria-label="Activity duration"
+                >
                   {QUICK_DURATIONS.map((minutes) => (
                     <button
                       key={minutes}
@@ -284,7 +288,10 @@ export default function ActivityPage() {
               </div>
 
               {activities.isLoading ? (
-                <Card className="surface-soft mt-3 flex items-center gap-3 rounded-2xl p-4" role="status">
+                <Card
+                  className="surface-soft mt-3 flex items-center gap-3 rounded-2xl p-4"
+                  role="status"
+                >
                   <Loader2 className="h-4 w-4 animate-spin text-primary" aria-hidden="true" />
                   <span className="text-sm text-muted-foreground">Loading canonical history…</span>
                 </Card>

--- a/apps/web/src/app/activity/page.tsx
+++ b/apps/web/src/app/activity/page.tsx
@@ -1,120 +1,362 @@
-"use client"
+'use client';
 
-import { useState } from "react"
-import { BottomNav } from "@/components/bottom-nav"
-import { ActivityStats } from "@/components/activity/activity-stats"
-import { ActivityHistory } from "@/components/activity/activity-history"
-import { ActiveWalkCard } from "@/components/activity/active-walk-card"
-import { Button } from "@/components/ui/button"
-import { Play, TrendingUp } from "lucide-react"
-import type { Activity } from "@/lib/types"
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  CheckCircle2,
+  Clock3,
+  History,
+  Loader2,
+  PawPrint,
+  Plus,
+  RefreshCw,
+  Sparkles,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { BottomNav } from '@/components/bottom-nav';
+import { PetSwitcher } from '@/components/pets/pet-switcher';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { getActivePetId, setActivePetId } from '@/lib/active-pet';
+import { activitiesApi, type CanonicalActivity } from '@/lib/api/activities';
+import { petsApi } from '@/lib/api/pets';
 
-// Mock activity data
-const mockActivities: Activity[] = [
-  {
-    id: "a1",
-    type: "walk",
-    petId: "p1",
-    startTime: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
-    endTime: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
-    duration: 3600,
-    distance: 2.5,
-    route: [
-      { lat: 37.7749, lng: -122.4194 },
-      { lat: 37.7759, lng: -122.4184 },
-      { lat: 37.7769, lng: -122.4174 },
-    ],
-    notes: "Great walk in the park! Max loved it.",
-  },
-  {
-    id: "a2",
-    type: "walk",
-    petId: "p1",
-    startTime: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
-    endTime: new Date(Date.now() - 1000 * 60 * 60 * 24 + 1000 * 60 * 45).toISOString(),
-    duration: 2700,
-    distance: 1.8,
-    route: [
-      { lat: 37.7749, lng: -122.4194 },
-      { lat: 37.7739, lng: -122.4204 },
-    ],
-    notes: "Morning walk around the neighborhood.",
-  },
-  {
-    id: "a3",
-    type: "walk",
-    petId: "p1",
-    startTime: new Date(Date.now() - 1000 * 60 * 60 * 48).toISOString(),
-    endTime: new Date(Date.now() - 1000 * 60 * 60 * 48 + 1000 * 60 * 30).toISOString(),
-    duration: 1800,
-    distance: 1.2,
-    route: [
-      { lat: 37.7749, lng: -122.4194 },
-      { lat: 37.7744, lng: -122.4199 },
-    ],
-    notes: "Quick evening walk.",
-  },
-  {
-    id: "a4",
-    type: "playdate",
-    petId: "p1",
-    startTime: new Date(Date.now() - 1000 * 60 * 60 * 72).toISOString(),
-    endTime: new Date(Date.now() - 1000 * 60 * 60 * 72 + 1000 * 60 * 90).toISOString(),
-    duration: 5400,
-    participants: ["o1", "o2"],
-    notes: "Playdate with Max and Luna at the dog park.",
-  },
-]
+const QUICK_TYPES = ['WALK', 'PLAY', 'TRAINING', 'RECOVERY'] as const;
+const QUICK_DURATIONS = [15, 30, 45, 60] as const;
+
+function friendlyType(type: string) {
+  return type
+    .toLowerCase()
+    .split('_')
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function activityDuration(activity: CanonicalActivity) {
+  if (!activity.endedAt) return null;
+  const start = new Date(activity.startedAt).getTime();
+  const end = new Date(activity.endedAt).getTime();
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return null;
+  return Math.round((end - start) / 60_000);
+}
+
+function activityDate(value: string) {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return 'Saved activity';
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+}
 
 export default function ActivityPage() {
-  const [activities] = useState<Activity[]>(mockActivities)
-  const [activeWalk, setActiveWalk] = useState<boolean>(false)
+  const queryClient = useQueryClient();
+  const [selectedPetId, setSelectedPetId] = useState<string | null>(null);
+  const [quickType, setQuickType] = useState<(typeof QUICK_TYPES)[number]>('WALK');
+  const [quickDuration, setQuickDuration] = useState<(typeof QUICK_DURATIONS)[number]>(30);
+  const [savedMessage, setSavedMessage] = useState<string | null>(null);
 
-  // Calculate stats
-  const thisWeekActivities = activities.filter(
-    (a) => new Date(a.startTime).getTime() > Date.now() - 1000 * 60 * 60 * 24 * 7,
-  )
-  const totalDistance = thisWeekActivities.reduce((sum, a) => sum + (a.distance || 0), 0)
-  const totalDuration = thisWeekActivities.reduce((sum, a) => sum + a.duration, 0)
-  const totalWalks = thisWeekActivities.filter((a) => a.type === "walk").length
+  const pets = useQuery({
+    queryKey: ['pets', 'mine'],
+    queryFn: () => petsApi.getMine(),
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  useEffect(() => {
+    const ownedPets = pets.data?.pets ?? [];
+    if (ownedPets.length === 0) {
+      setSelectedPetId(null);
+      return;
+    }
+
+    const remembered = getActivePetId();
+    const next = ownedPets.some((pet) => pet.id === remembered) ? remembered : ownedPets[0]?.id;
+    if (!next || next === selectedPetId) return;
+
+    setActivePetId(next);
+    setSelectedPetId(next);
+  }, [pets.data, selectedPetId]);
+
+  const activities = useInfiniteQuery({
+    queryKey: ['activities', selectedPetId],
+    enabled: Boolean(selectedPetId),
+    initialPageParam: 0,
+    queryFn: ({ pageParam }) =>
+      activitiesApi.getMine({ petId: selectedPetId ?? undefined, skip: pageParam, take: 20 }),
+    getNextPageParam: (lastPage) => {
+      const next = lastPage.skip + lastPage.activities.length;
+      return next < lastPage.total ? next : undefined;
+    },
+    retry: false,
+  });
+
+  const activityList = useMemo(
+    () => activities.data?.pages.flatMap((page) => page.activities) ?? [],
+    [activities.data]
+  );
+  const totalActivities = activities.data?.pages[0]?.total ?? 0;
+  const selectedPet = pets.data?.pets.find((pet) => pet.id === selectedPetId) ?? null;
+
+  const quickLog = useMutation({
+    mutationFn: async () => {
+      if (!selectedPetId) throw new Error('Choose a dog first');
+      const endedAt = new Date();
+      const startedAt = new Date(endedAt.getTime() - quickDuration * 60_000);
+      return activitiesApi.create({
+        petIds: [selectedPetId],
+        type: quickType,
+        startedAt: startedAt.toISOString(),
+        endedAt: endedAt.toISOString(),
+        jointMetrics: {
+          source: 'MANUAL_QUICK_LOG',
+          enteredDurationMinutes: quickDuration,
+        },
+      });
+    },
+    onSuccess: async () => {
+      setSavedMessage(
+        `${friendlyType(quickType)} saved for ${selectedPet?.name ?? 'your dog'}. Today, Adventure, and Story can now use it.`
+      );
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['activities', selectedPetId] }),
+        queryClient.invalidateQueries({ queryKey: ['adventure', 'me'] }),
+        queryClient.invalidateQueries({ queryKey: ['concierge', 'today'] }),
+        queryClient.invalidateQueries({ queryKey: ['story'] }),
+      ]);
+    },
+  });
 
   return (
-    <div className="min-h-screen pb-20">
-      {/* Header */}
-      <header className="sticky top-0 z-40 glass-strong border-b border-border/50">
-        <div className="px-4 py-4 max-w-lg mx-auto">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-bold">Activity</h1>
-              <p className="text-sm text-muted-foreground">Track your pet&apos;s activities</p>
-            </div>
-            <Button size="icon" className="shrink-0">
-              <TrendingUp className="w-5 h-5" />
-            </Button>
+    <div className="min-h-screen pb-24">
+      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/88 backdrop-blur-2xl">
+        <div className="mx-auto flex h-16 max-w-xl items-center justify-between px-4">
+          <div>
+            <p className="eyebrow">Canonical history</p>
+            <h1 className="mt-0.5 text-xl font-bold tracking-tight">Activity</h1>
           </div>
+          {selectedPet && (
+            <span className="rounded-full border border-border/70 bg-card/70 px-3 py-1.5 text-xs font-semibold">
+              {selectedPet.name}
+            </span>
+          )}
         </div>
       </header>
 
-      {/* Content */}
-      <main className="px-4 py-6 max-w-lg mx-auto space-y-6">
-        {/* Active Walk */}
-        {activeWalk ? (
-          <ActiveWalkCard onEnd={() => setActiveWalk(false)} />
-        ) : (
-          <Button size="lg" className="w-full gap-2" onClick={() => setActiveWalk(true)}>
-            <Play className="w-5 h-5" />
-            Start Walk
-          </Button>
-        )}
+      <main id="main-content" className="mx-auto max-w-xl space-y-5 px-4 py-5">
+        {pets.isLoading ? (
+          <Card className="surface-soft flex items-center gap-3 rounded-3xl p-5" role="status">
+            <Loader2 className="h-5 w-5 animate-spin text-primary" aria-hidden="true" />
+            <span className="text-sm text-muted-foreground">Loading your dogs…</span>
+          </Card>
+        ) : pets.isError ? (
+          <Card className="surface-soft rounded-3xl p-5 text-center">
+            <PawPrint className="mx-auto h-7 w-7 text-primary" aria-hidden="true" />
+            <h2 className="mt-3 font-semibold">We couldn&apos;t load your dogs</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Activity history stays hidden rather than guessing which pet it belongs to.
+            </p>
+            <Button className="mt-4" variant="outline" onClick={() => pets.refetch()}>
+              <RefreshCw className="mr-2 h-4 w-4" aria-hidden="true" />
+              Try again
+            </Button>
+          </Card>
+        ) : (pets.data?.pets.length ?? 0) === 0 ? (
+          <Card className="surface-soft rounded-3xl p-6 text-center">
+            <PawPrint className="mx-auto h-8 w-8 text-primary" aria-hidden="true" />
+            <h2 className="mt-3 text-lg font-semibold">Add your first dog to begin</h2>
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+              Woof keeps activity attached to a real pet profile. Nothing is logged into an
+              anonymous bucket.
+            </p>
+            <Button className="mt-5" asChild>
+              <Link href="/profile">Open your pack</Link>
+            </Button>
+          </Card>
+        ) : selectedPet ? (
+          <>
+            <Card className="rounded-3xl border-primary/15 bg-gradient-to-br from-primary/[0.07] via-card/95 to-secondary/[0.04] p-5">
+              <div className="flex items-start gap-3">
+                <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                  <Plus className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <div>
+                  <p className="eyebrow">Quick log</p>
+                  <h2 className="mt-1 text-lg font-bold">Save what just happened</h2>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                    One tap creates a real completed Activity. No fake routes, no inferred distance,
+                    and no background claim about where you went.
+                  </p>
+                </div>
+              </div>
 
-        {/* Stats */}
-        <ActivityStats totalDistance={totalDistance} totalDuration={totalDuration} totalWalks={totalWalks} />
+              <PetSwitcher
+                currentPetId={selectedPet.id}
+                label="Logging for"
+                onChange={(petId) => {
+                  setSavedMessage(null);
+                  setSelectedPetId(petId);
+                }}
+              />
 
-        {/* History */}
-        <ActivityHistory activities={activities} />
+              <div className="mt-4">
+                <p className="text-xs font-semibold text-muted-foreground">What did you do?</p>
+                <div className="mt-2 flex flex-wrap gap-2" role="group" aria-label="Activity type">
+                  {QUICK_TYPES.map((type) => (
+                    <button
+                      key={type}
+                      type="button"
+                      aria-pressed={quickType === type}
+                      onClick={() => setQuickType(type)}
+                      className={`rounded-full border px-3 py-2 text-sm font-semibold transition-colors ${
+                        quickType === type
+                          ? 'border-primary/30 bg-primary/10 text-primary'
+                          : 'border-border/70 bg-background/55 text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      {friendlyType(type)}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="mt-4">
+                <p className="text-xs font-semibold text-muted-foreground">About how long?</p>
+                <div className="mt-2 grid grid-cols-4 gap-2" role="group" aria-label="Activity duration">
+                  {QUICK_DURATIONS.map((minutes) => (
+                    <button
+                      key={minutes}
+                      type="button"
+                      aria-pressed={quickDuration === minutes}
+                      onClick={() => setQuickDuration(minutes)}
+                      className={`rounded-2xl border px-2 py-2 text-sm font-semibold transition-colors ${
+                        quickDuration === minutes
+                          ? 'border-primary/30 bg-primary/10 text-primary'
+                          : 'border-border/70 bg-background/55 text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      {minutes}m
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <Button
+                className="mt-4 w-full"
+                size="lg"
+                disabled={quickLog.isPending}
+                onClick={() => quickLog.mutate()}
+              >
+                {quickLog.isPending ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                ) : (
+                  <CheckCircle2 className="mr-2 h-4 w-4" aria-hidden="true" />
+                )}
+                Save {quickDuration} min {friendlyType(quickType).toLowerCase()}
+              </Button>
+
+              {quickLog.isError && (
+                <p className="mt-3 text-sm text-destructive" role="alert">
+                  That activity could not be saved. Nothing was added to history.
+                </p>
+              )}
+              {savedMessage && (
+                <div className="mt-3 flex items-start gap-2 rounded-2xl bg-primary/10 p-3 text-sm text-primary">
+                  <Sparkles className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+                  <span>{savedMessage}</span>
+                </div>
+              )}
+            </Card>
+
+            <section aria-labelledby="activity-history-heading">
+              <div className="flex items-end justify-between gap-3">
+                <div>
+                  <p className="eyebrow">What actually happened</p>
+                  <h2 id="activity-history-heading" className="mt-1 text-lg font-bold">
+                    {selectedPet.name}&apos;s history
+                  </h2>
+                </div>
+                <span className="text-xs text-muted-foreground">
+                  {totalActivities} record{totalActivities === 1 ? '' : 's'}
+                </span>
+              </div>
+
+              {activities.isLoading ? (
+                <Card className="surface-soft mt-3 flex items-center gap-3 rounded-2xl p-4" role="status">
+                  <Loader2 className="h-4 w-4 animate-spin text-primary" aria-hidden="true" />
+                  <span className="text-sm text-muted-foreground">Loading canonical history…</span>
+                </Card>
+              ) : activities.isError ? (
+                <Card className="surface-soft mt-3 rounded-2xl p-5 text-center">
+                  <History className="mx-auto h-6 w-6 text-primary" aria-hidden="true" />
+                  <p className="mt-3 font-semibold">History is temporarily unavailable</p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Woof will not substitute demo data while the real history cannot be read.
+                  </p>
+                  <Button className="mt-4" variant="outline" onClick={() => activities.refetch()}>
+                    Try again
+                  </Button>
+                </Card>
+              ) : activityList.length === 0 ? (
+                <Card className="surface-soft mt-3 rounded-2xl p-5 text-center">
+                  <History className="mx-auto h-6 w-6 text-primary" aria-hidden="true" />
+                  <p className="mt-3 font-semibold">No activity yet</p>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                    Your first real walk, play session, training session, or recovery block will
+                    appear here after it is saved.
+                  </p>
+                </Card>
+              ) : (
+                <div className="mt-3 space-y-2">
+                  {activityList.map((activity) => {
+                    const minutes = activityDuration(activity);
+                    const participantNames = activity.petParticipants
+                      .map((participant) => participant.pet.name)
+                      .filter(Boolean);
+                    return (
+                      <Card key={activity.id} className="surface-soft rounded-2xl p-4">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="font-semibold">{friendlyType(activity.type)}</p>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {activityDate(activity.startedAt)}
+                              {participantNames.length > 1
+                                ? ` · ${participantNames.join(' + ')}`
+                                : ''}
+                            </p>
+                          </div>
+                          <span className="flex shrink-0 items-center gap-1 rounded-full bg-background/70 px-2.5 py-1 text-xs font-semibold text-muted-foreground">
+                            <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
+                            {minutes === null ? 'In progress' : `${minutes} min`}
+                          </span>
+                        </div>
+                      </Card>
+                    );
+                  })}
+
+                  {activities.hasNextPage && (
+                    <Button
+                      variant="outline"
+                      className="w-full bg-transparent"
+                      disabled={activities.isFetchingNextPage}
+                      onClick={() => activities.fetchNextPage()}
+                    >
+                      {activities.isFetchingNextPage && (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                      )}
+                      Load older activity
+                    </Button>
+                  )}
+                </div>
+              )}
+            </section>
+          </>
+        ) : null}
       </main>
 
       <BottomNav />
     </div>
-  )
+  );
 }

--- a/apps/web/src/app/pets/new/page.tsx
+++ b/apps/web/src/app/pets/new/page.tsx
@@ -36,7 +36,7 @@ export default function NewPetPage() {
         queryClient.invalidateQueries({ queryKey: ['adventure', 'me'] }),
         queryClient.invalidateQueries({ queryKey: ['concierge', 'today'] }),
       ]);
-      router.replace('/');
+      router.replace(`/?pet=${encodeURIComponent(pet.id)}`);
     },
   });
 
@@ -94,7 +94,9 @@ export default function NewPetPage() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="dog-breed">Breed or mix <span className="text-muted-foreground">(optional)</span></Label>
+              <Label htmlFor="dog-breed">
+                Breed or mix <span className="text-muted-foreground">(optional)</span>
+              </Label>
               <Input
                 id="dog-breed"
                 autoComplete="off"
@@ -107,7 +109,9 @@ export default function NewPetPage() {
 
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <div className="space-y-2">
-                <Label htmlFor="dog-birthdate">Birthday <span className="text-muted-foreground">(optional)</span></Label>
+                <Label htmlFor="dog-birthdate">
+                  Birthday <span className="text-muted-foreground">(optional)</span>
+                </Label>
                 <Input
                   id="dog-birthdate"
                   type="date"
@@ -117,7 +121,9 @@ export default function NewPetPage() {
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="dog-sex">Sex <span className="text-muted-foreground">(optional)</span></Label>
+                <Label htmlFor="dog-sex">
+                  Sex <span className="text-muted-foreground">(optional)</span>
+                </Label>
                 <select
                   id="dog-sex"
                   value={sex}
@@ -147,7 +153,12 @@ export default function NewPetPage() {
               </p>
             )}
 
-            <Button className="w-full" size="lg" type="submit" disabled={!name.trim() || createDog.isPending}>
+            <Button
+              className="w-full"
+              size="lg"
+              type="submit"
+              disabled={!name.trim() || createDog.isPending}
+            >
               {createDog.isPending && (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
               )}

--- a/apps/web/src/app/pets/new/page.tsx
+++ b/apps/web/src/app/pets/new/page.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft, Loader2, PawPrint, Sparkles } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { FormEvent, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { setActivePetId } from '@/lib/active-pet';
+import { petsApi } from '@/lib/api/pets';
+
+export default function NewPetPage() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [name, setName] = useState('');
+  const [breed, setBreed] = useState('');
+  const [birthdate, setBirthdate] = useState('');
+  const [sex, setSex] = useState<'MALE' | 'FEMALE' | 'UNKNOWN'>('UNKNOWN');
+
+  const createDog = useMutation({
+    mutationFn: () =>
+      petsApi.createDog({
+        name: name.trim(),
+        species: 'DOG',
+        ...(breed.trim() ? { breed: breed.trim() } : {}),
+        ...(birthdate ? { birthdate } : {}),
+        sex,
+      }),
+    onSuccess: async (pet) => {
+      setActivePetId(pet.id);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['pets', 'mine'] }),
+        queryClient.invalidateQueries({ queryKey: ['adventure', 'me'] }),
+        queryClient.invalidateQueries({ queryKey: ['concierge', 'today'] }),
+      ]);
+      router.replace('/');
+    },
+  });
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!name.trim() || createDog.isPending) return;
+    createDog.mutate();
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="border-b border-border/60 bg-background/88 backdrop-blur-2xl">
+        <div className="mx-auto flex h-16 max-w-xl items-center gap-3 px-4">
+          <Button variant="ghost" size="icon" asChild className="rounded-xl">
+            <Link href="/profile" aria-label="Back to profile">
+              <ArrowLeft className="h-5 w-5" aria-hidden="true" />
+            </Link>
+          </Button>
+          <div>
+            <p className="eyebrow">Start dogOS</p>
+            <h1 className="mt-0.5 text-xl font-bold tracking-tight">Add your dog</h1>
+          </div>
+        </div>
+      </header>
+
+      <main id="main-content" className="mx-auto max-w-xl px-4 py-6">
+        <Card className="rounded-3xl border-primary/15 bg-gradient-to-br from-primary/[0.08] via-card/95 to-secondary/[0.04] p-5 sm:p-6">
+          <div className="flex items-start gap-3">
+            <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <PawPrint className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <div>
+              <p className="eyebrow">One minute setup</p>
+              <h2 className="mt-1 text-xl font-bold">Who are we caring for?</h2>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                Start with only the basics. You can enrich the profile later as Woof earns more
+                context from real activities and your explicit feedback.
+              </p>
+            </div>
+          </div>
+
+          <form className="mt-6 space-y-5" onSubmit={submit}>
+            <div className="space-y-2">
+              <Label htmlFor="dog-name">Name</Label>
+              <Input
+                id="dog-name"
+                autoFocus
+                autoComplete="off"
+                maxLength={80}
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="e.g. Shasta"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="dog-breed">Breed or mix <span className="text-muted-foreground">(optional)</span></Label>
+              <Input
+                id="dog-breed"
+                autoComplete="off"
+                maxLength={120}
+                value={breed}
+                onChange={(event) => setBreed(event.target.value)}
+                placeholder="e.g. Siberian Husky"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="dog-birthdate">Birthday <span className="text-muted-foreground">(optional)</span></Label>
+                <Input
+                  id="dog-birthdate"
+                  type="date"
+                  value={birthdate}
+                  max={new Date().toISOString().slice(0, 10)}
+                  onChange={(event) => setBirthdate(event.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="dog-sex">Sex <span className="text-muted-foreground">(optional)</span></Label>
+                <select
+                  id="dog-sex"
+                  value={sex}
+                  onChange={(event) => setSex(event.target.value as typeof sex)}
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  <option value="UNKNOWN">Prefer not to say</option>
+                  <option value="FEMALE">Female</option>
+                  <option value="MALE">Male</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-border/60 bg-background/55 p-4 text-xs leading-relaxed text-muted-foreground">
+              <div className="flex items-start gap-2">
+                <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+                <p>
+                  Woof does not infer medical status from this profile. Care guidance stays
+                  non-diagnostic, and you remain in control of every persistent change.
+                </p>
+              </div>
+            </div>
+
+            {createDog.isError && (
+              <p className="text-sm text-destructive" role="alert">
+                We couldn&apos;t create this dog profile. Nothing was saved. Please try again.
+              </p>
+            )}
+
+            <Button className="w-full" size="lg" type="submit" disabled={!name.trim() || createDog.isPending}>
+              {createDog.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+              )}
+              Meet {name.trim() || 'your dog'}
+            </Button>
+          </form>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/components/concierge/concierge-briefing.tsx
+++ b/apps/web/src/components/concierge/concierge-briefing.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { CloudOff, HeartHandshake, Loader2, Sparkles } from 'lucide-react';
 import Link from 'next/link';
+import { PetSwitcher } from '@/components/pets/pet-switcher';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { adventureApi } from '@/lib/api/adventure';
@@ -67,6 +68,8 @@ export function ConciergeBriefing() {
             </p>
           </div>
         </div>
+
+        <PetSwitcher currentPetId={petId} />
 
         {data.briefing.topQuest && (
           <div className="mt-4 rounded-2xl border border-border/70 bg-background/55 p-4">

--- a/apps/web/src/components/pets/pet-switcher.tsx
+++ b/apps/web/src/components/pets/pet-switcher.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { PawPrint } from 'lucide-react';
+import { setActivePetId } from '@/lib/active-pet';
+import { petsApi } from '@/lib/api/pets';
+
+export function PetSwitcher({ currentPetId }: { currentPetId: string }) {
+  const queryClient = useQueryClient();
+  const pets = useQuery({
+    queryKey: ['pets', 'mine'],
+    queryFn: () => petsApi.getMine(),
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  const ownedPets = pets.data?.pets ?? [];
+  if (pets.isError || ownedPets.length <= 1) return null;
+
+  const choosePet = async (petId: string) => {
+    if (petId === currentPetId) return;
+    setActivePetId(petId);
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['adventure', 'me'] }),
+      queryClient.invalidateQueries({ queryKey: ['concierge', 'today'] }),
+      queryClient.invalidateQueries({ queryKey: ['activities'] }),
+    ]);
+  };
+
+  return (
+    <div className="mt-4 border-t border-border/60 pt-3">
+      <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+        Today is for
+      </p>
+      <div className="flex gap-2 overflow-x-auto pb-1" role="group" aria-label="Choose active dog">
+        {ownedPets.map((pet) => {
+          const active = pet.id === currentPetId;
+          return (
+            <button
+              key={pet.id}
+              type="button"
+              aria-pressed={active}
+              onClick={() => void choosePet(pet.id)}
+              className={`flex shrink-0 items-center gap-2 rounded-full border px-3 py-2 text-sm font-semibold transition-colors ${
+                active
+                  ? 'border-primary/30 bg-primary/10 text-primary'
+                  : 'border-border/70 bg-background/55 text-muted-foreground hover:border-primary/30 hover:text-foreground'
+              }`}
+            >
+              <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-primary/10">
+                {pet.avatarUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element -- remote pet avatars are user-provided URLs.
+                  <img src={pet.avatarUrl} alt="" className="h-full w-full object-cover" />
+                ) : (
+                  <PawPrint className="h-3.5 w-3.5" aria-hidden="true" />
+                )}
+              </span>
+              {pet.name}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pets/pet-switcher.tsx
+++ b/apps/web/src/components/pets/pet-switcher.tsx
@@ -2,10 +2,19 @@
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { PawPrint } from 'lucide-react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { setActivePetId } from '@/lib/active-pet';
 import { petsApi } from '@/lib/api/pets';
 
-export function PetSwitcher({ currentPetId }: { currentPetId: string }) {
+export function PetSwitcher({
+  currentPetId,
+  label = 'Today is for',
+  onChange,
+}: {
+  currentPetId: string;
+  label?: string;
+  onChange?: (petId: string) => void;
+}) {
   const queryClient = useQueryClient();
   const pets = useQuery({
     queryKey: ['pets', 'mine'],
@@ -20,17 +29,19 @@ export function PetSwitcher({ currentPetId }: { currentPetId: string }) {
   const choosePet = async (petId: string) => {
     if (petId === currentPetId) return;
     setActivePetId(petId);
+    onChange?.(petId);
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ['adventure', 'me'] }),
       queryClient.invalidateQueries({ queryKey: ['concierge', 'today'] }),
       queryClient.invalidateQueries({ queryKey: ['activities'] }),
+      queryClient.invalidateQueries({ queryKey: ['story'] }),
     ]);
   };
 
   return (
     <div className="mt-4 border-t border-border/60 pt-3">
       <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-        Today is for
+        {label}
       </p>
       <div className="flex gap-2 overflow-x-auto pb-1" role="group" aria-label="Choose active dog">
         {ownedPets.map((pet) => {
@@ -47,14 +58,12 @@ export function PetSwitcher({ currentPetId }: { currentPetId: string }) {
                   : 'border-border/70 bg-background/55 text-muted-foreground hover:border-primary/30 hover:text-foreground'
               }`}
             >
-              <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-primary/10">
-                {pet.avatarUrl ? (
-                  // eslint-disable-next-line @next/next/no-img-element -- remote pet avatars are user-provided URLs.
-                  <img src={pet.avatarUrl} alt="" className="h-full w-full object-cover" />
-                ) : (
+              <Avatar className="h-6 w-6 border-0">
+                <AvatarImage src={pet.avatarUrl ?? undefined} alt="" />
+                <AvatarFallback className="bg-primary/10 text-primary">
                   <PawPrint className="h-3.5 w-3.5" aria-hidden="true" />
-                )}
-              </span>
+                </AvatarFallback>
+              </Avatar>
               {pet.name}
             </button>
           );

--- a/apps/web/src/lib/active-pet.spec.ts
+++ b/apps/web/src/lib/active-pet.spec.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { clearActivePetId, getActivePetId, setActivePetId } from './active-pet';
+
+describe('active pet context', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('persists the selected dog in both URL and local storage', () => {
+    setActivePetId('pet-2');
+
+    expect(getActivePetId()).toBe('pet-2');
+    expect(window.localStorage.getItem('woof.activePetId')).toBe('pet-2');
+    expect(new URLSearchParams(window.location.search).get('pet')).toBe('pet-2');
+  });
+
+  it('prefers explicit URL context over an older remembered dog', () => {
+    window.localStorage.setItem('woof.activePetId', 'pet-old');
+    window.history.replaceState({}, '', '/?pet=pet-current');
+
+    expect(getActivePetId()).toBe('pet-current');
+  });
+
+  it('clears both durable and URL context', () => {
+    setActivePetId('pet-3');
+    clearActivePetId();
+
+    expect(getActivePetId()).toBeNull();
+    expect(window.localStorage.getItem('woof.activePetId')).toBeNull();
+    expect(window.location.search).toBe('');
+  });
+});

--- a/apps/web/src/lib/active-pet.ts
+++ b/apps/web/src/lib/active-pet.ts
@@ -1,0 +1,29 @@
+const ACTIVE_PET_STORAGE_KEY = 'woof.activePetId';
+const ACTIVE_PET_QUERY_KEY = 'pet';
+
+export function getActivePetId() {
+  if (typeof window === 'undefined') return null;
+
+  const fromUrl = new URLSearchParams(window.location.search).get(ACTIVE_PET_QUERY_KEY);
+  if (fromUrl) return fromUrl;
+
+  return window.localStorage.getItem(ACTIVE_PET_STORAGE_KEY);
+}
+
+export function setActivePetId(petId: string) {
+  if (typeof window === 'undefined') return;
+
+  window.localStorage.setItem(ACTIVE_PET_STORAGE_KEY, petId);
+  const url = new URL(window.location.href);
+  url.searchParams.set(ACTIVE_PET_QUERY_KEY, petId);
+  window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
+}
+
+export function clearActivePetId() {
+  if (typeof window === 'undefined') return;
+
+  window.localStorage.removeItem(ACTIVE_PET_STORAGE_KEY);
+  const url = new URL(window.location.href);
+  url.searchParams.delete(ACTIVE_PET_QUERY_KEY);
+  window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
+}

--- a/apps/web/src/lib/api/activities.spec.ts
+++ b/apps/web/src/lib/api/activities.spec.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const transport = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.mock('./client', () => ({ apiClient: transport }));
+
+import { activitiesApi } from './activities';
+
+describe('activitiesApi', () => {
+  beforeEach(() => {
+    transport.get.mockReset();
+    transport.post.mockReset();
+  });
+
+  it('reads paginated canonical history scoped to the active dog', async () => {
+    transport.get.mockResolvedValue({ activities: [], total: 0, skip: 20, take: 20 });
+
+    await activitiesApi.getMine({ petId: 'pet-2', skip: 20, take: 20 });
+
+    expect(transport.get).toHaveBeenCalledWith('/activities', {
+      params: { petId: 'pet-2', skip: 20, take: 20 },
+    });
+  });
+
+  it('writes a completed activity without client-controlled rewards or fake route data', async () => {
+    transport.post.mockResolvedValue({ id: 'activity-1' });
+    const input = {
+      petIds: ['pet-2'],
+      type: 'WALK',
+      startedAt: '2026-08-22T17:00:00.000Z',
+      endedAt: '2026-08-22T17:30:00.000Z',
+      jointMetrics: {
+        source: 'MANUAL_QUICK_LOG',
+        enteredDurationMinutes: 30,
+      },
+    };
+
+    await activitiesApi.create(input);
+
+    expect(transport.post).toHaveBeenCalledWith('/activities', input);
+    const payload = transport.post.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('route');
+    expect(payload).not.toHaveProperty('distance');
+    expect(payload).not.toHaveProperty('bondXp');
+    expect(payload).not.toHaveProperty('xp');
+  });
+});

--- a/apps/web/src/lib/api/activities.ts
+++ b/apps/web/src/lib/api/activities.ts
@@ -1,0 +1,60 @@
+import { apiClient } from './client';
+
+export type ActivityPet = {
+  id: string;
+  name: string;
+  species: string;
+  avatarUrl?: string | null;
+};
+
+export type CanonicalActivity = {
+  id: string;
+  userId: string;
+  petId?: string | null;
+  householdId?: string | null;
+  startedAt: string;
+  endedAt?: string | null;
+  type: string;
+  route?: unknown;
+  humanMetrics?: unknown;
+  petMetrics?: unknown;
+  jointMetrics?: unknown;
+  pet?: ActivityPet | null;
+  petParticipants: Array<{
+    petId: string;
+    metrics?: unknown;
+    pet: ActivityPet;
+  }>;
+  _count?: {
+    posts: number;
+  };
+};
+
+export type ActivitiesResponse = {
+  activities: CanonicalActivity[];
+  total: number;
+  skip: number;
+  take: number;
+};
+
+export type CreateActivityInput = {
+  petIds: string[];
+  startedAt: string;
+  endedAt: string;
+  type: string;
+  jointMetrics?: Record<string, unknown>;
+};
+
+export const activitiesApi = {
+  getMine: (input: { petId?: string; skip?: number; take?: number } = {}) =>
+    apiClient.get<ActivitiesResponse>('/activities', {
+      params: {
+        ...(input.petId ? { petId: input.petId } : {}),
+        skip: input.skip ?? 0,
+        take: input.take ?? 25,
+      },
+    }),
+
+  create: (input: CreateActivityInput) =>
+    apiClient.post<CanonicalActivity, CreateActivityInput>('/activities', input),
+};

--- a/apps/web/src/lib/api/adventure.spec.ts
+++ b/apps/web/src/lib/api/adventure.spec.ts
@@ -15,15 +15,28 @@ describe('adventureApi', () => {
   beforeEach(() => {
     transport.get.mockReset();
     transport.post.mockReset();
+    window.localStorage.clear();
+    window.history.replaceState({}, '', '/');
   });
 
-  it('reads the server-owned dashboard with an optional pet scope', async () => {
+  it('reads the server-owned dashboard with an explicit pet scope', async () => {
     transport.get.mockResolvedValue({ quests: [] });
 
     await adventureApi.getMine('pet-1');
 
     expect(transport.get).toHaveBeenCalledWith('/adventure/me', {
       params: { petId: 'pet-1' },
+    });
+  });
+
+  it('uses the active dog context when the caller does not override it', async () => {
+    transport.get.mockResolvedValue({ quests: [] });
+    window.history.replaceState({}, '', '/?pet=pet-2');
+
+    await adventureApi.getMine();
+
+    expect(transport.get).toHaveBeenCalledWith('/adventure/me', {
+      params: { petId: 'pet-2' },
     });
   });
 

--- a/apps/web/src/lib/api/adventure.ts
+++ b/apps/web/src/lib/api/adventure.ts
@@ -2,14 +2,7 @@ import { getActivePetId } from '../active-pet';
 import { apiClient } from './client';
 
 export type WellbeingPathway =
-  | 'MOVE'
-  | 'EXPLORE'
-  | 'ENRICH'
-  | 'LEARN'
-  | 'CONNECT'
-  | 'CARE'
-  | 'RECOVER'
-  | 'BOND';
+  'MOVE' | 'EXPLORE' | 'ENRICH' | 'LEARN' | 'CONNECT' | 'CARE' | 'RECOVER' | 'BOND';
 
 export type AdventureQuest = {
   id: string;

--- a/apps/web/src/lib/api/adventure.ts
+++ b/apps/web/src/lib/api/adventure.ts
@@ -1,7 +1,15 @@
+import { getActivePetId } from '../active-pet';
 import { apiClient } from './client';
 
 export type WellbeingPathway =
-  'MOVE' | 'EXPLORE' | 'ENRICH' | 'LEARN' | 'CONNECT' | 'CARE' | 'RECOVER' | 'BOND';
+  | 'MOVE'
+  | 'EXPLORE'
+  | 'ENRICH'
+  | 'LEARN'
+  | 'CONNECT'
+  | 'CARE'
+  | 'RECOVER'
+  | 'BOND';
 
 export type AdventureQuest = {
   id: string;
@@ -73,11 +81,17 @@ export type QuestCompletion = {
   message: string;
 };
 
+function resolvedPetId(explicitPetId?: string) {
+  return explicitPetId ?? getActivePetId() ?? undefined;
+}
+
 export const adventureApi = {
-  getMine: (petId?: string) =>
-    apiClient.get<AdventureDashboard>('/adventure/me', {
-      params: petId ? { petId } : undefined,
-    }),
+  getMine: (petId?: string) => {
+    const activePetId = resolvedPetId(petId);
+    return apiClient.get<AdventureDashboard>('/adventure/me', {
+      params: activePetId ? { petId: activePetId } : undefined,
+    });
+  },
 
   selectQuest: (questId: string, petId: string) =>
     apiClient.post<{ ok: boolean }>(`/adventure/quests/${questId}/select`, { petId }),

--- a/apps/web/src/lib/api/pets.spec.ts
+++ b/apps/web/src/lib/api/pets.spec.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const transport = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.mock('./client', () => ({ apiClient: transport }));
+
+import { petsApi } from './pets';
+
+describe('petsApi', () => {
+  beforeEach(() => {
+    transport.get.mockReset();
+    transport.post.mockReset();
+  });
+
+  it('reads only the authenticated user owned-pet collection', async () => {
+    transport.get.mockResolvedValue({ pets: [], total: 0, skip: 0, take: 100 });
+
+    await petsApi.getMine();
+
+    expect(transport.get).toHaveBeenCalledWith('/pets/me', { params: { take: 100 } });
+  });
+
+  it('creates a dog without inventing temperament or health fields', async () => {
+    transport.post.mockResolvedValue({ id: 'pet-1', name: 'Mochi', species: 'DOG' });
+
+    await petsApi.createDog({
+      name: 'Mochi',
+      species: 'DOG',
+      breed: 'Mix',
+      sex: 'UNKNOWN',
+    });
+
+    expect(transport.post).toHaveBeenCalledWith('/pets', {
+      name: 'Mochi',
+      species: 'DOG',
+      breed: 'Mix',
+      sex: 'UNKNOWN',
+    });
+    const payload = transport.post.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('temperament');
+    expect(payload).not.toHaveProperty('vaccinations');
+  });
+});

--- a/apps/web/src/lib/api/pets.ts
+++ b/apps/web/src/lib/api/pets.ts
@@ -20,9 +20,19 @@ export type OwnedPetsResponse = {
   take: number;
 };
 
+export type CreateDogInput = {
+  name: string;
+  species: 'DOG';
+  breed?: string;
+  sex?: 'MALE' | 'FEMALE' | 'UNKNOWN';
+  birthdate?: string;
+};
+
 export const petsApi = {
   getMine: (take = 100) =>
     apiClient.get<OwnedPetsResponse>('/pets/me', {
       params: { take },
     }),
+
+  createDog: (input: CreateDogInput) => apiClient.post<OwnedPet, CreateDogInput>('/pets', input),
 };

--- a/apps/web/src/lib/api/pets.ts
+++ b/apps/web/src/lib/api/pets.ts
@@ -1,0 +1,28 @@
+import { apiClient } from './client';
+
+export type OwnedPet = {
+  id: string;
+  name: string;
+  species: string;
+  breed?: string | null;
+  avatarUrl?: string | null;
+  createdAt: string;
+  _count?: {
+    activities: number;
+    posts: number;
+  };
+};
+
+export type OwnedPetsResponse = {
+  pets: OwnedPet[];
+  total: number;
+  skip: number;
+  take: number;
+};
+
+export const petsApi = {
+  getMine: (take = 100) =>
+    apiClient.get<OwnedPetsResponse>('/pets/me', {
+      params: { take },
+    }),
+};

--- a/docs/DOGOS_RELEASE_POLISH.md
+++ b/docs/DOGOS_RELEASE_POLISH.md
@@ -1,0 +1,111 @@
+# dogOS Integration & Release Polish v1
+
+## Purpose
+
+The dogOS foundation is now layered and qualified. This release is not another subsystem. It is a product-integration pass that makes the existing system behave like one coherent consumer product under realistic household conditions.
+
+The target user loop is intentionally short:
+
+1. open Today,
+2. immediately know which dog the context belongs to,
+3. understand what matters now,
+4. take or log one useful action,
+5. see that action become canonical history that can inform Adventure, Concierge, and Our Story.
+
+## Release principles
+
+### The active dog is never implicit
+
+Multi-dog households must not silently inherit whichever database record happens to sort first.
+
+The web client now uses a deterministic active-dog context:
+
+- explicit `?pet=<id>` URL context wins,
+- otherwise the last user-selected dog is restored from local storage,
+- otherwise the existing server-owned fallback is used,
+- switching dogs updates the URL and the shared dogOS query surfaces.
+
+Today exposes the switcher only when the user owns more than one dog. The same selection drives Adventure and Concierge. Activity uses the same active-dog context and lets the user switch without entering a separate settings flow.
+
+### No production-facing demo history
+
+The old `/activity` page displayed hard-coded walks, coordinates, notes, and a playdate. That is unacceptable in a deployable product because it makes a real account appear to have events that never happened.
+
+The Activity surface now reads only authenticated, household-visible canonical Activities from the API. If that read fails, the UI shows a failure state. It never substitutes mock history.
+
+### Manual logging records only what the user actually supplied
+
+Quick Log is deliberately narrow. The user chooses:
+
+- the dog,
+- an activity type,
+- an approximate duration.
+
+The client writes a completed Activity with those values. It does not invent:
+
+- a route,
+- location points,
+- distance,
+- pace,
+- physiological measurements,
+- Bond XP or any other reward.
+
+Reward policy remains server-owned. A completed Activity can emit canonical CareEvents through the already-qualified Activity service, so downstream dogOS layers can react without creating a parallel history.
+
+### Day 1 has a real activation path
+
+`/pets/new` creates the first owned dog with the minimum useful identity fields. Name is required; breed, birthday, and sex are optional. The client does not seed temperament, vaccination, health, or behavioral claims.
+
+After creation, the new dog becomes the active context and the user returns to Today with the pet ID in the URL.
+
+### Long-lived accounts stay bounded
+
+Activity history is paginated in 20-record pages and loaded incrementally. The API already caps each page at 100 records.
+
+Our Story retains its existing bounded historical scan and coverage disclosure. This release must not convert either surface into an unbounded load of a multi-year account.
+
+### Degraded states remain truthful
+
+- pet-list failure never guesses a dog,
+- Activity failure never substitutes demo data,
+- zero-dog state routes to real onboarding,
+- Concierge continues to fail closed when unavailable,
+- weather remains explicitly not configured until a verified transport exists,
+- connector degradation remains local to the connector.
+
+## Product hierarchy
+
+### Today
+
+Today remains the primary surface. Concierge explains current context, then Adventure offers the ranked activity deck. The dog switcher lives inside the daily context so the user can immediately see whose day they are viewing.
+
+### Activity
+
+Activity is the canonical recent-history and low-friction manual-entry surface. It is no longer a demo dashboard or pseudo-live tracker.
+
+A future live-walk experience must use a real tracking transport and explicit location consent. It must not revive the old simulated route behavior.
+
+### Our Story
+
+Our Story remains the emotional chronology. Activity does not duplicate Story curation; it supplies canonical events that Story can compose.
+
+## Release invariants
+
+The dedicated release-polish CI lane must prove all of the following on the exact release candidate:
+
+1. No database schema or migration changes are introduced by this integration pass.
+2. Release-owned files are canonically formatted and pass zero-warning web lint/type-check.
+3. Production Activity code contains none of the retired mock-history signatures.
+4. Quick Log does not send route/location/distance or client-controlled reward fields.
+5. Active-dog URL context overrides stale remembered context.
+6. Adventure falls back to the active dog when no explicit pet is passed.
+7. Owned-pet reads use `/pets/me` rather than arbitrary owner IDs.
+8. First-dog creation does not invent temperament or vaccination state.
+9. Activity reads are pet-scoped and paginated.
+10. Chromium proves one household can switch between two dogs without Concierge/Adventure disagreement.
+11. Chromium proves canonical Activity history changes with the selected dog.
+12. Chromium proves a manual Activity write targets the selected dog and contains no fake route/reward fields.
+13. Chromium proves first-dog creation produces a usable Today state for that newly created dog.
+14. The web production build succeeds.
+
+The release-polish lane is additive. Foundation, Adventure, Autopilot, Our Story, Connectors, Concierge, and root CI remain mandatory inherited qualification lanes before merge.


### PR DESCRIPTION
## Integration & Release Polish v1

This PR starts directly from the exact merged Concierge release `44b01deff0d98881451bc65a2372e000266c473e`.

This is intentionally **not another dogOS subsystem**. It is the first whole-product deployability pass over the completed Foundation → Adventure → Autopilot → Our Story → Connectors → Concierge spine.

### Release target

A normal dog owner should be able to open Woof, know which dog they are looking at, understand what matters, log or take one useful action, and see that action become real history without encountering fake demo state.

### Explicit multi-pet context

The active dog is now a user-visible product concept rather than an implicit database ordering decision.

- `?pet=<id>` is the explicit URL context.
- A prior user selection is remembered locally when the URL does not specify a dog.
- Today exposes a dog switcher when the household owns multiple dogs.
- Adventure falls back to the active dog when a caller does not explicitly scope a request.
- Concierge continues to derive its pet from the current Adventure generation, so the reasoning card and quest deck cannot silently talk about different dogs.
- Activity uses the same active-dog context.

### Canonical Activity replaces production mock history

The old `/activity` page displayed hard-coded walks, coordinates, notes, and a fake playdate. That surface has been replaced.

Activity now:

- reads authenticated household-visible canonical `/activities`
- scopes history to the active dog
- loads history in bounded 20-record pages
- renders honest loading, empty, error, and zero-dog states
- never substitutes demo records when the API is degraded

### Low-friction real Quick Log

Quick Log records a completed canonical Activity from only the facts the user entered:

- dog
- activity type
- approximate duration

It does **not** invent route coordinates, distance, pace, physiological measurements, Bond XP, or any other reward. Server-owned Activity → CareEvent behavior remains authoritative.

Successful logging invalidates Activity, Adventure, Concierge, and Story query surfaces so the rest of dogOS can immediately use the new canonical event.

### Real Day-1 activation

`/pets/new` now provides a minimal first-dog flow:

- name required
- breed, birthday, and sex optional
- no seeded temperament, vaccination, health, or behavior claims
- successful creation makes that dog the active context and returns to `/?pet=<id>`

### Browser-level household validation

The release adds Chromium contracts for:

1. a two-dog household with an active dog and a senior/lower-intensity dog
2. switching Today from Nova to Miso while keeping Concierge + Adventure synchronized
3. switching canonical Activity history by dog
4. manually logging a real Activity for the selected dog without fake route/reward fields
5. first-dog onboarding producing a usable Today state for the newly created dog

### Dense-history behavior

Activity history is incremental rather than unbounded. Our Story retains its existing bounded historical scan and coverage disclosure. This release does not add a multi-year client-side memory dump.

### Hard release boundaries

- no schema or migration ownership in this integration pass
- no production-facing mock Activity history
- no anonymous activity bucket
- no fabricated route/location/distance in manual quick log
- no client-controlled reward fields
- no inferred health/temperament defaults during pet creation
- degraded canonical reads remain visibly degraded rather than becoming demo content

### Qualification

This PR stays draft until one exact head passes:

1. dogOS Release Polish CI
2. dogOS Concierge CI
3. dogOS Connectors CI
4. dogOS Our Story CI
5. dogOS Autopilot CI
6. dogOS Foundation CI
7. Adventure System CI
8. root CI, including Chromium smoke/accessibility/visual contracts and API/web production builds

See `docs/DOGOS_RELEASE_POLISH.md` for the release contract.