### PR TITLE
dogOS Behavior Moments: shadow video evidence and zero-authority evaluation

### DIFF
--- a/.github/workflows/dogos-behavior-moments-ci.yml
+++ b/.github/workflows/dogos-behavior-moments-ci.yml
@@ -52,16 +52,15 @@ jobs:
         run: pnpm --filter @woof/database db:generate
 
       - name: Check Behavior Moments formatting
-        run: |
-          pnpm exec prettier --write \
-            apps/api/src/behavior-vision \
-            apps/web/src/lib/api/behavior-vision.ts \
-            apps/web/src/lib/api/behavior-vision.spec.ts \
-            apps/web/src/app/coach/layout.tsx \
-            apps/web/src/app/coach/observe/shadow/page.tsx \
-            .github/workflows/dogos-behavior-moments-ci.yml \
-            docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md
-          git diff --exit-code
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/behavior-vision
+          apps/web/src/lib/api/behavior-vision.ts
+          apps/web/src/lib/api/behavior-vision.spec.ts
+          apps/web/src/app/coach/layout.tsx
+          apps/web/src/app/coach/observe/shadow/page.tsx
+          .github/workflows/dogos-behavior-moments-ci.yml
+          docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md
 
       - name: Lint Behavior Moments API surface
         run: >-

--- a/.github/workflows/dogos-behavior-moments-ci.yml
+++ b/.github/workflows/dogos-behavior-moments-ci.yml
@@ -9,6 +9,7 @@ on:
       - 'apps/web/src/lib/api/behavior-vision.spec.ts'
       - 'apps/web/src/app/coach/layout.tsx'
       - 'apps/web/src/app/coach/observe/shadow/**'
+      - 'apps/web/e2e/behavior-moments-shadow.spec.ts'
       - '.github/workflows/dogos-behavior-moments-ci.yml'
       - 'docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md'
 
@@ -59,6 +60,7 @@ jobs:
           apps/web/src/lib/api/behavior-vision.spec.ts
           apps/web/src/app/coach/layout.tsx
           apps/web/src/app/coach/observe/shadow/page.tsx
+          apps/web/e2e/behavior-moments-shadow.spec.ts
           .github/workflows/dogos-behavior-moments-ci.yml
           docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md
 
@@ -74,6 +76,7 @@ jobs:
           src/lib/api/behavior-vision.spec.ts
           src/app/coach/layout.tsx
           src/app/coach/observe/shadow/page.tsx
+          e2e/behavior-moments-shadow.spec.ts
 
       - name: Reject canonical pet mutation from Behavior Vision
         run: |
@@ -113,6 +116,12 @@ jobs:
 
       - name: Run Behavior Moments web transport contract
         run: pnpm --filter @woof/web exec vitest run src/lib/api/behavior-vision.spec.ts
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @woof/web exec playwright install --with-deps chromium
+
+      - name: Run Shadow Lab browser contract
+        run: pnpm --filter @woof/web exec playwright test e2e/behavior-moments-shadow.spec.ts --project=chromium
 
       - name: Build API
         run: pnpm --filter @woof/api build

--- a/.github/workflows/dogos-behavior-moments-ci.yml
+++ b/.github/workflows/dogos-behavior-moments-ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'apps/api/src/behavior-vision/**'
       - 'apps/web/src/lib/api/behavior-vision.ts'
+      - 'apps/web/src/lib/api/behavior-vision.spec.ts'
       - 'apps/web/src/app/coach/layout.tsx'
       - 'apps/web/src/app/coach/observe/shadow/**'
       - '.github/workflows/dogos-behavior-moments-ci.yml'
@@ -55,6 +56,7 @@ jobs:
           pnpm exec prettier --check
           apps/api/src/behavior-vision
           apps/web/src/lib/api/behavior-vision.ts
+          apps/web/src/lib/api/behavior-vision.spec.ts
           apps/web/src/app/coach/layout.tsx
           apps/web/src/app/coach/observe/shadow/page.tsx
           .github/workflows/dogos-behavior-moments-ci.yml
@@ -69,6 +71,7 @@ jobs:
         run: >-
           pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
           src/lib/api/behavior-vision.ts
+          src/lib/api/behavior-vision.spec.ts
           src/app/coach/layout.tsx
           src/app/coach/observe/shadow/page.tsx
 
@@ -107,6 +110,9 @@ jobs:
           src/behavior-vision/behavior-shadow.service.spec.ts
           src/behavior-vision/behavior-vision.service.spec.ts
           src/behavior-vision/behavior-profile.spec.ts
+
+      - name: Run Behavior Moments web transport contract
+        run: pnpm --filter @woof/web exec vitest run src/lib/api/behavior-vision.spec.ts
 
       - name: Build API
         run: pnpm --filter @woof/api build

--- a/.github/workflows/dogos-behavior-moments-ci.yml
+++ b/.github/workflows/dogos-behavior-moments-ci.yml
@@ -52,15 +52,16 @@ jobs:
         run: pnpm --filter @woof/database db:generate
 
       - name: Check Behavior Moments formatting
-        run: >-
-          pnpm exec prettier --check
-          apps/api/src/behavior-vision
-          apps/web/src/lib/api/behavior-vision.ts
-          apps/web/src/lib/api/behavior-vision.spec.ts
-          apps/web/src/app/coach/layout.tsx
-          apps/web/src/app/coach/observe/shadow/page.tsx
-          .github/workflows/dogos-behavior-moments-ci.yml
-          docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md
+        run: |
+          pnpm exec prettier --write \
+            apps/api/src/behavior-vision \
+            apps/web/src/lib/api/behavior-vision.ts \
+            apps/web/src/lib/api/behavior-vision.spec.ts \
+            apps/web/src/app/coach/layout.tsx \
+            apps/web/src/app/coach/observe/shadow/page.tsx \
+            .github/workflows/dogos-behavior-moments-ci.yml \
+            docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md
+          git diff --exit-code
 
       - name: Lint Behavior Moments API surface
         run: >-

--- a/.github/workflows/dogos-behavior-moments-ci.yml
+++ b/.github/workflows/dogos-behavior-moments-ci.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'apps/api/src/behavior-vision/**'
       - 'apps/web/src/lib/api/behavior-vision.ts'
+      - 'apps/web/src/app/coach/layout.tsx'
+      - 'apps/web/src/app/coach/observe/shadow/**'
       - '.github/workflows/dogos-behavior-moments-ci.yml'
       - 'docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md'
 
@@ -53,6 +55,8 @@ jobs:
           pnpm exec prettier --check
           apps/api/src/behavior-vision
           apps/web/src/lib/api/behavior-vision.ts
+          apps/web/src/app/coach/layout.tsx
+          apps/web/src/app/coach/observe/shadow/page.tsx
           .github/workflows/dogos-behavior-moments-ci.yml
           docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md
 
@@ -61,10 +65,12 @@ jobs:
           pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
           src/behavior-vision
 
-      - name: Lint Behavior Moments web contract
+      - name: Lint Behavior Moments web surface
         run: >-
           pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
           src/lib/api/behavior-vision.ts
+          src/app/coach/layout.tsx
+          src/app/coach/observe/shadow/page.tsx
 
       - name: Reject canonical pet mutation from Behavior Vision
         run: |

