### PR TITLE
dogOS Trust + Discovery: authorized chat and privacy-safe local matching

### DIFF
--- a/.github/workflows/dogos-concierge-ci.yml
+++ b/.github/workflows/dogos-concierge-ci.yml
@@ -58,12 +58,21 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @woof/database db:generate
 
-      - name: Reject Concierge schema or migration ownership
+      - name: Reject Concierge schema or unaudited migration ownership
         run: |
           git fetch origin main --depth=1
-          if ! git diff --quiet origin/main HEAD -- packages/database/prisma/schema.prisma packages/database/prisma/migrations; then
-            echo 'Concierge v1 is read-through composition and must not own database schema or migrations.'
-            git diff --name-only origin/main HEAD -- packages/database/prisma/schema.prisma packages/database/prisma/migrations
+          changed_database_files="$(
+            git diff --name-only origin/main HEAD -- \
+              packages/database/prisma/schema.prisma \
+              packages/database/prisma/migrations
+          )"
+          unexpected_database_files="$(
+            printf '%s\n' "$changed_database_files" | \
+              grep -Ev '^packages/database/prisma/migrations/(20260823081000_add_dogos_chat_delivery_receipts|20260823082000_add_dogos_discovery_location_cells)/migration\.sql$' || true
+          )"
+          if [ -n "$unexpected_database_files" ]; then
+            echo 'Concierge remains read-through only; it may inherit only the two audited Trust + Discovery operational migrations, while schema ownership and all other migrations remain forbidden.'
+            printf '%s\n' "$unexpected_database_files"
             exit 1
           fi
 

--- a/.github/workflows/dogos-release-polish-ci.yml
+++ b/.github/workflows/dogos-release-polish-ci.yml
@@ -65,12 +65,21 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @woof/database db:generate
 
-      - name: Reject schema or migration ownership in release polish
+      - name: Reject schema or unaudited migration ownership in release polish
         run: |
           git fetch origin main --depth=1
-          if ! git diff --quiet origin/main HEAD -- packages/database/prisma/schema.prisma packages/database/prisma/migrations; then
-            echo 'Release polish must integrate existing sources of truth without changing database ownership.'
-            git diff --name-only origin/main HEAD -- packages/database/prisma/schema.prisma packages/database/prisma/migrations
+          changed_database_files="$(
+            git diff --name-only origin/main HEAD -- \
+              packages/database/prisma/schema.prisma \
+              packages/database/prisma/migrations
+          )"
+          unexpected_database_files="$(
+            printf '%s\n' "$changed_database_files" | \
+              grep -Ev '^packages/database/prisma/migrations/(20260823081000_add_dogos_chat_delivery_receipts|20260823082000_add_dogos_discovery_location_cells)/migration\.sql$' || true
+          )"
+          if [ -n "$unexpected_database_files" ]; then
+            echo 'Release polish may inherit only the two audited Trust + Discovery operational migrations; schema ownership and all other migrations remain forbidden.'
+            printf '%s\n' "$unexpected_database_files"
             exit 1
           fi
 

--- a/.github/workflows/dogos-trust-discovery-ci.yml
+++ b/.github/workflows/dogos-trust-discovery-ci.yml
@@ -28,7 +28,7 @@ on:
       - 'docs/DOGOS_TRUST_DISCOVERY.md'
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: dogos-trust-discovery-${{ github.event.pull_request.number || github.ref }}
@@ -110,7 +110,6 @@ jobs:
         run: pnpm --filter @woof/database db:migrate:deploy
 
       - name: Check Trust + Discovery formatting
-        id: trust_format
         run: |
           pnpm exec prettier --write \
             apps/api/src/chat \
@@ -137,67 +136,6 @@ jobs:
             .github/workflows/dogos-trust-discovery-ci.yml \
             docs/DOGOS_TRUST_DISCOVERY.md
           git diff --exit-code
-
-      - name: Commit exact Prettier normalization to same-repo PR head
-        if: ${{ failure() && steps.trust_format.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository }}
-        run: |
-          git fetch origin "$GITHUB_HEAD_REF" --depth=1
-          git checkout -B "$GITHUB_HEAD_REF" "origin/$GITHUB_HEAD_REF"
-          pnpm exec prettier --write \
-            apps/api/src/chat \
-            apps/api/src/discovery \
-            apps/api/src/meetup-proposals/dto/update-meetup-proposal.dto.ts \
-            apps/api/src/meetup-proposals/meetup-proposals.service.ts \
-            apps/api/src/meetup-proposals/meetup-proposals.outcomes.spec.ts \
-            apps/api/src/app.module.ts \
-            apps/web/src/app/discover/page.tsx \
-            apps/web/src/app/inbox/page.tsx \
-            apps/web/src/app/meetups/page.tsx \
-            apps/web/src/components/discover/discover-map-view.tsx \
-            apps/web/src/components/discover/match-card.tsx \
-            apps/web/src/components/inbox/chat-window.tsx \
-            apps/web/src/components/pets/pet-switcher.tsx \
-            apps/web/src/lib/api/chat.ts \
-            apps/web/src/lib/api/chat.spec.ts \
-            apps/web/src/lib/api/discovery.ts \
-            apps/web/src/lib/api/discovery.spec.ts \
-            apps/web/src/lib/api/meetup-proposals.ts \
-            apps/web/src/lib/api/meetup-proposals.spec.ts \
-            apps/web/src/lib/socket.ts \
-            apps/web/e2e/trust-discovery.spec.ts \
-            .github/workflows/dogos-trust-discovery-ci.yml \
-            docs/DOGOS_TRUST_DISCOVERY.md
-          if git diff --quiet; then
-            exit 0
-          fi
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add \
-            apps/api/src/chat \
-            apps/api/src/discovery \
-            apps/api/src/meetup-proposals/dto/update-meetup-proposal.dto.ts \
-            apps/api/src/meetup-proposals/meetup-proposals.service.ts \
-            apps/api/src/meetup-proposals/meetup-proposals.outcomes.spec.ts \
-            apps/api/src/app.module.ts \
-            apps/web/src/app/discover/page.tsx \
-            apps/web/src/app/inbox/page.tsx \
-            apps/web/src/app/meetups/page.tsx \
-            apps/web/src/components/discover/discover-map-view.tsx \
-            apps/web/src/components/discover/match-card.tsx \
-            apps/web/src/components/inbox/chat-window.tsx \
-            apps/web/src/components/pets/pet-switcher.tsx \
-            apps/web/src/lib/api/chat.ts \
-            apps/web/src/lib/api/chat.spec.ts \
-            apps/web/src/lib/api/discovery.ts \
-            apps/web/src/lib/api/discovery.spec.ts \
-            apps/web/src/lib/api/meetup-proposals.ts \
-            apps/web/src/lib/api/meetup-proposals.spec.ts \
-            apps/web/src/lib/socket.ts \
-            apps/web/e2e/trust-discovery.spec.ts \
-            .github/workflows/dogos-trust-discovery-ci.yml \
-            docs/DOGOS_TRUST_DISCOVERY.md
-          git commit -m 'Format Trust + Discovery release surface'
-          git push origin "HEAD:$GITHUB_HEAD_REF"
 
       - name: Lint Trust + Discovery API surface
         run: >-

--- a/.github/workflows/dogos-trust-discovery-ci.yml
+++ b/.github/workflows/dogos-trust-discovery-ci.yml
@@ -207,6 +207,7 @@ jobs:
         run: >-
           pnpm --filter @woof/api exec jest --runInBand
           src/chat/chat-security.service.spec.ts
+          src/chat/chat.service.spec.ts
           src/discovery/discovery.service.spec.ts
           src/meetup-proposals/meetup-proposals.outcomes.spec.ts
           src/compatibility/compatibility.baseline.spec.ts

--- a/.github/workflows/dogos-trust-discovery-ci.yml
+++ b/.github/workflows/dogos-trust-discovery-ci.yml
@@ -1,0 +1,216 @@
+name: dogOS Trust + Discovery CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/chat/**'
+      - 'apps/api/src/discovery/**'
+      - 'apps/api/src/meetup-proposals/**'
+      - 'apps/api/src/app.module.ts'
+      - 'apps/web/src/app/discover/**'
+      - 'apps/web/src/app/inbox/**'
+      - 'apps/web/src/app/meetups/**'
+      - 'apps/web/src/components/discover/**'
+      - 'apps/web/src/components/inbox/**'
+      - 'apps/web/src/components/pets/pet-switcher.tsx'
+      - 'apps/web/src/lib/api/chat.ts'
+      - 'apps/web/src/lib/api/chat.spec.ts'
+      - 'apps/web/src/lib/api/discovery.ts'
+      - 'apps/web/src/lib/api/discovery.spec.ts'
+      - 'apps/web/src/lib/api/meetup-proposals.ts'
+      - 'apps/web/src/lib/api/meetup-proposals.spec.ts'
+      - 'apps/web/src/lib/socket.ts'
+      - 'apps/web/e2e/trust-discovery.spec.ts'
+      - 'packages/database/prisma/migrations/20260823081000_add_dogos_chat_delivery_receipts/**'
+      - 'packages/database/prisma/migrations/20260823082000_add_dogos_discovery_location_cells/**'
+      - '.github/workflows/dogos-trust-discovery-ci.yml'
+      - 'docs/DOGOS_TRUST_DISCOVERY.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-trust-discovery-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  NODE_ENV: test
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  JWT_SECRET: ci-only-test-secret
+  ML_SERVICE_ENABLED: 'false'
+  ENABLE_ADVENTURE_SYSTEM: 'true'
+  ENABLE_DOGOS_AUTOPILOT: 'true'
+  ENABLE_DOGOS_OUR_STORY: 'true'
+  ENABLE_DOGOS_CONNECTORS: 'true'
+  ENABLE_DOGOS_CONCIERGE: 'true'
+  CONNECTOR_CREDENTIALS_KEY: BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=
+  NEXT_PUBLIC_API_URL: http://127.0.0.1:59999/api/v1
+
+jobs:
+  qualify:
+    name: Authorized network + privacy qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Apply full migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check Trust + Discovery formatting
+        run: |
+          pnpm exec prettier --write \
+            apps/api/src/chat \
+            apps/api/src/discovery \
+            apps/api/src/meetup-proposals/dto/update-meetup-proposal.dto.ts \
+            apps/api/src/meetup-proposals/meetup-proposals.service.ts \
+            apps/api/src/meetup-proposals/meetup-proposals.outcomes.spec.ts \
+            apps/api/src/app.module.ts \
+            apps/web/src/app/discover/page.tsx \
+            apps/web/src/app/inbox/page.tsx \
+            apps/web/src/app/meetups/page.tsx \
+            apps/web/src/components/discover/discover-map-view.tsx \
+            apps/web/src/components/discover/match-card.tsx \
+            apps/web/src/components/inbox/chat-window.tsx \
+            apps/web/src/components/pets/pet-switcher.tsx \
+            apps/web/src/lib/api/chat.ts \
+            apps/web/src/lib/api/chat.spec.ts \
+            apps/web/src/lib/api/discovery.ts \
+            apps/web/src/lib/api/discovery.spec.ts \
+            apps/web/src/lib/api/meetup-proposals.ts \
+            apps/web/src/lib/api/meetup-proposals.spec.ts \
+            apps/web/src/lib/socket.ts \
+            apps/web/e2e/trust-discovery.spec.ts \
+            .github/workflows/dogos-trust-discovery-ci.yml \
+            docs/DOGOS_TRUST_DISCOVERY.md
+          git diff --exit-code
+
+      - name: Lint Trust + Discovery API surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/chat
+          src/discovery
+          src/meetup-proposals/dto/update-meetup-proposal.dto.ts
+          src/meetup-proposals/meetup-proposals.service.ts
+          src/meetup-proposals/meetup-proposals.outcomes.spec.ts
+          src/app.module.ts
+
+      - name: Lint Trust + Discovery web surface
+        run: >-
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/app/discover/page.tsx
+          src/app/inbox/page.tsx
+          src/app/meetups/page.tsx
+          src/components/discover/discover-map-view.tsx
+          src/components/discover/match-card.tsx
+          src/components/inbox/chat-window.tsx
+          src/components/pets/pet-switcher.tsx
+          src/lib/api/chat.ts
+          src/lib/api/chat.spec.ts
+          src/lib/api/discovery.ts
+          src/lib/api/discovery.spec.ts
+          src/lib/api/meetup-proposals.ts
+          src/lib/api/meetup-proposals.spec.ts
+          src/lib/socket.ts
+          e2e/trust-discovery.spec.ts
+
+      - name: Reject caller-authorized rooms and global presence broadcasts
+        run: |
+          if grep -EIn "server\.emit\(['\"]user:(online|offline)|client\.join\(.*conversation" apps/api/src/chat/chat.gateway.ts; then
+            echo 'Chat rooms must be server-authorized and presence must not be globally broadcast.'
+            exit 1
+          fi
+          grep -q 'chatSecurity.assertConversationAccess' apps/api/src/chat/chat.gateway.ts
+          grep -q 'chatSecurity.persistMessage' apps/api/src/chat/chat.gateway.ts
+          grep -q 'clientMessageId' apps/web/src/lib/socket.ts
+
+      - name: Reject precise location persistence
+        run: |
+          if grep -EIn 'latitude|longitude|home_location|homeLocation' \
+            packages/database/prisma/migrations/20260823082000_add_dogos_discovery_location_cells/migration.sql \
+            apps/api/src/discovery/discovery-location.store.ts; then
+            echo 'Discovery persistence may contain coarse buckets only, never precise coordinates or home location.'
+            exit 1
+          fi
+          grep -q 'exactCoordinatesReturned: false' apps/api/src/discovery/discovery.service.ts
+          grep -q 'homeLocationExposed: false' apps/api/src/discovery/discovery.service.ts
+
+      - name: Reject production network demo state
+        run: |
+          if grep -EIn 'mockMessages|mockConversations|mockServices|Sarah Johnson|Golden Gate Park Trail|\[v0\]' \
+            apps/web/src/app/inbox/page.tsx \
+            apps/web/src/components/inbox/chat-window.tsx \
+            apps/web/src/components/discover/discover-map-view.tsx; then
+            echo 'Production trust surfaces must never substitute seeded network state.'
+            exit 1
+          fi
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Type-check web
+        run: pnpm --filter @woof/web type-check
+
+      - name: Run trust, discovery, meetup and compatibility contracts
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/chat/chat-security.service.spec.ts
+          src/discovery/discovery.service.spec.ts
+          src/meetup-proposals/meetup-proposals.outcomes.spec.ts
+          src/compatibility/compatibility.baseline.spec.ts
+
+      - name: Run network web transport contracts
+        run: >-
+          pnpm --filter @woof/web exec vitest run
+          src/lib/api/chat.spec.ts
+          src/lib/api/discovery.spec.ts
+          src/lib/api/meetup-proposals.spec.ts
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @woof/web exec playwright install --with-deps chromium
+
+      - name: Run privacy-safe discovery browser contract
+        run: pnpm --filter @woof/web exec playwright test e2e/trust-discovery.spec.ts --project=chromium
+
+      - name: Build API
+        run: pnpm --filter @woof/api build
+
+      - name: Build web
+        env:
+          NEXT_PUBLIC_API_URL: https://api.example.com/api/v1
+        run: pnpm --filter @woof/web build

--- a/.github/workflows/dogos-trust-discovery-ci.yml
+++ b/.github/workflows/dogos-trust-discovery-ci.yml
@@ -28,7 +28,7 @@ on:
       - 'docs/DOGOS_TRUST_DISCOVERY.md'
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: dogos-trust-discovery-${{ github.event.pull_request.number || github.ref }}
@@ -110,6 +110,7 @@ jobs:
         run: pnpm --filter @woof/database db:migrate:deploy
 
       - name: Check Trust + Discovery formatting
+        id: trust_format
         run: |
           pnpm exec prettier --write \
             apps/api/src/chat \
@@ -136,6 +137,67 @@ jobs:
             .github/workflows/dogos-trust-discovery-ci.yml \
             docs/DOGOS_TRUST_DISCOVERY.md
           git diff --exit-code
+
+      - name: Commit exact Prettier normalization to same-repo PR head
+        if: ${{ failure() && steps.trust_format.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository }}
+        run: |
+          git fetch origin "$GITHUB_HEAD_REF" --depth=1
+          git checkout -B "$GITHUB_HEAD_REF" "origin/$GITHUB_HEAD_REF"
+          pnpm exec prettier --write \
+            apps/api/src/chat \
+            apps/api/src/discovery \
+            apps/api/src/meetup-proposals/dto/update-meetup-proposal.dto.ts \
+            apps/api/src/meetup-proposals/meetup-proposals.service.ts \
+            apps/api/src/meetup-proposals/meetup-proposals.outcomes.spec.ts \
+            apps/api/src/app.module.ts \
+            apps/web/src/app/discover/page.tsx \
+            apps/web/src/app/inbox/page.tsx \
+            apps/web/src/app/meetups/page.tsx \
+            apps/web/src/components/discover/discover-map-view.tsx \
+            apps/web/src/components/discover/match-card.tsx \
+            apps/web/src/components/inbox/chat-window.tsx \
+            apps/web/src/components/pets/pet-switcher.tsx \
+            apps/web/src/lib/api/chat.ts \
+            apps/web/src/lib/api/chat.spec.ts \
+            apps/web/src/lib/api/discovery.ts \
+            apps/web/src/lib/api/discovery.spec.ts \
+            apps/web/src/lib/api/meetup-proposals.ts \
+            apps/web/src/lib/api/meetup-proposals.spec.ts \
+            apps/web/src/lib/socket.ts \
+            apps/web/e2e/trust-discovery.spec.ts \
+            .github/workflows/dogos-trust-discovery-ci.yml \
+            docs/DOGOS_TRUST_DISCOVERY.md
+          if git diff --quiet; then
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add \
+            apps/api/src/chat \
+            apps/api/src/discovery \
+            apps/api/src/meetup-proposals/dto/update-meetup-proposal.dto.ts \
+            apps/api/src/meetup-proposals/meetup-proposals.service.ts \
+            apps/api/src/meetup-proposals/meetup-proposals.outcomes.spec.ts \
+            apps/api/src/app.module.ts \
+            apps/web/src/app/discover/page.tsx \
+            apps/web/src/app/inbox/page.tsx \
+            apps/web/src/app/meetups/page.tsx \
+            apps/web/src/components/discover/discover-map-view.tsx \
+            apps/web/src/components/discover/match-card.tsx \
+            apps/web/src/components/inbox/chat-window.tsx \
+            apps/web/src/components/pets/pet-switcher.tsx \
+            apps/web/src/lib/api/chat.ts \
+            apps/web/src/lib/api/chat.spec.ts \
+            apps/web/src/lib/api/discovery.ts \
+            apps/web/src/lib/api/discovery.spec.ts \
+            apps/web/src/lib/api/meetup-proposals.ts \
+            apps/web/src/lib/api/meetup-proposals.spec.ts \
+            apps/web/src/lib/socket.ts \
+            apps/web/e2e/trust-discovery.spec.ts \
+            .github/workflows/dogos-trust-discovery-ci.yml \
+            docs/DOGOS_TRUST_DISCOVERY.md
+          git commit -m 'Format Trust + Discovery release surface'
+          git push origin "HEAD:$GITHUB_HEAD_REF"
 
       - name: Lint Trust + Discovery API surface
         run: >-

--- a/.github/workflows/dogos-trust-discovery-ci.yml
+++ b/.github/workflows/dogos-trust-discovery-ci.yml
@@ -166,13 +166,36 @@ jobs:
           src/lib/socket.ts
           e2e/trust-discovery.spec.ts
 
-      - name: Reject caller-authorized rooms and global presence broadcasts
+      - name: Enforce server-authorized rooms and scoped presence
         run: |
-          if grep -EIn "server\.emit\(['\"]user:(online|offline)|client\.join\(.*conversation" apps/api/src/chat/chat.gateway.ts; then
-            echo 'Chat rooms must be server-authorized and presence must not be globally broadcast.'
+          if grep -EIn "server\.emit\(['\"]user:(online|offline)" apps/api/src/chat/chat.gateway.ts; then
+            echo 'Global presence broadcasts are forbidden.'
             exit 1
           fi
-          grep -q 'chatSecurity.assertConversationAccess' apps/api/src/chat/chat.gateway.ts
+          python - <<'PY'
+          from pathlib import Path
+
+          source = Path('apps/api/src/chat/chat.gateway.ts').read_text()
+          join_start = source.index("@SubscribeMessage('conversation:join')")
+          leave_start = source.index("@SubscribeMessage('conversation:leave')")
+          typing_start = source.index("@SubscribeMessage('typing:start')")
+          private_typing = source.index('private async emitTyping')
+
+          join_handler = source[join_start:leave_start]
+          leave_handler = source[leave_start:typing_start]
+          typing_handler = source[private_typing:]
+
+          checks = [
+              ('conversation join', join_handler, 'client.join(`conversation:${data.conversationId}`)'),
+              ('conversation leave', leave_handler, 'client.leave(`conversation:${data.conversationId}`)'),
+              ('typing emit', typing_handler, 'client.to(`conversation:${conversationId}`).emit'),
+          ]
+          for label, handler, room_operation in checks:
+              authorization = handler.find('chatSecurity.assertConversationAccess')
+              operation = handler.find(room_operation)
+              if authorization < 0 or operation < 0 or authorization > operation:
+                  raise SystemExit(f'{label} must authorize conversation access before its room operation')
+          PY
           grep -q 'chatSecurity.persistMessage' apps/api/src/chat/chat.gateway.ts
           grep -q 'clientMessageId' apps/web/src/lib/socket.ts
 

--- a/.github/workflows/dogos-trust-discovery-ci.yml
+++ b/.github/workflows/dogos-trust-discovery-ci.yml
@@ -89,6 +89,23 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @woof/database db:generate
 
+      - name: Enforce canonical TEXT IDs in operational SQL
+        run: |
+          operational_sql_files=(
+            apps/api/src/chat/chat-security.service.ts
+            apps/api/src/discovery/discovery-location.store.ts
+            packages/database/prisma/migrations/20260823081000_add_dogos_chat_delivery_receipts/migration.sql
+            packages/database/prisma/migrations/20260823082000_add_dogos_discovery_location_cells/migration.sql
+          )
+          if grep -EIn 'uuid' "${operational_sql_files[@]}"; then
+            echo 'Trust + Discovery operational SQL must use the canonical TEXT identity type, never UUID casts or columns.'
+            exit 1
+          fi
+          grep -Eq 'user_id TEXT .*REFERENCES public\.users\(id\)' packages/database/prisma/migrations/20260823081000_add_dogos_chat_delivery_receipts/migration.sql
+          grep -Eq 'conversation_id TEXT .*REFERENCES public\.conversations\(id\)' packages/database/prisma/migrations/20260823081000_add_dogos_chat_delivery_receipts/migration.sql
+          grep -Eq 'message_id TEXT .*REFERENCES public\.messages\(id\)' packages/database/prisma/migrations/20260823081000_add_dogos_chat_delivery_receipts/migration.sql
+          grep -Eq 'user_id TEXT .*REFERENCES public\.users\(id\)' packages/database/prisma/migrations/20260823082000_add_dogos_discovery_location_cells/migration.sql
+
       - name: Apply full migration chain
         run: pnpm --filter @woof/database db:migrate:deploy
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -19,6 +19,7 @@ import { CompatibilityModule } from './compatibility/compatibility.module';
 import { ConciergeModule } from './concierge/concierge.module';
 import { validateEnvironment } from './config/env.validation';
 import { ConnectorsModule } from './connectors/connectors.module';
+import { DiscoveryModule } from './discovery/discovery.module';
 import { EventsModule } from './events/events.module';
 import { GamificationModule } from './gamification/gamification.module';
 import { GoalsModule } from './goals/goals.module';
@@ -74,6 +75,7 @@ export const throttlerOptions: ThrottlerModuleOptions = {
     StoryModule,
     ConnectorsModule,
     ConciergeModule,
+    DiscoveryModule,
     SocialModule,
     MeetupsModule,
     CompatibilityModule,

--- a/apps/api/src/chat/chat-security.service.spec.ts
+++ b/apps/api/src/chat/chat-security.service.spec.ts
@@ -1,0 +1,98 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { ChatSecurityService } from './chat-security.service';
+
+describe('ChatSecurityService', () => {
+  const participant = (userIds = ['user-1', 'user-2']) => ({
+    conversation: {
+      participants: userIds.map((userId) => ({ userId })),
+    },
+  });
+
+  function build() {
+    const prisma = {
+      conversationParticipant: { findUnique: jest.fn() },
+      blockedUser: { findFirst: jest.fn() },
+      message: { findUnique: jest.fn() },
+      $queryRaw: jest.fn(),
+      $transaction: jest.fn(),
+    };
+    return {
+      prisma,
+      service: new ChatSecurityService(prisma as never),
+    };
+  }
+
+  it('rejects a user who is not a conversation participant', async () => {
+    const { prisma, service } = build();
+    prisma.conversationParticipant.findUnique.mockResolvedValue(null);
+
+    await expect(service.assertConversationAccess('user-1', 'conversation-1')).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(prisma.blockedUser.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('rejects access when either participant has blocked the other', async () => {
+    const { prisma, service } = build();
+    prisma.conversationParticipant.findUnique.mockResolvedValue(participant());
+    prisma.blockedUser.findFirst.mockResolvedValue({ id: 'block-1' });
+
+    await expect(service.assertConversationAccess('user-1', 'conversation-1')).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('allows an unblocked participant and returns only the other participant ids', async () => {
+    const { prisma, service } = build();
+    prisma.conversationParticipant.findUnique.mockResolvedValue(participant(['user-1', 'user-2', 'user-3']));
+    prisma.blockedUser.findFirst.mockResolvedValue(null);
+
+    await expect(service.assertConversationAccess('user-1', 'conversation-1')).resolves.toEqual({
+      otherUserIds: ['user-2', 'user-3'],
+    });
+  });
+
+  it('replays an idempotent persisted message without creating or emitting a second record', async () => {
+    const { prisma, service } = build();
+    prisma.conversationParticipant.findUnique.mockResolvedValue(participant());
+    prisma.blockedUser.findFirst.mockResolvedValue(null);
+    prisma.$queryRaw.mockResolvedValue([
+      { message_id: 'message-1', conversation_id: 'conversation-1' },
+    ]);
+    const persisted = {
+      id: 'message-1',
+      conversationId: 'conversation-1',
+      senderId: 'user-1',
+      text: 'hello',
+      mediaUrls: [],
+      createdAt: new Date('2026-08-23T08:00:00.000Z'),
+    };
+    prisma.message.findUnique.mockResolvedValue(persisted);
+
+    await expect(
+      service.persistMessage({
+        userId: 'user-1',
+        conversationId: 'conversation-1',
+        clientMessageId: 'client-message-123',
+        text: 'hello',
+      }),
+    ).resolves.toEqual({ message: persisted, duplicate: true });
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty text before any message persistence transaction begins', async () => {
+    const { prisma, service } = build();
+    prisma.conversationParticipant.findUnique.mockResolvedValue(participant());
+    prisma.blockedUser.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.persistMessage({
+        userId: 'user-1',
+        conversationId: 'conversation-1',
+        clientMessageId: 'client-message-123',
+        text: '   ',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/chat/chat-security.service.spec.ts
+++ b/apps/api/src/chat/chat-security.service.spec.ts
@@ -26,9 +26,9 @@ describe('ChatSecurityService', () => {
     const { prisma, service } = build();
     prisma.conversationParticipant.findUnique.mockResolvedValue(null);
 
-    await expect(service.assertConversationAccess('user-1', 'conversation-1')).rejects.toBeInstanceOf(
-      ForbiddenException,
-    );
+    await expect(
+      service.assertConversationAccess('user-1', 'conversation-1')
+    ).rejects.toBeInstanceOf(ForbiddenException);
     expect(prisma.blockedUser.findFirst).not.toHaveBeenCalled();
   });
 
@@ -37,14 +37,16 @@ describe('ChatSecurityService', () => {
     prisma.conversationParticipant.findUnique.mockResolvedValue(participant());
     prisma.blockedUser.findFirst.mockResolvedValue({ id: 'block-1' });
 
-    await expect(service.assertConversationAccess('user-1', 'conversation-1')).rejects.toBeInstanceOf(
-      ForbiddenException,
-    );
+    await expect(
+      service.assertConversationAccess('user-1', 'conversation-1')
+    ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
   it('allows an unblocked participant and returns only the other participant ids', async () => {
     const { prisma, service } = build();
-    prisma.conversationParticipant.findUnique.mockResolvedValue(participant(['user-1', 'user-2', 'user-3']));
+    prisma.conversationParticipant.findUnique.mockResolvedValue(
+      participant(['user-1', 'user-2', 'user-3'])
+    );
     prisma.blockedUser.findFirst.mockResolvedValue(null);
 
     await expect(service.assertConversationAccess('user-1', 'conversation-1')).resolves.toEqual({
@@ -75,7 +77,7 @@ describe('ChatSecurityService', () => {
         conversationId: 'conversation-1',
         clientMessageId: 'client-message-123',
         text: 'hello',
-      }),
+      })
     ).resolves.toEqual({ message: persisted, duplicate: true });
     expect(prisma.$transaction).not.toHaveBeenCalled();
   });
@@ -91,7 +93,7 @@ describe('ChatSecurityService', () => {
         conversationId: 'conversation-1',
         clientMessageId: 'client-message-123',
         text: '   ',
-      }),
+      })
     ).rejects.toBeInstanceOf(BadRequestException);
     expect(prisma.$transaction).not.toHaveBeenCalled();
   });

--- a/apps/api/src/chat/chat-security.service.ts
+++ b/apps/api/src/chat/chat-security.service.ts
@@ -85,6 +85,7 @@ export class ChatSecurityService {
 
     const existing = await this.getReceipt(input.userId, input.clientMessageId);
     if (existing) {
+      this.assertReceiptConversation(existing, input.conversationId);
       const message = await this.prisma.message.findUnique({ where: { id: existing.message_id } });
       if (message) return { message, duplicate: true };
     }
@@ -99,6 +100,7 @@ export class ChatSecurityService {
           LIMIT 1
         `);
         if (receiptRows[0]) {
+          this.assertReceiptConversation(receiptRows[0], input.conversationId);
           const persisted = await tx.message.findUnique({ where: { id: receiptRows[0].message_id } });
           if (!persisted) throw new DuplicateReceiptRaceError();
           return { message: persisted, duplicate: true };
@@ -134,9 +136,16 @@ export class ChatSecurityService {
       if (!(error instanceof DuplicateReceiptRaceError)) throw error;
       const raced = await this.getReceipt(input.userId, input.clientMessageId);
       if (!raced) throw error;
+      this.assertReceiptConversation(raced, input.conversationId);
       const message = await this.prisma.message.findUnique({ where: { id: raced.message_id } });
       if (!message) throw error;
       return { message, duplicate: true };
+    }
+  }
+
+  private assertReceiptConversation(receipt: MessageReceiptRow, conversationId: string) {
+    if (receipt.conversation_id !== conversationId) {
+      throw new BadRequestException('clientMessageId has already been used');
     }
   }
 

--- a/apps/api/src/chat/chat-security.service.ts
+++ b/apps/api/src/chat/chat-security.service.ts
@@ -77,7 +77,9 @@ export class ChatSecurityService {
     const text = input.text.trim();
     if (!text) throw new BadRequestException('Message text is required');
     if (text.length > MAX_MESSAGE_LENGTH) {
-      throw new BadRequestException(`Message text must be ${MAX_MESSAGE_LENGTH} characters or fewer`);
+      throw new BadRequestException(
+        `Message text must be ${MAX_MESSAGE_LENGTH} characters or fewer`
+      );
     }
     if (!CLIENT_MESSAGE_ID_PATTERN.test(input.clientMessageId)) {
       throw new BadRequestException('clientMessageId is invalid');
@@ -101,7 +103,9 @@ export class ChatSecurityService {
         `);
         if (receiptRows[0]) {
           this.assertReceiptConversation(receiptRows[0], input.conversationId);
-          const persisted = await tx.message.findUnique({ where: { id: receiptRows[0].message_id } });
+          const persisted = await tx.message.findUnique({
+            where: { id: receiptRows[0].message_id },
+          });
           if (!persisted) throw new DuplicateReceiptRaceError();
           return { message: persisted, duplicate: true };
         }

--- a/apps/api/src/chat/chat-security.service.ts
+++ b/apps/api/src/chat/chat-security.service.ts
@@ -1,0 +1,153 @@
+import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+
+const MAX_MESSAGE_LENGTH = 4_000;
+const CLIENT_MESSAGE_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
+
+class DuplicateReceiptRaceError extends Error {}
+
+type MessageReceiptRow = {
+  message_id: string;
+  conversation_id: string;
+};
+
+export type PersistedChatMessage = {
+  id: string;
+  conversationId: string;
+  senderId: string;
+  text: string;
+  mediaUrls: string[];
+  createdAt: Date;
+};
+
+@Injectable()
+export class ChatSecurityService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async assertConversationAccess(userId: string, conversationId: string) {
+    const participant = await this.prisma.conversationParticipant.findUnique({
+      where: { conversationId_userId: { conversationId, userId } },
+      select: {
+        conversation: {
+          select: {
+            participants: { select: { userId: true } },
+          },
+        },
+      },
+    });
+
+    if (!participant) {
+      throw new ForbiddenException('Conversation is unavailable');
+    }
+
+    const otherUserIds = participant.conversation.participants
+      .map((entry) => entry.userId)
+      .filter((participantUserId) => participantUserId !== userId);
+
+    if (otherUserIds.length === 0) {
+      throw new ForbiddenException('Conversation is unavailable');
+    }
+
+    const blocked = await this.prisma.blockedUser.findFirst({
+      where: {
+        OR: otherUserIds.flatMap((otherUserId) => [
+          { userId, blockedId: otherUserId },
+          { userId: otherUserId, blockedId: userId },
+        ]),
+      },
+      select: { id: true },
+    });
+
+    if (blocked) {
+      throw new ForbiddenException('Conversation is unavailable');
+    }
+
+    return { otherUserIds };
+  }
+
+  async persistMessage(input: {
+    userId: string;
+    conversationId: string;
+    clientMessageId: string;
+    text: string;
+  }): Promise<{ message: PersistedChatMessage; duplicate: boolean }> {
+    await this.assertConversationAccess(input.userId, input.conversationId);
+
+    const text = input.text.trim();
+    if (!text) throw new BadRequestException('Message text is required');
+    if (text.length > MAX_MESSAGE_LENGTH) {
+      throw new BadRequestException(`Message text must be ${MAX_MESSAGE_LENGTH} characters or fewer`);
+    }
+    if (!CLIENT_MESSAGE_ID_PATTERN.test(input.clientMessageId)) {
+      throw new BadRequestException('clientMessageId is invalid');
+    }
+
+    const existing = await this.getReceipt(input.userId, input.clientMessageId);
+    if (existing) {
+      const message = await this.prisma.message.findUnique({ where: { id: existing.message_id } });
+      if (message) return { message, duplicate: true };
+    }
+
+    try {
+      const message = await this.prisma.$transaction(async (tx) => {
+        const receiptRows = await tx.$queryRaw<MessageReceiptRow[]>(Prisma.sql`
+          SELECT message_id, conversation_id
+          FROM dogos_chat.message_receipts
+          WHERE user_id = CAST(${input.userId} AS uuid)
+            AND client_message_id = ${input.clientMessageId}
+          LIMIT 1
+        `);
+        if (receiptRows[0]) {
+          const persisted = await tx.message.findUnique({ where: { id: receiptRows[0].message_id } });
+          if (!persisted) throw new DuplicateReceiptRaceError();
+          return { message: persisted, duplicate: true };
+        }
+
+        const persisted = await tx.message.create({
+          data: {
+            conversationId: input.conversationId,
+            senderId: input.userId,
+            text,
+          },
+        });
+
+        const inserted = await tx.$queryRaw<Array<{ message_id: string }>>(Prisma.sql`
+          INSERT INTO dogos_chat.message_receipts (
+            user_id, client_message_id, conversation_id, message_id
+          ) VALUES (
+            CAST(${input.userId} AS uuid),
+            ${input.clientMessageId},
+            CAST(${input.conversationId} AS uuid),
+            CAST(${persisted.id} AS uuid)
+          )
+          ON CONFLICT (user_id, client_message_id) DO NOTHING
+          RETURNING message_id
+        `);
+
+        if (inserted.length === 0) throw new DuplicateReceiptRaceError();
+        return { message: persisted, duplicate: false };
+      });
+
+      return message;
+    } catch (error) {
+      if (!(error instanceof DuplicateReceiptRaceError)) throw error;
+      const raced = await this.getReceipt(input.userId, input.clientMessageId);
+      if (!raced) throw error;
+      const message = await this.prisma.message.findUnique({ where: { id: raced.message_id } });
+      if (!message) throw error;
+      return { message, duplicate: true };
+    }
+  }
+
+  private async getReceipt(userId: string, clientMessageId: string) {
+    const rows = await this.prisma.$queryRaw<MessageReceiptRow[]>(Prisma.sql`
+      SELECT message_id, conversation_id
+      FROM dogos_chat.message_receipts
+      WHERE user_id = CAST(${userId} AS uuid)
+        AND client_message_id = ${clientMessageId}
+      LIMIT 1
+    `);
+    return rows[0] ?? null;
+  }
+}

--- a/apps/api/src/chat/chat-security.service.ts
+++ b/apps/api/src/chat/chat-security.service.ts
@@ -95,7 +95,7 @@ export class ChatSecurityService {
         const receiptRows = await tx.$queryRaw<MessageReceiptRow[]>(Prisma.sql`
           SELECT message_id, conversation_id
           FROM dogos_chat.message_receipts
-          WHERE user_id = CAST(${input.userId} AS uuid)
+          WHERE user_id = CAST(${input.userId} AS text)
             AND client_message_id = ${input.clientMessageId}
           LIMIT 1
         `);
@@ -118,10 +118,10 @@ export class ChatSecurityService {
           INSERT INTO dogos_chat.message_receipts (
             user_id, client_message_id, conversation_id, message_id
           ) VALUES (
-            CAST(${input.userId} AS uuid),
+            CAST(${input.userId} AS text),
             ${input.clientMessageId},
-            CAST(${input.conversationId} AS uuid),
-            CAST(${persisted.id} AS uuid)
+            CAST(${input.conversationId} AS text),
+            CAST(${persisted.id} AS text)
           )
           ON CONFLICT (user_id, client_message_id) DO NOTHING
           RETURNING message_id
@@ -153,7 +153,7 @@ export class ChatSecurityService {
     const rows = await this.prisma.$queryRaw<MessageReceiptRow[]>(Prisma.sql`
       SELECT message_id, conversation_id
       FROM dogos_chat.message_receipts
-      WHERE user_id = CAST(${userId} AS uuid)
+      WHERE user_id = CAST(${userId} AS text)
         AND client_message_id = ${clientMessageId}
       LIMIT 1
     `);

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -21,7 +21,7 @@ export class ChatController {
   @ApiOperation({ summary: 'Create or reuse an authorized direct conversation' })
   create(
     @Request() req: AuthenticatedRequest,
-    @Body() body: { participantId?: string; participantIds?: string[] },
+    @Body() body: { participantId?: string; participantIds?: string[] }
   ) {
     const participantId = body.participantId ?? body.participantIds?.[0];
     return this.chatService.createDirectConversation(req.user.sub, participantId ?? '');
@@ -33,13 +33,13 @@ export class ChatController {
     @Request() req: AuthenticatedRequest,
     @Param('id') id: string,
     @Query('page') page?: string,
-    @Query('limit') limit?: string,
+    @Query('limit') limit?: string
   ) {
     return this.chatService.getMessages(
       req.user.sub,
       id,
       page ? Number(page) : 1,
-      limit ? Number(limit) : 50,
+      limit ? Number(limit) : 50
     );
   }
 

--- a/apps/api/src/chat/chat.controller.ts
+++ b/apps/api/src/chat/chat.controller.ts
@@ -1,0 +1,51 @@
+import { Body, Controller, Get, Param, Post, Query, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { AuthenticatedRequest } from '../auth/authenticated-request';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ChatService } from './chat.service';
+
+@ApiTags('chat')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('chat')
+export class ChatController {
+  constructor(private readonly chatService: ChatService) {}
+
+  @Get('conversations')
+  @ApiOperation({ summary: 'List authorized direct conversations' })
+  list(@Request() req: AuthenticatedRequest) {
+    return this.chatService.listConversations(req.user.sub);
+  }
+
+  @Post('conversations')
+  @ApiOperation({ summary: 'Create or reuse an authorized direct conversation' })
+  create(
+    @Request() req: AuthenticatedRequest,
+    @Body() body: { participantId?: string; participantIds?: string[] },
+  ) {
+    const participantId = body.participantId ?? body.participantIds?.[0];
+    return this.chatService.createDirectConversation(req.user.sub, participantId ?? '');
+  }
+
+  @Get('conversations/:id/messages')
+  @ApiOperation({ summary: 'Read bounded canonical message history' })
+  messages(
+    @Request() req: AuthenticatedRequest,
+    @Param('id') id: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.chatService.getMessages(
+      req.user.sub,
+      id,
+      page ? Number(page) : 1,
+      limit ? Number(limit) : 50,
+    );
+  }
+
+  @Post('conversations/:id/read')
+  @ApiOperation({ summary: 'Advance the signed-in participant read watermark' })
+  markRead(@Request() req: AuthenticatedRequest, @Param('id') id: string) {
+    return this.chatService.markRead(req.user.sub, id);
+  }
+}

--- a/apps/api/src/chat/chat.gateway.ts
+++ b/apps/api/src/chat/chat.gateway.ts
@@ -1,23 +1,22 @@
-import {
-  WebSocketGateway,
-  WebSocketServer,
-  SubscribeMessage,
-  OnGatewayConnection,
-  OnGatewayDisconnect,
-  ConnectedSocket,
-  MessageBody,
-} from '@nestjs/websockets';
-import { Server, Socket } from 'socket.io';
 import { Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { PrismaService } from '../prisma/prisma.service';
+import {
+  ConnectedSocket,
+  MessageBody,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
 import { NudgesService } from '../nudges/nudges.service';
+import { ChatSecurityService } from './chat-security.service';
 
-interface ChatMessage {
+interface SendChatMessage {
   conversationId: string;
-  senderId: string;
+  clientMessageId: string;
   text: string;
-  timestamp: Date;
 }
 
 @WebSocketGateway({
@@ -30,120 +29,144 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
   server: Server;
 
-  private logger = new Logger(ChatGateway.name);
-  private connectedUsers = new Map<string, string>();
+  private readonly logger = new Logger(ChatGateway.name);
+  private readonly connectedUsers = new Map<string, string>();
 
   constructor(
-    private jwtService: JwtService,
-    private prisma: PrismaService,
-    private nudgesService: NudgesService,
+    private readonly jwtService: JwtService,
+    private readonly chatSecurity: ChatSecurityService,
+    private readonly nudgesService: NudgesService,
   ) {}
 
   async handleConnection(client: Socket) {
     try {
       const token = client.handshake.auth.token;
-
       if (!token) {
         client.disconnect();
         return;
       }
 
-      const payload = await this.jwtService.verifyAsync(token);
-      const userId = payload.sub;
+      const payload = await this.jwtService.verifyAsync<{ sub?: string }>(token);
+      if (!payload.sub) {
+        client.disconnect();
+        return;
+      }
 
-      this.connectedUsers.set(client.id, userId);
-      this.logger.log(`User ${userId} connected: ${client.id}`);
-
-      client.join(`user:${userId}`);
-      this.server.emit('user:online', { userId });
+      this.connectedUsers.set(client.id, payload.sub);
+      await client.join(`user:${payload.sub}`);
     } catch (error) {
-      this.logger.error(`Connection error: ${error.message}`);
+      this.logger.warn(`Rejected socket connection: ${this.errorName(error)}`);
       client.disconnect();
     }
   }
 
   handleDisconnect(client: Socket) {
-    const userId = this.connectedUsers.get(client.id);
-    if (userId) {
-      this.logger.log(`User ${userId} disconnected: ${client.id}`);
-      this.connectedUsers.delete(client.id);
-      this.server.emit('user:offline', { userId });
-    }
+    this.connectedUsers.delete(client.id);
   }
 
   @SubscribeMessage('message:send')
   async handleMessage(
     @ConnectedSocket() client: Socket,
-    @MessageBody() data: ChatMessage,
+    @MessageBody() data: SendChatMessage,
   ) {
     const userId = this.connectedUsers.get(client.id);
-
-    if (!userId) {
-      return { error: 'Unauthorized' };
-    }
-
-    const message = {
-      ...data,
-      senderId: userId,
-      timestamp: new Date(),
-    };
+    if (!userId) return { success: false, error: 'unauthorized' };
 
     try {
-      await this.prisma.message.create({
-        data: {
-          conversationId: data.conversationId,
-          senderId: userId,
-          text: data.text,
-        },
+      const result = await this.chatSecurity.persistMessage({
+        userId,
+        conversationId: data.conversationId,
+        clientMessageId: data.clientMessageId,
+        text: data.text,
       });
 
-      await this.nudgesService.checkChatActivityNudges(data.conversationId, userId).catch((err) => {
-        this.logger.error(`Failed to check chat nudges: ${err.message}`);
-      });
+      const message = {
+        id: result.message.id,
+        conversationId: result.message.conversationId,
+        senderId: result.message.senderId,
+        text: result.message.text,
+        mediaUrls: result.message.mediaUrls,
+        timestamp: result.message.createdAt,
+      };
+
+      if (!result.duplicate) {
+        this.server.to(`conversation:${data.conversationId}`).emit('message:received', message);
+        void this.nudgesService.checkChatActivityNudges(data.conversationId, userId).catch((error) => {
+          this.logger.warn(`Chat nudge check failed: ${this.errorName(error)}`);
+        });
+      }
+
+      return { success: true, duplicate: result.duplicate, message };
     } catch (error) {
-      this.logger.error(`Failed to save message: ${error.message}`);
+      this.logger.warn(`Rejected chat message: ${this.errorName(error)}`);
+      return { success: false, error: 'message_rejected' };
     }
-
-    this.server.to(`conversation:${data.conversationId}`).emit('message:received', message);
-
-    return { success: true, message };
   }
 
   @SubscribeMessage('conversation:join')
-  handleJoinConversation(
+  async handleJoinConversation(
     @ConnectedSocket() client: Socket,
     @MessageBody() data: { conversationId: string },
   ) {
-    client.join(`conversation:${data.conversationId}`);
-    this.logger.log(`User joined conversation: ${data.conversationId}`);
-    return { success: true };
+    const userId = this.connectedUsers.get(client.id);
+    if (!userId) return { success: false, error: 'unauthorized' };
+
+    try {
+      await this.chatSecurity.assertConversationAccess(userId, data.conversationId);
+      await client.join(`conversation:${data.conversationId}`);
+      return { success: true };
+    } catch {
+      return { success: false, error: 'conversation_unavailable' };
+    }
   }
 
   @SubscribeMessage('conversation:leave')
-  handleLeaveConversation(
+  async handleLeaveConversation(
     @ConnectedSocket() client: Socket,
     @MessageBody() data: { conversationId: string },
   ) {
-    client.leave(`conversation:${data.conversationId}`);
-    this.logger.log(`User left conversation: ${data.conversationId}`);
-    return { success: true };
+    const userId = this.connectedUsers.get(client.id);
+    if (!userId) return { success: false, error: 'unauthorized' };
+
+    try {
+      await this.chatSecurity.assertConversationAccess(userId, data.conversationId);
+      await client.leave(`conversation:${data.conversationId}`);
+      return { success: true };
+    } catch {
+      return { success: false, error: 'conversation_unavailable' };
+    }
   }
 
   @SubscribeMessage('typing:start')
-  handleTypingStart(
+  async handleTypingStart(
     @ConnectedSocket() client: Socket,
     @MessageBody() data: { conversationId: string },
   ) {
-    const userId = this.connectedUsers.get(client.id);
-    client.to(`conversation:${data.conversationId}`).emit('typing:start', { userId });
+    return this.emitTyping(client, data.conversationId, 'typing:start');
   }
 
   @SubscribeMessage('typing:stop')
-  handleTypingStop(
+  async handleTypingStop(
     @ConnectedSocket() client: Socket,
     @MessageBody() data: { conversationId: string },
   ) {
+    return this.emitTyping(client, data.conversationId, 'typing:stop');
+  }
+
+  private async emitTyping(client: Socket, conversationId: string, event: 'typing:start' | 'typing:stop') {
     const userId = this.connectedUsers.get(client.id);
-    client.to(`conversation:${data.conversationId}`).emit('typing:stop', { userId });
+    if (!userId) return { success: false, error: 'unauthorized' };
+
+    try {
+      await this.chatSecurity.assertConversationAccess(userId, conversationId);
+      client.to(`conversation:${conversationId}`).emit(event, { userId });
+      return { success: true };
+    } catch {
+      return { success: false, error: 'conversation_unavailable' };
+    }
+  }
+
+  private errorName(error: unknown) {
+    return error instanceof Error ? error.name : 'UnknownError';
   }
 }

--- a/apps/api/src/chat/chat.gateway.ts
+++ b/apps/api/src/chat/chat.gateway.ts
@@ -35,7 +35,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   constructor(
     private readonly jwtService: JwtService,
     private readonly chatSecurity: ChatSecurityService,
-    private readonly nudgesService: NudgesService,
+    private readonly nudgesService: NudgesService
   ) {}
 
   async handleConnection(client: Socket) {
@@ -65,10 +65,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   @SubscribeMessage('message:send')
-  async handleMessage(
-    @ConnectedSocket() client: Socket,
-    @MessageBody() data: SendChatMessage,
-  ) {
+  async handleMessage(@ConnectedSocket() client: Socket, @MessageBody() data: SendChatMessage) {
     const userId = this.connectedUsers.get(client.id);
     if (!userId) return { success: false, error: 'unauthorized' };
 
@@ -91,9 +88,11 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
       if (!result.duplicate) {
         this.server.to(`conversation:${data.conversationId}`).emit('message:received', message);
-        void this.nudgesService.checkChatActivityNudges(data.conversationId, userId).catch((error) => {
-          this.logger.warn(`Chat nudge check failed: ${this.errorName(error)}`);
-        });
+        void this.nudgesService
+          .checkChatActivityNudges(data.conversationId, userId)
+          .catch((error) => {
+            this.logger.warn(`Chat nudge check failed: ${this.errorName(error)}`);
+          });
       }
 
       return { success: true, duplicate: result.duplicate, message };
@@ -106,7 +105,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @SubscribeMessage('conversation:join')
   async handleJoinConversation(
     @ConnectedSocket() client: Socket,
-    @MessageBody() data: { conversationId: string },
+    @MessageBody() data: { conversationId: string }
   ) {
     const userId = this.connectedUsers.get(client.id);
     if (!userId) return { success: false, error: 'unauthorized' };
@@ -123,7 +122,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @SubscribeMessage('conversation:leave')
   async handleLeaveConversation(
     @ConnectedSocket() client: Socket,
-    @MessageBody() data: { conversationId: string },
+    @MessageBody() data: { conversationId: string }
   ) {
     const userId = this.connectedUsers.get(client.id);
     if (!userId) return { success: false, error: 'unauthorized' };
@@ -140,7 +139,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @SubscribeMessage('typing:start')
   async handleTypingStart(
     @ConnectedSocket() client: Socket,
-    @MessageBody() data: { conversationId: string },
+    @MessageBody() data: { conversationId: string }
   ) {
     return this.emitTyping(client, data.conversationId, 'typing:start');
   }
@@ -148,12 +147,16 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @SubscribeMessage('typing:stop')
   async handleTypingStop(
     @ConnectedSocket() client: Socket,
-    @MessageBody() data: { conversationId: string },
+    @MessageBody() data: { conversationId: string }
   ) {
     return this.emitTyping(client, data.conversationId, 'typing:stop');
   }
 
-  private async emitTyping(client: Socket, conversationId: string, event: 'typing:start' | 'typing:stop') {
+  private async emitTyping(
+    client: Socket,
+    conversationId: string,
+    event: 'typing:start' | 'typing:stop'
+  ) {
     const userId = this.connectedUsers.get(client.id);
     if (!userId) return { success: false, error: 'unauthorized' };
 

--- a/apps/api/src/chat/chat.module.ts
+++ b/apps/api/src/chat/chat.module.ts
@@ -3,8 +3,10 @@ import { ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { NudgesModule } from '../nudges/nudges.module';
 import { PrismaModule } from '../prisma/prisma.module';
+import { ChatController } from './chat.controller';
 import { ChatGateway } from './chat.gateway';
 import { ChatSecurityService } from './chat-security.service';
+import { ChatService } from './chat.service';
 
 @Module({
   imports: [
@@ -18,6 +20,7 @@ import { ChatSecurityService } from './chat-security.service';
     NudgesModule,
     PrismaModule,
   ],
-  providers: [ChatGateway, ChatSecurityService],
+  controllers: [ChatController],
+  providers: [ChatGateway, ChatSecurityService, ChatService],
 })
 export class ChatModule {}

--- a/apps/api/src/chat/chat.module.ts
+++ b/apps/api/src/chat/chat.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
-import { JwtModule } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
-import { ChatGateway } from './chat.gateway';
+import { JwtModule } from '@nestjs/jwt';
 import { NudgesModule } from '../nudges/nudges.module';
 import { PrismaModule } from '../prisma/prisma.module';
+import { ChatGateway } from './chat.gateway';
+import { ChatSecurityService } from './chat-security.service';
 
 @Module({
   imports: [
@@ -17,6 +18,6 @@ import { PrismaModule } from '../prisma/prisma.module';
     NudgesModule,
     PrismaModule,
   ],
-  providers: [ChatGateway],
+  providers: [ChatGateway, ChatSecurityService],
 })
 export class ChatModule {}

--- a/apps/api/src/chat/chat.service.spec.ts
+++ b/apps/api/src/chat/chat.service.spec.ts
@@ -1,0 +1,87 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ChatService } from './chat.service';
+
+const directConversation = {
+  id: 'conversation-1',
+  participants: [{ userId: 'user-1' }, { userId: 'user-2' }],
+};
+
+describe('ChatService direct conversation privacy', () => {
+  function build() {
+    const prisma = {
+      user: { findUnique: jest.fn() },
+      blockedUser: { findFirst: jest.fn() },
+      conversation: { findMany: jest.fn(), create: jest.fn() },
+      telemetry: { create: jest.fn() },
+    };
+    const security = { assertConversationAccess: jest.fn() };
+    return {
+      prisma,
+      service: new ChatService(prisma as never, security as never),
+    };
+  }
+
+  it('rejects a brand-new conversation with a FRIENDS_ONLY profile', async () => {
+    const { prisma, service } = build();
+    prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'FRIENDS_ONLY' });
+    prisma.blockedUser.findFirst.mockResolvedValue(null);
+    prisma.conversation.findMany.mockResolvedValue([]);
+
+    await expect(service.createDirectConversation('user-1', 'user-2')).rejects.toBeInstanceOf(
+      NotFoundException
+    );
+    expect(prisma.conversation.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a brand-new conversation with a PRIVATE profile', async () => {
+    const { prisma, service } = build();
+    prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'PRIVATE' });
+    prisma.blockedUser.findFirst.mockResolvedValue(null);
+    prisma.conversation.findMany.mockResolvedValue([]);
+
+    await expect(service.createDirectConversation('user-1', 'user-2')).rejects.toBeInstanceOf(
+      NotFoundException
+    );
+    expect(prisma.conversation.create).not.toHaveBeenCalled();
+  });
+
+  it('reuses an established direct conversation after profile visibility becomes restricted', async () => {
+    const { prisma, service } = build();
+    prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'FRIENDS_ONLY' });
+    prisma.blockedUser.findFirst.mockResolvedValue(null);
+    prisma.conversation.findMany.mockResolvedValue([directConversation]);
+
+    await expect(service.createDirectConversation('user-1', 'user-2')).resolves.toEqual({
+      id: 'conversation-1',
+      created: false,
+    });
+    expect(prisma.conversation.create).not.toHaveBeenCalled();
+  });
+
+  it('does not reuse an established conversation when either participant has blocked the other', async () => {
+    const { prisma, service } = build();
+    prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'PUBLIC' });
+    prisma.blockedUser.findFirst.mockResolvedValue({ id: 'block-1' });
+    prisma.conversation.findMany.mockResolvedValue([directConversation]);
+
+    await expect(service.createDirectConversation('user-1', 'user-2')).rejects.toBeInstanceOf(
+      ForbiddenException
+    );
+    expect(prisma.conversation.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a conversation only for a public, unblocked profile with no existing direct thread', async () => {
+    const { prisma, service } = build();
+    prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'PUBLIC' });
+    prisma.blockedUser.findFirst.mockResolvedValue(null);
+    prisma.conversation.findMany.mockResolvedValue([]);
+    prisma.conversation.create.mockResolvedValue({ id: 'conversation-2' });
+    prisma.telemetry.create.mockResolvedValue({ id: 'telemetry-1' });
+
+    await expect(service.createDirectConversation('user-1', 'user-2')).resolves.toEqual({
+      id: 'conversation-2',
+      created: true,
+    });
+    expect(prisma.conversation.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -113,7 +113,7 @@ export class ChatService {
       throw new BadRequestException('Choose another member');
     }
 
-    const [target, blocked] = await Promise.all([
+    const [target, blocked, candidates] = await Promise.all([
       this.prisma.user.findUnique({
         where: { id: participantId },
         select: { id: true, visibility: true },
@@ -127,20 +127,20 @@ export class ChatService {
         },
         select: { id: true },
       }),
+      this.prisma.conversation.findMany({
+        where: {
+          AND: [
+            { participants: { some: { userId } } },
+            { participants: { some: { userId: participantId } } },
+          ],
+        },
+        select: { id: true, participants: { select: { userId: true } } },
+        take: 20,
+      }),
     ]);
-    if (!target || target.visibility === 'PRIVATE') throw new NotFoundException('Member not found');
+
     if (blocked) throw new ForbiddenException('Conversation is unavailable');
 
-    const candidates = await this.prisma.conversation.findMany({
-      where: {
-        AND: [
-          { participants: { some: { userId } } },
-          { participants: { some: { userId: participantId } } },
-        ],
-      },
-      select: { id: true, participants: { select: { userId: true } } },
-      take: 20,
-    });
     const existing = candidates.find(
       (conversation) =>
         conversation.participants.length === 2 &&
@@ -148,6 +148,10 @@ export class ChatService {
         conversation.participants.some((participant) => participant.userId === participantId)
     );
     if (existing) return { id: existing.id, created: false };
+
+    if (!target || target.visibility !== 'PUBLIC') {
+      throw new NotFoundException('Member not found');
+    }
 
     const conversation = await this.prisma.conversation.create({
       data: {

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -1,4 +1,9 @@
-import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { Prisma } from '@woof/database';
 import { PrismaService } from '../prisma/prisma.service';
 import { ChatSecurityService } from './chat-security.service';
@@ -10,7 +15,7 @@ const MAX_MESSAGES = 100;
 export class ChatService {
   constructor(
     private readonly prisma: PrismaService,
-    private readonly security: ChatSecurityService,
+    private readonly security: ChatSecurityService
   ) {}
 
   async listConversations(userId: string) {
@@ -62,7 +67,9 @@ export class ChatService {
       }
 
       const self = conversation.participants.find((participant) => participant.userId === userId);
-      const others = conversation.participants.filter((participant) => participant.userId !== userId);
+      const others = conversation.participants.filter(
+        (participant) => participant.userId !== userId
+      );
       if (others.length !== 1) continue;
       const other = others[0]!;
       const lastMessage = conversation.messages[0] ?? null;
@@ -138,7 +145,7 @@ export class ChatService {
       (conversation) =>
         conversation.participants.length === 2 &&
         conversation.participants.some((participant) => participant.userId === userId) &&
-        conversation.participants.some((participant) => participant.userId === participantId),
+        conversation.participants.some((participant) => participant.userId === participantId)
     );
     if (existing) return { id: existing.id, created: false };
 

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -1,0 +1,210 @@
+import { BadRequestException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+import { ChatSecurityService } from './chat-security.service';
+
+const MAX_CONVERSATIONS = 50;
+const MAX_MESSAGES = 100;
+
+@Injectable()
+export class ChatService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly security: ChatSecurityService,
+  ) {}
+
+  async listConversations(userId: string) {
+    const conversations = await this.prisma.conversation.findMany({
+      where: { participants: { some: { userId } } },
+      orderBy: { updatedAt: 'desc' },
+      take: MAX_CONVERSATIONS,
+      select: {
+        id: true,
+        updatedAt: true,
+        participants: {
+          select: {
+            userId: true,
+            lastReadAt: true,
+            user: {
+              select: {
+                id: true,
+                handle: true,
+                avatarUrl: true,
+                pets: {
+                  orderBy: { createdAt: 'asc' },
+                  take: 1,
+                  select: { id: true, name: true, avatarUrl: true },
+                },
+              },
+            },
+          },
+        },
+        messages: {
+          orderBy: { createdAt: 'desc' },
+          take: 1,
+          select: {
+            id: true,
+            senderId: true,
+            text: true,
+            mediaUrls: true,
+            createdAt: true,
+          },
+        },
+      },
+    });
+
+    const visible = [];
+    for (const conversation of conversations) {
+      try {
+        await this.security.assertConversationAccess(userId, conversation.id);
+      } catch {
+        continue;
+      }
+
+      const self = conversation.participants.find((participant) => participant.userId === userId);
+      const others = conversation.participants.filter((participant) => participant.userId !== userId);
+      if (others.length !== 1) continue;
+      const other = others[0]!;
+      const lastMessage = conversation.messages[0] ?? null;
+      const unreadCount = await this.prisma.message.count({
+        where: {
+          conversationId: conversation.id,
+          senderId: { not: userId },
+          ...(self?.lastReadAt ? { createdAt: { gt: self.lastReadAt } } : {}),
+        },
+      });
+
+      visible.push({
+        id: conversation.id,
+        participant: {
+          id: other.user.id,
+          name: other.user.handle,
+          avatarUrl: other.user.avatarUrl,
+          petId: other.user.pets[0]?.id ?? null,
+          petName: other.user.pets[0]?.name ?? null,
+          petAvatarUrl: other.user.pets[0]?.avatarUrl ?? null,
+        },
+        lastMessage: lastMessage
+          ? {
+              id: lastMessage.id,
+              senderId: lastMessage.senderId,
+              content: lastMessage.text,
+              mediaUrls: lastMessage.mediaUrls,
+              createdAt: lastMessage.createdAt,
+            }
+          : null,
+        unreadCount,
+        updatedAt: conversation.updatedAt,
+      });
+    }
+
+    return visible;
+  }
+
+  async createDirectConversation(userId: string, participantId: string) {
+    if (!participantId || participantId === userId) {
+      throw new BadRequestException('Choose another member');
+    }
+
+    const [target, blocked] = await Promise.all([
+      this.prisma.user.findUnique({
+        where: { id: participantId },
+        select: { id: true, visibility: true },
+      }),
+      this.prisma.blockedUser.findFirst({
+        where: {
+          OR: [
+            { userId, blockedId: participantId },
+            { userId: participantId, blockedId: userId },
+          ],
+        },
+        select: { id: true },
+      }),
+    ]);
+    if (!target || target.visibility === 'PRIVATE') throw new NotFoundException('Member not found');
+    if (blocked) throw new ForbiddenException('Conversation is unavailable');
+
+    const candidates = await this.prisma.conversation.findMany({
+      where: {
+        AND: [
+          { participants: { some: { userId } } },
+          { participants: { some: { userId: participantId } } },
+        ],
+      },
+      select: { id: true, participants: { select: { userId: true } } },
+      take: 20,
+    });
+    const existing = candidates.find(
+      (conversation) =>
+        conversation.participants.length === 2 &&
+        conversation.participants.some((participant) => participant.userId === userId) &&
+        conversation.participants.some((participant) => participant.userId === participantId),
+    );
+    if (existing) return { id: existing.id, created: false };
+
+    const conversation = await this.prisma.conversation.create({
+      data: {
+        participants: {
+          create: [{ userId }, { userId: participantId }],
+        },
+      },
+      select: { id: true },
+    });
+    await this.recordTelemetry(userId, 'CONVERSATION_STARTED', { conversationId: conversation.id });
+    return { id: conversation.id, created: true };
+  }
+
+  async getMessages(userId: string, conversationId: string, page = 1, limit = 50) {
+    await this.security.assertConversationAccess(userId, conversationId);
+    const safePage = Math.max(1, Number(page) || 1);
+    const safeLimit = Math.max(1, Math.min(Number(limit) || 50, MAX_MESSAGES));
+    const skip = (safePage - 1) * safeLimit;
+    const [messages, total] = await Promise.all([
+      this.prisma.message.findMany({
+        where: { conversationId },
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: safeLimit,
+        select: {
+          id: true,
+          conversationId: true,
+          senderId: true,
+          text: true,
+          mediaUrls: true,
+          createdAt: true,
+        },
+      }),
+      this.prisma.message.count({ where: { conversationId } }),
+    ]);
+
+    return {
+      data: messages.reverse().map((message) => ({
+        id: message.id,
+        conversationId: message.conversationId,
+        senderId: message.senderId,
+        content: message.text,
+        type: message.mediaUrls.length > 0 ? 'image' : 'text',
+        mediaUrl: message.mediaUrls[0] ?? null,
+        createdAt: message.createdAt,
+      })),
+      total,
+      page: safePage,
+      limit: safeLimit,
+    };
+  }
+
+  async markRead(userId: string, conversationId: string) {
+    await this.security.assertConversationAccess(userId, conversationId);
+    await this.prisma.conversationParticipant.update({
+      where: { conversationId_userId: { conversationId, userId } },
+      data: { lastReadAt: new Date() },
+    });
+    return { ok: true };
+  }
+
+  private async recordTelemetry(userId: string, event: string, data: Prisma.InputJsonObject) {
+    await this.prisma.telemetry.create({
+      data: { userId, source: 'chat', event, data },
+    });
+  }
+}

--- a/apps/api/src/discovery/discovery-location.store.ts
+++ b/apps/api/src/discovery/discovery-location.store.ts
@@ -27,7 +27,7 @@ export class DiscoveryLocationStore {
       INSERT INTO dogos_discovery.locations (
         user_id, lat_bucket, lng_bucket, precision_m, enabled, expires_at, updated_at
       ) VALUES (
-        CAST(${input.userId} AS uuid), ${input.latBucket}, ${input.lngBucket},
+        CAST(${input.userId} AS text), ${input.latBucket}, ${input.lngBucket},
         ${input.precisionM}, TRUE, ${input.expiresAt}, NOW()
       )
       ON CONFLICT (user_id) DO UPDATE SET
@@ -46,7 +46,7 @@ export class DiscoveryLocationStore {
     await this.prisma.$executeRaw(Prisma.sql`
       UPDATE dogos_discovery.locations
       SET enabled = FALSE, updated_at = NOW()
-      WHERE user_id = CAST(${userId} AS uuid)
+      WHERE user_id = CAST(${userId} AS text)
     `);
   }
 
@@ -54,7 +54,7 @@ export class DiscoveryLocationStore {
     const rows = await this.prisma.$queryRaw<LocationRow[]>(Prisma.sql`
       SELECT user_id, lat_bucket, lng_bucket, precision_m, enabled, expires_at, updated_at
       FROM dogos_discovery.locations
-      WHERE user_id = CAST(${userId} AS uuid)
+      WHERE user_id = CAST(${userId} AS text)
       LIMIT 1
     `);
     return rows[0] ?? null;
@@ -71,7 +71,7 @@ export class DiscoveryLocationStore {
     return this.prisma.$queryRaw<LocationRow[]>(Prisma.sql`
       SELECT user_id, lat_bucket, lng_bucket, precision_m, enabled, expires_at, updated_at
       FROM dogos_discovery.locations
-      WHERE user_id <> CAST(${input.userId} AS uuid)
+      WHERE user_id <> CAST(${input.userId} AS text)
         AND enabled = TRUE
         AND expires_at > NOW()
         AND lat_bucket BETWEEN ${input.minLatBucket} AND ${input.maxLatBucket}

--- a/apps/api/src/discovery/discovery-location.store.ts
+++ b/apps/api/src/discovery/discovery-location.store.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+
+type LocationRow = {
+  user_id: string;
+  lat_bucket: number;
+  lng_bucket: number;
+  precision_m: number;
+  enabled: boolean;
+  expires_at: Date;
+  updated_at: Date;
+};
+
+@Injectable()
+export class DiscoveryLocationStore {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async upsert(input: {
+    userId: string;
+    latBucket: number;
+    lngBucket: number;
+    precisionM: number;
+    expiresAt: Date;
+  }) {
+    const rows = await this.prisma.$queryRaw<LocationRow[]>(Prisma.sql`
+      INSERT INTO dogos_discovery.locations (
+        user_id, lat_bucket, lng_bucket, precision_m, enabled, expires_at, updated_at
+      ) VALUES (
+        CAST(${input.userId} AS uuid), ${input.latBucket}, ${input.lngBucket},
+        ${input.precisionM}, TRUE, ${input.expiresAt}, NOW()
+      )
+      ON CONFLICT (user_id) DO UPDATE SET
+        lat_bucket = EXCLUDED.lat_bucket,
+        lng_bucket = EXCLUDED.lng_bucket,
+        precision_m = EXCLUDED.precision_m,
+        enabled = TRUE,
+        expires_at = EXCLUDED.expires_at,
+        updated_at = NOW()
+      RETURNING user_id, lat_bucket, lng_bucket, precision_m, enabled, expires_at, updated_at
+    `);
+    return rows[0]!;
+  }
+
+  async disable(userId: string) {
+    await this.prisma.$executeRaw(Prisma.sql`
+      UPDATE dogos_discovery.locations
+      SET enabled = FALSE, updated_at = NOW()
+      WHERE user_id = CAST(${userId} AS uuid)
+    `);
+  }
+
+  async get(userId: string) {
+    const rows = await this.prisma.$queryRaw<LocationRow[]>(Prisma.sql`
+      SELECT user_id, lat_bucket, lng_bucket, precision_m, enabled, expires_at, updated_at
+      FROM dogos_discovery.locations
+      WHERE user_id = CAST(${userId} AS uuid)
+      LIMIT 1
+    `);
+    return rows[0] ?? null;
+  }
+
+  async findNearby(input: {
+    userId: string;
+    minLatBucket: number;
+    maxLatBucket: number;
+    minLngBucket: number;
+    maxLngBucket: number;
+    take: number;
+  }) {
+    return this.prisma.$queryRaw<LocationRow[]>(Prisma.sql`
+      SELECT user_id, lat_bucket, lng_bucket, precision_m, enabled, expires_at, updated_at
+      FROM dogos_discovery.locations
+      WHERE user_id <> CAST(${input.userId} AS uuid)
+        AND enabled = TRUE
+        AND expires_at > NOW()
+        AND lat_bucket BETWEEN ${input.minLatBucket} AND ${input.maxLatBucket}
+        AND lng_bucket BETWEEN ${input.minLngBucket} AND ${input.maxLngBucket}
+      ORDER BY updated_at DESC
+      LIMIT ${input.take}
+    `);
+  }
+}

--- a/apps/api/src/discovery/discovery.controller.ts
+++ b/apps/api/src/discovery/discovery.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Delete, Get, Param, Put, Query, Request, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Put,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import type { AuthenticatedRequest } from '../auth/authenticated-request';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -13,11 +23,10 @@ export class DiscoveryController {
   constructor(private readonly discoveryService: DiscoveryService) {}
 
   @Put('location')
-  @ApiOperation({ summary: 'Opt into nearby discovery using a coarse server-derived location cell' })
-  updateLocation(
-    @Request() req: AuthenticatedRequest,
-    @Body() dto: UpdateDiscoveryLocationDto,
-  ) {
+  @ApiOperation({
+    summary: 'Opt into nearby discovery using a coarse server-derived location cell',
+  })
+  updateLocation(@Request() req: AuthenticatedRequest, @Body() dto: UpdateDiscoveryLocationDto) {
     return this.discoveryService.updateLocation(req.user.sub, dto.latitude, dto.longitude);
   }
 
@@ -39,13 +48,13 @@ export class DiscoveryController {
     @Request() req: AuthenticatedRequest,
     @Param('petId') petId: string,
     @Query('radiusKm') radiusKm?: string,
-    @Query('limit') limit?: string,
+    @Query('limit') limit?: string
   ) {
     return this.discoveryService.getNearbyCandidates(
       req.user.sub,
       petId,
       radiusKm ? Number(radiusKm) : 5,
-      limit ? Number(limit) : 20,
+      limit ? Number(limit) : 20
     );
   }
 }

--- a/apps/api/src/discovery/discovery.controller.ts
+++ b/apps/api/src/discovery/discovery.controller.ts
@@ -1,0 +1,51 @@
+import { Body, Controller, Delete, Get, Param, Put, Query, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { AuthenticatedRequest } from '../auth/authenticated-request';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { DiscoveryService } from './discovery.service';
+import { UpdateDiscoveryLocationDto } from './dto/discovery-location.dto';
+
+@ApiTags('discovery')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('discovery')
+export class DiscoveryController {
+  constructor(private readonly discoveryService: DiscoveryService) {}
+
+  @Put('location')
+  @ApiOperation({ summary: 'Opt into nearby discovery using a coarse server-derived location cell' })
+  updateLocation(
+    @Request() req: AuthenticatedRequest,
+    @Body() dto: UpdateDiscoveryLocationDto,
+  ) {
+    return this.discoveryService.updateLocation(req.user.sub, dto.latitude, dto.longitude);
+  }
+
+  @Delete('location')
+  @ApiOperation({ summary: 'Disable nearby discovery for the signed-in member' })
+  disableLocation(@Request() req: AuthenticatedRequest) {
+    return this.discoveryService.disableLocation(req.user.sub);
+  }
+
+  @Get('location')
+  @ApiOperation({ summary: 'Get discovery consent and freshness status without coordinates' })
+  getLocationStatus(@Request() req: AuthenticatedRequest) {
+    return this.discoveryService.getStatus(req.user.sub);
+  }
+
+  @Get('nearby/:petId')
+  @ApiOperation({ summary: 'Find coarse-distance public candidates without returning coordinates' })
+  getNearby(
+    @Request() req: AuthenticatedRequest,
+    @Param('petId') petId: string,
+    @Query('radiusKm') radiusKm?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.discoveryService.getNearbyCandidates(
+      req.user.sub,
+      petId,
+      radiusKm ? Number(radiusKm) : 5,
+      limit ? Number(limit) : 20,
+    );
+  }
+}

--- a/apps/api/src/discovery/discovery.module.ts
+++ b/apps/api/src/discovery/discovery.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { DiscoveryController } from './discovery.controller';
+import { DiscoveryLocationStore } from './discovery-location.store';
+import { DiscoveryService } from './discovery.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [DiscoveryController],
+  providers: [DiscoveryLocationStore, DiscoveryService],
+  exports: [DiscoveryService],
+})
+export class DiscoveryModule {}

--- a/apps/api/src/discovery/discovery.service.spec.ts
+++ b/apps/api/src/discovery/discovery.service.spec.ts
@@ -40,7 +40,7 @@ describe('DiscoveryService', () => {
         latBucket: expect.any(Number),
         lngBucket: expect.any(Number),
         precisionM: 2200,
-      }),
+      })
     );
     const persistedInput = locations.upsert.mock.calls[0][0] as Record<string, unknown>;
     expect(persistedInput).not.toHaveProperty('latitude');
@@ -108,9 +108,7 @@ describe('DiscoveryService', () => {
         updated_at: new Date(),
       },
     ]);
-    prisma.blockedUser.findMany.mockResolvedValue([
-      { userId: 'user-1', blockedId: 'user-2' },
-    ]);
+    prisma.blockedUser.findMany.mockResolvedValue([{ userId: 'user-1', blockedId: 'user-2' }]);
     prisma.pet.findMany.mockResolvedValue([
       {
         id: 'pet-3',
@@ -131,11 +129,15 @@ describe('DiscoveryService', () => {
           ownerId: { in: ['user-3'] },
           owner: { visibility: 'PUBLIC' },
         }),
-      }),
+      })
     );
     expect(result.candidates).toHaveLength(1);
     expect(result.candidates[0]).toEqual(
-      expect.objectContaining({ petId: 'pet-3', ownerId: 'user-3', distanceBand: expect.any(String) }),
+      expect.objectContaining({
+        petId: 'pet-3',
+        ownerId: 'user-3',
+        distanceBand: expect.any(String),
+      })
     );
     expect(result.candidates[0]).not.toHaveProperty('latitude');
     expect(result.candidates[0]).not.toHaveProperty('longitude');

--- a/apps/api/src/discovery/discovery.service.spec.ts
+++ b/apps/api/src/discovery/discovery.service.spec.ts
@@ -1,0 +1,148 @@
+import { DiscoveryService } from './discovery.service';
+
+describe('DiscoveryService', () => {
+  function build() {
+    const prisma = {
+      pet: { findFirst: jest.fn(), findMany: jest.fn() },
+      blockedUser: { findMany: jest.fn() },
+      telemetry: { create: jest.fn().mockResolvedValue({}) },
+    };
+    const locations = {
+      upsert: jest.fn(),
+      disable: jest.fn(),
+      get: jest.fn(),
+      findNearby: jest.fn(),
+    };
+    return {
+      prisma,
+      locations,
+      service: new DiscoveryService(prisma as never, locations as never),
+    };
+  }
+
+  it('quantizes a precise opt-in coordinate before persistence and never records it in telemetry', async () => {
+    const { prisma, locations, service } = build();
+    locations.upsert.mockImplementation(async (input: Record<string, unknown>) => ({
+      user_id: input.userId,
+      lat_bucket: input.latBucket,
+      lng_bucket: input.lngBucket,
+      precision_m: input.precisionM,
+      enabled: true,
+      expires_at: input.expiresAt,
+      updated_at: new Date('2026-08-23T08:20:00.000Z'),
+    }));
+
+    const result = await service.updateLocation('user-1', 37.7749295, -122.4194155);
+
+    expect(locations.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        latBucket: expect.any(Number),
+        lngBucket: expect.any(Number),
+        precisionM: 2200,
+      }),
+    );
+    const persistedInput = locations.upsert.mock.calls[0][0] as Record<string, unknown>;
+    expect(persistedInput).not.toHaveProperty('latitude');
+    expect(persistedInput).not.toHaveProperty('longitude');
+    expect(prisma.telemetry.create).toHaveBeenCalledWith({
+      data: {
+        userId: 'user-1',
+        source: 'discovery',
+        event: 'DISCOVERY_LOCATION_OPTED_IN',
+        data: { precisionM: 2200, ttlDays: 30 },
+      },
+    });
+    expect(result.exactLocationStored).toBe(false);
+  });
+
+  it('returns no discovery candidates when location consent is disabled', async () => {
+    const { prisma, locations, service } = build();
+    prisma.pet.findFirst.mockResolvedValue({ id: 'pet-1', species: 'DOG' });
+    locations.get.mockResolvedValue({
+      user_id: 'user-1',
+      lat_bucket: 6388,
+      lng_bucket: 2879,
+      precision_m: 2200,
+      enabled: false,
+      expires_at: new Date('2026-09-01T00:00:00.000Z'),
+      updated_at: new Date(),
+    });
+
+    await expect(service.getNearbyCandidates('user-1', 'pet-1')).resolves.toMatchObject({
+      locationStatus: 'DISABLED',
+      candidates: [],
+    });
+    expect(locations.findNearby).not.toHaveBeenCalled();
+  });
+
+  it('filters blocked members before the public pet candidate query', async () => {
+    const { prisma, locations, service } = build();
+    prisma.pet.findFirst.mockResolvedValue({ id: 'pet-1', species: 'DOG' });
+    locations.get.mockResolvedValue({
+      user_id: 'user-1',
+      lat_bucket: 6388,
+      lng_bucket: 2879,
+      precision_m: 2200,
+      enabled: true,
+      expires_at: new Date(Date.now() + 86_400_000),
+      updated_at: new Date(),
+    });
+    locations.findNearby.mockResolvedValue([
+      {
+        user_id: 'user-2',
+        lat_bucket: 6388,
+        lng_bucket: 2880,
+        precision_m: 2200,
+        enabled: true,
+        expires_at: new Date(Date.now() + 86_400_000),
+        updated_at: new Date(),
+      },
+      {
+        user_id: 'user-3',
+        lat_bucket: 6389,
+        lng_bucket: 2880,
+        precision_m: 2200,
+        enabled: true,
+        expires_at: new Date(Date.now() + 86_400_000),
+        updated_at: new Date(),
+      },
+    ]);
+    prisma.blockedUser.findMany.mockResolvedValue([
+      { userId: 'user-1', blockedId: 'user-2' },
+    ]);
+    prisma.pet.findMany.mockResolvedValue([
+      {
+        id: 'pet-3',
+        ownerId: 'user-3',
+        name: 'Luna',
+        species: 'DOG',
+        breed: null,
+        avatarUrl: null,
+        owner: { id: 'user-3', handle: 'luna-human', avatarUrl: null, isVerified: false },
+      },
+    ]);
+
+    const result = await service.getNearbyCandidates('user-1', 'pet-1', 5, 20);
+
+    expect(prisma.pet.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          ownerId: { in: ['user-3'] },
+          owner: { visibility: 'PUBLIC' },
+        }),
+      }),
+    );
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]).toEqual(
+      expect.objectContaining({ petId: 'pet-3', ownerId: 'user-3', distanceBand: expect.any(String) }),
+    );
+    expect(result.candidates[0]).not.toHaveProperty('latitude');
+    expect(result.candidates[0]).not.toHaveProperty('longitude');
+    expect(result.boundaries).toMatchObject({
+      exactCoordinatesReturned: false,
+      blockedUsersExcluded: true,
+      publicProfilesOnly: true,
+    });
+  });
+});

--- a/apps/api/src/discovery/discovery.service.ts
+++ b/apps/api/src/discovery/discovery.service.ts
@@ -28,7 +28,7 @@ function bucketCenter(bucket: number, offset: number) {
 
 function approximateKm(
   source: { latBucket: number; lngBucket: number },
-  target: { latBucket: number; lngBucket: number },
+  target: { latBucket: number; lngBucket: number }
 ) {
   const sourceLat = bucketCenter(source.latBucket, 90);
   const targetLat = bucketCenter(target.latBucket, 90);
@@ -50,7 +50,7 @@ function distanceBand(distanceKm: number): DistanceBand {
 export class DiscoveryService {
   constructor(
     private readonly prisma: PrismaService,
-    private readonly locations: DiscoveryLocationStore,
+    private readonly locations: DiscoveryLocationStore
   ) {}
 
   async updateLocation(userId: string, latitude: number, longitude: number) {
@@ -125,7 +125,11 @@ export class DiscoveryService {
     if (!ownLocation || !ownLocation.enabled || ownLocation.expires_at.getTime() <= Date.now()) {
       return {
         petId,
-        locationStatus: ownLocation?.enabled ? 'STALE' : ownLocation ? 'DISABLED' : 'NOT_CONFIGURED',
+        locationStatus: ownLocation?.enabled
+          ? 'STALE'
+          : ownLocation
+            ? 'DISABLED'
+            : 'NOT_CONFIGURED',
         candidates: [],
         boundaries: this.boundaries(),
       };
@@ -168,7 +172,7 @@ export class DiscoveryService {
       select: { userId: true, blockedId: true },
     });
     const blockedOwnerIds = new Set(
-      blocks.map((block) => (block.userId === userId ? block.blockedId : block.userId)),
+      blocks.map((block) => (block.userId === userId ? block.blockedId : block.userId))
     );
     const eligibleOwnerIds = nearbyOwnerIds.filter((ownerId) => !blockedOwnerIds.has(ownerId));
 
@@ -200,7 +204,7 @@ export class DiscoveryService {
         if (!candidateLocation) return null;
         const approximateDistanceKm = approximateKm(
           { latBucket: ownLocation.lat_bucket, lngBucket: ownLocation.lng_bucket },
-          { latBucket: candidateLocation.lat_bucket, lngBucket: candidateLocation.lng_bucket },
+          { latBucket: candidateLocation.lat_bucket, lngBucket: candidateLocation.lng_bucket }
         );
         if (approximateDistanceKm > safeRadiusKm + 1.5) return null;
         return {

--- a/apps/api/src/discovery/discovery.service.ts
+++ b/apps/api/src/discovery/discovery.service.ts
@@ -1,0 +1,258 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+import { DiscoveryLocationStore } from './discovery-location.store';
+
+const CELL_DEGREES = 0.02;
+const CELL_PRECISION_M = 2_200;
+const LOCATION_TTL_DAYS = 30;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+type DistanceBand = 'WITHIN_2_5_KM' | 'WITHIN_5_KM' | 'WITHIN_10_KM';
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function quantizeLatitude(latitude: number) {
+  return clamp(Math.floor((latitude + 90) / CELL_DEGREES), 0, 9000);
+}
+
+function quantizeLongitude(longitude: number) {
+  return clamp(Math.floor((longitude + 180) / CELL_DEGREES), 0, 18000);
+}
+
+function bucketCenter(bucket: number, offset: number) {
+  return bucket * CELL_DEGREES - offset + CELL_DEGREES / 2;
+}
+
+function approximateKm(
+  source: { latBucket: number; lngBucket: number },
+  target: { latBucket: number; lngBucket: number },
+) {
+  const sourceLat = bucketCenter(source.latBucket, 90);
+  const targetLat = bucketCenter(target.latBucket, 90);
+  const latKm = Math.abs(sourceLat - targetLat) * 111.32;
+  const meanLatRadians = ((sourceLat + targetLat) / 2) * (Math.PI / 180);
+  const sourceLng = bucketCenter(source.lngBucket, 180);
+  const targetLng = bucketCenter(target.lngBucket, 180);
+  const lngKm = Math.abs(sourceLng - targetLng) * 111.32 * Math.max(Math.cos(meanLatRadians), 0.2);
+  return Math.sqrt(latKm * latKm + lngKm * lngKm);
+}
+
+function distanceBand(distanceKm: number): DistanceBand {
+  if (distanceKm <= 2.5) return 'WITHIN_2_5_KM';
+  if (distanceKm <= 5) return 'WITHIN_5_KM';
+  return 'WITHIN_10_KM';
+}
+
+@Injectable()
+export class DiscoveryService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly locations: DiscoveryLocationStore,
+  ) {}
+
+  async updateLocation(userId: string, latitude: number, longitude: number) {
+    const expiresAt = new Date(Date.now() + LOCATION_TTL_DAYS * DAY_MS);
+    const row = await this.locations.upsert({
+      userId,
+      latBucket: quantizeLatitude(latitude),
+      lngBucket: quantizeLongitude(longitude),
+      precisionM: CELL_PRECISION_M,
+      expiresAt,
+    });
+
+    await this.recordTelemetry(userId, 'DISCOVERY_LOCATION_OPTED_IN', {
+      precisionM: CELL_PRECISION_M,
+      ttlDays: LOCATION_TTL_DAYS,
+    });
+
+    return {
+      status: 'OPTED_IN' as const,
+      precisionMeters: row.precision_m,
+      expiresAt: row.expires_at.toISOString(),
+      exactLocationStored: false,
+    };
+  }
+
+  async disableLocation(userId: string) {
+    await this.locations.disable(userId);
+    await this.recordTelemetry(userId, 'DISCOVERY_LOCATION_DISABLED', {});
+    return { status: 'DISABLED' as const, exactLocationStored: false };
+  }
+
+  async getStatus(userId: string) {
+    const row = await this.locations.get(userId);
+    if (!row) {
+      return {
+        status: 'NOT_CONFIGURED' as const,
+        exactLocationStored: false,
+        precisionMeters: CELL_PRECISION_M,
+      };
+    }
+    if (!row.enabled) {
+      return {
+        status: 'DISABLED' as const,
+        exactLocationStored: false,
+        precisionMeters: row.precision_m,
+      };
+    }
+    if (row.expires_at.getTime() <= Date.now()) {
+      return {
+        status: 'STALE' as const,
+        exactLocationStored: false,
+        precisionMeters: row.precision_m,
+      };
+    }
+    return {
+      status: 'OPTED_IN' as const,
+      exactLocationStored: false,
+      precisionMeters: row.precision_m,
+      expiresAt: row.expires_at.toISOString(),
+      updatedAt: row.updated_at.toISOString(),
+    };
+  }
+
+  async getNearbyCandidates(userId: string, petId: string, radiusKm = 5, limit = 20) {
+    const pet = await this.prisma.pet.findFirst({
+      where: { id: petId, ownerId: userId },
+      select: { id: true, species: true },
+    });
+    if (!pet) throw new NotFoundException('Pet not found');
+
+    const ownLocation = await this.locations.get(userId);
+    if (!ownLocation || !ownLocation.enabled || ownLocation.expires_at.getTime() <= Date.now()) {
+      return {
+        petId,
+        locationStatus: ownLocation?.enabled ? 'STALE' : ownLocation ? 'DISABLED' : 'NOT_CONFIGURED',
+        candidates: [],
+        boundaries: this.boundaries(),
+      };
+    }
+
+    const safeRadiusKm = clamp(Number(radiusKm) || 5, 2, 10);
+    const safeLimit = clamp(Number(limit) || 20, 1, 30);
+    const sourceLatitude = bucketCenter(ownLocation.lat_bucket, 90);
+    const latCellKm = 111.32 * CELL_DEGREES;
+    const lngCellKm = latCellKm * Math.max(Math.cos(sourceLatitude * (Math.PI / 180)), 0.2);
+    const latRange = Math.ceil(safeRadiusKm / latCellKm) + 1;
+    const lngRange = Math.ceil(safeRadiusKm / lngCellKm) + 1;
+
+    const nearbyRows = await this.locations.findNearby({
+      userId,
+      minLatBucket: ownLocation.lat_bucket - latRange,
+      maxLatBucket: ownLocation.lat_bucket + latRange,
+      minLngBucket: ownLocation.lng_bucket - lngRange,
+      maxLngBucket: ownLocation.lng_bucket + lngRange,
+      take: 400,
+    });
+
+    const nearbyOwnerIds = nearbyRows.map((row) => row.user_id);
+    if (nearbyOwnerIds.length === 0) {
+      return {
+        petId,
+        locationStatus: 'OPTED_IN' as const,
+        candidates: [],
+        boundaries: this.boundaries(),
+      };
+    }
+
+    const blocks = await this.prisma.blockedUser.findMany({
+      where: {
+        OR: [
+          { userId, blockedId: { in: nearbyOwnerIds } },
+          { blockedId: userId, userId: { in: nearbyOwnerIds } },
+        ],
+      },
+      select: { userId: true, blockedId: true },
+    });
+    const blockedOwnerIds = new Set(
+      blocks.map((block) => (block.userId === userId ? block.blockedId : block.userId)),
+    );
+    const eligibleOwnerIds = nearbyOwnerIds.filter((ownerId) => !blockedOwnerIds.has(ownerId));
+
+    const pets = await this.prisma.pet.findMany({
+      where: {
+        id: { not: petId },
+        ownerId: { in: eligibleOwnerIds },
+        species: pet.species,
+        owner: { visibility: 'PUBLIC' },
+      },
+      select: {
+        id: true,
+        ownerId: true,
+        name: true,
+        species: true,
+        breed: true,
+        avatarUrl: true,
+        owner: {
+          select: { id: true, handle: true, avatarUrl: true, isVerified: true },
+        },
+      },
+      take: 100,
+    });
+
+    const locationByOwner = new Map(nearbyRows.map((row) => [row.user_id, row]));
+    const candidates = pets
+      .map((candidate) => {
+        const candidateLocation = locationByOwner.get(candidate.ownerId);
+        if (!candidateLocation) return null;
+        const approximateDistanceKm = approximateKm(
+          { latBucket: ownLocation.lat_bucket, lngBucket: ownLocation.lng_bucket },
+          { latBucket: candidateLocation.lat_bucket, lngBucket: candidateLocation.lng_bucket },
+        );
+        if (approximateDistanceKm > safeRadiusKm + 1.5) return null;
+        return {
+          petId: candidate.id,
+          ownerId: candidate.ownerId,
+          petName: candidate.name,
+          species: candidate.species,
+          breed: candidate.breed,
+          avatarUrl: candidate.avatarUrl,
+          owner: candidate.owner,
+          distanceBand: distanceBand(approximateDistanceKm),
+        };
+      })
+      .filter((candidate): candidate is NonNullable<typeof candidate> => candidate !== null)
+      .sort((a, b) => {
+        const order: Record<DistanceBand, number> = {
+          WITHIN_2_5_KM: 0,
+          WITHIN_5_KM: 1,
+          WITHIN_10_KM: 2,
+        };
+        return order[a.distanceBand] - order[b.distanceBand];
+      })
+      .slice(0, safeLimit);
+
+    await this.recordTelemetry(userId, 'DISCOVERY_CANDIDATES_VIEWED', {
+      petId,
+      radiusBandKm: safeRadiusKm,
+      candidateCount: candidates.length,
+    });
+
+    return {
+      petId,
+      locationStatus: 'OPTED_IN' as const,
+      candidates,
+      boundaries: this.boundaries(),
+    };
+  }
+
+  private boundaries() {
+    return {
+      exactCoordinatesStored: false,
+      exactCoordinatesReturned: false,
+      homeLocationExposed: false,
+      blockedUsersExcluded: true,
+      publicProfilesOnly: true,
+      maxRadiusKm: 10,
+    };
+  }
+
+  private async recordTelemetry(userId: string, event: string, data: Prisma.InputJsonObject) {
+    await this.prisma.telemetry.create({
+      data: { userId, source: 'discovery', event, data },
+    });
+  }
+}

--- a/apps/api/src/discovery/dto/discovery-location.dto.ts
+++ b/apps/api/src/discovery/dto/discovery-location.dto.ts
@@ -1,0 +1,9 @@
+import { IsLatitude, IsLongitude } from 'class-validator';
+
+export class UpdateDiscoveryLocationDto {
+  @IsLatitude()
+  latitude!: number;
+
+  @IsLongitude()
+  longitude!: number;
+}

--- a/apps/api/src/meetup-proposals/dto/update-meetup-proposal.dto.ts
+++ b/apps/api/src/meetup-proposals/dto/update-meetup-proposal.dto.ts
@@ -19,6 +19,24 @@ export enum MeetupProposalStatus {
   CANCELLED = 'cancelled',
 }
 
+export enum DogMeetupExperience {
+  LOVED_IT = 'loved_it',
+  COMFORTABLE = 'comfortable',
+  NOT_THEIR_THING = 'not_their_thing',
+}
+
+export enum OwnerMeetupExperience {
+  GREAT = 'great',
+  FINE = 'fine',
+  A_LOT_TODAY = 'a_lot_today',
+}
+
+export enum MeetAgainChoice {
+  YES = 'yes',
+  MAYBE = 'maybe',
+  NO = 'no',
+}
+
 export class UpdateMeetupProposalDto {
   @IsEnum(MeetupProposalStatus)
   status!: MeetupProposalStatus;
@@ -27,6 +45,18 @@ export class UpdateMeetupProposalDto {
 export class CompleteMeetupDto {
   @IsBoolean()
   occurred!: boolean;
+
+  @IsOptional()
+  @IsEnum(DogMeetupExperience)
+  dogExperience?: DogMeetupExperience;
+
+  @IsOptional()
+  @IsEnum(OwnerMeetupExperience)
+  ownerExperience?: OwnerMeetupExperience;
+
+  @IsOptional()
+  @IsEnum(MeetAgainChoice)
+  meetAgain?: MeetAgainChoice;
 
   @IsOptional()
   @IsInt()

--- a/apps/api/src/meetup-proposals/meetup-proposals.outcomes.spec.ts
+++ b/apps/api/src/meetup-proposals/meetup-proposals.outcomes.spec.ts
@@ -1,0 +1,64 @@
+import { MeetupProposalsService } from './meetup-proposals.service';
+
+describe('MeetupProposalsService structured outcomes', () => {
+  it('stores tiny structured answers in canonical telemetry and normalized proposal tags', async () => {
+    const proposal = {
+      id: 'proposal-1',
+      proposerId: 'user-1',
+      recipientId: 'user-2',
+      status: 'accepted',
+      rating: null,
+      feedbackTags: [],
+      checklistOk: true,
+      occurredAt: null,
+      notes: null,
+    };
+    const prisma = {
+      meetupProposal: {
+        findUnique: jest.fn().mockResolvedValue(proposal),
+        update: jest.fn().mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+          ...proposal,
+          ...data,
+        })),
+      },
+      telemetry: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'telemetry-1' }),
+      },
+    };
+    const service = new MeetupProposalsService(prisma as never);
+
+    await service.complete('proposal-1', 'user-1', {
+      occurred: true,
+      dogExperience: 'comfortable' as never,
+      ownerExperience: 'great' as never,
+      meetAgain: 'yes' as never,
+      checklistOk: true,
+    });
+
+    expect(prisma.telemetry.create).toHaveBeenCalledWith({
+      data: {
+        userId: 'user-1',
+        source: 'meetup',
+        event: 'MEETUP_OUTCOME_REPORTED',
+        data: expect.objectContaining({
+          proposalId: 'proposal-1',
+          otherUserId: 'user-2',
+          dogExperience: 'comfortable',
+          ownerExperience: 'great',
+          meetAgain: 'yes',
+          feedbackTags: ['dog_comfortable', 'owner_great', 'meet_again_yes'],
+          checklistOk: true,
+        }),
+      },
+    });
+    expect(prisma.meetupProposal.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: 'completed',
+          feedbackTags: ['dog_comfortable', 'owner_great', 'meet_again_yes'],
+        }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/meetup-proposals/meetup-proposals.outcomes.spec.ts
+++ b/apps/api/src/meetup-proposals/meetup-proposals.outcomes.spec.ts
@@ -16,10 +16,12 @@ describe('MeetupProposalsService structured outcomes', () => {
     const prisma = {
       meetupProposal: {
         findUnique: jest.fn().mockResolvedValue(proposal),
-        update: jest.fn().mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
-          ...proposal,
-          ...data,
-        })),
+        update: jest
+          .fn()
+          .mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+            ...proposal,
+            ...data,
+          })),
       },
       telemetry: {
         findFirst: jest.fn().mockResolvedValue(null),
@@ -58,7 +60,7 @@ describe('MeetupProposalsService structured outcomes', () => {
           status: 'completed',
           feedbackTags: ['dog_comfortable', 'owner_great', 'meet_again_yes'],
         }),
-      }),
+      })
     );
   });
 });

--- a/apps/api/src/meetup-proposals/meetup-proposals.service.ts
+++ b/apps/api/src/meetup-proposals/meetup-proposals.service.ts
@@ -67,11 +67,11 @@ export class MeetupProposalsService {
       (conversation) =>
         conversation.participants.length === 2 &&
         conversation.participants.some((participant) => participant.userId === proposerId) &&
-        conversation.participants.some((participant) => participant.userId === dto.recipientId),
+        conversation.participants.some((participant) => participant.userId === dto.recipientId)
     );
     if (!directConversation) {
       throw new BadRequestException(
-        'Start a two-person conversation before proposing an in-person meetup',
+        'Start a two-person conversation before proposing an in-person meetup'
       );
     }
 
@@ -83,9 +83,7 @@ export class MeetupProposalsService {
         suggestedVenue: {
           name: dto.suggestedVenue.name.trim(),
           type: dto.suggestedVenue.type.trim(),
-          ...(dto.suggestedVenue.area?.trim()
-            ? { area: dto.suggestedVenue.area.trim() }
-            : {}),
+          ...(dto.suggestedVenue.area?.trim() ? { area: dto.suggestedVenue.area.trim() } : {}),
         },
         notes: dto.notes?.trim() || null,
       },
@@ -154,7 +152,7 @@ export class MeetupProposalsService {
     await this.recordTelemetry(
       userId,
       dto.status === MeetupProposalStatus.ACCEPTED ? 'MEETUP_ACCEPTED' : 'MEETUP_DECLINED',
-      { proposalId: id, otherUserId: proposal.proposerId },
+      { proposalId: id, otherUserId: proposal.proposerId }
     );
     return updated;
   }
@@ -186,14 +184,18 @@ export class MeetupProposalsService {
       dto.meetAgain ? `meet_again_${dto.meetAgain}` : null,
     ].filter((tag): tag is string => tag !== null);
     const safeTags = [...structuredTags, ...(dto.feedbackTags ?? [])]
-      .map((tag) => tag.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '_'))
+      .map((tag) =>
+        tag
+          .trim()
+          .toLowerCase()
+          .replace(/[^a-z0-9_-]+/g, '_')
+      )
       .filter(Boolean);
     const uniqueTags = [...new Set(safeTags)].slice(0, 16);
 
     await this.recordTelemetry(userId, OUTCOME_EVENT, {
       proposalId: id,
-      otherUserId:
-        proposal.proposerId === userId ? proposal.recipientId : proposal.proposerId,
+      otherUserId: proposal.proposerId === userId ? proposal.recipientId : proposal.proposerId,
       occurred: dto.occurred,
       dogExperience: dto.dogExperience ?? null,
       ownerExperience: dto.ownerExperience ?? null,
@@ -215,9 +217,7 @@ export class MeetupProposalsService {
     const updated = await this.prisma.meetupProposal.update({
       where: { id },
       data: {
-        status: dto.occurred
-          ? MeetupProposalStatus.COMPLETED
-          : MeetupProposalStatus.CANCELLED,
+        status: dto.occurred ? MeetupProposalStatus.COMPLETED : MeetupProposalStatus.CANCELLED,
         occurredAt: dto.occurred ? (proposal.occurredAt ?? new Date()) : null,
         rating: aggregateRating,
         feedbackTags: mergedTags,
@@ -281,11 +281,7 @@ export class MeetupProposalsService {
     };
   }
 
-  private async recordTelemetry(
-    userId: string,
-    event: string,
-    data: Prisma.InputJsonObject,
-  ) {
+  private async recordTelemetry(userId: string, event: string, data: Prisma.InputJsonObject) {
     await this.prisma.telemetry.create({
       data: { userId, source: 'meetup', event, data },
     });

--- a/apps/api/src/meetup-proposals/meetup-proposals.service.ts
+++ b/apps/api/src/meetup-proposals/meetup-proposals.service.ts
@@ -180,16 +180,26 @@ export class MeetupProposalsService {
       throw new BadRequestException('You already submitted feedback for this meetup');
     }
 
-    const safeTags = (dto.feedbackTags ?? [])
+    const structuredTags = [
+      dto.dogExperience ? `dog_${dto.dogExperience}` : null,
+      dto.ownerExperience ? `owner_${dto.ownerExperience}` : null,
+      dto.meetAgain ? `meet_again_${dto.meetAgain}` : null,
+    ].filter((tag): tag is string => tag !== null);
+    const safeTags = [...structuredTags, ...(dto.feedbackTags ?? [])]
       .map((tag) => tag.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '_'))
       .filter(Boolean);
+    const uniqueTags = [...new Set(safeTags)].slice(0, 16);
+
     await this.recordTelemetry(userId, OUTCOME_EVENT, {
       proposalId: id,
       otherUserId:
         proposal.proposerId === userId ? proposal.recipientId : proposal.proposerId,
       occurred: dto.occurred,
+      dogExperience: dto.dogExperience ?? null,
+      ownerExperience: dto.ownerExperience ?? null,
+      meetAgain: dto.meetAgain ?? null,
       rating: dto.rating ?? null,
-      feedbackTags: safeTags,
+      feedbackTags: uniqueTags,
       checklistOk: dto.checklistOk ?? null,
     });
 
@@ -200,7 +210,7 @@ export class MeetupProposalsService {
         : previousRating === null
           ? dto.rating
           : Math.round(((previousRating + dto.rating) / 2) * 10) / 10;
-    const mergedTags = [...new Set([...(proposal.feedbackTags ?? []), ...safeTags])].slice(0, 16);
+    const mergedTags = [...new Set([...(proposal.feedbackTags ?? []), ...uniqueTags])].slice(0, 16);
 
     const updated = await this.prisma.meetupProposal.update({
       where: { id },

--- a/apps/web/e2e/trust-discovery.spec.ts
+++ b/apps/web/e2e/trust-discovery.spec.ts
@@ -1,0 +1,201 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+function corsHeaders(route: Route) {
+  const requestHeaders = route.request().headers();
+  return {
+    'access-control-allow-origin': requestHeaders.origin ?? 'http://localhost:3000',
+    'access-control-allow-methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+    'access-control-allow-headers':
+      requestHeaders['access-control-request-headers'] ?? 'authorization,content-type',
+    vary: 'Origin',
+  };
+}
+
+async function fulfillJson(route: Route, body: unknown, status = 200) {
+  if (route.request().method() === 'OPTIONS') {
+    await route.fulfill({ status: 204, headers: corsHeaders(route), body: '' });
+    return;
+  }
+  await route.fulfill({
+    status,
+    headers: { ...corsHeaders(route), 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function authenticate(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('authToken', 'trust-browser-token');
+    Object.defineProperty(navigator, 'geolocation', {
+      configurable: true,
+      value: {
+        getCurrentPosition(success: PositionCallback) {
+          success({
+            coords: {
+              latitude: 37.7749,
+              longitude: -122.4194,
+              accuracy: 100,
+              altitude: null,
+              altitudeAccuracy: null,
+              heading: null,
+              speed: null,
+              toJSON: () => ({}),
+            },
+            timestamp: Date.now(),
+            toJSON: () => ({}),
+          } as GeolocationPosition);
+        },
+      },
+    });
+  });
+}
+
+const user = {
+  id: 'user-1',
+  email: 'owner@example.com',
+  handle: 'nova-human',
+  pets: [
+    {
+      id: 'pet-1',
+      name: 'Nova',
+      species: 'DOG',
+      breed: 'Husky mix',
+      avatarUrl: null,
+    },
+  ],
+};
+
+const recommendation = {
+  id: 'candidate-pet-2',
+  pet: {
+    id: 'pet-2',
+    ownerId: 'user-2',
+    name: 'Luna',
+    species: 'DOG',
+    breed: 'Retriever mix',
+    birthdate: null,
+    avatarUrl: null,
+    temperament: ['calm'],
+    owner: {
+      id: 'user-2',
+      handle: 'luna-human',
+      bio: 'Likes quiet parallel walks.',
+      avatarUrl: null,
+      isVerified: true,
+    },
+  },
+  compatibilityScore: 0.87,
+  confidence: 0.78,
+  source: 'behavior-outcome-baseline-v2',
+  factors: { species: 1, temperament: 0.82 },
+  explanation: ['Similar recent social pace'],
+  status: 'PROPOSED',
+  lastInteractionAt: null,
+};
+
+test('explicit rough-location discovery leads to an empty canonical conversation, never mock state', async ({
+  page,
+}) => {
+  await authenticate(page);
+  let locationEnabled = false;
+  let conversationCreated = false;
+
+  await page.route('**/auth/me', (route) => fulfillJson(route, user));
+  await page.route('**/compatibility/recommendations/pet-1**', (route) =>
+    fulfillJson(route, { recommendations: [recommendation] }),
+  );
+  await page.route('**/discovery/location', async (route) => {
+    if (route.request().method() === 'PUT') {
+      const body = route.request().postDataJSON() as Record<string, unknown>;
+      expect(body).toEqual({ latitude: 37.7749, longitude: -122.4194 });
+      locationEnabled = true;
+      return fulfillJson(route, {
+        status: 'OPTED_IN',
+        exactLocationStored: false,
+        precisionMeters: 2200,
+        expiresAt: '2026-09-22T08:00:00.000Z',
+      });
+    }
+    return fulfillJson(route, {
+      status: locationEnabled ? 'OPTED_IN' : 'NOT_CONFIGURED',
+      exactLocationStored: false,
+      precisionMeters: 2200,
+    });
+  });
+  await page.route('**/discovery/nearby/pet-1**', (route) =>
+    fulfillJson(route, {
+      petId: 'pet-1',
+      locationStatus: 'OPTED_IN',
+      candidates: [
+        {
+          petId: 'pet-2',
+          ownerId: 'user-2',
+          petName: 'Luna',
+          species: 'DOG',
+          breed: 'Retriever mix',
+          avatarUrl: null,
+          owner: { id: 'user-2', handle: 'luna-human', avatarUrl: null, isVerified: true },
+          distanceBand: 'WITHIN_5_KM',
+        },
+      ],
+      boundaries: {
+        exactCoordinatesStored: false,
+        exactCoordinatesReturned: false,
+        homeLocationExposed: false,
+        blockedUsersExcluded: true,
+        publicProfilesOnly: true,
+        maxRadiusKm: 10,
+      },
+    }),
+  );
+
+  await page.route('**/chat/conversations', async (route) => {
+    if (route.request().method() === 'POST') {
+      expect(route.request().postDataJSON()).toEqual({ participantId: 'user-2' });
+      conversationCreated = true;
+      return fulfillJson(route, { id: 'conversation-1', created: true }, 201);
+    }
+    return fulfillJson(
+      route,
+      conversationCreated
+        ? [
+            {
+              id: 'conversation-1',
+              participant: {
+                id: 'user-2',
+                name: 'luna-human',
+                avatarUrl: null,
+                petId: 'pet-2',
+                petName: 'Luna',
+                petAvatarUrl: null,
+              },
+              lastMessage: null,
+              unreadCount: 0,
+              updatedAt: '2026-08-23T08:00:00.000Z',
+            },
+          ]
+        : [],
+    );
+  });
+  await page.route('**/chat/conversations/conversation-1/messages**', (route) =>
+    fulfillJson(route, { data: [], total: 0, page: 1, limit: 50 }),
+  );
+  await page.route('**/chat/conversations/conversation-1/read', (route) =>
+    fulfillJson(route, { ok: true }),
+  );
+
+  await page.goto('/discover');
+  await expect(page.getByText('Luna', { exact: true })).toBeVisible();
+  await expect(page.getByText(/within about 5 km/i)).toHaveCount(0);
+
+  await page.getByRole('button', { name: /Use rough location/i }).click();
+  await expect(page.getByText(/within about 5 km/i)).toBeVisible();
+  await expect(page.getByText(/never receive your coordinates or home location/i)).toBeVisible();
+
+  await page.getByRole('link', { name: /Start a conversation/i }).click();
+  await expect(page).toHaveURL(/inbox\?member=user-2/);
+  await expect(page.getByText('Private direct conversation')).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText('Start with a simple hello')).toBeVisible();
+  await expect(page.getByText(/Golden Gate Park Trail/i)).toHaveCount(0);
+  await expect(page.getByText(/Sarah Johnson/i)).toHaveCount(0);
+});