--- a/.github/workflows/dogos-behavior-moments-ci.yml
+++ b/.github/workflows/dogos-behavior-moments-ci.yml
@@ -1,0 +1,111 @@
+name: dogOS Behavior Moments Shadow CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/behavior-vision/**'
+      - 'apps/web/src/lib/api/behavior-vision.ts'
+      - '.github/workflows/dogos-behavior-moments-ci.yml'
+      - 'docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-behavior-moments-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  NODE_ENV: test
+  JWT_SECRET: ci-only-test-secret
+  ML_SERVICE_ENABLED: 'false'
+
+jobs:
+  qualify:
+    name: Shadow evidence + zero-authority qualification
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Check Behavior Moments formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/behavior-vision
+          apps/web/src/lib/api/behavior-vision.ts
+          .github/workflows/dogos-behavior-moments-ci.yml
+          docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md
+
+      - name: Lint Behavior Moments API surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/behavior-vision
+
+      - name: Lint Behavior Moments web contract
+        run: >-
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/lib/api/behavior-vision.ts
+
+      - name: Reject canonical pet mutation from Behavior Vision
+        run: |
+          if grep -ERIn 'prisma\.pet\.(create|update|updateMany|upsert|delete|deleteMany)' apps/api/src/behavior-vision; then
+            echo 'Behavior Moments shadow code may read owned pets but cannot mutate canonical pet state.'
+            exit 1
+          fi
+
+      - name: Reject compatibility authority escape
+        run: |
+          if grep -ERIn 'behavior-vision|BEHAVIOR_VISION|BehaviorShadow|BehaviorMoment' apps/api/src/compatibility; then
+            echo 'Behavior Moments shadow evidence cannot influence compatibility in this release.'
+            exit 1
+          fi
+
+      - name: Require literal zero-authority policy
+        run: |
+          grep -q "mode: 'shadow-evidence-only'" apps/api/src/behavior-vision/behavior-shadow.service.ts
+          grep -q 'canInfluenceCompatibility: false' apps/api/src/behavior-vision/behavior-shadow.service.ts
+          grep -q 'canMutateCanonicalPetState: false' apps/api/src/behavior-vision/behavior-shadow.service.ts
+          grep -q 'canMakeSafetyDecision: false' apps/api/src/behavior-vision/behavior-shadow.service.ts
+          grep -q 'promotionEnabled: false' apps/api/src/behavior-vision/behavior-shadow.service.ts
+          grep -q 'promotionRequiresSeparateQualifiedRelease: true' apps/api/src/behavior-vision/behavior-shadow.service.ts
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Type-check web
+        run: pnpm --filter @woof/web type-check
+
+      - name: Run Behavior Moments shadow contracts
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/behavior-vision/behavior-shadow.service.spec.ts
+          src/behavior-vision/behavior-vision.service.spec.ts
+          src/behavior-vision/behavior-profile.spec.ts
+
+      - name: Build API
+        run: pnpm --filter @woof/api build
+
+      - name: Build web
+        env:
+          NEXT_PUBLIC_API_URL: https://api.example.com/api/v1
+        run: pnpm --filter @woof/web build

--- a/apps/api/src/behavior-vision/behavior-shadow.service.spec.ts
+++ b/apps/api/src/behavior-vision/behavior-shadow.service.spec.ts
@@ -103,7 +103,13 @@ describe('BehaviorShadowService', () => {
       const sessionKey = `session-${index}`;
       const context = index % 3 === 0 ? 'home' : index % 3 === 1 ? 'park' : 'street';
       observations.push(
-        observation({ id: `base-${index}`, sessionKey, phase: 'baseline', context, accurate: true }),
+        observation({
+          id: `base-${index}`,
+          sessionKey,
+          phase: 'baseline',
+          context,
+          accurate: true,
+        }),
         observation({
           id: `recovery-${index}`,
           sessionKey,

--- a/apps/api/src/behavior-vision/behavior-shadow.service.spec.ts
+++ b/apps/api/src/behavior-vision/behavior-shadow.service.spec.ts
@@ -1,0 +1,136 @@
+import { BehaviorShadowService } from './behavior-shadow.service';
+import { BehaviorVisionService } from './behavior-vision.service';
+import type { StoredBehaviorObservation } from './behavior-vision.types';
+
+function observation(input: {
+  id: string;
+  context?: 'street' | 'park' | 'home';
+  sessionKey?: string;
+  phase?: 'baseline' | 'during-intervention' | 'recovery';
+  accurate?: boolean;
+  startMs?: number;
+  endMs?: number;
+}): StoredBehaviorObservation {
+  return {
+    id: input.id,
+    petId: 'pet-1',
+    createdAt: '2026-08-23T12:00:00.000Z',
+    mediaType: 'video',
+    mediaSha256: `sha-${input.id}`,
+    context: {
+      context: input.context ?? 'street',
+      sessionKey: input.sessionKey,
+      phase: input.phase ?? 'baseline',
+      handlerAction: input.phase === 'baseline' || !input.phase ? 'none' : 'increase-distance',
+      leashState: 'loose',
+      otherDogsPresent: true,
+      audioAnalysisAllowed: false,
+    },
+    analysis: {
+      schemaVersion: 'woof-behavior-observation-v1',
+      modelVersion: 'shadow-model-1',
+      featureVersion: 'features-1',
+      mediaQuality: { usable: true, confidence: 0.9, issues: [], recaptureInstructions: [] },
+      evidence: [
+        {
+          label: 'oriented toward dog',
+          source: 'pose',
+          confidence: 0.8,
+          startMs: input.startMs ?? 1000,
+          endMs: input.endMs ?? 1800,
+        },
+        {
+          label: 'forward movement',
+          source: 'motion',
+          confidence: 0.9,
+          startMs: (input.startMs ?? 1000) + 500,
+          endMs: (input.endMs ?? 1800) + 700,
+        },
+      ],
+      dimensions: [],
+      hypotheses: [],
+      observableSummary: 'Visible movement only.',
+      uncertainty: 'Internal state cannot be determined.',
+    },
+    ...(input.accurate === undefined ? {} : { ownerFeedback: { accurate: input.accurate } }),
+  };
+}
+
+function makeVision(observations: StoredBehaviorObservation[]) {
+  return {
+    timeline: jest.fn().mockResolvedValue(observations),
+    profile: jest.fn().mockResolvedValue({
+      schemaVersion: 'woof-individual-behavior-profile-v1',
+      petId: 'pet-1',
+      sampleCount: observations.length,
+      contextsSeen: ['home', 'park', 'street'],
+      baselines: [],
+      interventionEffects: [],
+      personalizationConfidence: 0.8,
+      recommendation: {
+        headline: 'Keep testing',
+        explanation: 'Evidence only',
+        nextSafeExperiment: [],
+        neverAutoRecommendGreeting: true,
+      },
+    }),
+  };
+}
+
+describe('BehaviorShadowService', () => {
+  it('groups nearby timestamped evidence into reviewable moments', async () => {
+    const vision = makeVision([observation({ id: 'obs-1', accurate: true })]);
+    const service = new BehaviorShadowService(vision as unknown as BehaviorVisionService);
+
+    const result = await service.snapshot('user-1', 'pet-1');
+
+    expect(result.policy.mode).toBe('shadow-evidence-only');
+    expect(result.moments).toEqual([
+      expect.objectContaining({
+        observationId: 'obs-1',
+        startMs: 1000,
+        endMs: 2500,
+        confidence: 0.9,
+        labels: ['oriented toward dog', 'forward movement'],
+        sources: ['pose', 'motion'],
+      }),
+    ]);
+  });
+
+  it('never grants downstream authority even when evidence readiness gates are satisfied', async () => {
+    const observations: StoredBehaviorObservation[] = [];
+    for (let index = 0; index < 10; index += 1) {
+      const sessionKey = `session-${index}`;
+      const context = index % 3 === 0 ? 'home' : index % 3 === 1 ? 'park' : 'street';
+      observations.push(
+        observation({ id: `base-${index}`, sessionKey, phase: 'baseline', context, accurate: true }),
+        observation({
+          id: `recovery-${index}`,
+          sessionKey,
+          phase: 'recovery',
+          context,
+          accurate: true,
+        })
+      );
+    }
+    const vision = makeVision(observations);
+    const service = new BehaviorShadowService(vision as unknown as BehaviorVisionService);
+
+    const result = await service.snapshot('user-1', 'pet-1');
+
+    expect(result.evaluation.evidenceReady).toBe(true);
+    expect(result.evaluation.usableObservations).toBe(20);
+    expect(result.evaluation.ownerReviewedObservations).toBe(20);
+    expect(result.evaluation.confirmationRate).toBe(1);
+    expect(result.evaluation.pairedSessions).toBe(10);
+    expect(result.policy).toEqual(
+      expect.objectContaining({
+        canInfluenceCompatibility: false,
+        canMutateCanonicalPetState: false,
+        canMakeSafetyDecision: false,
+        promotionEnabled: false,
+        promotionRequiresSeparateQualifiedRelease: true,
+      })
+    );
+  });
+});

--- a/apps/api/src/behavior-vision/behavior-shadow.service.spec.ts
+++ b/apps/api/src/behavior-vision/behavior-shadow.service.spec.ts
@@ -8,6 +8,7 @@ function observation(input: {
   sessionKey?: string;
   phase?: 'baseline' | 'during-intervention' | 'recovery';
   accurate?: boolean;
+  usable?: boolean;
   startMs?: number;
   endMs?: number;
 }): StoredBehaviorObservation {
@@ -30,7 +31,12 @@ function observation(input: {
       schemaVersion: 'woof-behavior-observation-v1',
       modelVersion: 'shadow-model-1',
       featureVersion: 'features-1',
-      mediaQuality: { usable: true, confidence: 0.9, issues: [], recaptureInstructions: [] },
+      mediaQuality: {
+        usable: input.usable ?? true,
+        confidence: 0.9,
+        issues: [],
+        recaptureInstructions: [],
+      },
       evidence: [
         {
           label: 'oriented toward dog',
@@ -95,6 +101,25 @@ describe('BehaviorShadowService', () => {
         sources: ['pose', 'motion'],
       }),
     ]);
+  });
+
+  it('does not let confirmations on unusable observations inflate agreement', async () => {
+    const observations = [observation({ id: 'usable-rejected', accurate: false })];
+    for (let index = 0; index < 9; index += 1) {
+      observations.push(
+        observation({ id: `unusable-confirmed-${index}`, accurate: true, usable: false })
+      );
+    }
+    const vision = makeVision(observations);
+    const service = new BehaviorShadowService(vision as unknown as BehaviorVisionService);
+
+    const result = await service.snapshot('user-1', 'pet-1');
+
+    expect(result.evaluation.ownerReviewedObservations).toBe(1);
+    expect(result.evaluation.ownerConfirmedObservations).toBe(0);
+    expect(result.evaluation.ownerRejectedObservations).toBe(1);
+    expect(result.evaluation.confirmationRate).toBe(0);
+    expect(result.evaluation.evidenceReady).toBe(false);
   });
 
   it('never grants downstream authority even when evidence readiness gates are satisfied', async () => {

--- a/apps/api/src/behavior-vision/behavior-shadow.service.ts
+++ b/apps/api/src/behavior-vision/behavior-shadow.service.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { BehaviorVisionService } from './behavior-vision.service';
-import type { BehaviorEvidenceSource, StoredBehaviorObservation } from './behavior-vision.types';
+import type {
+  BehaviorContext,
+  BehaviorEvidenceSource,
+  BehaviorPhase,
+  StoredBehaviorObservation,
+} from './behavior-vision.types';
 
 export const BEHAVIOR_SHADOW_POLICY_VERSION = 'woof-behavior-shadow-v1';
 
@@ -14,6 +19,9 @@ const READINESS_GATES = {
 
 export type BehaviorMoment = {
   observationId: string;
+  observationCreatedAt: string;
+  context: BehaviorContext;
+  phase: BehaviorPhase;
   startMs: number;
   endMs: number;
   confidence: number;
@@ -136,6 +144,9 @@ export class BehaviorShadowService {
 
     return groups.slice(0, 12).map((group) => ({
       observationId: observation.id,
+      observationCreatedAt: observation.createdAt,
+      context: observation.context.context,
+      phase: observation.context.phase,
       startMs: group.startMs,
       endMs: group.endMs,
       confidence: group.confidence,

--- a/apps/api/src/behavior-vision/behavior-shadow.service.ts
+++ b/apps/api/src/behavior-vision/behavior-shadow.service.ts
@@ -1,0 +1,146 @@
+import { Injectable } from '@nestjs/common';
+import { BehaviorVisionService } from './behavior-vision.service';
+import type { BehaviorEvidenceSource, StoredBehaviorObservation } from './behavior-vision.types';
+
+export const BEHAVIOR_SHADOW_POLICY_VERSION = 'woof-behavior-shadow-v1';
+
+const READINESS_GATES = {
+  usableObservations: 20,
+  ownerReviewedObservations: 10,
+  confirmationRate: 0.8,
+  contexts: 3,
+  pairedSessions: 5,
+} as const;
+
+export type BehaviorMoment = {
+  observationId: string;
+  startMs: number;
+  endMs: number;
+  confidence: number;
+  labels: string[];
+  sources: BehaviorEvidenceSource[];
+};
+
+@Injectable()
+export class BehaviorShadowService {
+  constructor(private readonly behaviorVision: BehaviorVisionService) {}
+
+  async snapshot(userId: string, petId: string) {
+    const [observations, profile] = await Promise.all([
+      this.behaviorVision.timeline(userId, petId, 100),
+      this.behaviorVision.profile(userId, petId),
+    ]);
+
+    const reviewed = observations.filter((entry) => entry.ownerFeedback !== undefined);
+    const confirmed = reviewed.filter((entry) => entry.ownerFeedback?.accurate === true);
+    const rejected = reviewed.filter((entry) => entry.ownerFeedback?.accurate === false);
+    const usable = observations.filter(
+      (entry) => entry.analysis.mediaQuality.usable && entry.ownerFeedback?.accurate !== false
+    );
+    const pairedSessions = this.countPairedSessions(usable);
+    const confirmationRate = reviewed.length ? confirmed.length / reviewed.length : null;
+    const evidenceReady =
+      usable.length >= READINESS_GATES.usableObservations &&
+      reviewed.length >= READINESS_GATES.ownerReviewedObservations &&
+      confirmationRate !== null &&
+      confirmationRate >= READINESS_GATES.confirmationRate &&
+      profile.contextsSeen.length >= READINESS_GATES.contexts &&
+      pairedSessions >= READINESS_GATES.pairedSessions;
+
+    return {
+      policy: {
+        version: BEHAVIOR_SHADOW_POLICY_VERSION,
+        mode: 'shadow-evidence-only' as const,
+        canInfluenceCompatibility: false as const,
+        canMutateCanonicalPetState: false as const,
+        canMakeSafetyDecision: false as const,
+        promotionEnabled: false as const,
+        promotionRequiresSeparateQualifiedRelease: true as const,
+      },
+      evaluation: {
+        observations: observations.length,
+        usableObservations: usable.length,
+        ownerReviewedObservations: reviewed.length,
+        ownerConfirmedObservations: confirmed.length,
+        ownerRejectedObservations: rejected.length,
+        ownerUnreviewedObservations: observations.length - reviewed.length,
+        confirmationRate,
+        usableRate: observations.length ? usable.length / observations.length : 0,
+        contextsSeen: profile.contextsSeen.length,
+        pairedSessions,
+        personalizationConfidence: profile.personalizationConfidence,
+        modelVersions: [...new Set(observations.map((entry) => entry.analysis.modelVersion))].sort(),
+        evidenceReady,
+        readinessGates: READINESS_GATES,
+      },
+      moments: observations.flatMap((observation) => this.deriveMoments(observation)),
+    };
+  }
+
+  private countPairedSessions(observations: StoredBehaviorObservation[]) {
+    const sessions = new Map<string, Set<string>>();
+    for (const observation of observations) {
+      const sessionKey = observation.context.sessionKey;
+      if (!sessionKey) continue;
+      const phases = sessions.get(sessionKey) ?? new Set<string>();
+      phases.add(observation.context.phase);
+      sessions.set(sessionKey, phases);
+    }
+    return [...sessions.values()].filter(
+      (phases) => phases.has('baseline') && (phases.has('during-intervention') || phases.has('recovery'))
+    ).length;
+  }
+
+  private deriveMoments(observation: StoredBehaviorObservation): BehaviorMoment[] {
+    const timed = observation.analysis.evidence
+      .filter(
+        (entry) =>
+          Number.isFinite(entry.startMs) &&
+          Number.isFinite(entry.endMs) &&
+          (entry.endMs ?? -1) >= (entry.startMs ?? 0)
+      )
+      .map((entry) => ({
+        startMs: Math.max(0, entry.startMs ?? 0),
+        endMs: Math.max(0, entry.endMs ?? entry.startMs ?? 0),
+        confidence: Math.max(0, Math.min(1, entry.confidence)),
+        label: entry.label,
+        source: entry.source,
+      }))
+      .sort((left, right) => left.startMs - right.startMs || left.endMs - right.endMs);
+
+    const groups: Array<{
+      startMs: number;
+      endMs: number;
+      confidence: number;
+      labels: Set<string>;
+      sources: Set<BehaviorEvidenceSource>;
+    }> = [];
+
+    for (const entry of timed) {
+      const current = groups.at(-1);
+      if (current && entry.startMs <= current.endMs + 1000 && entry.endMs - current.startMs <= 12_000) {
+        current.endMs = Math.max(current.endMs, entry.endMs);
+        current.confidence = Math.max(current.confidence, entry.confidence);
+        current.labels.add(entry.label);
+        current.sources.add(entry.source);
+        continue;
+      }
+      groups.push({
+        startMs: entry.startMs,
+        endMs: entry.endMs,
+        confidence: entry.confidence,
+        labels: new Set([entry.label]),
+        sources: new Set([entry.source]),
+      });
+    }
+
+    return groups.slice(0, 12).map((group) => ({
+      observationId: observation.id,
+      startMs: group.startMs,
+      endMs: group.endMs,
+      confidence: group.confidence,
+      labels: [...group.labels].slice(0, 8),
+      sources: [...group.sources].slice(0, 6),
+    }));
+  }
+}

--- a/apps/api/src/behavior-vision/behavior-shadow.service.ts
+++ b/apps/api/src/behavior-vision/behavior-shadow.service.ts
@@ -39,12 +39,11 @@ export class BehaviorShadowService {
       this.behaviorVision.profile(userId, petId),
     ]);
 
-    const reviewed = observations.filter((entry) => entry.ownerFeedback !== undefined);
+    const modelUsable = observations.filter((entry) => entry.analysis.mediaQuality.usable);
+    const reviewed = modelUsable.filter((entry) => entry.ownerFeedback !== undefined);
     const confirmed = reviewed.filter((entry) => entry.ownerFeedback?.accurate === true);
     const rejected = reviewed.filter((entry) => entry.ownerFeedback?.accurate === false);
-    const usable = observations.filter(
-      (entry) => entry.analysis.mediaQuality.usable && entry.ownerFeedback?.accurate !== false
-    );
+    const usable = modelUsable.filter((entry) => entry.ownerFeedback?.accurate !== false);
     const pairedSessions = this.countPairedSessions(usable);
     const confirmationRate = reviewed.length ? confirmed.length / reviewed.length : null;
     const evidenceReady =
@@ -71,7 +70,7 @@ export class BehaviorShadowService {
         ownerReviewedObservations: reviewed.length,
         ownerConfirmedObservations: confirmed.length,
         ownerRejectedObservations: rejected.length,
-        ownerUnreviewedObservations: observations.length - reviewed.length,
+        ownerUnreviewedObservations: modelUsable.length - reviewed.length,
         confirmationRate,
         usableRate: observations.length ? usable.length / observations.length : 0,
         contextsSeen: profile.contextsSeen.length,

--- a/apps/api/src/behavior-vision/behavior-shadow.service.ts
+++ b/apps/api/src/behavior-vision/behavior-shadow.service.ts
@@ -77,7 +77,9 @@ export class BehaviorShadowService {
         contextsSeen: profile.contextsSeen.length,
         pairedSessions,
         personalizationConfidence: profile.personalizationConfidence,
-        modelVersions: [...new Set(observations.map((entry) => entry.analysis.modelVersion))].sort(),
+        modelVersions: [
+          ...new Set(observations.map((entry) => entry.analysis.modelVersion)),
+        ].sort(),
         evidenceReady,
         readinessGates: READINESS_GATES,
       },
@@ -95,7 +97,8 @@ export class BehaviorShadowService {
       sessions.set(sessionKey, phases);
     }
     return [...sessions.values()].filter(
-      (phases) => phases.has('baseline') && (phases.has('during-intervention') || phases.has('recovery'))
+      (phases) =>
+        phases.has('baseline') && (phases.has('during-intervention') || phases.has('recovery'))
     ).length;
   }
 
@@ -126,7 +129,11 @@ export class BehaviorShadowService {
 
     for (const entry of timed) {
       const current = groups.at(-1);
-      if (current && entry.startMs <= current.endMs + 1000 && entry.endMs - current.startMs <= 12_000) {
+      if (
+        current &&
+        entry.startMs <= current.endMs + 1000 &&
+        entry.endMs - current.startMs <= 12_000
+      ) {
         current.endMs = Math.max(current.endMs, entry.endMs);
         current.confidence = Math.max(current.confidence, entry.confidence);
         current.labels.add(entry.label);

--- a/apps/api/src/behavior-vision/behavior-vision.controller.ts
+++ b/apps/api/src/behavior-vision/behavior-vision.controller.ts
@@ -16,6 +16,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiBearerAuth, ApiConsumes, ApiOperation, ApiTags } from '@nestjs/swagger';
 import type { AuthenticatedRequest } from '../auth/authenticated-request';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { BehaviorShadowService } from './behavior-shadow.service';
 import { BehaviorVisionService } from './behavior-vision.service';
 import {
   AnalyzeBehaviorMediaDto,
@@ -37,7 +38,10 @@ const ALLOWED_MEDIA_TYPES = new Set([
 @UseGuards(JwtAuthGuard)
 @Controller('behavior-vision')
 export class BehaviorVisionController {
-  constructor(private readonly behaviorVision: BehaviorVisionService) {}
+  constructor(
+    private readonly behaviorVision: BehaviorVisionService,
+    private readonly behaviorShadow: BehaviorShadowService
+  ) {}
 
   @Post('analyze')
   @ApiConsumes('multipart/form-data')
@@ -73,6 +77,14 @@ export class BehaviorVisionController {
   @ApiOperation({ summary: 'Get recent derived behavior observations for one owned pet' })
   timeline(@Request() req: AuthenticatedRequest, @Query() query: BehaviorTimelineQueryDto) {
     return this.behaviorVision.timeline(req.user.sub, query.petId, query.limit ?? 30);
+  }
+
+  @Get('shadow')
+  @ApiOperation({
+    summary: 'Inspect Behavior Moments evidence and promotion-readiness metrics with zero authority',
+  })
+  shadow(@Request() req: AuthenticatedRequest, @Query() query: BehaviorTimelineQueryDto) {
+    return this.behaviorShadow.snapshot(req.user.sub, query.petId);
   }
 
   @Post('feedback')

--- a/apps/api/src/behavior-vision/behavior-vision.controller.ts
+++ b/apps/api/src/behavior-vision/behavior-vision.controller.ts
@@ -81,7 +81,8 @@ export class BehaviorVisionController {
 
   @Get('shadow')
   @ApiOperation({
-    summary: 'Inspect Behavior Moments evidence and promotion-readiness metrics with zero authority',
+    summary:
+      'Inspect Behavior Moments evidence and promotion-readiness metrics with zero authority',
   })
   shadow(@Request() req: AuthenticatedRequest, @Query() query: BehaviorTimelineQueryDto) {
     return this.behaviorShadow.snapshot(req.user.sub, query.petId);

--- a/apps/api/src/behavior-vision/behavior-vision.module.ts
+++ b/apps/api/src/behavior-vision/behavior-vision.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
+import { BehaviorShadowService } from './behavior-shadow.service';
 import { BehaviorVisionController } from './behavior-vision.controller';
 import { BehaviorVisionModelService } from './behavior-vision.model';
 import { BehaviorVisionService } from './behavior-vision.service';
 
 @Module({
   controllers: [BehaviorVisionController],
-  providers: [BehaviorVisionService, BehaviorVisionModelService],
-  exports: [BehaviorVisionService],
+  providers: [BehaviorVisionService, BehaviorVisionModelService, BehaviorShadowService],
+  exports: [BehaviorVisionService, BehaviorShadowService],
 })
 export class BehaviorVisionModule {}

--- a/apps/web/e2e/behavior-moments-shadow.spec.ts
+++ b/apps/web/e2e/behavior-moments-shadow.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+function corsHeaders(route: Route) {
+  const requestHeaders = route.request().headers();
+  return {
+    'access-control-allow-origin': requestHeaders.origin ?? 'http://localhost:3000',
+    'access-control-allow-methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+    'access-control-allow-headers':
+      requestHeaders['access-control-request-headers'] ?? 'authorization,content-type',
+    vary: 'Origin',
+  };
+}
+
+async function fulfillJson(route: Route, body: unknown, status = 200) {
+  if (route.request().method() === 'OPTIONS') {
+    await route.fulfill({ status: 204, headers: corsHeaders(route), body: '' });
+    return;
+  }
+  await route.fulfill({
+    status,
+    headers: { ...corsHeaders(route), 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function seedSession(page: Page) {
+  await page.addInitScript(() => {
+    const pet = {
+      id: 'pet-1',
+      name: 'Nova',
+      species: 'DOG',
+      breed: 'Husky mix',
+    };
+    const user = {
+      id: 'user-1',
+      email: 'owner@example.com',
+      handle: 'nova-human',
+      pets: [pet],
+    };
+    window.localStorage.setItem('authToken', 'shadow-browser-token');
+    window.localStorage.setItem(
+      'woof-session-storage',
+      JSON.stringify({
+        state: {
+          user,
+          pets: [pet],
+          token: 'shadow-browser-token',
+          refreshToken: null,
+          isAuthenticated: true,
+        },
+        version: 0,
+      })
+    );
+  });
+}
+
+test('Shadow Lab renders reviewable evidence without requesting compatibility authority', async ({
+  page,
+}) => {
+  await seedSession(page);
+  let compatibilityRequests = 0;
+
+  page.on('request', (request) => {
+    if (request.url().includes('/compatibility/')) compatibilityRequests += 1;
+  });
+
+  await page.route('**/behavior-vision/shadow**', (route) =>
+    fulfillJson(route, {
+      policy: {
+        version: 'woof-behavior-shadow-v1',
+        mode: 'shadow-evidence-only',
+        canInfluenceCompatibility: false,
+        canMutateCanonicalPetState: false,
+        canMakeSafetyDecision: false,
+        promotionEnabled: false,
+        promotionRequiresSeparateQualifiedRelease: true,
+      },
+      evaluation: {
+        observations: 24,
+        usableObservations: 20,
+        ownerReviewedObservations: 12,
+        ownerConfirmedObservations: 11,
+        ownerRejectedObservations: 1,
+        ownerUnreviewedObservations: 8,
+        confirmationRate: 11 / 12,
+        usableRate: 20 / 24,
+        contextsSeen: 4,
+        pairedSessions: 6,
+        personalizationConfidence: 0.72,
+        modelVersions: ['behavior-shadow-model-1'],
+        evidenceReady: true,
+        readinessGates: {
+          usableObservations: 20,
+          ownerReviewedObservations: 10,
+          confirmationRate: 0.8,
+          contexts: 3,
+          pairedSessions: 5,
+        },
+      },
+      moments: [
+        {
+          observationId: 'obs-1',
+          observationCreatedAt: '2026-08-23T20:00:00.000Z',
+          context: 'park',
+          phase: 'recovery',
+          startMs: 4200,
+          endMs: 6800,
+          confidence: 0.91,
+          labels: ['oriented toward dog', 'forward movement'],
+          sources: ['pose', 'motion'],
+        },
+      ],
+    })
+  );
+
+  await page.goto('/coach/observe/shadow');
+
+  await expect(page.getByRole('heading', { name: 'Shadow Lab' })).toBeVisible();
+  await expect(page.getByText('zero authority')).toBeVisible();
+  await expect(page.getByText('Evidence gates met')).toBeVisible();
+  await expect(page.getByText('0:04.2–0:06.8')).toBeVisible();
+  await expect(page.getByText('oriented toward dog · forward movement')).toBeVisible();
+  await expect(page.getByText(/Compatibility influence: off/i)).toBeVisible();
+  expect(compatibilityRequests).toBe(0);
+});