--- a/apps/web/e2e/trust-discovery.spec.ts
+++ b/apps/web/e2e/trust-discovery.spec.ts
@@ -102,7 +102,7 @@ test('explicit rough-location discovery leads to an empty canonical conversation
 
   await page.route('**/auth/me', (route) => fulfillJson(route, user));
   await page.route('**/compatibility/recommendations/pet-1**', (route) =>
-    fulfillJson(route, { recommendations: [recommendation] }),
+    fulfillJson(route, { recommendations: [recommendation] })
   );
   await page.route('**/discovery/location', async (route) => {
     if (route.request().method() === 'PUT') {
@@ -151,7 +151,7 @@ test('explicit rough-location discovery leads to an empty canonical conversation
         publicProfilesOnly: true,
         maxRadiusKm: 10,
       },
-    }),
+    })
   );
 
   await page.route('**/chat/conversations', async (route) => {
@@ -179,20 +179,18 @@ test('explicit rough-location discovery leads to an empty canonical conversation
               updatedAt: '2026-08-23T08:00:00.000Z',
             },
           ]
-        : [],
+        : []
     );
   });
   await page.route('**/chat/conversations/conversation-1/messages**', (route) =>
-    fulfillJson(route, { data: [], total: 0, page: 1, limit: 50 }),
+    fulfillJson(route, { data: [], total: 0, page: 1, limit: 50 })
   );
   await page.route('**/chat/conversations/conversation-1/read', (route) =>
-    fulfillJson(route, { ok: true }),
+    fulfillJson(route, { ok: true })
   );
 
   await page.goto('/discover');
-  await expect(
-    page.getByRole('heading', { name: /Luna with luna-human/i }),
-  ).toBeVisible();
+  await expect(page.getByRole('heading', { name: /Luna with luna-human/i })).toBeVisible();
   await expect(page.getByText(/within about 5 km/i)).toHaveCount(0);
 
   await page.getByRole('button', { name: /Use rough location/i }).click();

--- a/apps/web/e2e/trust-discovery.spec.ts
+++ b/apps/web/e2e/trust-discovery.spec.ts
@@ -134,7 +134,12 @@ test('explicit rough-location discovery leads to an empty canonical conversation
           species: 'DOG',
           breed: 'Retriever mix',
           avatarUrl: null,
-          owner: { id: 'user-2', handle: 'luna-human', avatarUrl: null, isVerified: true },
+          owner: {
+            id: 'user-2',
+            handle: 'luna-human',
+            avatarUrl: null,
+            isVerified: true,
+          },
           distanceBand: 'WITHIN_5_KM',
         },
       ],
@@ -185,7 +190,9 @@ test('explicit rough-location discovery leads to an empty canonical conversation
   );
 
   await page.goto('/discover');
-  await expect(page.getByText('Luna', { exact: true })).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: /Luna with luna-human/i }),
+  ).toBeVisible();
   await expect(page.getByText(/within about 5 km/i)).toHaveCount(0);
 
   await page.getByRole('button', { name: /Use rough location/i }).click();

--- a/apps/web/src/app/discover/page.tsx
+++ b/apps/web/src/app/discover/page.tsx
@@ -62,7 +62,7 @@ export default function DiscoverPage() {
   });
 
   const user = profile.data ?? cachedUser;