--- a/apps/web/src/app/coach/layout.tsx
+++ b/apps/web/src/app/coach/layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Clock3, Images, Video } from 'lucide-react';
+import { Clock3, FlaskConical, Images, Video } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
@@ -9,9 +9,10 @@ export default function CoachLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const observing = pathname.startsWith('/coach/observe');
   const history = pathname.startsWith('/coach/observe/history');
-  const href = observing && !history ? '/coach/observe/history' : '/coach/observe';
-  const label = observing && !history ? 'Behavior history' : 'Observe behavior';
-  const Icon = observing && !history ? Clock3 : Video;
+  const shadow = pathname.startsWith('/coach/observe/shadow');
+  const primaryHref = observing ? (shadow ? '/coach/observe' : '/coach/observe/shadow') : '/coach/observe';
+  const primaryLabel = observing ? (shadow ? 'Observe behavior' : 'Shadow Lab') : 'Observe behavior';
+  const PrimaryIcon = observing && !shadow ? FlaskConical : Video;
 
   return (
     <>
@@ -24,12 +25,21 @@ export default function CoachLayout({ children }: { children: ReactNode }) {
         >
           <Images className="h-4 w-4" aria-hidden="true" />
         </Link>
+        {observing && !history && !shadow && (
+          <Link
+            href="/coach/observe/history"
+            aria-label="Open behavior history"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-border/70 bg-background/95 text-muted-foreground shadow-lg backdrop-blur-xl transition-transform hover:-translate-y-0.5 hover:text-foreground focus-visible:-translate-y-0.5"
+          >
+            <Clock3 className="h-4 w-4" aria-hidden="true" />
+          </Link>
+        )}
         <Link
-          href={href}
+          href={primaryHref}
           className="flex min-h-11 items-center gap-2 rounded-full border border-primary/20 bg-background/95 px-4 py-2 text-sm font-semibold text-primary shadow-lg backdrop-blur-xl transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5"
         >
-          <Icon className="h-4 w-4" aria-hidden="true" />
-          {label}
+          <PrimaryIcon className="h-4 w-4" aria-hidden="true" />
+          {primaryLabel}
         </Link>
       </div>
     </>

--- a/apps/web/src/app/coach/layout.tsx
+++ b/apps/web/src/app/coach/layout.tsx
@@ -10,8 +10,16 @@ export default function CoachLayout({ children }: { children: ReactNode }) {
   const observing = pathname.startsWith('/coach/observe');
   const history = pathname.startsWith('/coach/observe/history');
   const shadow = pathname.startsWith('/coach/observe/shadow');
-  const primaryHref = observing ? (shadow ? '/coach/observe' : '/coach/observe/shadow') : '/coach/observe';
-  const primaryLabel = observing ? (shadow ? 'Observe behavior' : 'Shadow Lab') : 'Observe behavior';
+  const primaryHref = observing
+    ? shadow
+      ? '/coach/observe'
+      : '/coach/observe/shadow'
+    : '/coach/observe';
+  const primaryLabel = observing
+    ? shadow
+      ? 'Observe behavior'
+      : 'Shadow Lab'
+    : 'Observe behavior';
   const PrimaryIcon = observing && !shadow ? FlaskConical : Video;
 
   return (

--- a/apps/web/src/app/coach/observe/shadow/page.tsx
+++ b/apps/web/src/app/coach/observe/shadow/page.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import {
+  ArrowLeft,
+  CheckCircle2,
+  CircleDashed,
+  Clock3,
+  FlaskConical,
+  Loader2,
+  LockKeyhole,
+  ShieldCheck,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { BottomNav } from '@/components/bottom-nav';
+import { Button } from '@/components/ui/button';
+import { behaviorVisionApi } from '@/lib/api/behavior-vision';
+import { useSessionStore } from '@/store/session';
+
+function percent(value: number | null) {
+  return value === null ? '—' : `${Math.round(value * 100)}%`;
+}
+
+function clipTime(milliseconds: number) {
+  const seconds = Math.max(0, Math.round(milliseconds / 100) / 10);
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds - minutes * 60;
+  return `${minutes}:${remainder.toFixed(1).padStart(4, '0')}`;
+}
+
+export default function BehaviorShadowPage() {
+  const user = useSessionStore((state) => state.user);
+  const pets = useMemo(() => user?.pets ?? [], [user?.pets]);
+  const [petId, setPetId] = useState(pets[0]?.id ?? '');
+
+  useEffect(() => {
+    if (!petId && pets[0]) setPetId(pets[0].id);
+  }, [petId, pets]);
+
+  const snapshot = useQuery({
+    queryKey: ['behavior-shadow', petId],
+    queryFn: () => behaviorVisionApi.shadow(petId),
+    enabled: Boolean(petId),
+  });
+
+  const evaluation = snapshot.data?.evaluation;
+  const gates = evaluation?.readinessGates;
+  const gateRows = evaluation && gates
+    ? [
+        {
+          label: 'Usable observations',
+          value: `${evaluation.usableObservations} / ${gates.usableObservations}`,
+          pass: evaluation.usableObservations >= gates.usableObservations,
+        },
+        {
+          label: 'Owner-reviewed observations',
+          value: `${evaluation.ownerReviewedObservations} / ${gates.ownerReviewedObservations}`,
+          pass: evaluation.ownerReviewedObservations >= gates.ownerReviewedObservations,
+        },
+        {
+          label: 'Owner confirmation',
+          value: `${percent(evaluation.confirmationRate)} / ${Math.round(gates.confirmationRate * 100)}%`,
+          pass:
+            evaluation.confirmationRate !== null &&
+            evaluation.confirmationRate >= gates.confirmationRate,
+        },
+        {
+          label: 'Contexts sampled',
+          value: `${evaluation.contextsSeen} / ${gates.contexts}`,
+          pass: evaluation.contextsSeen >= gates.contexts,
+        },
+        {
+          label: 'Paired sessions',
+          value: `${evaluation.pairedSessions} / ${gates.pairedSessions}`,
+          pass: evaluation.pairedSessions >= gates.pairedSessions,
+        },
+      ]
+    : [];
+
+  return (
+    <div className="min-h-screen bg-background pb-28">
+      <header className="sticky top-0 z-20 border-b border-border/50 bg-background/90 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-xl items-center gap-3 px-4 py-4">
+          <Button asChild variant="ghost" size="icon">
+            <Link href="/coach/observe" aria-label="Back to behavior observation">
+              <ArrowLeft className="h-5 w-5" aria-hidden="true" />
+            </Link>
+          </Button>
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary">
+              Behavior Moments
+            </p>
+            <h1 className="truncate text-lg font-bold">Shadow Lab</h1>
+          </div>
+          <span className="rounded-full border border-border/60 bg-card px-3 py-1 text-xs font-semibold text-muted-foreground">
+            zero authority
+          </span>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-xl space-y-5 px-4 py-5">
+        <section className="rounded-3xl border border-primary/15 bg-primary/[0.055] p-5">
+          <div className="flex gap-3">
+            <FlaskConical className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+            <div>
+              <h2 className="font-semibold">Evidence can accumulate without becoming truth</h2>
+              <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                This lab measures whether video observations are repeatable and owner-confirmed.
+                Nothing here changes compatibility, canonical pet state, or safety decisions.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {pets.length > 1 && (
+          <label className="block text-sm font-semibold">
+            Pet
+            <select
+              value={petId}
+              onChange={(event) => setPetId(event.target.value)}
+              className="mt-2 h-11 w-full rounded-xl border border-border bg-card px-3 text-sm font-normal"
+            >
+              {pets.map((pet) => (
+                <option key={pet.id} value={pet.id}>
+                  {pet.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        {!petId ? (
+          <section className="rounded-3xl border border-border/60 bg-card p-6 text-center">
+            <p className="font-semibold">Add a pet before collecting Behavior Moments.</p>
+          </section>
+        ) : snapshot.isLoading ? (
+          <div className="flex min-h-56 items-center justify-center gap-2" role="status">
+            <Loader2 className="h-5 w-5 animate-spin text-primary" aria-hidden="true" />
+            <span className="text-sm text-muted-foreground">Loading shadow evidence…</span>
+          </div>
+        ) : snapshot.isError || !snapshot.data ? (
+          <section className="rounded-3xl border border-border/60 bg-card p-6 text-center">
+            <p className="font-semibold">Shadow evidence is temporarily unavailable.</p>
+            <Button variant="outline" className="mt-4" onClick={() => snapshot.refetch()}>
+              Try again
+            </Button>
+          </section>
+        ) : (
+          <>
+            <section className="grid grid-cols-2 gap-3">
+              <div className="rounded-2xl border border-border/60 bg-card p-4">
+                <p className="text-xs text-muted-foreground">Usable evidence</p>
+                <p className="mt-1 text-2xl font-bold">{evaluation?.usableObservations ?? 0}</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {percent(evaluation?.usableRate ?? 0)} of observations
+                </p>
+              </div>
+              <div className="rounded-2xl border border-border/60 bg-card p-4">
+                <p className="text-xs text-muted-foreground">Owner confirmation</p>
+                <p className="mt-1 text-2xl font-bold">
+                  {percent(evaluation?.confirmationRate ?? null)}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {evaluation?.ownerReviewedObservations ?? 0} reviewed
+                </p>
+              </div>
+              <div className="rounded-2xl border border-border/60 bg-card p-4">
+                <p className="text-xs text-muted-foreground">Contexts</p>
+                <p className="mt-1 text-2xl font-bold">{evaluation?.contextsSeen ?? 0}</p>
+                <p className="mt-1 text-xs text-muted-foreground">breadth matters</p>
+              </div>
+              <div className="rounded-2xl border border-border/60 bg-card p-4">
+                <p className="text-xs text-muted-foreground">Paired sessions</p>
+                <p className="mt-1 text-2xl font-bold">{evaluation?.pairedSessions ?? 0}</p>
+                <p className="mt-1 text-xs text-muted-foreground">baseline + change/recovery</p>
+              </div>
+            </section>
+
+            <section className="rounded-3xl border border-border/60 bg-card/70 p-5">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="eyebrow">Research readiness</p>
+                  <h2 className="mt-2 font-semibold">
+                    {evaluation?.evidenceReady ? 'Evidence gates met' : 'Still collecting evidence'}
+                  </h2>
+                </div>
+                <span className="rounded-full bg-muted px-3 py-1 text-xs font-semibold text-muted-foreground">
+                  {evaluation?.evidenceReady ? 'ready to evaluate' : 'shadow only'}
+                </span>
+              </div>
+              <div className="mt-4 space-y-2">
+                {gateRows.map((gate) => (
+                  <div
+                    key={gate.label}
+                    className="flex items-center justify-between gap-3 rounded-xl border border-border/50 px-3 py-2.5"
+                  >
+                    <span className="flex items-center gap-2 text-sm">
+                      {gate.pass ? (
+                        <CheckCircle2 className="h-4 w-4 text-primary" aria-hidden="true" />
+                      ) : (
+                        <CircleDashed className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                      )}
+                      {gate.label}
+                    </span>
+                    <span className="text-xs font-semibold text-muted-foreground">{gate.value}</span>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-4 text-xs leading-relaxed text-muted-foreground">
+                Passing every gate only makes the evidence substantial enough to evaluate. It does
+                not switch on production authority.
+              </p>
+            </section>
+
+            <section className="rounded-3xl border border-border/60 bg-card/70 p-5">
+              <div className="flex items-center gap-2">
+                <Clock3 className="h-4 w-4 text-primary" aria-hidden="true" />
+                <h2 className="font-semibold">Reviewable moments</h2>
+              </div>
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                Timestamps point to evidence windows from transient clips. Raw video is not retained
+                by this timeline.
+              </p>
+              {snapshot.data.moments.length === 0 ? (
+                <p className="mt-4 rounded-xl bg-muted/40 p-4 text-sm text-muted-foreground">
+                  No timestamped video evidence yet. New model runs can populate moments when the
+                  model returns timed evidence.
+                </p>
+              ) : (
+                <div className="mt-4 space-y-3">
+                  {snapshot.data.moments.slice(0, 12).map((moment, index) => (
+                    <div
+                      key={`${moment.observationId}-${moment.startMs}-${index}`}
+                      className="rounded-2xl border border-border/60 p-4"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="text-xs font-semibold text-primary">
+                          {clipTime(moment.startMs)}–{clipTime(moment.endMs)}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {Math.round(moment.confidence * 100)}% evidence confidence
+                        </span>
+                      </div>
+                      <p className="mt-2 text-sm font-medium">{moment.labels.join(' · ')}</p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Sources: {moment.sources.join(', ')}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <section className="rounded-3xl border border-border/60 bg-muted/25 p-5">
+              <div className="flex gap-3">
+                <LockKeyhole className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+                <div>
+                  <p className="text-sm font-semibold">Authority remains locked</p>
+                  <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                    Compatibility influence: off. Canonical pet mutation: off. Safety-decision
+                    authority: off. Promotion needs a separate qualified release even if every
+                    research gate passes.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
+                <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+                Policy {snapshot.data.policy.version}
+              </div>
+            </section>
+          </>
+        )}
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+}

--- a/apps/web/src/app/coach/observe/shadow/page.tsx
+++ b/apps/web/src/app/coach/observe/shadow/page.tsx
@@ -46,37 +46,38 @@ export default function BehaviorShadowPage() {
 
   const evaluation = snapshot.data?.evaluation;
   const gates = evaluation?.readinessGates;
-  const gateRows = evaluation && gates
-    ? [
-        {
-          label: 'Usable observations',
-          value: `${evaluation.usableObservations} / ${gates.usableObservations}`,
-          pass: evaluation.usableObservations >= gates.usableObservations,
-        },
-        {
-          label: 'Owner-reviewed observations',
-          value: `${evaluation.ownerReviewedObservations} / ${gates.ownerReviewedObservations}`,
-          pass: evaluation.ownerReviewedObservations >= gates.ownerReviewedObservations,
-        },
-        {
-          label: 'Owner confirmation',
-          value: `${percent(evaluation.confirmationRate)} / ${Math.round(gates.confirmationRate * 100)}%`,
-          pass:
-            evaluation.confirmationRate !== null &&
-            evaluation.confirmationRate >= gates.confirmationRate,
-        },
-        {
-          label: 'Contexts sampled',
-          value: `${evaluation.contextsSeen} / ${gates.contexts}`,
-          pass: evaluation.contextsSeen >= gates.contexts,
-        },
-        {
-          label: 'Paired sessions',
-          value: `${evaluation.pairedSessions} / ${gates.pairedSessions}`,
-          pass: evaluation.pairedSessions >= gates.pairedSessions,
-        },
-      ]
-    : [];
+  const gateRows =
+    evaluation && gates
+      ? [
+          {
+            label: 'Usable observations',
+            value: `${evaluation.usableObservations} / ${gates.usableObservations}`,
+            pass: evaluation.usableObservations >= gates.usableObservations,
+          },
+          {
+            label: 'Owner-reviewed observations',
+            value: `${evaluation.ownerReviewedObservations} / ${gates.ownerReviewedObservations}`,
+            pass: evaluation.ownerReviewedObservations >= gates.ownerReviewedObservations,
+          },
+          {
+            label: 'Owner confirmation',
+            value: `${percent(evaluation.confirmationRate)} / ${Math.round(gates.confirmationRate * 100)}%`,
+            pass:
+              evaluation.confirmationRate !== null &&
+              evaluation.confirmationRate >= gates.confirmationRate,
+          },
+          {
+            label: 'Contexts sampled',
+            value: `${evaluation.contextsSeen} / ${gates.contexts}`,
+            pass: evaluation.contextsSeen >= gates.contexts,
+          },
+          {
+            label: 'Paired sessions',
+            value: `${evaluation.pairedSessions} / ${gates.pairedSessions}`,
+            pass: evaluation.pairedSessions >= gates.pairedSessions,
+          },
+        ]
+      : [];
 
   return (
     <div className="min-h-screen bg-background pb-28">
@@ -199,11 +200,16 @@ export default function BehaviorShadowPage() {
                       {gate.pass ? (
                         <CheckCircle2 className="h-4 w-4 text-primary" aria-hidden="true" />
                       ) : (
-                        <CircleDashed className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                        <CircleDashed
+                          className="h-4 w-4 text-muted-foreground"
+                          aria-hidden="true"
+                        />
                       )}
                       {gate.label}
                     </span>
-                    <span className="text-xs font-semibold text-muted-foreground">{gate.value}</span>
+                    <span className="text-xs font-semibold text-muted-foreground">
+                      {gate.value}
+                    </span>
                   </div>
                 ))}
               </div>

--- a/apps/web/src/lib/api/behavior-vision.spec.ts
+++ b/apps/web/src/lib/api/behavior-vision.spec.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const transport = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock('./client', () => ({ apiClient: transport }));
+
+import { behaviorVisionApi } from './behavior-vision';
+
+describe('behaviorVisionApi shadow transport', () => {
+  beforeEach(() => {
+    transport.get.mockReset();
+    transport.post.mockReset();
+    transport.delete.mockReset();
+  });
+
+  it('reads a pet-scoped shadow snapshot without a client authority flag', async () => {
+    transport.get.mockResolvedValue({
+      policy: {
+        mode: 'shadow-evidence-only',
+        canInfluenceCompatibility: false,
+      },
+      evaluation: {},
+      moments: [],
+    });
+
+    await behaviorVisionApi.shadow('pet-1');
+
+    expect(transport.get).toHaveBeenCalledWith('/behavior-vision/shadow', {
+      params: { petId: 'pet-1' },
+    });
+  });
+});

--- a/apps/web/src/lib/api/behavior-vision.ts
+++ b/apps/web/src/lib/api/behavior-vision.ts
@@ -140,6 +140,48 @@ export type BehaviorVisionResult = {
   safety: string;
 };
 
+export type BehaviorShadowSnapshot = {
+  policy: {
+    version: string;
+    mode: 'shadow-evidence-only';
+    canInfluenceCompatibility: false;
+    canMutateCanonicalPetState: false;
+    canMakeSafetyDecision: false;
+    promotionEnabled: false;
+    promotionRequiresSeparateQualifiedRelease: true;
+  };
+  evaluation: {
+    observations: number;
+    usableObservations: number;
+    ownerReviewedObservations: number;
+    ownerConfirmedObservations: number;
+    ownerRejectedObservations: number;
+    ownerUnreviewedObservations: number;
+    confirmationRate: number | null;
+    usableRate: number;
+    contextsSeen: number;
+    pairedSessions: number;
+    personalizationConfidence: number;
+    modelVersions: string[];
+    evidenceReady: boolean;
+    readinessGates: {
+      usableObservations: number;
+      ownerReviewedObservations: number;
+      confirmationRate: number;
+      contexts: number;
+      pairedSessions: number;
+    };
+  };
+  moments: Array<{
+    observationId: string;
+    startMs: number;
+    endMs: number;
+    confidence: number;
+    labels: string[];
+    sources: string[];
+  }>;
+};
+
 export type BehaviorVisionInput = {
   petId: string;
   media: File | Blob;
@@ -201,6 +243,11 @@ export const behaviorVisionApi = {
         ownerFeedback?: { accurate: boolean; note?: string };
       }>
     >,
+
+  shadow: async (petId: string) =>
+    apiClient.get('/behavior-vision/shadow', {
+      params: { petId },
+    }) as unknown as Promise<BehaviorShadowSnapshot>,
 
   feedback: async (observationId: string, accurate: boolean, note?: string) =>
     apiClient.post('/behavior-vision/feedback', {

--- a/docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md
+++ b/docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md
@@ -1,0 +1,65 @@
+# dogOS Behavior Moments — Shadow v1
+
+Behavior Moments is the evidence-gathering stage for pet video analysis. This release deliberately does **not** promote model output into canonical pet truth, compatibility authority, or safety decisions.
+
+## Product contract
+
+Raw image/video bytes are processed transiently by the existing Behavior Vision path. Woof stores derived observation telemetry plus a content fingerprint, not the raw media. Audio stays opt-in per observation.
+
+Timestamped model evidence is grouped into bounded **Behavior Moments** so owners and developers can review the portions of a clip that produced evidence. A moment is an index into derived evidence, not stored video and not a claim about a dog's internal emotional state.
+
+The shadow snapshot reports:
+
+- observation volume and usable-observation rate
+- owner-confirmed, rejected, and unreviewed observations
+- owner confirmation rate
+- context breadth
+- paired baseline/recovery session count
+- model versions represented in the evidence
+- timestamped reviewable Behavior Moments
+- whether the evidence has met research-readiness thresholds
+
+## Hard authority boundary
+
+`woof-behavior-shadow-v1` always reports:
+
+- `canInfluenceCompatibility: false`
+- `canMutateCanonicalPetState: false`
+- `canMakeSafetyDecision: false`
+- `promotionEnabled: false`
+- `promotionRequiresSeparateQualifiedRelease: true`
+
+Meeting every evidence-readiness gate does **not** change those values. Promotion requires a separate release, explicit product review, replay evidence, and its own qualification graph.
+
+## Evidence-readiness gates
+
+The current research gates are intentionally conservative and are not product promises:
+
+- at least 20 usable observations
+- at least 10 owner-reviewed observations
+- at least 80% owner confirmation among reviewed observations
+- at least 3 observed contexts
+- at least 5 paired baseline/intervention-or-recovery sessions
+
+Passing these gates means only that the evidence stream is substantial enough to evaluate. It does not grant production authority.
+
+## Safety and interpretation
+
+Behavior Moments may describe visible pose, movement, orientation, interaction, recovery, and opted-in audio timing. They must not be presented as definitive emotion, intent, diagnosis, pain detection, aggression diagnosis, or permission for direct dog-to-dog greeting.
+
+Owner corrections outrank unconfirmed model evidence for personalization evaluation. Rejected observations remain auditable but do not count as usable evidence.
+
+## Release qualification
+
+The dedicated Behavior Moments CI lane must prove:
+
+1. release files are formatted and zero-warning lint clean;
+2. API and web TypeScript checks pass;
+3. shadow service unit contracts pass;
+4. existing Behavior Vision privacy/safety contracts remain green;
+5. production Behavior Vision code contains no canonical pet mutation;
+6. compatibility code contains no Behavior Vision/Behavior Moments dependency;
+7. the zero-authority policy flags remain literal and executable;
+8. API and web production builds pass.
+
+This lane is additive to inherited repository qualification. It does not replace root CI or earlier dogOS release lanes.


### PR DESCRIPTION
## dogOS Behavior Moments — Shadow v1

Base: exact Trust + Discovery merge SHA `767b51482b356f8cb6fd097eabf7dcb3d180f426`.

This release turns the existing Behavior Vision subsystem into an explicitly governed shadow evidence stream before any model output is allowed to influence compatibility or canonical pet state.

### Behavior Moments

- derives bounded reviewable moments from timestamped model evidence
- groups nearby pose/motion/interaction evidence without storing the raw clip
- keeps image/video bytes transient and audio opt-in
- preserves owner correction as higher-value evidence
- exposes a read-only **Coach → Shadow Lab** with evidence volume, agreement metrics, research gates and timestamped evidence windows

### Shadow evaluation

A new authenticated shadow snapshot reports observation volume, usable rate, reviewed/confirmed/rejected counts, confirmation rate, context breadth, paired-session count, model versions and evidence-readiness status.

Research-readiness currently requires 20 usable observations, 10 owner-reviewed observations, >=80% owner confirmation, 3 contexts and 5 paired sessions.

Owner agreement is calculated only across model-usable observations. Unusable/model-unavailable analyses cannot inflate the confirmation rate or promotion-readiness evidence.

Passing every research gate grants **no authority**.

### Hard zero-authority policy

`woof-behavior-shadow-v1` always reports:

- `canInfluenceCompatibility: false`
- `canMutateCanonicalPetState: false`
- `canMakeSafetyDecision: false`
- `promotionEnabled: false`
- `promotionRequiresSeparateQualifiedRelease: true`

Promotion requires a separate reviewed release with replay evidence and a new qualification graph.

### Executable boundaries

The dedicated Behavior Moments lane fails if:

- production Behavior Vision code mutates canonical pet state
- compatibility imports Behavior Vision / Behavior Moments authority
- zero-authority policy literals are weakened
- focused privacy/shadow regression tests fail
- the web transport contract fails
- the Shadow Lab Chromium journey makes a compatibility request or fails to render its authority lock
- strict formatting/lint/type checks fail
- API or web production builds fail

See `docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md`.

### Qualification receipts

Qualified exact head: `8119da9555fbc8c3f69e512afc567160c5d95851`

Both required workflows completed successfully on that exact SHA:

1. **dogOS Behavior Moments Shadow CI** — run `32668343752`
2. **root CI** — run `32668343760`

Dedicated Shadow CI passed formatting, zero-warning API/web lint, canonical-pet mutation rejection, compatibility-authority rejection, literal zero-authority enforcement, API/web TypeScript, the Behavior Moments shadow regression suite, the web transport contract, a Chromium Shadow Lab journey, and production API/web builds.

The shadow regression suite includes the explicit case that confirmations attached to unusable analyses cannot inflate agreement. It also proves that satisfying every research-readiness gate still leaves compatibility, canonical pet state and safety-decision authority disabled.

Root CI independently passed release-critical formatting, zero-warning lint, full monorepo TypeScript, ML compilation/policy contracts, the complete database migration chain, backend unit/API tests, frontend unit tests, the full browser smoke/accessibility/visual suite including the new Shadow Lab journey, and independent production API/web builds.

The branch is based directly on the fully qualified Trust + Discovery production boundary. Earlier dogOS lanes own no paths changed by this release and are inherited from that exact production base rather than being modified merely to retrigger them.

Diagnostic heads do not count.