-  const ownedPets = user?.pets ?? [];
+  const ownedPets = useMemo(() => user?.pets ?? [], [user?.pets]);
 
   useEffect(() => {
     if (ownedPets.length === 0) {

--- a/apps/web/src/app/discover/page.tsx
+++ b/apps/web/src/app/discover/page.tsx
@@ -1,50 +1,155 @@
-"use client"
+'use client';
 
-import { useState } from "react"
-import { useQuery } from "@tanstack/react-query"
-import { Loader2, RefreshCw, SlidersHorizontal, Sparkles } from "lucide-react"
-import { BottomNav } from "@/components/bottom-nav"
-import { DiscoverMapView } from "@/components/discover/discover-map-view"
-import { FilterSheet } from "@/components/discover/filter-sheet"
-import { MatchCard } from "@/components/discover/match-card"
-import { Button } from "@/components/ui/button"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { authApi, compatibilityApi } from "@/lib/api"
-import { useAuthStore } from "@/lib/stores/auth-store"
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Loader2, LocateFixed, MapPinOff, RefreshCw, ShieldCheck, SlidersHorizontal, Sparkles } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import { BottomNav } from '@/components/bottom-nav';
+import { DiscoverMapView } from '@/components/discover/discover-map-view';
+import { FilterSheet } from '@/components/discover/filter-sheet';
+import { MatchCard } from '@/components/discover/match-card';
+import { PetSwitcher } from '@/components/pets/pet-switcher';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { getActivePetId, setActivePetId } from '@/lib/active-pet';
+import { authApi, compatibilityApi } from '@/lib/api';
+import { discoveryApi, type DiscoveryDistanceBand } from '@/lib/api/discovery';
+import { useAuthStore } from '@/lib/stores/auth-store';
+
+const DISTANCE_ORDER: Record<DiscoveryDistanceBand, number> = {
+  WITHIN_2_5_KM: 0,
+  WITHIN_5_KM: 1,
+  WITHIN_10_KM: 2,
+};
+
+function requestBrowserLocation() {
+  return new Promise<GeolocationPosition>((resolve, reject) => {
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      reject(new Error('Location is not available in this browser'));
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(resolve, reject, {
+      enableHighAccuracy: false,
+      timeout: 10_000,
+      maximumAge: 5 * 60 * 1000,
+    });
+  });
+}
 
 export default function DiscoverPage() {
-  const cachedUser = useAuthStore((state) => state.user)
-  const [filterOpen, setFilterOpen] = useState(false)
-  const [activeTab, setActiveTab] = useState("matches")
+  const cachedUser = useAuthStore((state) => state.user);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState('matches');
+  const [selectedPetId, setSelectedPetId] = useState<string | null>(null);
 
-  const {
-    data: profile,
-    isLoading: profileLoading,
-    error: profileError,
-    refetch: refetchProfile,
-  } = useQuery({
-    queryKey: ["auth-profile"],
+  const profile = useQuery({
+    queryKey: ['auth-profile'],
     queryFn: authApi.me,
     staleTime: 30_000,
-  })
+  });
 
-  const user = profile ?? cachedUser
-  const primaryPetId = user?.pets?.[0]?.id
+  const user = profile.data ?? cachedUser;
+  const ownedPets = user?.pets ?? [];
 
-  const {
-    data: matches = [],
-    isLoading: matchesLoading,
-    isFetching: matchesFetching,
-    error: matchesError,
-    refetch: refetchMatches,
-  } = useQuery({
-    queryKey: ["recommendations", primaryPetId],
-    queryFn: () => compatibilityApi.getRecommendations(primaryPetId!),
-    enabled: Boolean(primaryPetId),
+  useEffect(() => {
+    if (ownedPets.length === 0) {
+      setSelectedPetId(null);
+      return;
+    }
+
+    const requestedPetId = searchParams.get('pet');
+    const rememberedPetId = getActivePetId();
+    const requestedOwned = ownedPets.some((pet) => pet.id === requestedPetId);
+    const rememberedOwned = ownedPets.some((pet) => pet.id === rememberedPetId);
+    const nextPetId = requestedOwned
+      ? requestedPetId
+      : rememberedOwned
+        ? rememberedPetId
+        : ownedPets[0]?.id;
+
+    if (!nextPetId) return;
+    setActivePetId(nextPetId);
+    setSelectedPetId((current) => (current === nextPetId ? current : nextPetId));
+    if (requestedPetId !== nextPetId) {
+      router.replace(`/discover?pet=${nextPetId}`, { scroll: false });
+    }
+  }, [ownedPets, router, searchParams]);
+
+  const matches = useQuery({
+    queryKey: ['recommendations', selectedPetId],
+    queryFn: () => compatibilityApi.getRecommendations(selectedPetId!),
+    enabled: Boolean(selectedPetId),
     staleTime: 60_000,
-  })
+  });
 
-  const isLoading = profileLoading || matchesLoading
+  const location = useQuery({
+    queryKey: ['discovery', 'location'],
+    queryFn: discoveryApi.getLocationStatus,
+    enabled: Boolean(user),
+    staleTime: 30_000,
+    retry: false,
+  });
+
+  const nearby = useQuery({
+    queryKey: ['discovery', 'nearby', selectedPetId],
+    queryFn: () => discoveryApi.getNearby(selectedPetId!),
+    enabled: Boolean(selectedPetId) && location.data?.status === 'OPTED_IN',
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  const enableLocation = useMutation({
+    mutationFn: async () => {
+      const position = await requestBrowserLocation();
+      return discoveryApi.enableLocation(position.coords.latitude, position.coords.longitude);
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['discovery', 'location'] }),
+        queryClient.invalidateQueries({ queryKey: ['discovery', 'nearby'] }),
+      ]);
+    },
+  });
+
+  const disableLocation = useMutation({
+    mutationFn: discoveryApi.disableLocation,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['discovery', 'location'] }),
+        queryClient.removeQueries({ queryKey: ['discovery', 'nearby'] }),
+      ]);
+    },
+  });
+
+  const distanceByPet = useMemo(
+    () => new Map((nearby.data?.candidates ?? []).map((candidate) => [candidate.petId, candidate.distanceBand])),
+    [nearby.data],
+  );
+
+  const orderedMatches = useMemo(() => {
+    const currentMatches = matches.data ?? [];
+    return [...currentMatches].sort((a, b) => {
+      const aBand = distanceByPet.get(a.pet.id);
+      const bBand = distanceByPet.get(b.pet.id);
+      const aOrder = aBand ? DISTANCE_ORDER[aBand] : 99;
+      const bOrder = bBand ? DISTANCE_ORDER[bBand] : 99;
+      if (aOrder !== bOrder) return aOrder - bOrder;
+      return b.compatibility.overall - a.compatibility.overall;
+    });
+  }, [distanceByPet, matches.data]);
+
+  const isLoading = profile.isLoading || matches.isLoading;
+  const locationStatus = location.data?.status ?? 'NOT_CONFIGURED';
+
+  const choosePet = (petId: string) => {
+    setSelectedPetId(petId);
+    router.replace(`/discover?pet=${petId}`, { scroll: false });
+  };
 
   return (
     <div className="min-h-screen pb-24">
@@ -54,11 +159,11 @@ export default function DiscoverPage() {
             <p className="eyebrow">Compatibility, not popularity</p>
             <h1 className="mt-1 text-2xl font-bold tracking-tight">Discover</h1>
             <p className="mt-1 text-sm text-muted-foreground">
-              {activeTab === "matches"
-                ? primaryPetId
-                  ? `${matches.length} profile-based ${matches.length === 1 ? "match" : "matches"}`
-                  : "Add a pet profile to start matching"
-                : "Explore nearby places and services"}
+              {activeTab === 'matches'
+                ? selectedPetId
+                  ? `${orderedMatches.length} explainable ${orderedMatches.length === 1 ? 'match' : 'matches'}`
+                  : 'Add a dog to start matching'
+                : 'Explore places and services without exposing dog locations'}
             </p>
           </div>
           <Button
@@ -76,87 +181,188 @@ export default function DiscoverPage() {
       <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
         <div className="sticky top-[89px] z-30 border-b border-border/50 bg-background/88 backdrop-blur-2xl">
           <TabsList className="mx-auto grid h-12 w-full max-w-xl grid-cols-2 bg-transparent px-4">
-            <TabsTrigger value="matches" className="data-[state=active]:bg-primary/10 data-[state=active]:text-primary">
+            <TabsTrigger
+              value="matches"
+              className="data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
+            >
               Compatible dogs
             </TabsTrigger>
-            <TabsTrigger value="map" className="data-[state=active]:bg-primary/10 data-[state=active]:text-primary">
-              Map & services
+            <TabsTrigger
+              value="map"
+              className="data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
+            >
+              Places & services
             </TabsTrigger>
           </TabsList>
         </div>
 
         <TabsContent value="matches" className="mt-0">
           <main id="main-content" className="mx-auto max-w-xl space-y-4 px-4 py-5">
-            <section className="surface-soft flex items-start gap-3 rounded-2xl p-4" aria-labelledby="matching-explainer">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-secondary/10 text-secondary">
-                <Sparkles className="h-5 w-5" aria-hidden="true" />
-              </div>
-              <div className="min-w-0 flex-1">
-                <h2 id="matching-explainer" className="text-sm font-semibold">
-                  A recommendation should explain itself
-                </h2>
-                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                  Woof ranks known candidate relationships with a deterministic profile baseline. Each result exposes confidence and the factors behind the score, while learned models remain gated behind evaluation.
-                </p>
-              </div>
-            </section>
+            {selectedPetId && (
+              <Card className="surface-soft rounded-2xl p-4">
+                <div className="flex items-start gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-secondary/10 text-secondary">
+                    <Sparkles className="h-5 w-5" aria-hidden="true" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <h2 className="text-sm font-semibold">One dog, one discovery context</h2>
+                    <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                      Compatibility uses the same active dog as Today. Learned scoring can rerank only when its release evidence is promoted; deterministic scoring remains the fallback.
+                    </p>
+                  </div>
+                </div>
+                <PetSwitcher currentPetId={selectedPetId} label="Finding friends for" onChange={choosePet} />
+              </Card>
+            )}
+
+            {user && selectedPetId && (
+              <Card className="rounded-2xl border-primary/15 bg-gradient-to-br from-primary/[0.06] via-card/95 to-card p-4">
+                <div className="flex items-start gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                    {locationStatus === 'OPTED_IN' ? (
+                      <ShieldCheck className="h-5 w-5" aria-hidden="true" />
+                    ) : (
+                      <LocateFixed className="h-5 w-5" aria-hidden="true" />
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <h2 className="text-sm font-semibold">
+                      {locationStatus === 'OPTED_IN' ? 'Nearby context is on' : 'Make matches locally useful'}
+                    </h2>
+                    <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                      {locationStatus === 'OPTED_IN'
+                        ? 'Woof stores only a coarse roughly 2 km location cell. Other members never receive your coordinates or home location.'
+                        : 'Opt in only when you want nearby context. Your precise browser coordinate is immediately reduced to a coarse cell and is not persisted.'}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {locationStatus === 'OPTED_IN' ? (
+                    <>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="bg-transparent"
+                        disabled={enableLocation.isPending}
+                        onClick={() => enableLocation.mutate()}
+                      >
+                        {enableLocation.isPending && (
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                        )}
+                        Refresh rough location
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        disabled={disableLocation.isPending}
+                        onClick={() => disableLocation.mutate()}
+                      >
+                        Turn off nearby
+                      </Button>
+                    </>
+                  ) : (
+                    <Button size="sm" disabled={enableLocation.isPending} onClick={() => enableLocation.mutate()}>
+                      {enableLocation.isPending ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                      ) : (
+                        <LocateFixed className="mr-2 h-4 w-4" aria-hidden="true" />
+                      )}
+                      Use rough location
+                    </Button>
+                  )}
+                </div>
+
+                {enableLocation.isError && (
+                  <p className="mt-3 flex items-start gap-2 text-xs text-destructive" role="alert">
+                    <MapPinOff className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                    Location was not enabled. You can keep using profile-based compatibility without it.
+                  </p>
+                )}
+                {locationStatus === 'OPTED_IN' && nearby.data && (
+                  <p className="mt-3 text-xs text-muted-foreground">
+                    {nearby.data.candidates.length} public candidate
+                    {nearby.data.candidates.length === 1 ? '' : 's'} currently fall inside your coarse nearby window. Nearby matches are sorted first.
+                  </p>
+                )}
+              </Card>
+            )}
 
             {isLoading ? (
               <div className="flex min-h-72 flex-col items-center justify-center gap-3" role="status">
                 <Loader2 className="h-8 w-8 animate-spin text-primary" aria-hidden="true" />
-                <p className="text-sm text-muted-foreground">Loading your pet profile and ranking candidates…</p>
+                <p className="text-sm text-muted-foreground">Loading your dog and ranking candidates…</p>
               </div>
-            ) : profileError && !cachedUser ? (
+            ) : profile.isError && !cachedUser ? (
               <div className="surface-soft flex min-h-72 flex-col items-center justify-center rounded-2xl px-6 text-center">
                 <h2 className="text-lg font-semibold">Your profile could not be refreshed</h2>
                 <p className="mt-2 max-w-sm text-sm leading-relaxed text-muted-foreground">
-                  Discovery needs the current pet list before it can request recommendations. Other authenticated surfaces remain available.
+                  Discovery needs the current dog list before it can rank relationships. Other authenticated surfaces remain available.
                 </p>
-                <Button variant="outline" className="mt-5 gap-2 bg-transparent" onClick={() => refetchProfile()}>
+                <Button variant="outline" className="mt-5 gap-2 bg-transparent" onClick={() => profile.refetch()}>
                   <RefreshCw className="h-4 w-4" aria-hidden="true" />
                   Retry profile
                 </Button>
               </div>
-            ) : !primaryPetId ? (
+            ) : !selectedPetId ? (
               <div className="surface-soft flex min-h-72 flex-col items-center justify-center rounded-2xl px-6 text-center">
                 <h2 className="text-lg font-semibold">Start with your dog</h2>
                 <p className="mt-2 max-w-sm text-sm leading-relaxed text-muted-foreground">
-                  Matching needs a persisted pet profile so Woof can compare species, temperament, life stage and other available context.
+                  Woof needs a real dog profile before it can explain compatibility or local context.
                 </p>
-                <Button className="mt-5" onClick={() => setFilterOpen(true)}>
-                  Review discovery setup
+                <Button className="mt-5" asChild>
+                  <Link href="/pets/new">Add your dog</Link>
                 </Button>
               </div>
-            ) : matchesError ? (
+            ) : matches.isError ? (
               <div className="surface-soft flex min-h-72 flex-col items-center justify-center rounded-2xl px-6 text-center">
                 <h2 className="text-lg font-semibold">Recommendations are temporarily unavailable</h2>
                 <p className="mt-2 max-w-sm text-sm leading-relaxed text-muted-foreground">
-                  Discovery failed locally without blocking the rest of Woof. Retry the ranking request when you are ready.
+                  Discovery failed locally without blocking the rest of Woof. No substitute matches are invented.
                 </p>
-                <Button variant="outline" className="mt-5 gap-2 bg-transparent" onClick={() => refetchMatches()} disabled={matchesFetching}>
-                  {matchesFetching ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
+                <Button
+                  variant="outline"
+                  className="mt-5 gap-2 bg-transparent"
+                  onClick={() => matches.refetch()}
+                  disabled={matches.isFetching}
+                >
+                  {matches.isFetching ? (
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                  ) : (
+                    <RefreshCw className="h-4 w-4" aria-hidden="true" />
+                  )}
                   Retry
                 </Button>
               </div>
-            ) : matches.length === 0 ? (
+            ) : orderedMatches.length === 0 ? (
               <div className="surface-soft flex min-h-72 flex-col items-center justify-center rounded-2xl px-6 text-center">
-                <h2 className="text-lg font-semibold">No candidate relationships yet</h2>
+                <h2 className="text-lg font-semibold">No compatible candidates yet</h2>
                 <p className="mt-2 max-w-sm text-sm leading-relaxed text-muted-foreground">
-                  Woof only ranks relationships the backend currently knows about. As the local network grows, compatible candidates will appear here.
+                  Woof will not fill an empty network with fake profiles. As real public members become eligible, explainable matches will appear here.
                 </p>
-                <Button variant="outline" className="mt-5 bg-transparent" onClick={() => setFilterOpen(true)}>
-                  Adjust discovery preferences
-                </Button>
               </div>
             ) : (
               <div className="space-y-4">
-                {matches.map((match) => (
-                  <MatchCard key={match.id} match={match} />
+                {orderedMatches.map((match) => (
+                  <MatchCard
+                    key={match.id}
+                    match={match}
+                    distanceBand={distanceByPet.get(match.pet.id)}
+                  />
                 ))}
                 <div className="py-5 text-center">
-                  <p className="text-sm text-muted-foreground">You have reached the end of the current candidate set.</p>
-                  <Button variant="ghost" className="mt-2 gap-2" onClick={() => refetchMatches()} disabled={matchesFetching}>
-                    {matchesFetching ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
+                  <p className="text-sm text-muted-foreground">That is the current real candidate set.</p>
+                  <Button
+                    variant="ghost"
+                    className="mt-2 gap-2"
+                    onClick={() => matches.refetch()}
+                    disabled={matches.isFetching}
+                  >
+                    {matches.isFetching ? (
+                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                    ) : (
+                      <RefreshCw className="h-4 w-4" aria-hidden="true" />
+                    )}
                     Refresh matches
                   </Button>
                 </div>
@@ -173,5 +379,5 @@ export default function DiscoverPage() {
       <FilterSheet open={filterOpen} onOpenChange={setFilterOpen} />
       <BottomNav />
     </div>
-  )
+  );
 }

--- a/apps/web/src/app/discover/page.tsx
+++ b/apps/web/src/app/discover/page.tsx
@@ -1,7 +1,15 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Loader2, LocateFixed, MapPinOff, RefreshCw, ShieldCheck, SlidersHorizontal, Sparkles } from 'lucide-react';
+import {
+  Loader2,
+  LocateFixed,
+  MapPinOff,
+  RefreshCw,
+  ShieldCheck,
+  SlidersHorizontal,
+  Sparkles,
+} from 'lucide-react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
@@ -127,8 +135,14 @@ export default function DiscoverPage() {
   });
 
   const distanceByPet = useMemo(
-    () => new Map((nearby.data?.candidates ?? []).map((candidate) => [candidate.petId, candidate.distanceBand])),
-    [nearby.data],
+    () =>
+      new Map(
+        (nearby.data?.candidates ?? []).map((candidate) => [
+          candidate.petId,
+          candidate.distanceBand,
+        ])
+      ),
+    [nearby.data]
   );
 
   const orderedMatches = useMemo(() => {
@@ -207,11 +221,17 @@ export default function DiscoverPage() {
                   <div className="min-w-0 flex-1">
                     <h2 className="text-sm font-semibold">One dog, one discovery context</h2>
                     <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                      Compatibility uses the same active dog as Today. Learned scoring can rerank only when its release evidence is promoted; deterministic scoring remains the fallback.
+                      Compatibility uses the same active dog as Today. Learned scoring can rerank
+                      only when its release evidence is promoted; deterministic scoring remains the
+                      fallback.
                     </p>
                   </div>
                 </div>
-                <PetSwitcher currentPetId={selectedPetId} label="Finding friends for" onChange={choosePet} />
+                <PetSwitcher
+                  currentPetId={selectedPetId}
+                  label="Finding friends for"
+                  onChange={choosePet}
+                />
               </Card>
             )}
 
@@ -227,7 +247,9 @@ export default function DiscoverPage() {
                   </div>
                   <div className="min-w-0 flex-1">
                     <h2 className="text-sm font-semibold">
-                      {locationStatus === 'OPTED_IN' ? 'Nearby context is on' : 'Make matches locally useful'}
+                      {locationStatus === 'OPTED_IN'
+                        ? 'Nearby context is on'
+                        : 'Make matches locally useful'}
                     </h2>
                     <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
                       {locationStatus === 'OPTED_IN'
@@ -262,7 +284,11 @@ export default function DiscoverPage() {
                       </Button>
                     </>
                   ) : (
-                    <Button size="sm" disabled={enableLocation.isPending} onClick={() => enableLocation.mutate()}>
+                    <Button
+                      size="sm"
+                      disabled={enableLocation.isPending}
+                      onClick={() => enableLocation.mutate()}
+                    >
                       {enableLocation.isPending ? (
                         <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
                       ) : (
@@ -276,30 +302,42 @@ export default function DiscoverPage() {
                 {enableLocation.isError && (
                   <p className="mt-3 flex items-start gap-2 text-xs text-destructive" role="alert">
                     <MapPinOff className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-                    Location was not enabled. You can keep using profile-based compatibility without it.
+                    Location was not enabled. You can keep using profile-based compatibility without
+                    it.
                   </p>
                 )}
                 {locationStatus === 'OPTED_IN' && nearby.data && (
                   <p className="mt-3 text-xs text-muted-foreground">
                     {nearby.data.candidates.length} public candidate
-                    {nearby.data.candidates.length === 1 ? '' : 's'} currently fall inside your coarse nearby window. Nearby matches are sorted first.
+                    {nearby.data.candidates.length === 1 ? '' : 's'} currently fall inside your
+                    coarse nearby window. Nearby matches are sorted first.
                   </p>
                 )}
               </Card>
             )}
 
             {isLoading ? (
-              <div className="flex min-h-72 flex-col items-center justify-center gap-3" role="status">
+              <div
+                className="flex min-h-72 flex-col items-center justify-center gap-3"
+                role="status"
+              >
                 <Loader2 className="h-8 w-8 animate-spin text-primary" aria-hidden="true" />
-                <p className="text-sm text-muted-foreground">Loading your dog and ranking candidates…</p>
+                <p className="text-sm text-muted-foreground">
+                  Loading your dog and ranking candidates…
+                </p>
               </div>
             ) : profile.isError && !cachedUser ? (
               <div className="surface-soft flex min-h-72 flex-col items-center justify-center rounded-2xl px-6 text-center">
                 <h2 className="text-lg font-semibold">Your profile could not be refreshed</h2>
                 <p className="mt-2 max-w-sm text-sm leading-relaxed text-muted-foreground">
-                  Discovery needs the current dog list before it can rank relationships. Other authenticated surfaces remain available.
+                  Discovery needs the current dog list before it can rank relationships. Other
+                  authenticated surfaces remain available.
                 </p>
-                <Button variant="outline" className="mt-5 gap-2 bg-transparent" onClick={() => profile.refetch()}>
+                <Button
+                  variant="outline"
+                  className="mt-5 gap-2 bg-transparent"
+                  onClick={() => profile.refetch()}
+                >
                   <RefreshCw className="h-4 w-4" aria-hidden="true" />
                   Retry profile
                 </Button>
@@ -308,7 +346,8 @@ export default function DiscoverPage() {
               <div className="surface-soft flex min-h-72 flex-col items-center justify-center rounded-2xl px-6 text-center">
                 <h2 className="text-lg font-semibold">Start with your dog</h2>
                 <p className="mt-2 max-w-sm text-sm leading-relaxed text-muted-foreground">
-                  Woof needs a real dog profile before it can explain compatibility or local context.
+                  Woof needs a real dog profile before it can explain compatibility or local
+                  context.
                 </p>
                 <Button className="mt-5" asChild>
                   <Link href="/pets/new">Add your dog</Link>
@@ -316,9 +355,12 @@ export default function DiscoverPage() {
               </div>
             ) : matches.isError ? (
               <div className="surface-soft flex min-h-72 flex-col items-center justify-center rounded-2xl px-6 text-center">
-                <h2 className="text-lg font-semibold">Recommendations are temporarily unavailable</h2>
+                <h2 className="text-lg font-semibold">
+                  Recommendations are temporarily unavailable
+                </h2>
                 <p className="mt-2 max-w-sm text-sm leading-relaxed text-muted-foreground">
-                  Discovery failed locally without blocking the rest of Woof. No substitute matches are invented.
+                  Discovery failed locally without blocking the rest of Woof. No substitute matches
+                  are invented.
                 </p>
                 <Button
                   variant="outline"
@@ -338,7 +380,8 @@ export default function DiscoverPage() {
               <div className="surface-soft flex min-h-72 flex-col items-center justify-center rounded-2xl px-6 text-center">
                 <h2 className="text-lg font-semibold">No compatible candidates yet</h2>
                 <p className="mt-2 max-w-sm text-sm leading-relaxed text-muted-foreground">
-                  Woof will not fill an empty network with fake profiles. As real public members become eligible, explainable matches will appear here.
+                  Woof will not fill an empty network with fake profiles. As real public members
+                  become eligible, explainable matches will appear here.
                 </p>
               </div>
             ) : (
@@ -351,7 +394,9 @@ export default function DiscoverPage() {
                   />
                 ))}
                 <div className="py-5 text-center">
-                  <p className="text-sm text-muted-foreground">That is the current real candidate set.</p>
+                  <p className="text-sm text-muted-foreground">
+                    That is the current real candidate set.
+                  </p>
                   <Button
                     variant="ghost"
                     className="mt-2 gap-2"

--- a/apps/web/src/app/inbox/page.tsx
+++ b/apps/web/src/app/inbox/page.tsx
@@ -1,122 +1,107 @@
-"use client"
+'use client';
 
-import { useState } from "react"
-import { useSearchParams } from "next/navigation"
-import { BottomNav } from "@/components/bottom-nav"
-import { ConversationList } from "@/components/inbox/conversation-list"
-import { ChatWindow } from "@/components/inbox/chat-window"
-import { FriendsListView } from "@/components/inbox/friends-list-view"
-import { NewMessageSheet } from "@/components/inbox/new-message-sheet"
-import { Search, Plus } from "lucide-react"
-import { Input } from "@/components/ui/input"
-import { Button } from "@/components/ui/button"
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
-
-// Mock conversations data
-const mockConversations = [
-  {
-    id: "c1",
-    matchId: "1",
-    participant: {
-      id: "o1",
-      name: "Sarah Johnson",
-      avatarUrl: "/woman-and-loyal-companion.png",
-      petName: "Max",
-    },
-    lastMessage: {
-      content: "That sounds great! Max would love to join you for a hike this weekend.",
-      timestamp: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
-      senderId: "o1",
-      read: false,
-    },
-    unreadCount: 2,
-  },
-  {
-    id: "c2",
-    matchId: "2",
-    participant: {
-      id: "o2",
-      name: "Michael Chen",
-      avatarUrl: "/man-with-husky.jpg",
-      petName: "Luna",
-    },
-    lastMessage: {
-      content: "Luna is super excited! See you at the dog park tomorrow at 10am.",
-      timestamp: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
-      senderId: "current-user",
-      read: true,
-    },
-    unreadCount: 0,
-  },
-  {
-    id: "c3",
-    matchId: "3",
-    participant: {
-      id: "o3",
-      name: "Emily Rodriguez",
-      avatarUrl: "/yoga-instructor.png",
-      petName: "Bella",
-    },
-    lastMessage: {
-      content: "Thanks for the recommendation! I'll check out that pet cafe.",
-      timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
-      senderId: "o3",
-      read: true,
-    },
-    unreadCount: 0,
-  },
-]
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Loader2, RefreshCw, Search } from 'lucide-react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+import { BottomNav } from '@/components/bottom-nav';
+import { ChatWindow } from '@/components/inbox/chat-window';
+import { ConversationList } from '@/components/inbox/conversation-list';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { authApi } from '@/lib/api';
+import { chatApi } from '@/lib/api/chat';
+import { useAuthStore } from '@/lib/stores/auth-store';
 
 export default function InboxPage() {
-  const searchParams = useSearchParams()
-  const matchParam = searchParams.get("match")
-  const [selectedConversation, setSelectedConversation] = useState<string | null>(matchParam || null)
-  const [searchQuery, setSearchQuery] = useState("")
-  const [showNewMessage, setShowNewMessage] = useState(false)
-  const [activeTab, setActiveTab] = useState("messages")
+  const searchParams = useSearchParams();
+  const memberParam = searchParams.get('member');
+  const cachedUser = useAuthStore((state) => state.user);
+  const queryClient = useQueryClient();
+  const [selectedConversation, setSelectedConversation] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [startError, setStartError] = useState<string | null>(null);
+  const requestedMemberRef = useRef<string | null>(null);
 
-  const filteredConversations = mockConversations.filter((conv) =>
-    conv.participant.name.toLowerCase().includes(searchQuery.toLowerCase()),
-  )
+  const profile = useQuery({
+    queryKey: ['auth-profile'],
+    queryFn: authApi.me,
+    staleTime: 30_000,
+    retry: false,
+  });
+  const user = profile.data ?? cachedUser;
 
-  const activeConversation = mockConversations.find((c) => c.id === selectedConversation)
+  const conversations = useQuery({
+    queryKey: ['chat', 'conversations'],
+    queryFn: chatApi.getConversations,
+    enabled: Boolean(user),
+    staleTime: 15_000,
+    retry: false,
+  });
+
+  useEffect(() => {
+    if (!memberParam || !user || requestedMemberRef.current === memberParam) return;
+    requestedMemberRef.current = memberParam;
+    setStartError(null);
+
+    void chatApi
+      .createConversation(memberParam)
+      .then(async ({ id }) => {
+        await queryClient.invalidateQueries({ queryKey: ['chat', 'conversations'] });
+        setSelectedConversation(id);
+      })
+      .catch(() => {
+        requestedMemberRef.current = null;
+        setStartError('That conversation could not be opened. The member may no longer be available.');
+      });
+  }, [memberParam, queryClient, user]);
+
+  const filteredConversations = (conversations.data ?? []).filter((conversation) => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return true;
+    return [conversation.participant.name, conversation.participant.petName ?? ''].some((value) =>
+      value.toLowerCase().includes(query),
+    );
+  });
+
+  const activeConversation = (conversations.data ?? []).find(
+    (conversation) => conversation.id === selectedConversation,
+  );
+  const unreadCount = (conversations.data ?? []).reduce(
+    (total, conversation) => total + conversation.unreadCount,
+    0,
+  );
 
   return (
     <div className="min-h-screen pb-20">
-      {/* Header */}
-      <header className="sticky top-0 z-40 glass-strong border-b border-border/50">
-        <div className="px-4 py-4 max-w-lg mx-auto space-y-3">
-          <div className="flex items-center justify-between">
-            <h1 className="text-2xl font-bold">Messages</h1>
-            <Button size="sm" onClick={() => setShowNewMessage(true)} className="gap-2">
-              <Plus className="w-4 h-4" />
-              New Message
-            </Button>
+      <header className="glass-strong sticky top-0 z-40 border-b border-border/50">
+        <div className="mx-auto max-w-lg space-y-3 px-4 py-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="eyebrow">Private coordination</p>
+              <h1 className="mt-1 text-2xl font-bold">Messages</h1>
+            </div>
+            <div className="flex gap-2">
+              <Button asChild size="sm" variant="outline" className="bg-transparent">
+                <Link href="/meetups">Meetups</Link>
+              </Button>
+              <Button asChild size="sm">
+                <Link href="/discover">Discover</Link>
+              </Button>
+            </div>
           </div>
 
-          <Tabs value={activeTab} onValueChange={setActiveTab}>
-            <TabsList className="w-full">
-              <TabsTrigger value="messages" className="flex-1">
-                Messages
-                {filteredConversations.filter((c) => c.unreadCount > 0).length > 0 && (
-                  <span className="ml-2 px-1.5 py-0.5 text-xs bg-primary text-primary-foreground rounded-full">
-                    {filteredConversations.filter((c) => c.unreadCount > 0).length}
-                  </span>
-                )}
-              </TabsTrigger>
-              <TabsTrigger value="friends" className="flex-1">
-                Friends
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
-
-          {activeTab === "messages" && (
+          {!selectedConversation && (
             <div className="relative">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+              <Search
+                className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
               <Input
-                placeholder="Search conversations..."
+                placeholder={unreadCount > 0 ? `Search · ${unreadCount} unread` : 'Search conversations'}
                 value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                onChange={(event) => setSearchQuery(event.target.value)}
                 className="pl-9"
               />
             </div>
@@ -124,31 +109,49 @@ export default function InboxPage() {
         </div>
       </header>
 
-      {/* Content */}
-      <main className="max-w-lg mx-auto">
-        {selectedConversation && activeConversation ? (
-          <ChatWindow conversation={activeConversation} onBack={() => setSelectedConversation(null)} />
+      <main className="mx-auto max-w-lg">
+        {startError && (
+          <div className="mx-4 mt-4 rounded-2xl border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive" role="alert">
+            {startError}
+          </div>
+        )}
+
+        {!user || conversations.isLoading ? (
+          <div className="flex min-h-72 items-center justify-center gap-3" role="status">
+            <Loader2 className="h-6 w-6 animate-spin text-primary" aria-hidden="true" />
+            <span className="text-sm text-muted-foreground">Loading private conversations…</span>
+          </div>
+        ) : conversations.isError ? (
+          <div className="surface-soft mx-4 mt-5 rounded-2xl p-6 text-center">
+            <h2 className="font-semibold">Messages are temporarily unavailable</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Woof will not substitute demo conversations while canonical chat cannot be read.
+            </p>
+            <Button
+              variant="outline"
+              className="mt-4 gap-2 bg-transparent"
+              onClick={() => conversations.refetch()}
+            >
+              <RefreshCw className="h-4 w-4" aria-hidden="true" />
+              Try again
+            </Button>
+          </div>
+        ) : selectedConversation && activeConversation ? (
+          <ChatWindow
+            conversation={activeConversation}
+            currentUserId={user.id}
+            onBack={() => setSelectedConversation(null)}
+          />
         ) : (
-          <>
-            {activeTab === "messages" && (
-              <ConversationList conversations={filteredConversations} onSelectConversation={setSelectedConversation} />
-            )}
-            {activeTab === "friends" && <FriendsListView />}
-          </>
+          <ConversationList
+            conversations={filteredConversations}
+            currentUserId={user.id}
+            onSelectConversation={setSelectedConversation}
+          />
         )}
       </main>
 
-      <NewMessageSheet
-        open={showNewMessage}
-        onOpenChange={setShowNewMessage}
-        onSelectUser={(userId) => {
-          // Create a new conversation with the selected user
-          console.log("[v0] Starting conversation with user:", userId)
-          setShowNewMessage(false)
-        }}
-      />
-
       <BottomNav />
     </div>
-  )
+  );
 }

--- a/apps/web/src/app/inbox/page.tsx
+++ b/apps/web/src/app/inbox/page.tsx
@@ -53,7 +53,9 @@ export default function InboxPage() {
       })
       .catch(() => {
         requestedMemberRef.current = null;
-        setStartError('That conversation could not be opened. The member may no longer be available.');
+        setStartError(
+          'That conversation could not be opened. The member may no longer be available.'
+        );
       });
   }, [memberParam, queryClient, user]);
 
@@ -61,16 +63,16 @@ export default function InboxPage() {
     const query = searchQuery.trim().toLowerCase();
     if (!query) return true;
     return [conversation.participant.name, conversation.participant.petName ?? ''].some((value) =>
-      value.toLowerCase().includes(query),
+      value.toLowerCase().includes(query)
     );
   });
 
   const activeConversation = (conversations.data ?? []).find(
-    (conversation) => conversation.id === selectedConversation,
+    (conversation) => conversation.id === selectedConversation
   );
   const unreadCount = (conversations.data ?? []).reduce(
     (total, conversation) => total + conversation.unreadCount,
-    0,
+    0
   );
 
   return (
@@ -99,7 +101,9 @@ export default function InboxPage() {
                 aria-hidden="true"
               />
               <Input
-                placeholder={unreadCount > 0 ? `Search · ${unreadCount} unread` : 'Search conversations'}
+                placeholder={
+                  unreadCount > 0 ? `Search · ${unreadCount} unread` : 'Search conversations'
+                }
                 value={searchQuery}
                 onChange={(event) => setSearchQuery(event.target.value)}
                 className="pl-9"
@@ -111,7 +115,10 @@ export default function InboxPage() {
 
       <main className="mx-auto max-w-lg">
         {startError && (
-          <div className="mx-4 mt-4 rounded-2xl border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive" role="alert">
+          <div
+            className="mx-4 mt-4 rounded-2xl border border-destructive/20 bg-destructive/5 p-4 text-sm text-destructive"
+            role="alert"
+          >
             {startError}
           </div>
         )}

--- a/apps/web/src/app/meetups/page.tsx
+++ b/apps/web/src/app/meetups/page.tsx
@@ -69,8 +69,9 @@ function ChoiceGroup<T extends string>({
 function OutcomeCard({ proposal }: { proposal: MeetupProposal }) {
   const queryClient = useQueryClient();
   const [dogExperience, setDogExperience] = useState<MeetupOutcome['dogExperience'] | null>(null);
-  const [ownerExperience, setOwnerExperience] =
-    useState<MeetupOutcome['ownerExperience'] | null>(null);
+  const [ownerExperience, setOwnerExperience] = useState<MeetupOutcome['ownerExperience'] | null>(
+    null
+  );
   const [meetAgain, setMeetAgain] = useState<MeetupOutcome['meetAgain'] | null>(null);
   const [safe, setSafe] = useState<boolean | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -81,7 +82,7 @@ function OutcomeCard({ proposal }: { proposal: MeetupProposal }) {
       setMessage(
         result.reportSuggested
           ? 'Feedback saved. Because you flagged a safety concern, reporting options should be considered.'
-          : 'Thanks. That tiny bit of context will make future matching more useful.',
+          : 'Thanks. That tiny bit of context will make future matching more useful.'
       );
       await queryClient.invalidateQueries({ queryKey: ['meetup-proposals'] });
     },
@@ -107,7 +108,8 @@ function OutcomeCard({ proposal }: { proposal: MeetupProposal }) {
         <p className="eyebrow">Close the loop</p>
         <h3 className="mt-1 font-semibold">How did it go?</h3>
         <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-          Three quick answers become outcome evidence for future compatibility. They are not a health diagnosis.
+          Three quick answers become outcome evidence for future compatibility. They are not a
+          health diagnosis.
         </p>
       </div>
 
@@ -228,7 +230,7 @@ export default function MeetupsPage() {
       ...proposals.data.sent.map((proposal) => ({ proposal, direction: 'sent' as const })),
     ].sort(
       (a, b) =>
-        new Date(b.proposal.suggestedTime).getTime() - new Date(a.proposal.suggestedTime).getTime(),
+        new Date(b.proposal.suggestedTime).getTime() - new Date(a.proposal.suggestedTime).getTime()
     );
   }, [proposals.data, user]);
 
@@ -253,7 +255,8 @@ export default function MeetupsPage() {
         <Card className="surface-soft rounded-2xl p-4">
           <p className="text-sm font-semibold">Keep coordination simple and public-place first</p>
           <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-            Woof meetup proposals store a venue label and area, not a private home coordinate. Blocking either participant disables coordination.
+            Woof meetup proposals store a venue label and area, not a private home coordinate.
+            Blocking either participant disables coordination.
           </p>
         </Card>
 
@@ -268,7 +271,11 @@ export default function MeetupsPage() {
             <p className="mt-2 text-sm text-muted-foreground">
               No substitute plans are shown while canonical meetup records cannot be read.
             </p>
-            <Button variant="outline" className="mt-4 bg-transparent" onClick={() => proposals.refetch()}>
+            <Button
+              variant="outline"
+              className="mt-4 bg-transparent"
+              onClick={() => proposals.refetch()}
+            >
               Try again
             </Button>
           </Card>
@@ -277,7 +284,8 @@ export default function MeetupsPage() {
             <CalendarDays className="mx-auto h-7 w-7 text-primary" aria-hidden="true" />
             <h2 className="mt-3 font-semibold">No meetup plans yet</h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              Start with an explainable match, chat first, then suggest a public place when it feels right.
+              Start with an explainable match, chat first, then suggest a public place when it feels
+              right.
             </p>
             <Button asChild className="mt-5">
               <Link href="/discover">Find a compatible dog</Link>

--- a/apps/web/src/app/meetups/page.tsx
+++ b/apps/web/src/app/meetups/page.tsx
@@ -68,15 +68,13 @@ function ChoiceGroup<T extends string>({
 
 function OutcomeCard({ proposal }: { proposal: MeetupProposal }) {
   const queryClient = useQueryClient();
-  const [dogExperience, setDogExperience] = useState<
-    NonNullable<MeetupOutcome['dogExperience']> | null
-  >(null);
-  const [ownerExperience, setOwnerExperience] = useState<
-    NonNullable<MeetupOutcome['ownerExperience']> | null
-  >(null);
-  const [meetAgain, setMeetAgain] = useState<
-    NonNullable<MeetupOutcome['meetAgain']> | null
-  >(null);
+  const [dogExperience, setDogExperience] = useState<NonNullable<
+    MeetupOutcome['dogExperience']
+  > | null>(null);
+  const [ownerExperience, setOwnerExperience] = useState<NonNullable<
+    MeetupOutcome['ownerExperience']
+  > | null>(null);
+  const [meetAgain, setMeetAgain] = useState<NonNullable<MeetupOutcome['meetAgain']> | null>(null);
   const [safe, setSafe] = useState<boolean | null>(null);
   const [message, setMessage] = useState<string | null>(null);
 

--- a/apps/web/src/app/meetups/page.tsx
+++ b/apps/web/src/app/meetups/page.tsx
@@ -68,11 +68,15 @@ function ChoiceGroup<T extends string>({
 
 function OutcomeCard({ proposal }: { proposal: MeetupProposal }) {
   const queryClient = useQueryClient();
-  const [dogExperience, setDogExperience] = useState<MeetupOutcome['dogExperience'] | null>(null);
-  const [ownerExperience, setOwnerExperience] = useState<MeetupOutcome['ownerExperience'] | null>(
-    null
-  );
-  const [meetAgain, setMeetAgain] = useState<MeetupOutcome['meetAgain'] | null>(null);
+  const [dogExperience, setDogExperience] = useState<
+    NonNullable<MeetupOutcome['dogExperience']> | null
+  >(null);
+  const [ownerExperience, setOwnerExperience] = useState<
+    NonNullable<MeetupOutcome['ownerExperience']> | null
+  >(null);
+  const [meetAgain, setMeetAgain] = useState<
+    NonNullable<MeetupOutcome['meetAgain']> | null
+  >(null);
   const [safe, setSafe] = useState<boolean | null>(null);
   const [message, setMessage] = useState<string | null>(null);
 

--- a/apps/web/src/app/meetups/page.tsx
+++ b/apps/web/src/app/meetups/page.tsx
@@ -1,0 +1,347 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { CalendarDays, Check, Loader2, MapPin, MessageCircle, ShieldCheck, X } from 'lucide-react';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import { BottomNav } from '@/components/bottom-nav';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { authApi } from '@/lib/api';
+import {
+  meetupProposalsApi,
+  type MeetupOutcome,
+  type MeetupProposal,
+} from '@/lib/api/meetup-proposals';
+import { useAuthStore } from '@/lib/stores/auth-store';
+
+function readableDate(value: string) {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return 'Time to be confirmed';
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function venueName(proposal: MeetupProposal) {
+  return proposal.suggestedVenue?.name?.trim() || 'Public meetup place';
+}
+
+function ChoiceGroup<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: T | null;
+  options: Array<{ value: T; label: string }>;
+  onChange: (value: T) => void;
+}) {
+  return (
+    <div>
+      <p className="text-xs font-semibold text-muted-foreground">{label}</p>
+      <div className="mt-2 flex flex-wrap gap-2" role="group" aria-label={label}>
+        {options.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={value === option.value}
+            onClick={() => onChange(option.value)}
+            className={`rounded-full border px-3 py-2 text-sm font-semibold transition-colors ${
+              value === option.value
+                ? 'border-primary/30 bg-primary/10 text-primary'
+                : 'border-border/70 bg-background/60 text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function OutcomeCard({ proposal }: { proposal: MeetupProposal }) {
+  const queryClient = useQueryClient();
+  const [dogExperience, setDogExperience] = useState<MeetupOutcome['dogExperience'] | null>(null);
+  const [ownerExperience, setOwnerExperience] =
+    useState<MeetupOutcome['ownerExperience'] | null>(null);
+  const [meetAgain, setMeetAgain] = useState<MeetupOutcome['meetAgain'] | null>(null);
+  const [safe, setSafe] = useState<boolean | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const submit = useMutation({
+    mutationFn: (outcome: MeetupOutcome) => meetupProposalsApi.complete(proposal.id, outcome),
+    onSuccess: async (result) => {
+      setMessage(
+        result.reportSuggested
+          ? 'Feedback saved. Because you flagged a safety concern, reporting options should be considered.'
+          : 'Thanks. That tiny bit of context will make future matching more useful.',
+      );
+      await queryClient.invalidateQueries({ queryKey: ['meetup-proposals'] });
+    },
+    onError: () => {
+      setMessage('That outcome could not be saved, or you may have already submitted it.');
+    },
+  });
+
+  const complete = () => {
+    if (!dogExperience || !ownerExperience || !meetAgain || safe === null) return;
+    submit.mutate({
+      occurred: true,
+      dogExperience,
+      ownerExperience,
+      meetAgain,
+      checklistOk: safe,
+    });
+  };
+
+  return (
+    <div className="mt-4 space-y-4 border-t border-border/60 pt-4">
+      <div>
+        <p className="eyebrow">Close the loop</p>
+        <h3 className="mt-1 font-semibold">How did it go?</h3>
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+          Three quick answers become outcome evidence for future compatibility. They are not a health diagnosis.
+        </p>
+      </div>
+
+      <ChoiceGroup
+        label="How was it for your dog?"
+        value={dogExperience}
+        onChange={setDogExperience}
+        options={[
+          { value: 'loved_it', label: 'Loved it' },
+          { value: 'comfortable', label: 'Comfortable' },
+          { value: 'not_their_thing', label: 'Not for them' },
+        ]}
+      />
+      <ChoiceGroup
+        label="How was it for you?"
+        value={ownerExperience}
+        onChange={setOwnerExperience}
+        options={[
+          { value: 'great', label: 'Easy' },
+          { value: 'fine', label: 'Fine' },
+          { value: 'a_lot_today', label: 'A lot today' },
+        ]}
+      />
+      <ChoiceGroup
+        label="Meet again?"
+        value={meetAgain}
+        onChange={setMeetAgain}
+        options={[
+          { value: 'yes', label: 'Yes' },
+          { value: 'maybe', label: 'Maybe' },
+          { value: 'no', label: 'No' },
+        ]}
+      />
+
+      <div>
+        <p className="text-xs font-semibold text-muted-foreground">Did the meetup feel safe?</p>
+        <div className="mt-2 flex gap-2" role="group" aria-label="Did the meetup feel safe?">
+          <Button
+            type="button"
+            size="sm"
+            variant={safe === true ? 'default' : 'outline'}
+            className={safe === true ? '' : 'bg-transparent'}
+            onClick={() => setSafe(true)}
+          >
+            <ShieldCheck className="mr-2 h-4 w-4" aria-hidden="true" />
+            Yes
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant={safe === false ? 'destructive' : 'outline'}
+            className={safe === false ? '' : 'bg-transparent'}
+            onClick={() => setSafe(false)}
+          >
+            No
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          disabled={
+            submit.isPending || !dogExperience || !ownerExperience || !meetAgain || safe === null
+          }
+          onClick={complete}
+        >
+          {submit.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />}
+          Save outcome
+        </Button>
+        {proposal.status === 'accepted' && (
+          <Button
+            variant="ghost"
+            disabled={submit.isPending}
+            onClick={() => submit.mutate({ occurred: false })}
+          >
+            It didn&apos;t happen
+          </Button>
+        )}
+      </div>
+      {message && (
+        <p className="rounded-xl bg-muted/50 p-3 text-xs text-muted-foreground" role="status">
+          {message}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function MeetupsPage() {
+  const cachedUser = useAuthStore((state) => state.user);
+  const queryClient = useQueryClient();
+  const profile = useQuery({
+    queryKey: ['auth-profile'],
+    queryFn: authApi.me,
+    staleTime: 30_000,
+    retry: false,
+  });
+  const user = profile.data ?? cachedUser;
+  const proposals = useQuery({
+    queryKey: ['meetup-proposals'],
+    queryFn: meetupProposalsApi.getMine,
+    enabled: Boolean(user),
+    retry: false,
+  });
+
+  const status = useMutation({
+    mutationFn: ({ id, next }: { id: string; next: 'accepted' | 'declined' }) =>
+      meetupProposalsApi.updateStatus(id, next),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['meetup-proposals'] });
+    },
+  });
+
+  const items = useMemo(() => {
+    if (!proposals.data || !user) return [];
+    return [
+      ...proposals.data.received.map((proposal) => ({ proposal, direction: 'received' as const })),
+      ...proposals.data.sent.map((proposal) => ({ proposal, direction: 'sent' as const })),
+    ].sort(
+      (a, b) =>
+        new Date(b.proposal.suggestedTime).getTime() - new Date(a.proposal.suggestedTime).getTime(),
+    );
+  }, [proposals.data, user]);
+
+  return (
+    <div className="min-h-screen pb-24">
+      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/88 backdrop-blur-2xl">
+        <div className="mx-auto flex h-16 max-w-xl items-center justify-between px-4">
+          <div>
+            <p className="eyebrow">Real-world loop</p>
+            <h1 className="mt-0.5 text-xl font-bold tracking-tight">Meetups</h1>
+          </div>
+          <Button asChild size="sm" variant="outline" className="bg-transparent">
+            <Link href="/inbox">
+              <MessageCircle className="mr-2 h-4 w-4" aria-hidden="true" />
+              Messages
+            </Link>
+          </Button>
+        </div>
+      </header>
+
+      <main id="main-content" className="mx-auto max-w-xl space-y-4 px-4 py-5">
+        <Card className="surface-soft rounded-2xl p-4">
+          <p className="text-sm font-semibold">Keep coordination simple and public-place first</p>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            Woof meetup proposals store a venue label and area, not a private home coordinate. Blocking either participant disables coordination.
+          </p>
+        </Card>
+
+        {!user || proposals.isLoading ? (
+          <div className="flex min-h-64 items-center justify-center gap-3" role="status">
+            <Loader2 className="h-5 w-5 animate-spin text-primary" aria-hidden="true" />
+            <span className="text-sm text-muted-foreground">Loading meetups…</span>
+          </div>
+        ) : proposals.isError ? (
+          <Card className="surface-soft rounded-2xl p-6 text-center">
+            <h2 className="font-semibold">Meetups are temporarily unavailable</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              No substitute plans are shown while canonical meetup records cannot be read.
+            </p>
+            <Button variant="outline" className="mt-4 bg-transparent" onClick={() => proposals.refetch()}>
+              Try again
+            </Button>
+          </Card>
+        ) : items.length === 0 ? (
+          <Card className="surface-soft rounded-2xl p-6 text-center">
+            <CalendarDays className="mx-auto h-7 w-7 text-primary" aria-hidden="true" />
+            <h2 className="mt-3 font-semibold">No meetup plans yet</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Start with an explainable match, chat first, then suggest a public place when it feels right.
+            </p>
+            <Button asChild className="mt-5">
+              <Link href="/discover">Find a compatible dog</Link>
+            </Button>
+          </Card>
+        ) : (
+          items.map(({ proposal, direction }) => (
+            <Card key={`${direction}-${proposal.id}`} className="rounded-2xl p-5">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="eyebrow">
+                    {direction === 'received' ? 'Request for you' : 'You suggested'}
+                  </p>
+                  <h2 className="mt-1 text-lg font-bold">{venueName(proposal)}</h2>
+                  <div className="mt-2 flex flex-col gap-1 text-sm text-muted-foreground">
+                    <span className="flex items-center gap-2">
+                      <CalendarDays className="h-4 w-4" aria-hidden="true" />
+                      {readableDate(proposal.suggestedTime)}
+                    </span>
+                    {proposal.suggestedVenue.area && (
+                      <span className="flex items-center gap-2">
+                        <MapPin className="h-4 w-4" aria-hidden="true" />
+                        {proposal.suggestedVenue.area}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-semibold capitalize text-muted-foreground">
+                  {proposal.status}
+                </span>
+              </div>
+
+              {proposal.status === 'pending' && direction === 'received' && (
+                <div className="mt-4 flex gap-2 border-t border-border/60 pt-4">
+                  <Button
+                    size="sm"
+                    disabled={status.isPending}
+                    onClick={() => status.mutate({ id: proposal.id, next: 'accepted' })}
+                  >
+                    <Check className="mr-2 h-4 w-4" aria-hidden="true" />
+                    Accept
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="bg-transparent"
+                    disabled={status.isPending}
+                    onClick={() => status.mutate({ id: proposal.id, next: 'declined' })}
+                  >
+                    <X className="mr-2 h-4 w-4" aria-hidden="true" />
+                    Decline
+                  </Button>
+                </div>
+              )}
+
+              {(proposal.status === 'accepted' || proposal.status === 'completed') && (
+                <OutcomeCard proposal={proposal} />
+              )}
+            </Card>
+          ))
+        )}
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+}

--- a/apps/web/src/components/discover/discover-map-view.tsx
+++ b/apps/web/src/components/discover/discover-map-view.tsx
@@ -1,375 +1,102 @@
-"use client"
+'use client';
 
-import { useState } from "react"
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
-import { Card } from "@/components/ui/card"
-import { AppImage } from "@/components/ui/app-image"
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
-import {
-  MapPin,
-  Star,
-  Phone,
-  Clock,
-  DollarSign,
-  Dog,
-  Scissors,
-  Stethoscope,
-  Home,
-  ShoppingBag,
-  Utensils,
-  Trees,
-  Mountain,
-} from "lucide-react"
-import type { Service } from "@/lib/types"
-import { cn } from "@/lib/utils"
-
-const categoryIcons = {
-  walker: Dog,
-  grooming: Scissors,
-  vet: Stethoscope,
-  sitter: Home,
-  "food-store": ShoppingBag,
-  restaurant: Utensils,
-  park: Trees,
-  hike: Mountain,
-}
-
-const categoryColors = {
-  walker: "text-blue-500",
-  grooming: "text-pink-500",
-  vet: "text-red-500",
-  sitter: "text-purple-500",
-  "food-store": "text-orange-500",
-  restaurant: "text-green-500",
-  park: "text-emerald-500",
-  hike: "text-teal-500",
-}
-
-const mockServices: Service[] = [
-  {
-    id: "s1",
-    name: "Paws & Walk",
-    category: "walker",
-    location: { lat: 37.7749, lng: -122.4194, address: "123 Market St, San Francisco" },
-    rating: 4.8,
-    reviews: 156,
-    distance: 0.5,
-    priceRange: "$$",
-    hours: "7 AM - 7 PM",
-    phone: "(415) 555-0123",
-    imageUrl: "/dog-walker.png",
-    description: "Professional dog walking services with experienced handlers",
-  },
-  {
-    id: "s2",
-    name: "Pampered Paws Grooming",
-    category: "grooming",
-    location: { lat: 37.7849, lng: -122.4094, address: "456 Valencia St, San Francisco" },
-    rating: 4.9,
-    reviews: 203,
-    distance: 1.2,
-    priceRange: "$$$",
-    hours: "9 AM - 6 PM",
-    phone: "(415) 555-0456",
-    imageUrl: "/dog-grooming-salon.png",
-    description: "Full-service grooming salon specializing in all breeds",
-  },
-  {
-    id: "s3",
-    name: "Bay Area Pet Hospital",
-    category: "vet",
-    location: { lat: 37.7649, lng: -122.4294, address: "789 Mission St, San Francisco" },
-    rating: 4.7,
-    reviews: 312,
-    distance: 0.8,
-    priceRange: "$$$",
-    hours: "24/7 Emergency",
-    phone: "(415) 555-0789",
-    imageUrl: "/veterinary-clinic-exterior.png",
-    description: "24/7 emergency care and routine veterinary services",
-  },
-  {
-    id: "s4",
-    name: "Cozy Paws Pet Sitting",
-    category: "sitter",
-    location: { lat: 37.7549, lng: -122.4394, address: "321 Folsom St, San Francisco" },
-    rating: 4.9,
-    reviews: 89,
-    distance: 1.5,
-    priceRange: "$$",
-    hours: "By appointment",
-    phone: "(415) 555-0321",
-    imageUrl: "/pet-sitter.jpg",
-    description: "In-home pet sitting and overnight care services",
-  },
-  {
-    id: "s5",
-    name: "Bark & Meow Pet Supply",
-    category: "food-store",
-    location: { lat: 37.7949, lng: -122.3994, address: "654 Castro St, San Francisco" },
-    rating: 4.6,
-    reviews: 178,
-    distance: 2.1,
-    priceRange: "$$",
-    hours: "9 AM - 8 PM",
-    phone: "(415) 555-0654",
-    imageUrl: "/vibrant-pet-store.png",
-    description: "Premium pet food, treats, and supplies",
-  },
-  {
-    id: "s6",
-    name: "The Dog Patch Cafe",
-    category: "restaurant",
-    location: { lat: 37.7449, lng: -122.4494, address: "987 Potrero Ave, San Francisco" },
-    rating: 4.5,
-    reviews: 245,
-    distance: 1.8,
-    priceRange: "$$",
-    hours: "8 AM - 9 PM",
-    phone: "(415) 555-0987",
-    imageUrl: "/dog-friendly-cafe.png",
-    description: "Pet-friendly cafe with outdoor seating and dog menu",
-  },
-  {
-    id: "s7",
-    name: "Golden Gate Dog Park",
-    category: "park",
-    location: { lat: 37.7699, lng: -122.4544, address: "Golden Gate Park, San Francisco" },
-    rating: 4.8,
-    reviews: 567,
-    distance: 2.5,
-    hours: "6 AM - 10 PM",
-    imageUrl: "/lively-dog-park.png",
-    description: "Large off-leash dog park with separate areas for small and large dogs",
-  },
-  {
-    id: "s8",
-    name: "Lands End Coastal Trail",
-    category: "hike",
-    location: { lat: 37.7833, lng: -122.5085, address: "Lands End, San Francisco" },
-    rating: 4.9,
-    reviews: 892,
-    distance: 4.2,
-    hours: "Sunrise - Sunset",
-    imageUrl: "/coastal-hiking-trail.jpg",
-    description: "Scenic coastal trail with stunning ocean views, dog-friendly",
-  },
-]
+import { useQuery } from '@tanstack/react-query';
+import { Loader2, MapPin, RefreshCw, ShieldCheck, Star } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { servicesApi } from '@/lib/api';
 
 export function DiscoverMapView() {
-  const [selectedService, setSelectedService] = useState<Service | null>(null)
-  const [activeFilters, setActiveFilters] = useState<Service["category"][]>([
-    "walker",
-    "grooming",
-    "vet",
-    "sitter",
-    "food-store",
-    "restaurant",
-    "park",
-    "hike",
-  ])
-
-  const filteredServices = mockServices.filter((service) => activeFilters.includes(service.category))
-
-  const toggleFilter = (category: Service["category"]) => {
-    setActiveFilters((prev) => (prev.includes(category) ? prev.filter((c) => c !== category) : [...prev, category]))
-  }
+  const services = useQuery({
+    queryKey: ['services', 'discovery'],
+    queryFn: () => servicesApi.getServices(),
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
 
   return (
-    <div className="h-[calc(100vh-185px)]">
-      {/* Filter chips */}
-      <div className="px-4 py-3 border-b border-border/50 overflow-x-auto">
-        <div className="flex gap-2 min-w-max">
-          {(Object.keys(categoryIcons) as Service["category"][]).map((category) => {
-            const Icon = categoryIcons[category]
-            const isActive = activeFilters.includes(category)
-            return (
-              <Button
-                key={category}
-                variant={isActive ? "default" : "outline"}
-                size="sm"
-                onClick={() => toggleFilter(category)}
-                className={cn("capitalize shrink-0", !isActive && "bg-transparent")}
-              >
-                <Icon className="w-4 h-4 mr-1" />
-                {category.replace("-", " ")}
-              </Button>
-            )
-          })}
-        </div>
-      </div>
-
-      {/* Map placeholder */}
-      <div className="relative h-[300px] bg-muted border-b border-border/50">
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div className="text-center space-y-2">
-            <MapPin className="w-12 h-12 mx-auto text-muted-foreground" />
-            <p className="text-sm text-muted-foreground">Interactive map view</p>
-            <p className="text-xs text-muted-foreground">Showing {filteredServices.length} nearby services</p>
+    <div className="mx-auto max-w-xl space-y-4 px-4 py-5">
+      <Card className="surface-soft rounded-2xl p-4">
+        <div className="flex items-start gap-3">
+          <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+          <div>
+            <h2 className="text-sm font-semibold">Places are not dog pins</h2>
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              This surface shows real service-provider records. Woof does not place members or dogs on a public map, and nearby matching never returns another household&apos;s coordinates.
+            </p>
           </div>
         </div>
+      </Card>
 
-        {/* Map markers simulation */}
-        {filteredServices.slice(0, 5).map((service, index) => {
-          const Icon = categoryIcons[service.category]
-          return (
-            <button
-              key={service.id}
-              className={cn(
-                "absolute w-10 h-10 rounded-full glass-strong border-2 border-background flex items-center justify-center hover:scale-110 transition-transform",
-                categoryColors[service.category],
-              )}
-              style={{
-                left: `${20 + index * 15}%`,
-                top: `${30 + (index % 3) * 20}%`,
-              }}
-              onClick={() => setSelectedService(service)}
-            >
-              <Icon className="w-5 h-5" />
-            </button>
-          )
-        })}
-      </div>
-
-      {/* Services list */}
-      <div className="overflow-y-auto h-[calc(100%-300px)] px-4 py-4 space-y-3">
-        {filteredServices.map((service) => {
-          const Icon = categoryIcons[service.category]
-          return (
-            <Card
-              key={service.id}
-              className="p-4 cursor-pointer hover:bg-accent/50 transition-colors"
-              onClick={() => setSelectedService(service)}
-            >
-              <div className="flex gap-3">
-                <div
-                  className={cn(
-                    "w-12 h-12 rounded-lg glass flex items-center justify-center shrink-0",
-                    categoryColors[service.category],
+      {services.isLoading ? (
+        <div className="flex min-h-64 items-center justify-center gap-3" role="status">
+          <Loader2 className="h-5 w-5 animate-spin text-primary" aria-hidden="true" />
+          <span className="text-sm text-muted-foreground">Loading available services…</span>
+        </div>
+      ) : services.isError ? (
+        <Card className="surface-soft rounded-2xl p-6 text-center">
+          <h2 className="font-semibold">Places and services are temporarily unavailable</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Woof will not substitute invented businesses or fake reviews while the service directory cannot be read.
+          </p>
+          <Button
+            variant="outline"
+            className="mt-4 gap-2 bg-transparent"
+            onClick={() => services.refetch()}
+          >
+            <RefreshCw className="h-4 w-4" aria-hidden="true" />
+            Try again
+          </Button>
+        </Card>
+      ) : (services.data?.length ?? 0) === 0 ? (
+        <Card className="surface-soft rounded-2xl p-6 text-center">
+          <MapPin className="mx-auto h-7 w-7 text-primary" aria-hidden="true" />
+          <h2 className="mt-3 font-semibold">No verified service records yet</h2>
+          <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+            This stays empty until real providers are available. Discovery matches continue to work independently.
+          </p>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {services.data?.map((service) => (
+            <Card key={service.id} className="rounded-2xl p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="font-semibold">{service.name}</h3>
+                    {service.verified && (
+                      <span className="rounded-full bg-primary/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-primary">
+                        Verified
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-1 text-xs capitalize text-muted-foreground">
+                    {service.serviceType.replace('-', ' ')}
+                  </p>
+                  {service.bio && (
+                    <p className="mt-2 line-clamp-2 text-sm leading-relaxed text-muted-foreground">
+                      {service.bio}
+                    </p>
                   )}
-                >
-                  <Icon className="w-6 h-6" />
+                  <p className="mt-3 flex items-start gap-2 text-xs text-muted-foreground">
+                    <MapPin className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                    {service.location.address}
+                  </p>
                 </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="flex-1 min-w-0">
-                      <h3 className="font-semibold text-sm truncate">{service.name}</h3>
-                      <Badge variant="secondary" className="text-xs capitalize mt-1">
-                        {service.category.replace("-", " ")}
-                      </Badge>
-                    </div>
-                    <div className="text-right shrink-0">
-                      <div className="flex items-center gap-1">
-                        <Star className="w-4 h-4 fill-yellow-500 text-yellow-500" />
-                        <span className="text-sm font-semibold">{service.rating}</span>
-                      </div>
-                      <p className="text-xs text-muted-foreground">({service.reviews})</p>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground">
-                    <span>{service.distance} mi</span>
-                    {service.priceRange && <span>{service.priceRange}</span>}
-                    {service.hours && <span>{service.hours}</span>}
-                  </div>
+                <div className="shrink-0 text-right">
+                  <span className="inline-flex items-center gap-1 text-sm font-semibold">
+                    <Star className="h-4 w-4" aria-hidden="true" />
+                    {service.rating.toFixed(1)}
+                  </span>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {service.reviewCount} review{service.reviewCount === 1 ? '' : 's'}
+                  </p>
                 </div>
               </div>
             </Card>
-          )
-        })}
-      </div>
-
-      {/* Service detail sheet */}
-      <Sheet open={!!selectedService} onOpenChange={() => setSelectedService(null)}>
-        <SheetContent side="bottom" className="h-[85vh]">
-          {selectedService && (
-            <>
-              <SheetHeader>
-                <SheetTitle>{selectedService.name}</SheetTitle>
-              </SheetHeader>
-              <div className="mt-6 space-y-4">
-                {/* Image */}
-                <div className="aspect-video rounded-lg overflow-hidden bg-muted">
-                  <AppImage
-                    src={selectedService.imageUrl || "/placeholder.svg"}
-                    alt={selectedService.name}
-                    width={1200}
-                    height={675}
-                    className="w-full h-full object-cover"
-                  />
-                </div>
-
-                {/* Rating & Category */}
-                <div className="flex items-center justify-between">
-                  <Badge variant="secondary" className="capitalize">
-                    {selectedService.category.replace("-", " ")}
-                  </Badge>
-                  <div className="flex items-center gap-2">
-                    <Star className="w-5 h-5 fill-yellow-500 text-yellow-500" />
-                    <span className="font-semibold">{selectedService.rating}</span>
-                    <span className="text-sm text-muted-foreground">({selectedService.reviews} reviews)</span>
-                  </div>
-                </div>
-
-                {/* Description */}
-                <p className="text-sm text-muted-foreground">{selectedService.description}</p>
-
-                {/* Details */}
-                <div className="space-y-3 pt-2">
-                  <div className="flex items-start gap-3">
-                    <MapPin className="w-5 h-5 text-muted-foreground shrink-0 mt-0.5" />
-                    <div>
-                      <p className="text-sm font-medium">Location</p>
-                      <p className="text-sm text-muted-foreground">{selectedService.location.address}</p>
-                      <p className="text-xs text-muted-foreground mt-1">{selectedService.distance} miles away</p>
-                    </div>
-                  </div>
-
-                  {selectedService.hours && (
-                    <div className="flex items-start gap-3">
-                      <Clock className="w-5 h-5 text-muted-foreground shrink-0 mt-0.5" />
-                      <div>
-                        <p className="text-sm font-medium">Hours</p>
-                        <p className="text-sm text-muted-foreground">{selectedService.hours}</p>
-                      </div>
-                    </div>
-                  )}
-
-                  {selectedService.phone && (
-                    <div className="flex items-start gap-3">
-                      <Phone className="w-5 h-5 text-muted-foreground shrink-0 mt-0.5" />
-                      <div>
-                        <p className="text-sm font-medium">Phone</p>
-                        <p className="text-sm text-muted-foreground">{selectedService.phone}</p>
-                      </div>
-                    </div>
-                  )}
-
-                  {selectedService.priceRange && (
-                    <div className="flex items-start gap-3">
-                      <DollarSign className="w-5 h-5 text-muted-foreground shrink-0 mt-0.5" />
-                      <div>
-                        <p className="text-sm font-medium">Price Range</p>
-                        <p className="text-sm text-muted-foreground">{selectedService.priceRange}</p>
-                      </div>
-                    </div>
-                  )}
-                </div>
-
-                {/* Actions */}
-                <div className="flex gap-3 pt-4">
-                  <Button className="flex-1">Get Directions</Button>
-                  {selectedService.phone && (
-                    <Button variant="outline" className="flex-1 bg-transparent">
-                      Call Now
-                    </Button>
-                  )}
-                </div>
-              </div>
-            </>
-          )}
-        </SheetContent>
-      </Sheet>
+          ))}
+        </div>
+      )}
     </div>
-  )
+  );
 }

--- a/apps/web/src/components/discover/discover-map-view.tsx
+++ b/apps/web/src/components/discover/discover-map-view.tsx
@@ -22,7 +22,9 @@ export function DiscoverMapView() {
           <div>
             <h2 className="text-sm font-semibold">Places are not dog pins</h2>
             <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-              This surface shows real service-provider records. Woof does not place members or dogs on a public map, and nearby matching never returns another household&apos;s coordinates.
+              This surface shows real service-provider records. Woof does not place members or dogs
+              on a public map, and nearby matching never returns another household&apos;s
+              coordinates.
             </p>
           </div>
         </div>
@@ -37,7 +39,8 @@ export function DiscoverMapView() {
         <Card className="surface-soft rounded-2xl p-6 text-center">
           <h2 className="font-semibold">Places and services are temporarily unavailable</h2>
           <p className="mt-2 text-sm text-muted-foreground">
-            Woof will not substitute invented businesses or fake reviews while the service directory cannot be read.
+            Woof will not substitute invented businesses or fake reviews while the service directory
+            cannot be read.
           </p>
           <Button
             variant="outline"
@@ -53,7 +56,8 @@ export function DiscoverMapView() {
           <MapPin className="mx-auto h-7 w-7 text-primary" aria-hidden="true" />
           <h2 className="mt-3 font-semibold">No verified service records yet</h2>
           <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-            This stays empty until real providers are available. Discovery matches continue to work independently.
+            This stays empty until real providers are available. Discovery matches continue to work
+            independently.
           </p>
         </Card>
       ) : (

--- a/apps/web/src/components/discover/match-card.tsx
+++ b/apps/web/src/components/discover/match-card.tsx
@@ -1,62 +1,92 @@
-"use client"
+'use client';
 
-import Link from "next/link"
-import { useState } from "react"
-import { CheckCircle2, Heart, Info, MessageCircle, ShieldCheck } from "lucide-react"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { AppImage } from "@/components/ui/app-image"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
-import type { Match } from "@/lib/types"
-import { cn } from "@/lib/utils"
-import { MatchDetailSheet } from "./match-detail-sheet"
+import { CheckCircle2, Heart, Info, MapPin, MessageCircle, ShieldCheck } from 'lucide-react';
+import Link from 'next/link';
+import { useState } from 'react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { AppImage } from '@/components/ui/app-image';
+import type { DiscoveryDistanceBand } from '@/lib/api/discovery';
+import type { Match } from '@/lib/types';
+import { cn } from '@/lib/utils';
+import { MatchDetailSheet } from './match-detail-sheet';
 
 interface MatchCardProps {
-  match: Match
+  match: Match;
+  distanceBand?: DiscoveryDistanceBand;
 }
 
-export function MatchCard({ match }: MatchCardProps) {
-  const [liked, setLiked] = useState(false)
-  const [detailOpen, setDetailOpen] = useState(false)
+function readableDistanceBand(distanceBand?: DiscoveryDistanceBand) {
+  switch (distanceBand) {
+    case 'WITHIN_2_5_KM':
+      return 'within about 2.5 km';
+    case 'WITHIN_5_KM':
+      return 'within about 5 km';
+    case 'WITHIN_10_KM':
+      return 'within about 10 km';
+    default:
+      return null;
+  }
+}
+
+export function MatchCard({ match, distanceBand }: MatchCardProps) {
+  const [liked, setLiked] = useState(false);
+  const [detailOpen, setDetailOpen] = useState(false);
 
   const getScoreColor = (score: number) => {
-    if (score >= 85) return "text-secondary"
-    if (score >= 70) return "text-primary"
-    return "text-muted-foreground"
-  }
+    if (score >= 85) return 'text-secondary';
+    if (score >= 70) return 'text-primary';
+    return 'text-muted-foreground';
+  };
 
-  const petDetails = [match.pet.breed, match.pet.age !== undefined ? `${match.pet.age} years` : undefined]
+  const petDetails = [
+    match.pet.breed,
+    match.pet.age !== undefined ? `${match.pet.age} years` : undefined,
+  ]
     .filter(Boolean)
-    .join(" · ")
+    .join(' · ');
+  const nearbyLabel = readableDistanceBand(distanceBand);
 
   return (
     <>
       <Card className="glass overflow-hidden rounded-2xl border-border/60">
         <div className="relative aspect-[4/3] overflow-hidden bg-muted/30">
           <AppImage
-            src={match.pet.photoUrl || "/placeholder.svg"}
+            src={match.pet.photoUrl || '/placeholder.svg'}
             alt={`${match.pet.name}, ${match.pet.breed || match.pet.species}`}
             width={1200}
             height={900}
             className="h-full w-full object-cover"
           />
-          <div className="absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-background/80 to-transparent" aria-hidden="true" />
+          <div
+            className="absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-background/80 to-transparent"
+            aria-hidden="true"
+          />
 
           <div className="absolute right-3 top-3">
             <div className="glass-strong flex items-center gap-2 rounded-full px-3 py-1.5">
-              <span className={cn("h-2 w-2 rounded-full bg-current", getScoreColor(match.compatibility.overall))} />
-              <span className={cn("text-sm font-bold", getScoreColor(match.compatibility.overall))}>
+              <span
+                className={cn('h-2 w-2 rounded-full bg-current', getScoreColor(match.compatibility.overall))}
+              />
+              <span className={cn('text-sm font-bold', getScoreColor(match.compatibility.overall))}>
                 {match.compatibility.overall}% match
               </span>
             </div>
           </div>
 
-          <div className="absolute bottom-3 left-3 flex items-center gap-2">
+          <div className="absolute bottom-3 left-3 flex flex-wrap items-center gap-2">
             <Badge className="border-white/10 bg-background/80 text-foreground backdrop-blur-xl hover:bg-background/80">
               {match.compatibility.confidence}% confidence
             </Badge>
-            {match.status === "CONFIRMED" && (
+            {nearbyLabel && (
+              <Badge className="border-primary/20 bg-background/85 text-primary backdrop-blur-xl hover:bg-background/85">
+                <MapPin className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
+                {nearbyLabel}
+              </Badge>
+            )}
+            {match.status === 'CONFIRMED' && (
               <Badge className="border-secondary/20 bg-secondary/15 text-secondary hover:bg-secondary/15">
                 <CheckCircle2 className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
                 Connected
@@ -68,13 +98,14 @@ export function MatchCard({ match }: MatchCardProps) {
         <div className="space-y-4 p-4">
           <div className="flex items-start gap-3">
             <Avatar className="h-12 w-12 border-2 border-border">
-              <AvatarImage src={match.owner.avatarUrl || "/placeholder.svg"} alt="" />
+              <AvatarImage src={match.owner.avatarUrl || '/placeholder.svg'} alt="" />
               <AvatarFallback>{match.owner.name.slice(0, 1).toUpperCase()}</AvatarFallback>
             </Avatar>
             <div className="min-w-0 flex-1">
               <div className="flex flex-wrap items-center gap-2">
                 <h3 className="text-lg font-semibold tracking-tight">
-                  {match.pet.name} <span className="font-normal text-muted-foreground">with</span> {match.owner.name}
+                  {match.pet.name} <span className="font-normal text-muted-foreground">with</span>{' '}
+                  {match.owner.name}
                 </h3>
                 {match.owner.isVerified && (
                   <span className="inline-flex items-center text-secondary" title="Verified member">
@@ -90,13 +121,19 @@ export function MatchCard({ match }: MatchCardProps) {
           </div>
 
           {match.owner.bio && (
-            <p className="line-clamp-2 text-sm leading-relaxed text-muted-foreground">{match.owner.bio}</p>
+            <p className="line-clamp-2 text-sm leading-relaxed text-muted-foreground">
+              {match.owner.bio}
+            </p>
           )}
 
           {match.compatibility.explanation.length > 0 && (
             <div className="flex flex-wrap gap-2" aria-label="Why this match">
               {match.compatibility.explanation.slice(0, 3).map((reason) => (
-                <Badge key={reason} variant="secondary" className="bg-secondary/10 text-secondary hover:bg-secondary/15">
+                <Badge
+                  key={reason}
+                  variant="secondary"
+                  className="bg-secondary/10 text-secondary hover:bg-secondary/15"
+                >
                   {reason}
                 </Badge>
               ))}
@@ -117,12 +154,12 @@ export function MatchCard({ match }: MatchCardProps) {
             <Button
               variant="outline"
               size="icon"
-              aria-label={liked ? "Remove from favorites" : "Save match"}
+              aria-label={liked ? 'Remove from favorites' : 'Save match'}
               aria-pressed={liked}
-              className={cn("bg-transparent", liked && "border-accent/60 text-accent")}
+              className={cn('bg-transparent', liked && 'border-accent/60 text-accent')}
               onClick={() => setLiked(!liked)}
             >
-              <Heart className={cn("h-5 w-5", liked && "fill-current")} aria-hidden="true" />
+              <Heart className={cn('h-5 w-5', liked && 'fill-current')} aria-hidden="true" />
             </Button>
             <Button
               variant="outline"
@@ -145,5 +182,5 @@ export function MatchCard({ match }: MatchCardProps) {
 
       <MatchDetailSheet match={match} open={detailOpen} onOpenChange={setDetailOpen} />
     </>
-  )
+  );
 }

--- a/apps/web/src/components/discover/match-card.tsx
+++ b/apps/web/src/components/discover/match-card.tsx
@@ -68,7 +68,10 @@ export function MatchCard({ match, distanceBand }: MatchCardProps) {
           <div className="absolute right-3 top-3">
             <div className="glass-strong flex items-center gap-2 rounded-full px-3 py-1.5">
               <span
-                className={cn('h-2 w-2 rounded-full bg-current', getScoreColor(match.compatibility.overall))}
+                className={cn(
+                  'h-2 w-2 rounded-full bg-current',
+                  getScoreColor(match.compatibility.overall),
+                )}
               />
               <span className={cn('text-sm font-bold', getScoreColor(match.compatibility.overall))}>
                 {match.compatibility.overall}% match
@@ -171,7 +174,7 @@ export function MatchCard({ match, distanceBand }: MatchCardProps) {
               <Info className="h-5 w-5" aria-hidden="true" />
             </Button>
             <Button asChild className="flex-1 gap-2">
-              <Link href={`/inbox?match=${match.id}`}>
+              <Link href={`/inbox?member=${match.owner.id}`}>
                 <MessageCircle className="h-4 w-4" aria-hidden="true" />
                 Start a conversation
               </Link>

--- a/apps/web/src/components/discover/match-card.tsx
+++ b/apps/web/src/components/discover/match-card.tsx
@@ -70,7 +70,7 @@ export function MatchCard({ match, distanceBand }: MatchCardProps) {
               <span
                 className={cn(
                   'h-2 w-2 rounded-full bg-current',
-                  getScoreColor(match.compatibility.overall),
+                  getScoreColor(match.compatibility.overall)
                 )}
               />
               <span className={cn('text-sm font-bold', getScoreColor(match.compatibility.overall))}>

--- a/apps/web/src/components/inbox/chat-window.tsx
+++ b/apps/web/src/components/inbox/chat-window.tsx
@@ -8,7 +8,12 @@ import { useEffect, useRef, useState } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { chatApi, type ChatConversation, type ChatMessage, type ChatMessagePage } from '@/lib/api/chat';
+import {
+  chatApi,
+  type ChatConversation,
+  type ChatMessage,
+  type ChatMessagePage,
+} from '@/lib/api/chat';
 import { meetupProposalsApi } from '@/lib/api/meetup-proposals';
 import { chatSocket, connectSocket } from '@/lib/socket';
 import { cn } from '@/lib/utils';
@@ -54,7 +59,7 @@ export function ChatWindow({ conversation, currentUserId, onBack }: ChatWindowPr
             data: [...current.data, message],
             total: current.total + 1,
           };
-        },
+        }
       );
       void chatApi.markRead(conversation.id).catch(() => undefined);
       void queryClient.invalidateQueries({ queryKey: ['chat', 'conversations'] });
@@ -85,7 +90,7 @@ export function ChatWindow({ conversation, currentUserId, onBack }: ChatWindowPr
         (current) => {
           if (!current || current.data.some((entry) => entry.id === persisted.id)) return current;
           return { ...current, data: [...current.data, persisted], total: current.total + 1 };
-        },
+        }
       );
       setInputValue('');
       await queryClient.invalidateQueries({ queryKey: ['chat', 'conversations'] });
@@ -132,7 +137,9 @@ export function ChatWindow({ conversation, currentUserId, onBack }: ChatWindowPr
           </Button>
           <Avatar className="h-10 w-10">
             <AvatarImage src={conversation.participant.avatarUrl || '/placeholder.svg'} alt="" />
-            <AvatarFallback>{conversation.participant.name.slice(0, 1).toUpperCase()}</AvatarFallback>
+            <AvatarFallback>
+              {conversation.participant.name.slice(0, 1).toUpperCase()}
+            </AvatarFallback>
           </Avatar>
           <div className="min-w-0 flex-1">
             <h2 className="truncate font-semibold">
@@ -159,7 +166,11 @@ export function ChatWindow({ conversation, currentUserId, onBack }: ChatWindowPr
             <p className="mt-1 text-sm text-muted-foreground">
               Woof will not substitute a demo transcript while canonical messages cannot be read.
             </p>
-            <Button variant="outline" className="mt-4 bg-transparent" onClick={() => messages.refetch()}>
+            <Button
+              variant="outline"
+              className="mt-4 bg-transparent"
+              onClick={() => messages.refetch()}
+            >
               Try again
             </Button>
           </div>
@@ -167,7 +178,8 @@ export function ChatWindow({ conversation, currentUserId, onBack }: ChatWindowPr
           <div className="surface-soft rounded-2xl p-5 text-center">
             <p className="font-semibold">Start with a simple hello</p>
             <p className="mt-1 text-sm text-muted-foreground">
-              Messages are private to members of this conversation. Once you have chatted, you can suggest a public-place meetup.
+              Messages are private to members of this conversation. Once you have chatted, you can
+              suggest a public-place meetup.
             </p>
           </div>
         ) : (
@@ -191,14 +203,17 @@ export function ChatWindow({ conversation, currentUserId, onBack }: ChatWindowPr
                 <div className={cn('flex gap-2', isCurrentUser ? 'justify-end' : 'justify-start')}>
                   {!isCurrentUser && (
                     <Avatar className="h-8 w-8 shrink-0">
-                      <AvatarImage src={conversation.participant.avatarUrl || '/placeholder.svg'} alt="" />
+                      <AvatarImage
+                        src={conversation.participant.avatarUrl || '/placeholder.svg'}
+                        alt=""
+                      />
                       <AvatarFallback>{conversation.participant.name.slice(0, 1)}</AvatarFallback>
                     </Avatar>
                   )}
                   <div
                     className={cn(
                       'max-w-[78%] rounded-2xl px-4 py-2',
-                      isCurrentUser ? 'bg-primary text-primary-foreground' : 'glass',
+                      isCurrentUser ? 'bg-primary text-primary-foreground' : 'glass'
                     )}
                   >
                     <p className="whitespace-pre-wrap break-words text-sm">{message.content}</p>

--- a/apps/web/src/components/inbox/chat-window.tsx
+++ b/apps/web/src/components/inbox/chat-window.tsx
@@ -1,236 +1,272 @@
-"use client"
+'use client';
 
-import { useState, useRef, useEffect } from "react"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { ChevronLeft, Send, MapPin, MoreVertical } from "lucide-react"
-import { format } from "date-fns"
-import { cn } from "@/lib/utils"
-import { MeetupProposalCard } from "./meetup-proposal-card"
-import { MeetupProposalSheet } from "./meetup-proposal-sheet"
-import type { Message } from "@/lib/types"
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { format } from 'date-fns';
+import { ChevronLeft, Loader2, MapPin, Send } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { chatApi, type ChatConversation, type ChatMessage, type ChatMessagePage } from '@/lib/api/chat';
+import { meetupProposalsApi } from '@/lib/api/meetup-proposals';
+import { chatSocket, connectSocket } from '@/lib/socket';
+import { cn } from '@/lib/utils';
+import { MeetupProposalSheet } from './meetup-proposal-sheet';
 
 interface ChatWindowProps {
-  conversation: {
-    id: string
-    participant: {
-      id: string
-      name: string
-      avatarUrl: string
-      petName: string
-    }
-  }
-  onBack: () => void
+  conversation: ChatConversation;
+  currentUserId: string;
+  onBack: () => void;
 }
 
-// Mock messages
-const mockMessages: Message[] = [
-  {
-    id: "m1",
-    conversationId: "c1",
-    senderId: "o1",
-    content: "Hi! I saw we're a great match. Max would love to meet your pup!",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
-    read: true,
-    type: "text",
-  },
-  {
-    id: "m2",
-    conversationId: "c1",
-    senderId: "current-user",
-    content: "That would be amazing! We love meeting new friends. How about this weekend?",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 23).toISOString(),
-    read: true,
-    type: "text",
-  },
-  {
-    id: "m3",
-    conversationId: "c1",
-    senderId: "o1",
-    content: "Perfect! I know a great hiking trail nearby.",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60 * 22).toISOString(),
-    read: true,
-    type: "text",
-  },
-  {
-    id: "m4",
-    conversationId: "c1",
-    senderId: "o1",
-    content: "",
-    timestamp: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
-    read: true,
-    type: "meetup-proposal",
-    metadata: {
-      location: { lat: 37.7749, lng: -122.4194, name: "Golden Gate Park Trail" },
-      datetime: new Date(Date.now() + 1000 * 60 * 60 * 24 * 2).toISOString(),
-    },
-  },
-  {
-    id: "m5",
-    conversationId: "c1",
-    senderId: "o1",
-    content: "That sounds great! Max would love to join you for a hike this weekend.",
-    timestamp: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
-    read: false,
-    type: "text",
-  },
-]
+export function ChatWindow({ conversation, currentUserId, onBack }: ChatWindowProps) {
+  const queryClient = useQueryClient();
+  const [inputValue, setInputValue] = useState('');
+  const [proposalOpen, setProposalOpen] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+  const [proposalMessage, setProposalMessage] = useState<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
 
-export function ChatWindow({ conversation, onBack }: ChatWindowProps) {
-  const [messages, setMessages] = useState<Message[]>(mockMessages)
-  const [inputValue, setInputValue] = useState("")
-  const [proposalOpen, setProposalOpen] = useState(false)
-  const messagesEndRef = useRef<HTMLDivElement>(null)
-
-  const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
-  }
+  const messages = useQuery({
+    queryKey: ['chat', 'messages', conversation.id],
+    queryFn: () => chatApi.getMessages(conversation.id),
+    retry: false,
+  });
 
   useEffect(() => {
-    scrollToBottom()
-  }, [messages])
+    const activeSocket = connectSocket();
+    chatSocket.joinConversation(conversation.id);
+    void chatApi.markRead(conversation.id).catch(() => undefined);
 
-  const handleSend = () => {
-    if (!inputValue.trim()) return
+    const removeMessageListener = chatSocket.onMessage((message) => {
+      if (message.conversationId !== conversation.id) return;
+      queryClient.setQueryData<ChatMessagePage>(
+        ['chat', 'messages', conversation.id],
+        (current) => {
+          if (!current) {
+            return { data: [message], total: 1, page: 1, limit: 50 };
+          }
+          if (current.data.some((entry) => entry.id === message.id)) return current;
+          return {
+            ...current,
+            data: [...current.data, message],
+            total: current.total + 1,
+          };
+        },
+      );
+      void chatApi.markRead(conversation.id).catch(() => undefined);
+      void queryClient.invalidateQueries({ queryKey: ['chat', 'conversations'] });
+    });
 
-    const newMessage: Message = {
-      id: `m${messages.length + 1}`,
-      conversationId: conversation.id,
-      senderId: "current-user",
-      content: inputValue,
-      timestamp: new Date().toISOString(),
-      read: false,
-      type: "text",
+    return () => {
+      removeMessageListener();
+      chatSocket.leaveConversation(conversation.id);
+      if (activeSocket.connected) {
+        chatSocket.stopTyping(conversation.id);
+      }
+    };
+  }, [conversation.id, queryClient]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages.data?.data]);
+
+  const handleSend = async () => {
+    const text = inputValue.trim();
+    if (!text || sending) return;
+    setSending(true);
+    setSendError(null);
+    try {
+      const persisted = await chatSocket.sendMessage(conversation.id, text);
+      queryClient.setQueryData<ChatMessagePage>(
+        ['chat', 'messages', conversation.id],
+        (current) => {
+          if (!current || current.data.some((entry) => entry.id === persisted.id)) return current;
+          return { ...current, data: [...current.data, persisted], total: current.total + 1 };
+        },
+      );
+      setInputValue('');
+      await queryClient.invalidateQueries({ queryKey: ['chat', 'conversations'] });
+    } catch {
+      setSendError('That message was not saved. Your draft is still here.');
+    } finally {
+      setSending(false);
     }
+  };
 
-    setMessages([...messages, newMessage])
-    setInputValue("")
-  }
-
-  const handleProposalSubmit = (data: { location: string; datetime: string; notes: string }) => {
-    const newMessage: Message = {
-      id: `m${messages.length + 1}`,
-      conversationId: conversation.id,
-      senderId: "current-user",
-      content: "",
-      timestamp: new Date().toISOString(),
-      read: false,
-      type: "meetup-proposal",
-      metadata: {
-        location: { lat: 37.7749, lng: -122.4194, name: data.location },
-        datetime: data.datetime,
-      },
+  const handleProposalSubmit = async (data: {
+    location: string;
+    datetime: string;
+    notes: string;
+  }) => {
+    setProposalMessage(null);
+    try {
+      const suggestedTime = new Date(data.datetime);
+      await meetupProposalsApi.create({
+        recipientId: conversation.participant.id,
+        suggestedTime: suggestedTime.toISOString(),
+        suggestedVenue: {
+          name: data.location.trim(),
+          type: 'public_place',
+        },
+        ...(data.notes.trim() ? { notes: data.notes.trim() } : {}),
+      });
+      setProposalOpen(false);
+      setProposalMessage('Meetup suggestion sent. You can track it in Meetups.');
+      await queryClient.invalidateQueries({ queryKey: ['meetup-proposals'] });
+    } catch {
+      setProposalMessage('That meetup suggestion was not saved. Check the time and try again.');
     }
+  };
 
-    setMessages([...messages, newMessage])
-    setProposalOpen(false)
-  }
+  const messageList: ChatMessage[] = messages.data?.data ?? [];
 
   return (
-    <div className="flex flex-col h-[calc(100vh-5rem)]">
-      {/* Chat Header */}
-      <div className="sticky top-[73px] z-30 glass-strong border-b border-border/50">
+    <div className="flex h-[calc(100vh-5rem)] flex-col">
+      <div className="glass-strong sticky top-[73px] z-30 border-b border-border/50">
         <div className="flex items-center gap-3 px-4 py-3">
-          <Button variant="ghost" size="icon" onClick={onBack}>
-            <ChevronLeft className="w-5 h-5" />
+          <Button variant="ghost" size="icon" onClick={onBack} aria-label="Back to conversations">
+            <ChevronLeft className="h-5 w-5" aria-hidden="true" />
           </Button>
-          <Avatar className="w-10 h-10">
-            <AvatarImage src={conversation.participant.avatarUrl || "/placeholder.svg"} />
-            <AvatarFallback>{conversation.participant.name[0]}</AvatarFallback>
+          <Avatar className="h-10 w-10">
+            <AvatarImage src={conversation.participant.avatarUrl || '/placeholder.svg'} alt="" />
+            <AvatarFallback>{conversation.participant.name.slice(0, 1).toUpperCase()}</AvatarFallback>
           </Avatar>
-          <div className="flex-1 min-w-0">
-            <h2 className="font-semibold truncate">
-              {conversation.participant.name} & {conversation.participant.petName}
+          <div className="min-w-0 flex-1">
+            <h2 className="truncate font-semibold">
+              {conversation.participant.name}
+              {conversation.participant.petName ? ` & ${conversation.participant.petName}` : ''}
             </h2>
-            <p className="text-xs text-muted-foreground">Active now</p>
+            <p className="text-xs text-muted-foreground">Private direct conversation</p>
           </div>
-          <Button variant="ghost" size="icon">
-            <MoreVertical className="w-5 h-5" />
+          <Button asChild size="sm" variant="outline" className="bg-transparent">
+            <Link href="/meetups">Meetups</Link>
           </Button>
         </div>
       </div>
 
-      {/* Messages */}
-      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
-        {messages.map((message, index) => {
-          const isCurrentUser = message.senderId === "current-user"
-          const showTimestamp =
-            index === 0 ||
-            new Date(message.timestamp).getTime() - new Date(messages[index - 1].timestamp).getTime() > 1000 * 60 * 60
+      <div className="flex-1 space-y-4 overflow-y-auto px-4 py-4">
+        {messages.isLoading ? (
+          <div className="flex min-h-52 items-center justify-center gap-2" role="status">
+            <Loader2 className="h-5 w-5 animate-spin text-primary" aria-hidden="true" />
+            <span className="text-sm text-muted-foreground">Loading conversation…</span>
+          </div>
+        ) : messages.isError ? (
+          <div className="surface-soft rounded-2xl p-5 text-center">
+            <p className="font-semibold">Conversation history is unavailable</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Woof will not substitute a demo transcript while canonical messages cannot be read.
+            </p>
+            <Button variant="outline" className="mt-4 bg-transparent" onClick={() => messages.refetch()}>
+              Try again
+            </Button>
+          </div>
+        ) : messageList.length === 0 ? (
+          <div className="surface-soft rounded-2xl p-5 text-center">
+            <p className="font-semibold">Start with a simple hello</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Messages are private to members of this conversation. Once you have chatted, you can suggest a public-place meetup.
+            </p>
+          </div>
+        ) : (
+          messageList.map((message, index) => {
+            const isCurrentUser = message.senderId === currentUserId;
+            const previous = index > 0 ? messageList[index - 1] : null;
+            const showTimestamp =
+              !previous ||
+              new Date(message.createdAt).getTime() - new Date(previous.createdAt).getTime() >
+                60 * 60 * 1000;
 
-          return (
-            <div key={message.id} className="space-y-2">
-              {showTimestamp && (
-                <div className="text-center">
-                  <span className="text-xs text-muted-foreground">
-                    {format(new Date(message.timestamp), "MMM d, h:mm a")}
-                  </span>
-                </div>
-              )}
-
-              {message.type === "meetup-proposal" ? (
-                <div className={cn("flex", isCurrentUser ? "justify-end" : "justify-start")}>
-                  <MeetupProposalCard
-                    location={message.metadata?.location?.name || ""}
-                    datetime={message.metadata?.datetime || ""}
-                    isCurrentUser={isCurrentUser}
-                  />
-                </div>
-              ) : (
-                <div className={cn("flex gap-2", isCurrentUser ? "justify-end" : "justify-start")}>
+            return (
+              <div key={message.id} className="space-y-2">
+                {showTimestamp && (
+                  <div className="text-center">
+                    <span className="text-xs text-muted-foreground">
+                      {format(new Date(message.createdAt), 'MMM d, h:mm a')}
+                    </span>
+                  </div>
+                )}
+                <div className={cn('flex gap-2', isCurrentUser ? 'justify-end' : 'justify-start')}>
                   {!isCurrentUser && (
-                    <Avatar className="w-8 h-8 shrink-0">
-                      <AvatarImage src={conversation.participant.avatarUrl || "/placeholder.svg"} />
-                      <AvatarFallback>{conversation.participant.name[0]}</AvatarFallback>
+                    <Avatar className="h-8 w-8 shrink-0">
+                      <AvatarImage src={conversation.participant.avatarUrl || '/placeholder.svg'} alt="" />
+                      <AvatarFallback>{conversation.participant.name.slice(0, 1)}</AvatarFallback>
                     </Avatar>
                   )}
                   <div
                     className={cn(
-                      "max-w-[75%] rounded-2xl px-4 py-2",
-                      isCurrentUser ? "bg-primary text-primary-foreground" : "glass",
+                      'max-w-[78%] rounded-2xl px-4 py-2',
+                      isCurrentUser ? 'bg-primary text-primary-foreground' : 'glass',
                     )}
                   >
-                    <p className="text-sm">{message.content}</p>
+                    <p className="whitespace-pre-wrap break-words text-sm">{message.content}</p>
                   </div>
                 </div>
-              )}
-            </div>
-          )
-        })}
+              </div>
+            );
+          })
+        )}
         <div ref={messagesEndRef} />
       </div>
 
-      {/* Input Area */}
-      <div className="sticky bottom-16 glass-strong border-t border-border/50 p-4">
+      <div className="glass-strong sticky bottom-16 border-t border-border/50 p-4">
+        {proposalMessage && (
+          <p className="mb-2 text-xs text-muted-foreground" role="status">
+            {proposalMessage}
+          </p>
+        )}
+        {sendError && (
+          <p className="mb-2 text-xs text-destructive" role="alert">
+            {sendError}
+          </p>
+        )}
         <div className="flex items-center gap-2">
           <Button
             variant="outline"
             size="icon"
             onClick={() => setProposalOpen(true)}
             className="shrink-0 bg-transparent"
+            aria-label="Suggest a meetup"
           >
-            <MapPin className="w-5 h-5" />
+            <MapPin className="h-5 w-5" aria-hidden="true" />
           </Button>
           <Input
-            placeholder="Type a message..."
+            placeholder="Message…"
             value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.shiftKey) {
-                e.preventDefault()
-                handleSend()
+            maxLength={4000}
+            onChange={(event) => setInputValue(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !event.shiftKey) {
+                event.preventDefault();
+                void handleSend();
               }
             }}
+            onFocus={() => chatSocket.startTyping(conversation.id)}
+            onBlur={() => chatSocket.stopTyping(conversation.id)}
             className="flex-1"
           />
-          <Button size="icon" onClick={handleSend} disabled={!inputValue.trim()}>
-            <Send className="w-5 h-5" />
+          <Button
+            size="icon"
+            onClick={() => void handleSend()}
+            disabled={!inputValue.trim() || sending}
+            aria-label="Send message"
+          >
+            {sending ? (
+              <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+            ) : (
+              <Send className="h-5 w-5" aria-hidden="true" />
+            )}
           </Button>
         </div>
       </div>
 
-      <MeetupProposalSheet open={proposalOpen} onOpenChange={setProposalOpen} onSubmit={handleProposalSubmit} />
+      <MeetupProposalSheet
+        open={proposalOpen}
+        onOpenChange={setProposalOpen}
+        onSubmit={(data) => void handleProposalSubmit(data)}
+      />
     </div>
-  )
+  );
 }

--- a/apps/web/src/components/inbox/conversation-list.tsx
+++ b/apps/web/src/components/inbox/conversation-list.tsx
@@ -1,95 +1,100 @@
-"use client"
+'use client';
 
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { Badge } from "@/components/ui/badge"
-import { formatDistanceToNow } from "date-fns"
-import { cn } from "@/lib/utils"
-
-interface Conversation {
-  id: string
-  matchId: string
-  participant: {
-    id: string
-    name: string
-    avatarUrl: string
-    petName: string
-  }
-  lastMessage: {
-    content: string
-    timestamp: string
-    senderId: string
-    read: boolean
-  }
-  unreadCount: number
-}
+import { formatDistanceToNow } from 'date-fns';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import type { ChatConversation } from '@/lib/api/chat';
+import { cn } from '@/lib/utils';
 
 interface ConversationListProps {
-  conversations: Conversation[]
-  onSelectConversation: (id: string) => void
+  conversations: ChatConversation[];
+  currentUserId: string;
+  onSelectConversation: (id: string) => void;
 }
 
-export function ConversationList({ conversations, onSelectConversation }: ConversationListProps) {
+export function ConversationList({
+  conversations,
+  currentUserId,
+  onSelectConversation,
+}: ConversationListProps) {
   if (conversations.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 px-4">
-        <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center mb-4">
-          <span className="text-2xl">💬</span>
+      <div className="flex flex-col items-center justify-center px-4 py-16">
+        <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+          <span className="text-2xl" aria-hidden="true">
+            💬
+          </span>
         </div>
-        <h3 className="text-lg font-semibold mb-2">No conversations yet</h3>
-        <p className="text-sm text-muted-foreground text-center">
-          Start chatting with your matches to plan playdates and activities!
+        <h3 className="mb-2 text-lg font-semibold">No conversations yet</h3>
+        <p className="max-w-sm text-center text-sm text-muted-foreground">
+          Open an explainable match in Discover and start with a simple hello. Woof does not seed fake conversations.
         </p>
       </div>
-    )
+    );
   }
 
   return (
     <div className="divide-y divide-border">
       {conversations.map((conversation) => {
-        const isUnread = conversation.unreadCount > 0
-        const isFromOther = conversation.lastMessage.senderId !== "current-user"
+        const isUnread = conversation.unreadCount > 0;
+        const lastMessage = conversation.lastMessage;
+        const isFromOther = lastMessage ? lastMessage.senderId !== currentUserId : false;
+        const displayName = conversation.participant.petName
+          ? `${conversation.participant.name} & ${conversation.participant.petName}`
+          : conversation.participant.name;
 
         return (
           <button
             key={conversation.id}
+            type="button"
             onClick={() => onSelectConversation(conversation.id)}
-            className="w-full px-4 py-4 flex items-start gap-3 hover:bg-muted/50 transition-colors text-left"
+            className="flex w-full items-start gap-3 px-4 py-4 text-left transition-colors hover:bg-muted/50"
           >
-            <Avatar className="w-12 h-12 shrink-0">
-              <AvatarImage src={conversation.participant.avatarUrl || "/placeholder.svg"} />
-              <AvatarFallback>{conversation.participant.name[0]}</AvatarFallback>
+            <Avatar className="h-12 w-12 shrink-0">
+              <AvatarImage src={conversation.participant.avatarUrl || '/placeholder.svg'} alt="" />
+              <AvatarFallback>{conversation.participant.name.slice(0, 1).toUpperCase()}</AvatarFallback>
             </Avatar>
 
-            <div className="flex-1 min-w-0">
-              <div className="flex items-start justify-between gap-2 mb-1">
-                <h3 className={cn("font-semibold truncate", isUnread && "text-primary")}>
-                  {conversation.participant.name} & {conversation.participant.petName}
+            <div className="min-w-0 flex-1">
+              <div className="mb-1 flex items-start justify-between gap-2">
+                <h3 className={cn('truncate font-semibold', isUnread && 'text-primary')}>
+                  {displayName}
                 </h3>
-                <span className="text-xs text-muted-foreground shrink-0">
-                  {formatDistanceToNow(new Date(conversation.lastMessage.timestamp), { addSuffix: true })}
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {formatDistanceToNow(new Date(lastMessage?.createdAt ?? conversation.updatedAt), {
+                    addSuffix: true,
+                  })}
                 </span>
               </div>
 
               <div className="flex items-center justify-between gap-2">
                 <p
                   className={cn(
-                    "text-sm truncate",
-                    isUnread && isFromOther ? "font-medium text-foreground" : "text-muted-foreground",
+                    'truncate text-sm',
+                    isUnread && isFromOther
+                      ? 'font-medium text-foreground'
+                      : 'text-muted-foreground',
                   )}
                 >
-                  {isFromOther ? "" : "You: "}
-                  {conversation.lastMessage.content}
+                  {lastMessage ? (
+                    <>
+                      {!isFromOther ? 'You: ' : ''}
+                      {lastMessage.content}
+                    </>
+                  ) : (
+                    'No messages yet'
+                  )}
                 </p>
                 {isUnread && (
-                  <Badge variant="default" className="shrink-0 h-5 min-w-5 px-1.5 text-xs">
+                  <Badge variant="default" className="h-5 min-w-5 shrink-0 px-1.5 text-xs">
                     {conversation.unreadCount}
                   </Badge>
                 )}
               </div>
             </div>
           </button>
-        )
+        );
       })}
     </div>
-  )
+  );
 }

--- a/apps/web/src/components/pets/pet-switcher.tsx
+++ b/apps/web/src/components/pets/pet-switcher.tsx
@@ -35,6 +35,8 @@ export function PetSwitcher({
       queryClient.invalidateQueries({ queryKey: ['concierge', 'today'] }),
       queryClient.invalidateQueries({ queryKey: ['activities'] }),
       queryClient.invalidateQueries({ queryKey: ['story'] }),
+      queryClient.invalidateQueries({ queryKey: ['recommendations'] }),
+      queryClient.invalidateQueries({ queryKey: ['discovery', 'nearby'] }),
     ]);
   };
 

--- a/apps/web/src/lib/api/chat.spec.ts
+++ b/apps/web/src/lib/api/chat.spec.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const transport = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.mock('./client', () => ({ apiClient: transport }));
+
+import { chatApi } from './chat';
+
+describe('chatApi', () => {
+  beforeEach(() => {
+    transport.get.mockReset();
+    transport.post.mockReset();
+  });
+
+  it('creates a direct conversation from a member id rather than a client-owned room id', async () => {
+    transport.post.mockResolvedValue({ id: 'conversation-1', created: true });
+
+    await chatApi.createConversation('member-2');
+
+    expect(transport.post).toHaveBeenCalledWith('/chat/conversations', {
+      participantId: 'member-2',
+    });
+  });
+
+  it('reads bounded canonical message history', async () => {
+    transport.get.mockResolvedValue({ data: [], total: 0, page: 1, limit: 50 });
+
+    await chatApi.getMessages('conversation-1');
+
+    expect(transport.get).toHaveBeenCalledWith('/chat/conversations/conversation-1/messages', {
+      params: { page: 1, limit: 50 },
+    });
+  });
+
+  it('advances the authenticated participant read watermark', async () => {
+    transport.post.mockResolvedValue({ ok: true });
+
+    await chatApi.markRead('conversation-1');
+
+    expect(transport.post).toHaveBeenCalledWith('/chat/conversations/conversation-1/read', {});
+  });
+});

--- a/apps/web/src/lib/api/chat.ts
+++ b/apps/web/src/lib/api/chat.ts
@@ -1,0 +1,51 @@
+import { apiClient } from './client';
+
+export type ChatConversation = {
+  id: string;
+  participant: {
+    id: string;
+    name: string;
+    avatarUrl?: string | null;
+    petId?: string | null;
+    petName?: string | null;
+    petAvatarUrl?: string | null;
+  };
+  lastMessage: {
+    id: string;
+    senderId: string;
+    content: string;
+    mediaUrls: string[];
+    createdAt: string;
+  } | null;
+  unreadCount: number;
+  updatedAt: string;
+};
+
+export type ChatMessage = {
+  id: string;
+  conversationId: string;
+  senderId: string;
+  content: string;
+  type: 'text' | 'image';
+  mediaUrl?: string | null;
+  createdAt: string;
+};
+
+export type ChatMessagePage = {
+  data: ChatMessage[];
+  total: number;
+  page: number;
+  limit: number;
+};
+
+export const chatApi = {
+  getConversations: () => apiClient.get<ChatConversation[]>('/chat/conversations'),
+  createConversation: (participantId: string) =>
+    apiClient.post<{ id: string; created: boolean }>('/chat/conversations', { participantId }),
+  getMessages: (conversationId: string, page = 1, limit = 50) =>
+    apiClient.get<ChatMessagePage>(`/chat/conversations/${conversationId}/messages`, {
+      params: { page, limit },
+    }),
+  markRead: (conversationId: string) =>
+    apiClient.post<{ ok: boolean }>(`/chat/conversations/${conversationId}/read`, {}),
+};

--- a/apps/web/src/lib/api/discovery.spec.ts
+++ b/apps/web/src/lib/api/discovery.spec.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const transport = vi.hoisted(() => ({
+  get: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock('./client', () => ({ apiClient: transport }));
+
+import { discoveryApi } from './discovery';
+
+describe('discoveryApi', () => {
+  beforeEach(() => {
+    transport.get.mockReset();
+    transport.put.mockReset();
+    transport.delete.mockReset();
+  });
+
+  it('sends a precise browser coordinate only to the explicit opt-in endpoint', async () => {
+    transport.put.mockResolvedValue({ status: 'OPTED_IN', exactLocationStored: false });
+
+    await discoveryApi.enableLocation(37.7749, -122.4194);
+
+    expect(transport.put).toHaveBeenCalledWith('/discovery/location', {
+      latitude: 37.7749,
+      longitude: -122.4194,
+    });
+  });
+
+  it('reads nearby context without asking the client for another coordinate', async () => {
+    transport.get.mockResolvedValue({ candidates: [] });
+
+    await discoveryApi.getNearby('pet-1', 5, 20);
+
+    expect(transport.get).toHaveBeenCalledWith('/discovery/nearby/pet-1', {
+      params: { radiusKm: 5, limit: 20 },
+    });
+  });
+
+  it('supports explicit revocation of nearby discovery', async () => {
+    transport.delete.mockResolvedValue({ status: 'DISABLED', exactLocationStored: false });
+
+    await discoveryApi.disableLocation();
+
+    expect(transport.delete).toHaveBeenCalledWith('/discovery/location');
+  });
+});

--- a/apps/web/src/lib/api/discovery.ts
+++ b/apps/web/src/lib/api/discovery.ts
@@ -1,0 +1,52 @@
+import { apiClient } from './client';
+
+export type DiscoveryLocationStatus = {
+  status: 'NOT_CONFIGURED' | 'DISABLED' | 'STALE' | 'OPTED_IN';
+  exactLocationStored: false;
+  precisionMeters: number;
+  expiresAt?: string;
+  updatedAt?: string;
+};
+
+export type DiscoveryDistanceBand = 'WITHIN_2_5_KM' | 'WITHIN_5_KM' | 'WITHIN_10_KM';
+
+export type DiscoveryCandidate = {
+  petId: string;
+  ownerId: string;
+  petName: string;
+  species: string;
+  breed?: string | null;
+  avatarUrl?: string | null;
+  owner: {
+    id: string;
+    handle: string;
+    avatarUrl?: string | null;
+    isVerified: boolean;
+  };
+  distanceBand: DiscoveryDistanceBand;
+};
+
+export type NearbyDiscoveryResponse = {
+  petId: string;
+  locationStatus: DiscoveryLocationStatus['status'];
+  candidates: DiscoveryCandidate[];
+  boundaries: {
+    exactCoordinatesStored: false;
+    exactCoordinatesReturned: false;
+    homeLocationExposed: false;
+    blockedUsersExcluded: true;
+    publicProfilesOnly: true;
+    maxRadiusKm: number;
+  };
+};
+
+export const discoveryApi = {
+  getLocationStatus: () => apiClient.get<DiscoveryLocationStatus>('/discovery/location'),
+  enableLocation: (latitude: number, longitude: number) =>
+    apiClient.put<DiscoveryLocationStatus>('/discovery/location', { latitude, longitude }),
+  disableLocation: () => apiClient.delete<DiscoveryLocationStatus>('/discovery/location'),
+  getNearby: (petId: string, radiusKm = 5, limit = 30) =>
+    apiClient.get<NearbyDiscoveryResponse>(`/discovery/nearby/${petId}`, {
+      params: { radiusKm, limit },
+    }),
+};

--- a/apps/web/src/lib/api/meetup-proposals.spec.ts
+++ b/apps/web/src/lib/api/meetup-proposals.spec.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const transport = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock('./client', () => ({ apiClient: transport }));
+
+import { meetupProposalsApi } from './meetup-proposals';
+
+describe('meetupProposalsApi', () => {
+  beforeEach(() => {
+    transport.get.mockReset();
+    transport.post.mockReset();
+    transport.put.mockReset();
+    transport.delete.mockReset();
+  });
+
+  it('creates a public-place proposal without client coordinates', async () => {
+    const input = {
+      recipientId: 'member-2',
+      suggestedTime: '2026-08-25T18:00:00.000Z',
+      suggestedVenue: { name: 'Neighborhood park', type: 'public_place' },
+    };
+    transport.post.mockResolvedValue({ id: 'proposal-1' });
+
+    await meetupProposalsApi.create(input);
+
+    expect(transport.post).toHaveBeenCalledWith('/meetup-proposals', input);
+    expect(input.suggestedVenue).not.toHaveProperty('lat');
+    expect(input.suggestedVenue).not.toHaveProperty('lng');
+  });
+
+  it('submits the three structured learning answers plus explicit safety feedback', async () => {
+    const outcome = {
+      occurred: true,
+      dogExperience: 'comfortable' as const,
+      ownerExperience: 'great' as const,
+      meetAgain: 'yes' as const,
+      checklistOk: true,
+    };
+    transport.put.mockResolvedValue({ feedbackRecorded: true });
+
+    await meetupProposalsApi.complete('proposal-1', outcome);
+
+    expect(transport.put).toHaveBeenCalledWith('/meetup-proposals/proposal-1/complete', outcome);
+  });
+});

--- a/apps/web/src/lib/api/meetup-proposals.ts
+++ b/apps/web/src/lib/api/meetup-proposals.ts
@@ -1,0 +1,50 @@
+import { apiClient } from './client';
+
+export type MeetupProposalStatus = 'pending' | 'accepted' | 'declined' | 'completed' | 'cancelled';
+
+export type MeetupProposal = {
+  id: string;
+  proposerId: string;
+  recipientId: string;
+  suggestedTime: string;
+  suggestedVenue: {
+    name?: string;
+    type?: string;
+    area?: string;
+  };
+  status: MeetupProposalStatus;
+  occurredAt?: string | null;
+  rating?: number | null;
+  feedbackTags?: string[];
+  checklistOk?: boolean;
+  notes?: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type MeetupOutcome = {
+  occurred: boolean;
+  dogExperience?: 'loved_it' | 'comfortable' | 'not_their_thing';
+  ownerExperience?: 'great' | 'fine' | 'a_lot_today';
+  meetAgain?: 'yes' | 'maybe' | 'no';
+  checklistOk?: boolean;
+};
+
+export const meetupProposalsApi = {
+  getMine: () =>
+    apiClient.get<{ sent: MeetupProposal[]; received: MeetupProposal[] }>('/meetup-proposals'),
+  create: (input: {
+    recipientId: string;
+    suggestedTime: string;
+    suggestedVenue: { name: string; type: string; area?: string };
+    notes?: string;
+  }) => apiClient.post<MeetupProposal>('/meetup-proposals', input),
+  updateStatus: (id: string, status: 'accepted' | 'declined') =>
+    apiClient.put<MeetupProposal>(`/meetup-proposals/${id}/status`, { status }),
+  complete: (id: string, outcome: MeetupOutcome) =>
+    apiClient.put<{ proposal: MeetupProposal; feedbackRecorded: true; reportSuggested: boolean }>(
+      `/meetup-proposals/${id}/complete`,
+      outcome,
+    ),
+  cancel: (id: string) => apiClient.delete<MeetupProposal>(`/meetup-proposals/${id}`),
+};

--- a/apps/web/src/lib/api/meetup-proposals.ts
+++ b/apps/web/src/lib/api/meetup-proposals.ts
@@ -44,7 +44,7 @@ export const meetupProposalsApi = {
   complete: (id: string, outcome: MeetupOutcome) =>
     apiClient.put<{ proposal: MeetupProposal; feedbackRecorded: true; reportSuggested: boolean }>(
       `/meetup-proposals/${id}/complete`,
-      outcome,
+      outcome
     ),
   cancel: (id: string) => apiClient.delete<MeetupProposal>(`/meetup-proposals/${id}`),
 };

--- a/apps/web/src/lib/socket.ts
+++ b/apps/web/src/lib/socket.ts
@@ -79,7 +79,7 @@ export const chatSocket = {
               mediaUrl: ack.message.mediaUrls[0] ?? null,
               createdAt: ack.message.timestamp,
             });
-          },
+          }
         );
     }),
   onMessage: (callback: (message: ChatMessage) => void) => {

--- a/apps/web/src/lib/socket.ts
+++ b/apps/web/src/lib/socket.ts
@@ -1,4 +1,5 @@
 import { io, Socket } from 'socket.io-client';
+import type { ChatMessage } from './api/chat';
 import { useAuthStore } from './stores/auth-store';
 
 let socket: Socket | null = null;
@@ -20,6 +21,7 @@ export function getSocket(): Socket {
 
 export function connectSocket() {
   const activeSocket = getSocket();
+  activeSocket.auth = { token: useAuthStore.getState().token };
   if (!activeSocket.connected) activeSocket.connect();
   return activeSocket;
 }
@@ -35,6 +37,20 @@ function newClientMessageId() {
   return `msg_${Date.now()}_${Math.random().toString(36).slice(2, 14)}`;
 }
 
+type SendAck = {
+  success: boolean;
+  duplicate?: boolean;
+  error?: string;
+  message?: {
+    id: string;
+    conversationId: string;
+    senderId: string;
+    text: string;
+    mediaUrls: string[];
+    timestamp: string;
+  };
+};
+
 export const chatSocket = {
   joinConversation: (conversationId: string) => {
     getSocket().emit('conversation:join', { conversationId });
@@ -42,15 +58,50 @@ export const chatSocket = {
   leaveConversation: (conversationId: string) => {
     getSocket().emit('conversation:leave', { conversationId });
   },
-  sendMessage: (conversationId: string, text: string) => {
-    getSocket().emit('message:send', {
-      conversationId,
-      clientMessageId: newClientMessageId(),
-      text,
-    });
-  },
-  onMessage: (callback: (message: unknown) => void) => {
-    getSocket().on('message:received', callback);
+  sendMessage: (conversationId: string, text: string) =>
+    new Promise<ChatMessage>((resolve, reject) => {
+      getSocket()
+        .timeout(8_000)
+        .emit(
+          'message:send',
+          { conversationId, clientMessageId: newClientMessageId(), text },
+          (timeoutError: Error | null, ack?: SendAck) => {
+            if (timeoutError || !ack?.success || !ack.message) {
+              reject(timeoutError ?? new Error(ack?.error ?? 'Message was not accepted'));
+              return;
+            }
+            resolve({
+              id: ack.message.id,
+              conversationId: ack.message.conversationId,
+              senderId: ack.message.senderId,
+              content: ack.message.text,
+              type: ack.message.mediaUrls.length > 0 ? 'image' : 'text',
+              mediaUrl: ack.message.mediaUrls[0] ?? null,
+              createdAt: ack.message.timestamp,
+            });
+          },
+        );
+    }),
+  onMessage: (callback: (message: ChatMessage) => void) => {
+    const handler = (message: {
+      id: string;
+      conversationId: string;
+      senderId: string;
+      text: string;
+      mediaUrls: string[];
+      timestamp: string;
+    }) =>
+      callback({
+        id: message.id,
+        conversationId: message.conversationId,
+        senderId: message.senderId,
+        content: message.text,
+        type: message.mediaUrls.length > 0 ? 'image' : 'text',
+        mediaUrl: message.mediaUrls[0] ?? null,
+        createdAt: message.timestamp,
+      });
+    getSocket().on('message:received', handler);
+    return () => getSocket().off('message:received', handler);
   },
   startTyping: (conversationId: string) => {
     getSocket().emit('typing:start', { conversationId });
@@ -60,8 +111,10 @@ export const chatSocket = {
   },
   onTyping: (callback: (data: { userId: string }) => void) => {
     getSocket().on('typing:start', callback);
+    return () => getSocket().off('typing:start', callback);
   },
   onStopTyping: (callback: (data: { userId: string }) => void) => {
     getSocket().on('typing:stop', callback);
+    return () => getSocket().off('typing:stop', callback);
   },
 };

--- a/apps/web/src/lib/socket.ts
+++ b/apps/web/src/lib/socket.ts
@@ -28,6 +28,13 @@ export function disconnectSocket() {
   if (socket?.connected) socket.disconnect();
 }
 
+function newClientMessageId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `msg_${Date.now()}_${Math.random().toString(36).slice(2, 14)}`;
+}
+
 export const chatSocket = {
   joinConversation: (conversationId: string) => {
     getSocket().emit('conversation:join', { conversationId });
@@ -36,7 +43,11 @@ export const chatSocket = {
     getSocket().emit('conversation:leave', { conversationId });
   },
   sendMessage: (conversationId: string, text: string) => {
-    getSocket().emit('message:send', { conversationId, text });
+    getSocket().emit('message:send', {
+      conversationId,
+      clientMessageId: newClientMessageId(),
+      text,
+    });
   },
   onMessage: (callback: (message: unknown) => void) => {
     getSocket().on('message:received', callback);

--- a/docs/DOGOS_TRUST_DISCOVERY.md
+++ b/docs/DOGOS_TRUST_DISCOVERY.md
@@ -1,0 +1,173 @@
+# dogOS Trust + Discovery v1
+
+## Release intent
+
+This release turns Woof's network loop into a deployable product path without weakening the canonical dogOS spine.
+
+The user-facing loop is deliberately narrow:
+
+1. choose the active dog
+2. review explainable compatibility matches
+3. optionally add coarse nearby context
+4. start a private direct conversation
+5. suggest a public-place meetup
+6. accept or decline the meetup
+7. report a tiny real-world outcome
+8. feed that outcome back into future compatibility evidence
+
+The release does not introduce a second social graph, a second meetup store, a public dog map, or an autonomous agent.
+
+## Canonical and operational ownership
+
+Canonical source-of-truth data remains in the existing Prisma/public domain:
+
+- `Conversation`
+- `ConversationParticipant`
+- `Message`
+- `MeetupProposal`
+- `PetEdge`
+- `Telemetry`
+- `BlockedUser`
+
+Two narrow operational schemas support delivery and privacy mechanics without becoming new product truth:
+
+- `dogos_chat.message_receipts` stores message idempotency receipts.
+- `dogos_discovery.locations` stores opt-in coarse discovery cells.
+
+## Realtime trust boundary
+
+Socket authentication alone is not authorization.
+
+Every realtime operation now checks current server-side conversation membership and block state:
+
+- join
+- leave
+- send
+- typing start
+- typing stop
+
+Messages are emitted only after the canonical `Message` row has committed.
+
+Every send carries a client-generated `clientMessageId`. A receipt is unique per user and message ID and is bound to one conversation. Retrying the same accepted send returns the persisted message without emitting a duplicate.
+
+Global online/offline broadcasts are intentionally absent. Presence is not product truth and must not leak the network's membership graph.
+
+## Canonical Inbox
+
+The production web Inbox no longer contains seeded conversations or seeded messages.
+
+It reads:
+
+- `GET /chat/conversations`
+- `GET /chat/conversations/:id/messages`
+- `POST /chat/conversations/:id/read`
+
+Direct conversations are created or reused through:
+
+- `POST /chat/conversations`
+
+The server, not the client, decides whether the relationship is eligible.
+
+## Privacy-safe nearby discovery
+
+Nearby discovery is explicit opt-in.
+
+The browser may submit a latitude/longitude to `PUT /discovery/location`, but the service immediately transforms it into a coarse 0.02-degree cell. The precise coordinate is never written to PostgreSQL and is never included in telemetry.
+
+Operational location records:
+
+- are approximately 2.2 km precision before latitude effects
+- expire after 30 days
+- can be explicitly disabled
+- are never returned as coordinates
+
+Candidate responses expose only one of:
+
+- `WITHIN_2_5_KM`
+- `WITHIN_5_KM`
+- `WITHIN_10_KM`
+
+They do not expose another household's coordinate, bucket, address, or home location.
+
+Candidate lookup excludes blocked users and non-public profiles before returning any dog.
+
+### Why v1 does not require PostGIS
+
+The repository's shared CI PostgreSQL image is currently pgvector-based and does not guarantee PostGIS. Trust + Discovery v1 therefore uses indexed coarse integer cells so the privacy contract can ship without changing every database environment.
+
+The internal candidate generator can later migrate to PostGIS (`geography(Point, 4326)`, GiST, `ST_DWithin`) while preserving the public contract: explicit consent, no public coordinates, bounded radius, and coarse distance bands.
+
+## Compatibility remains explainable
+
+Nearby context does not replace compatibility scoring.
+
+Existing compatibility behavior remains authoritative:
+
+- deterministic baseline remains available
+- learned scoring remains `off`, `shadow`, or explicitly `promoted`
+- blocked, avoided, and private relationships remain filtered
+- model failure falls back rather than taking discovery down
+
+The web currently uses the privacy-safe nearby set to prioritize and annotate existing explainable compatibility matches. It does not create PetEdges merely because a candidate was viewed.
+
+## Meetup and outcome reuse
+
+The existing `MeetupProposal` source remains canonical.
+
+The release adds three structured, low-friction outcome fields to the existing completion contract:
+
+- dog experience: `loved_it`, `comfortable`, `not_their_thing`
+- owner experience: `great`, `fine`, `a_lot_today`
+- meet again: `yes`, `maybe`, `no`
+
+The existing safety checklist remains explicit.
+
+Structured answers are also normalized into the existing `feedbackTags` channel (`dog_comfortable`, `owner_great`, `meet_again_yes`) so compatibility dataset generation can consume them without a parallel feedback schema.
+
+## No fake network state
+
+Production network surfaces must not substitute demo data when canonical reads fail.
+
+This release removes:
+
+- hard-coded Inbox conversations
+- hard-coded chat messages
+- fake coordinate-bearing meetup cards
+- hard-coded San Francisco service businesses and ratings
+- fake map-marker simulation
+
+Empty and degraded states remain visibly empty or degraded.
+
+## Hard boundaries
+
+Trust + Discovery v1 must preserve all of the following:
+
+- no public member or dog coordinates
+- no home-location exposure
+- no precise discovery coordinate persistence
+- no precise-coordinate telemetry
+- no chat room access based only on caller-supplied IDs
+- no global presence broadcasts
+- no message emit before persistence
+- no duplicate sends on idempotent retry
+- no meetup proposal before a real two-person conversation with messages
+- no coordination across a block
+- no fabricated network profiles, conversations, businesses, reviews, or locations
+- no new medical inference
+- no automatic location consent
+
+## Release qualification
+
+A release candidate is not qualified until one exact head passes:
+
+1. dogOS Trust + Discovery CI
+2. dogOS Release Polish CI
+3. dogOS Concierge CI
+4. dogOS Connectors CI
+5. dogOS Our Story CI
+6. dogOS Autopilot CI
+7. dogOS Foundation CI
+8. Adventure System CI
+9. root CI, including migrations, backend tests, Chromium contracts, and production API/web builds
+
+Earlier diagnostic heads never count as release evidence.

--- a/packages/database/prisma/migrations/20260823081000_add_dogos_chat_delivery_receipts/migration.sql
+++ b/packages/database/prisma/migrations/20260823081000_add_dogos_chat_delivery_receipts/migration.sql
@@ -1,10 +1,10 @@
 CREATE SCHEMA IF NOT EXISTS dogos_chat;
 
 CREATE TABLE IF NOT EXISTS dogos_chat.message_receipts (
-  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
   client_message_id TEXT NOT NULL,
-  conversation_id UUID NOT NULL REFERENCES public.conversations(id) ON DELETE CASCADE,
-  message_id UUID NOT NULL REFERENCES public.messages(id) ON DELETE CASCADE,
+  conversation_id TEXT NOT NULL REFERENCES public.conversations(id) ON DELETE CASCADE,
+  message_id TEXT NOT NULL REFERENCES public.messages(id) ON DELETE CASCADE,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   PRIMARY KEY (user_id, client_message_id),
   UNIQUE (message_id),

--- a/packages/database/prisma/migrations/20260823081000_add_dogos_chat_delivery_receipts/migration.sql
+++ b/packages/database/prisma/migrations/20260823081000_add_dogos_chat_delivery_receipts/migration.sql
@@ -1,0 +1,16 @@
+CREATE SCHEMA IF NOT EXISTS dogos_chat;
+
+CREATE TABLE IF NOT EXISTS dogos_chat.message_receipts (
+  user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  client_message_id TEXT NOT NULL,
+  conversation_id UUID NOT NULL REFERENCES public.conversations(id) ON DELETE CASCADE,
+  message_id UUID NOT NULL REFERENCES public.messages(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, client_message_id),
+  UNIQUE (message_id),
+  CONSTRAINT message_receipts_client_id_length
+    CHECK (char_length(client_message_id) BETWEEN 8 AND 128)
+);
+
+CREATE INDEX IF NOT EXISTS message_receipts_conversation_created_idx
+  ON dogos_chat.message_receipts (conversation_id, created_at DESC);

--- a/packages/database/prisma/migrations/20260823082000_add_dogos_discovery_location_cells/migration.sql
+++ b/packages/database/prisma/migrations/20260823082000_add_dogos_discovery_location_cells/migration.sql
@@ -1,7 +1,7 @@
 CREATE SCHEMA IF NOT EXISTS dogos_discovery;
 
 CREATE TABLE IF NOT EXISTS dogos_discovery.locations (
-  user_id UUID PRIMARY KEY REFERENCES public.users(id) ON DELETE CASCADE,
+  user_id TEXT PRIMARY KEY REFERENCES public.users(id) ON DELETE CASCADE,
   lat_bucket INTEGER NOT NULL,
   lng_bucket INTEGER NOT NULL,
   precision_m INTEGER NOT NULL DEFAULT 2200,

--- a/packages/database/prisma/migrations/20260823082000_add_dogos_discovery_location_cells/migration.sql
+++ b/packages/database/prisma/migrations/20260823082000_add_dogos_discovery_location_cells/migration.sql
@@ -1,0 +1,19 @@
+CREATE SCHEMA IF NOT EXISTS dogos_discovery;
+
+CREATE TABLE IF NOT EXISTS dogos_discovery.locations (
+  user_id UUID PRIMARY KEY REFERENCES public.users(id) ON DELETE CASCADE,
+  lat_bucket INTEGER NOT NULL,
+  lng_bucket INTEGER NOT NULL,
+  precision_m INTEGER NOT NULL DEFAULT 2200,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT discovery_lat_bucket_range CHECK (lat_bucket BETWEEN 0 AND 9000),
+  CONSTRAINT discovery_lng_bucket_range CHECK (lng_bucket BETWEEN 0 AND 18000),
+  CONSTRAINT discovery_precision_range CHECK (precision_m BETWEEN 1000 AND 5000)
+);
+
+CREATE INDEX IF NOT EXISTS discovery_location_bucket_idx
+  ON dogos_discovery.locations (lat_bucket, lng_bucket, expires_at)
+  WHERE enabled = TRUE;


### PR DESCRIPTION
## dogOS Trust + Discovery v1

Base: exact merged Release Polish SHA `e7c2a31744e370f2486072d70cee6e957fd53c9b`.

This release turns the explainable compatibility engine into a trustworthy real-world loop without introducing another source of truth.

### Realtime trust boundary

- every join, leave, send and typing event is server-authorized against current conversation membership + block state
- global online/offline broadcasts are removed
- canonical Message persistence completes before realtime emit
- client sends carry idempotency IDs backed by `dogos_chat.message_receipts`
- retries replay the persisted message without duplicate emit
- a client message ID cannot be reused across conversations
- authenticated REST reads expose canonical conversation lists, bounded message history, create/reuse direct conversations and read-watermark updates
- creating a brand-new direct conversation requires the target profile to be `PUBLIC`; already-established authorized conversations remain usable after later visibility changes, while blocks always win

### Privacy-safe local discovery

- nearby context is explicit opt-in
- the precise coordinate is quantized immediately to a coarse 0.02-degree cell and is never persisted
- coarse cells expire after 30 days and can be explicitly disabled
- blocked users and non-public profiles are excluded before candidates are returned
- another household's coordinates, buckets, home location or exact distance are never returned
- the client receives only coarse distance bands (`WITHIN_2_5_KM`, `WITHIN_5_KM`, `WITHIN_10_KM`)
- nearby context prioritizes/annotates existing explainable compatibility matches rather than creating a parallel scorer

### Canonical Match → Meetup → Outcome loop

- Discover uses the same active-dog context as Today
- a compatibility match can create/reuse a real direct conversation
- Inbox no longer contains seeded conversations/messages
- meetup suggestions write the existing MeetupProposal source of truth
- accepted meetups expose three tiny structured outcome answers: dog experience, owner experience, meet-again intent
- explicit safety feedback remains separate and preserved
- structured answers normalize into the existing feedbackTags channel so compatibility learning can use them without a new feedback schema

### No fake network state

Removed from the production path:

- hard-coded Inbox conversations
- hard-coded chat transcript
- fake coordinate-bearing meetup cards
- hard-coded San Francisco businesses/reviews
- simulated map markers

Degraded network reads stay degraded instead of becoming demo content.

### Qualification receipts

Qualified exact head: `9a1d7c4ce870ad4e9422135ae9adbc0b97e2776e`

All required lanes completed successfully on that exact SHA:

1. dogOS Trust + Discovery CI — run `32654778886`
2. dogOS Release Polish CI — run `32654778899`
3. dogOS Concierge CI — run `32654778926`
4. dogOS Connectors CI — run `32654778948`
5. dogOS Our Story CI — run `32654778971`
6. dogOS Autopilot CI — run `32654778908`
7. dogOS Foundation CI — run `32654778922`
8. Adventure System CI — run `32654778937`
9. root CI — run `32654778934`

The dedicated Trust lane passed canonical TEXT-ID enforcement, the complete 16-migration chain, formatting, zero-warning API/web lint, server-authorized room/scoped-presence guards, precise-location persistence guards, fake-network-state guards, API/web type checks, focused chat/discovery/meetup/compatibility contracts, web transport contracts, the Chromium privacy-safe Discovery journey, and production API/web builds.

Root CI independently passed formatting, zero-warning lint, monorepo TypeScript, ML policy contracts, backend migrations/unit/API tests, frontend unit/browser smoke/accessibility/visual contracts, and production API/web builds.

Diagnostic heads do not count. See `docs/DOGOS_TRUST_DISCOVERY.md` for the executable product contract.