### PR TITLE
dogOS Observability + Device Contracts: real readiness and private partner telemetry

### DIFF
--- a/.github/workflows/dogos-observability-device-ci.yml
+++ b/.github/workflows/dogos-observability-device-ci.yml
@@ -1,0 +1,191 @@
+name: dogOS Observability + Device Contracts CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/observability/**'
+      - 'apps/api/src/connectors/device-partner-contract*.ts'
+      - 'apps/api/src/connectors/connectors.service.ts'
+      - 'apps/api/src/connectors/connectors.service.spec.ts'
+      - 'apps/api/src/app.module.ts'
+      - 'apps/api/src/app.service.ts'
+      - 'apps/api/src/config/env.validation.ts'
+      - 'apps/api/src/config/env.validation.spec.ts'
+      - 'apps/api/.env.example'
+      - '.github/workflows/dogos-observability-device-ci.yml'
+      - 'docs/DOGOS_OBSERVABILITY_DEVICE_CONTRACTS.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-observability-device-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  qualify:
+    name: Real readiness + private metrics + device contract qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+      SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_shadow
+      JWT_SECRET: ci-only-observability-device-secret
+      NODE_ENV: test
+      ML_SERVICE_ENABLED: 'false'
+      ENABLE_DOGOS_CONNECTORS: 'true'
+      CONNECTOR_CREDENTIALS_KEY: BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=
+      OPS_METRICS_TOKEN: ci-only-ops-metrics-secret-0123456789abcdef
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject schema and migration ownership changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
+            echo 'Observability + Device Contracts v1 does not own database schema or migration changes.'
+            exit 1
+          fi
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check Observability + Device formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/observability
+          apps/api/src/connectors/device-partner-contract.ts
+          apps/api/src/connectors/device-partner-contract.spec.ts
+          apps/api/src/connectors/connectors.service.ts
+          apps/api/src/connectors/connectors.service.spec.ts
+          apps/api/src/app.module.ts
+          apps/api/src/app.service.ts
+          apps/api/src/config/env.validation.ts
+          apps/api/src/config/env.validation.spec.ts
+          .github/workflows/dogos-observability-device-ci.yml
+          docs/DOGOS_OBSERVABILITY_DEVICE_CONTRACTS.md
+
+      - name: Lint Observability + Device API surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          'src/observability/**/*.ts'
+          src/connectors/device-partner-contract.ts
+          src/connectors/device-partner-contract.spec.ts
+          src/connectors/connectors.service.ts
+          src/connectors/connectors.service.spec.ts
+          src/app.module.ts
+          src/app.service.ts
+          src/config/env.validation.ts
+          src/config/env.validation.spec.ts
+
+      - name: Enforce real database readiness
+        run: |
+          if grep -EIn "database:[[:space:]]*['\"]connected['\"]" apps/api/src/app.service.ts apps/api/src/observability; then
+            echo 'Health endpoints cannot hard-code database readiness.'
+            exit 1
+          fi
+          grep -Fq '$queryRaw`SELECT 1`' apps/api/src/observability/observability.service.ts
+          grep -Fq 'ServiceUnavailableException' apps/api/src/observability/observability.service.ts
+
+      - name: Enforce identifier-free operational metrics
+        run: |
+          metrics='apps/api/src/observability/operational-metrics.service.ts'
+          interceptor='apps/api/src/observability/request-metrics.interceptor.ts'
+          if grep -EIn '\b(userId|petId|externalObjectId|externalPetId|accountId)\b|request\.(url|originalUrl|body|query|params)' "$metrics" "$interceptor"; then
+            echo 'Operational metrics cannot collect entity identifiers, request URLs, bodies, query strings, or route parameters.'
+            exit 1
+          fi
+          grep -Fq 'userIdentifiersCollected: false' "$metrics"
+          grep -Fq 'petIdentifiersCollected: false' "$metrics"
+          grep -Fq 'providerExternalIdentifiersCollected: false' "$metrics"
+          grep -Fq 'rawPayloadsCollected: false' "$metrics"
+          grep -Fq 'requestUrlsCollected: false' "$metrics"
+
+      - name: Enforce fail-closed protected metrics access
+        run: |
+          guard='apps/api/src/observability/ops-token.guard.ts'
+          grep -Fq "createHash('sha256')" "$guard"
+          grep -Fq 'timingSafeEqual' "$guard"
+          grep -Fq 'ServiceUnavailableException' "$guard"
+          grep -Fq 'x-woof-ops-token' "$guard"
+
+      - name: Enforce private wearable partner transport
+        run: |
+          controller='apps/api/src/connectors/connectors.controller.ts'
+          contract='apps/api/src/connectors/device-partner-contract.ts'
+          if grep -EIn 'ingestDevicePartner|ingestWearable|DevicePartnerEnvelope|import/wearable' "$controller"; then
+            echo 'Provider-originated wearable events must remain on verified internal transport seams.'
+            exit 1
+          fi
+          grep -Fq "woof-device-partner-v1" "$contract"
+          grep -Fq 'DEVICE_PARTNER_MAX_PAYLOAD_BYTES' "$contract"
+          grep -Fq 'containsLocationTelemetry' "$contract"
+          grep -Fq 'does not accept precise location telemetry' "$contract"
+
+      - name: Enforce canonical connector delegation
+        run: |
+          production_sources=$(find apps/api/src/connectors -type f -name '*.ts' ! -name '*.spec.ts' -print)
+          if grep -EIn '\.(pet|activity|careEvent|mediaAsset)\.(create|update|delete|upsert|createMany|updateMany|deleteMany)\b|\b(INSERT[[:space:]]+INTO|UPDATE|DELETE[[:space:]]+FROM)[[:space:]]+(public\.)?(pets|activities|care_events|media_assets)\b' $production_sources; then
+            echo 'Device transport must delegate canonical writes to existing domain importers.'
+            exit 1
+          fi
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Run Observability contracts
+        run: pnpm --filter @woof/api exec jest src/observability --runInBand
+
+      - name: Run Device partner contract
+        run: >-
+          pnpm --filter @woof/api exec jest
+          src/connectors/device-partner-contract.spec.ts
+          src/connectors/connectors.service.spec.ts
+          --runInBand
+
+      - name: Run environment validation contracts
+        run: pnpm --filter @woof/api exec jest src/config/env.validation.spec.ts --runInBand
+
+      - name: Run Autopilot source-truth regression
+        run: pnpm --filter @woof/api exec jest src/autopilot/autopilot.service.spec.ts --runInBand
+
+      - name: Build API
+        run: pnpm --filter @woof/api build

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -31,6 +31,11 @@ ENABLE_DOGOS_CONCIERGE=true
 # Required when ENABLE_DOGOS_CONNECTORS=true in production. Do not reuse JWT/VAPID keys.
 CONNECTOR_CREDENTIALS_KEY=
 
+# Operational metrics access is fail-closed when this is absent.
+# Generate a distinct secret, for example: openssl rand -hex 32
+# Do not reuse JWT, VAPID, webhook, or connector encryption credentials.
+OPS_METRICS_TOKEN=
+
 # File Upload
 MAX_FILE_SIZE=10485760
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -32,6 +32,7 @@ import { MeetupsModule } from './meetups/meetups.module';
 import { MLModule } from './ml/ml.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { NudgesModule } from './nudges/nudges.module';
+import { ObservabilityModule } from './observability/observability.module';
 import { PetsModule } from './pets/pets.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { PrivacyModule } from './privacy/privacy.module';
@@ -63,6 +64,7 @@ export const throttlerOptions: ThrottlerModuleOptions = {
     ThrottlerModule.forRoot(throttlerOptions),
     ScheduleModule.forRoot(),
     PrismaModule,
+    ObservabilityModule,
     PrivacyModule,
     TrustSafetyModule,
     AuthModule,

--- a/apps/api/src/app.service.ts
+++ b/apps/api/src/app.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
+import { ObservabilityService } from './observability/observability.service';
 
 @Injectable()
 export class AppService {
+  constructor(private readonly observability: ObservabilityService) {}
+
   getInfo() {
     return {
       name: 'Woof API',
@@ -21,12 +24,6 @@ export class AppService {
   }
 
   getHealth() {
-    return {
-      status: 'healthy',
-      timestamp: new Date().toISOString(),
-      uptime: process.uptime(),
-      environment: process.env.NODE_ENV || 'development',
-      database: 'connected', // Will be updated when we add real health checks
-    };
+    return this.observability.health();
   }
 }

--- a/apps/api/src/config/env.validation.spec.ts
+++ b/apps/api/src/config/env.validation.spec.ts
@@ -20,7 +20,7 @@ describe('validateEnvironment', () => {
       validateEnvironment({
         NODE_ENV: 'test',
         JWT_SECRET: base.JWT_SECRET,
-      }),
+      })
     ).toThrow(/DATABASE_URL/i);
   });
 
@@ -29,8 +29,26 @@ describe('validateEnvironment', () => {
       validateEnvironment({
         ...base,
         JWT_SECRET: 'too-short',
-      }),
+      })
     ).toThrow(/JWT_SECRET/i);
+  });
+
+  it('rejects short operational metrics credentials when configured', () => {
+    expect(() =>
+      validateEnvironment({
+        ...base,
+        OPS_METRICS_TOKEN: 'short-token',
+      })
+    ).toThrow(/OPS_METRICS_TOKEN/i);
+  });
+
+  it('accepts a distinct long operational metrics credential', () => {
+    const config = validateEnvironment({
+      ...base,
+      OPS_METRICS_TOKEN: 'ops-8f3f89a744824fd99ee61797d67dc1023f6f7717',
+    });
+
+    expect(config.OPS_METRICS_TOKEN).toBe('ops-8f3f89a744824fd99ee61797d67dc1023f6f7717');
   });
 
   it('requires stronger non-development secrets in production', () => {
@@ -39,7 +57,7 @@ describe('validateEnvironment', () => {
         ...base,
         NODE_ENV: 'production',
         JWT_SECRET: 'dev-this-is-long-but-still-not-production-safe',
-      }),
+      })
     ).toThrow(/production/i);
   });
 

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -11,6 +11,7 @@ const envSchema = z.object({
   JWT_EXPIRES_IN: z.string().default('7d'),
   CORS_ORIGIN: z.string().default('http://localhost:3000'),
   SENTRY_DSN: z.string().optional(),
+  OPS_METRICS_TOKEN: z.string().optional(),
   S3_ENDPOINT: z.string().optional(),
   S3_BUCKET: z.string().optional(),
   S3_ACCESS_KEY_ID: z.string().optional(),
@@ -74,6 +75,10 @@ export function validateEnvironment(config: Record<string, unknown>) {
 
   if (env.CONNECTOR_CREDENTIALS_KEY && !connectorKeyIsValid(env.CONNECTOR_CREDENTIALS_KEY)) {
     throw new Error('CONNECTOR_CREDENTIALS_KEY must decode to exactly 32 bytes');
+  }
+
+  if (env.OPS_METRICS_TOKEN && env.OPS_METRICS_TOKEN.length < 32) {
+    throw new Error('OPS_METRICS_TOKEN must be at least 32 characters when configured');
   }
 
   if (env.NODE_ENV === 'production') {

--- a/apps/api/src/connectors/connectors.service.spec.ts
+++ b/apps/api/src/connectors/connectors.service.spec.ts
@@ -1,5 +1,6 @@
 import { ConflictException, UnauthorizedException } from '@nestjs/common';
 import { AutopilotService } from '../autopilot/autopilot.service';
+import { OperationalMetricsService } from '../observability/operational-metrics.service';
 import { ConnectorCredentialStore } from './connector-credential.store';
 import { ConnectorOperationalStore } from './connector-operational.store';
 import { ConnectorsService } from './connectors.service';
@@ -57,14 +58,19 @@ function harness() {
       signal: null,
     }),
   };
+  const metrics = {
+    recordConnectorImport: jest.fn(),
+  };
   return {
     credentials,
     operational,
     autopilot,
+    metrics,
     service: new ConnectorsService(
       credentials as unknown as ConnectorCredentialStore,
       operational as unknown as ConnectorOperationalStore,
-      autopilot as unknown as AutopilotService
+      autopilot as unknown as AutopilotService,
+      metrics as unknown as OperationalMetricsService
     ),
   };
 }
@@ -225,6 +231,48 @@ describe('ConnectorsService', () => {
         payloadHash: expect.stringMatching(/^[0-9a-f]{64}$/),
       })
     );
+  });
+
+  it('accepts a versioned wearable partner envelope and emits identifier-free outcome metrics', async () => {
+    const { service, operational, credentials, metrics } = harness();
+    operational.getConnection.mockResolvedValue(connection);
+    credentials.state.mockResolvedValue('USABLE');
+    operational.getPetIdentity.mockResolvedValue({
+      connectionId: connection.id,
+      petId,
+      externalPetId: 'tractive-pet-1',
+      externalPetLabel: 'Scout',
+      verifiedAt: '2026-08-22T00:00:00.000Z',
+    });
+
+    await expect(
+      service.ingestDevicePartnerEnvelopeFromTransport(userId, {
+        schemaVersion: 'woof-device-partner-v1',
+        provider: 'TRACTIVE',
+        externalPetId: 'tractive-pet-1',
+        externalObjectId: 'day-1',
+        kind: 'DAILY_ACTIVITY',
+        observedAt: '2026-08-22T08:00:00.000Z',
+        payload: { activeMinutes: 51 },
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        contractVersion: 'woof-device-partner-v1',
+        careEventId: 'care-event-1',
+      })
+    );
+
+    expect(metrics.recordConnectorImport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'TRACTIVE',
+        kind: 'DAILY_ACTIVITY',
+        outcome: 'IMPORTED',
+      })
+    );
+    const metric = metrics.recordConnectorImport.mock.calls[0]?.[0];
+    expect(JSON.stringify(metric)).not.toContain(userId);
+    expect(JSON.stringify(metric)).not.toContain('tractive-pet-1');
+    expect(JSON.stringify(metric)).not.toContain('day-1');
   });
 
   it('repairs a missing receipt from canonical truth and rejects an altered replay payload', async () => {

--- a/apps/api/src/connectors/connectors.service.ts
+++ b/apps/api/src/connectors/connectors.service.ts
@@ -4,9 +4,15 @@ import type { IngestTrackerObservationDto } from '../autopilot/dto/autopilot.dto
 import { normalizeProviderObservation } from '../autopilot/provider-adapters';
 import { AutopilotService } from '../autopilot/autopilot.service';
 import type { NormalizedTrackerObservation } from '../autopilot/autopilot.types';
+import { OperationalMetricsService } from '../observability/operational-metrics.service';
 import { ConnectorCredentialStore } from './connector-credential.store';
 import { ConnectorOperationalStore } from './connector-operational.store';
 import type { ConnectorProvider, VerifiedWearableTransportEvent } from './connectors.types';
+import {
+  parseDevicePartnerEnvelope,
+  toVerifiedWearableTransportEvent,
+  type DevicePartnerEnvelope,
+} from './device-partner-contract';
 import { CONNECTOR_PROVIDER_REGISTRY, parseConnectorProvider } from './provider-registry';
 
 function hashObservation(observation: NormalizedTrackerObservation) {
@@ -30,7 +36,8 @@ export class ConnectorsService {
   constructor(
     private readonly credentials: ConnectorCredentialStore,
     private readonly operational: ConnectorOperationalStore,
-    private readonly autopilot: AutopilotService
+    private readonly autopilot: AutopilotService,
+    private readonly metrics: OperationalMetricsService
   ) {}
 
   async getDashboard(userId: string) {
@@ -179,6 +186,41 @@ export class ConnectorsService {
       );
     }
     return identity;
+  }
+
+  /**
+   * Versioned partner seam for future verified wearable transports. The raw
+   * envelope is validated and reduced before entering the existing idempotent
+   * connector import path. It is intentionally not exposed to browser callers.
+   */
+  async ingestDevicePartnerEnvelopeFromTransport(userId: string, input: unknown) {
+    const envelope: DevicePartnerEnvelope = parseDevicePartnerEnvelope(input);
+    const started = performance.now();
+    try {
+      const result = await this.ingestWearableFromTransport(
+        userId,
+        envelope.provider,
+        toVerifiedWearableTransportEvent(envelope)
+      );
+      this.metrics.recordConnectorImport({
+        provider: envelope.provider,
+        kind: envelope.kind,
+        outcome: result.duplicate ? 'DUPLICATE' : 'IMPORTED',
+        durationMs: Math.max(0, performance.now() - started),
+      });
+      return {
+        contractVersion: envelope.schemaVersion,
+        ...result,
+      };
+    } catch (error) {
+      this.metrics.recordConnectorImport({
+        provider: envelope.provider,
+        kind: envelope.kind,
+        outcome: 'REJECTED',
+        durationMs: Math.max(0, performance.now() - started),
+      });
+      throw error;
+    }
   }
 
   /**

--- a/apps/api/src/connectors/connectors.service.ts
+++ b/apps/api/src/connectors/connectors.service.ts
@@ -194,7 +194,14 @@ export class ConnectorsService {
    * connector import path. It is intentionally not exposed to browser callers.
    */
   async ingestDevicePartnerEnvelopeFromTransport(userId: string, input: unknown) {
-    const envelope: DevicePartnerEnvelope = parseDevicePartnerEnvelope(input);
+    let envelope: DevicePartnerEnvelope;
+    try {
+      envelope = parseDevicePartnerEnvelope(input);
+    } catch (error) {
+      this.metrics.recordDeviceContractRejection();
+      throw error;
+    }
+
     const started = performance.now();
     try {
       const result = await this.ingestWearableFromTransport(

--- a/apps/api/src/connectors/device-partner-contract.spec.ts
+++ b/apps/api/src/connectors/device-partner-contract.spec.ts
@@ -1,0 +1,62 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  DEVICE_PARTNER_MAX_PAYLOAD_BYTES,
+  parseDevicePartnerEnvelope,
+} from './device-partner-contract';
+
+const now = new Date('2026-08-23T21:00:00.000Z');
+
+function envelope(overrides: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: 'woof-device-partner-v1',
+    provider: 'TRACTIVE',
+    externalPetId: 'pet-external-1',
+    externalObjectId: 'activity-1',
+    kind: 'DAILY_ACTIVITY',
+    observedAt: '2026-08-23T20:00:00.000Z',
+    payload: { activeMinutes: 42, distance: 3500 },
+    ...overrides,
+  };
+}
+
+describe('device partner contract', () => {
+  it('accepts a bounded versioned wearable event and normalizes its timestamp', () => {
+    expect(parseDevicePartnerEnvelope(envelope(), now)).toEqual(
+      expect.objectContaining({
+        schemaVersion: 'woof-device-partner-v1',
+        provider: 'TRACTIVE',
+        externalPetId: 'pet-external-1',
+        externalObjectId: 'activity-1',
+        observedAt: '2026-08-23T20:00:00.000Z',
+      })
+    );
+  });
+
+  it('rejects precise location telemetry anywhere in the payload', () => {
+    expect(() =>
+      parseDevicePartnerEnvelope(
+        envelope({ payload: { activeMinutes: 42, nested: { coordinates: [1, 2] } } }),
+        now
+      )
+    ).toThrow(BadRequestException);
+  });
+
+  it('rejects stale, future-skewed, or unversioned events', () => {
+    expect(() =>
+      parseDevicePartnerEnvelope(envelope({ observedAt: '2026-06-01T00:00:00.000Z' }), now)
+    ).toThrow(BadRequestException);
+    expect(() =>
+      parseDevicePartnerEnvelope(envelope({ observedAt: '2026-08-23T21:06:00.000Z' }), now)
+    ).toThrow(BadRequestException);
+    expect(() => parseDevicePartnerEnvelope(envelope({ schemaVersion: 'v0' }), now)).toThrow(
+      BadRequestException
+    );
+  });
+
+  it('rejects oversized payloads before they reach provider normalization', () => {
+    const oversized = 'x'.repeat(DEVICE_PARTNER_MAX_PAYLOAD_BYTES + 1);
+    expect(() => parseDevicePartnerEnvelope(envelope({ payload: { blob: oversized } }), now)).toThrow(
+      BadRequestException
+    );
+  });
+});

--- a/apps/api/src/connectors/device-partner-contract.spec.ts
+++ b/apps/api/src/connectors/device-partner-contract.spec.ts
@@ -55,8 +55,8 @@ describe('device partner contract', () => {
 
   it('rejects oversized payloads before they reach provider normalization', () => {
     const oversized = 'x'.repeat(DEVICE_PARTNER_MAX_PAYLOAD_BYTES + 1);
-    expect(() => parseDevicePartnerEnvelope(envelope({ payload: { blob: oversized } }), now)).toThrow(
-      BadRequestException
-    );
+    expect(() =>
+      parseDevicePartnerEnvelope(envelope({ payload: { blob: oversized } }), now)
+    ).toThrow(BadRequestException);
   });
 });

--- a/apps/api/src/connectors/device-partner-contract.ts
+++ b/apps/api/src/connectors/device-partner-contract.ts
@@ -40,7 +40,9 @@ function boundedIdentifier(value: unknown, label: string) {
   if (typeof value !== 'string') throw new BadRequestException(`${label} must be a string`);
   const normalized = value.trim();
   if (!normalized || normalized.length > 160 || /[\u0000-\u001f\u007f]/.test(normalized)) {
-    throw new BadRequestException(`${label} must be a non-empty identifier of at most 160 characters`);
+    throw new BadRequestException(
+      `${label} must be a non-empty identifier of at most 160 characters`
+    );
   }
   return normalized;
 }
@@ -54,7 +56,8 @@ function containsLocationTelemetry(value: unknown): boolean {
 }
 
 function parseObservedAt(value: unknown, now: Date) {
-  if (typeof value !== 'string') throw new BadRequestException('observedAt must be an ISO timestamp');
+  if (typeof value !== 'string')
+    throw new BadRequestException('observedAt must be an ISO timestamp');
   const observedAt = new Date(value);
   if (!Number.isFinite(observedAt.getTime())) {
     throw new BadRequestException('observedAt must be a valid timestamp');
@@ -81,7 +84,9 @@ export function parseDevicePartnerEnvelope(
 
   const provider = parseConnectorProvider(String(input.provider ?? ''));
   if (provider !== 'FI' && provider !== 'TRACTIVE') {
-    throw new BadRequestException('Device partner envelopes are supported only for wearable providers');
+    throw new BadRequestException(
+      'Device partner envelopes are supported only for wearable providers'
+    );
   }
   if (input.kind !== 'DAILY_ACTIVITY' && input.kind !== 'DEVICE_STATUS') {
     throw new BadRequestException('Unsupported device partner event kind');

--- a/apps/api/src/connectors/device-partner-contract.ts
+++ b/apps/api/src/connectors/device-partner-contract.ts
@@ -1,0 +1,127 @@
+import { BadRequestException } from '@nestjs/common';
+import type { ConnectorProvider, VerifiedWearableTransportEvent } from './connectors.types';
+import { parseConnectorProvider } from './provider-registry';
+
+export const DEVICE_PARTNER_SCHEMA_VERSION = 'woof-device-partner-v1' as const;
+export const DEVICE_PARTNER_MAX_PAYLOAD_BYTES = 16 * 1024;
+export const DEVICE_PARTNER_MAX_AGE_DAYS = 35;
+export const DEVICE_PARTNER_MAX_FUTURE_SKEW_MINUTES = 5;
+
+const LOCATION_KEYS = new Set([
+  'lat',
+  'latitude',
+  'lng',
+  'lon',
+  'longitude',
+  'coordinates',
+  'position',
+  'positions',
+  'route',
+  'track',
+  'trace',
+  'gps',
+]);
+
+export type DevicePartnerEnvelope = {
+  schemaVersion: typeof DEVICE_PARTNER_SCHEMA_VERSION;
+  provider: ConnectorProvider;
+  externalPetId: string;
+  externalObjectId: string;
+  kind: 'DAILY_ACTIVITY' | 'DEVICE_STATUS';
+  observedAt: string;
+  payload: Record<string, unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function boundedIdentifier(value: unknown, label: string) {
+  if (typeof value !== 'string') throw new BadRequestException(`${label} must be a string`);
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 160 || /[\u0000-\u001f\u007f]/.test(normalized)) {
+    throw new BadRequestException(`${label} must be a non-empty identifier of at most 160 characters`);
+  }
+  return normalized;
+}
+
+function containsLocationTelemetry(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+  if (Array.isArray(value)) return value.some((entry) => containsLocationTelemetry(entry));
+  return Object.entries(value as Record<string, unknown>).some(
+    ([key, nested]) => LOCATION_KEYS.has(key.toLowerCase()) || containsLocationTelemetry(nested)
+  );
+}
+
+function parseObservedAt(value: unknown, now: Date) {
+  if (typeof value !== 'string') throw new BadRequestException('observedAt must be an ISO timestamp');
+  const observedAt = new Date(value);
+  if (!Number.isFinite(observedAt.getTime())) {
+    throw new BadRequestException('observedAt must be a valid timestamp');
+  }
+  const futureLimit = now.getTime() + DEVICE_PARTNER_MAX_FUTURE_SKEW_MINUTES * 60_000;
+  const historyLimit = now.getTime() - DEVICE_PARTNER_MAX_AGE_DAYS * 86_400_000;
+  if (observedAt.getTime() > futureLimit) {
+    throw new BadRequestException('observedAt is too far in the future');
+  }
+  if (observedAt.getTime() < historyLimit) {
+    throw new BadRequestException('observedAt is outside the supported backfill window');
+  }
+  return observedAt.toISOString();
+}
+
+export function parseDevicePartnerEnvelope(
+  input: unknown,
+  now = new Date()
+): DevicePartnerEnvelope {
+  if (!isRecord(input)) throw new BadRequestException('Device partner event must be an object');
+  if (input.schemaVersion !== DEVICE_PARTNER_SCHEMA_VERSION) {
+    throw new BadRequestException(`schemaVersion must be ${DEVICE_PARTNER_SCHEMA_VERSION}`);
+  }
+
+  const provider = parseConnectorProvider(String(input.provider ?? ''));
+  if (provider !== 'FI' && provider !== 'TRACTIVE') {
+    throw new BadRequestException('Device partner envelopes are supported only for wearable providers');
+  }
+  if (input.kind !== 'DAILY_ACTIVITY' && input.kind !== 'DEVICE_STATUS') {
+    throw new BadRequestException('Unsupported device partner event kind');
+  }
+  if (!isRecord(input.payload)) throw new BadRequestException('payload must be an object');
+  if (containsLocationTelemetry(input.payload)) {
+    throw new BadRequestException('Device partner v1 does not accept precise location telemetry');
+  }
+
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(input.payload);
+  } catch {
+    throw new BadRequestException('payload must be JSON serializable');
+  }
+  if (Buffer.byteLength(serialized, 'utf8') > DEVICE_PARTNER_MAX_PAYLOAD_BYTES) {
+    throw new BadRequestException(
+      `payload exceeds the ${DEVICE_PARTNER_MAX_PAYLOAD_BYTES}-byte device contract limit`
+    );
+  }
+
+  return {
+    schemaVersion: DEVICE_PARTNER_SCHEMA_VERSION,
+    provider,
+    externalPetId: boundedIdentifier(input.externalPetId, 'externalPetId'),
+    externalObjectId: boundedIdentifier(input.externalObjectId, 'externalObjectId'),
+    kind: input.kind,
+    observedAt: parseObservedAt(input.observedAt, now),
+    payload: input.payload,
+  };
+}
+
+export function toVerifiedWearableTransportEvent(
+  envelope: DevicePartnerEnvelope
+): VerifiedWearableTransportEvent {
+  return {
+    externalPetId: envelope.externalPetId,
+    externalObjectId: envelope.externalObjectId,
+    kind: envelope.kind,
+    observedAt: envelope.observedAt,
+    payload: envelope.payload,
+  };
+}

--- a/apps/api/src/observability/observability.controller.ts
+++ b/apps/api/src/observability/observability.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Header, UseGuards } from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+import { ObservabilityService } from './observability.service';
+import { OperationalMetricsService } from './operational-metrics.service';
+import { OpsTokenGuard } from './ops-token.guard';
+
+@ApiExcludeController()
+@Controller('ops')
+export class ObservabilityController {
+  constructor(
+    private readonly metrics: OperationalMetricsService,
+    private readonly observability: ObservabilityService
+  ) {}
+
+  @Get('health/live')
+  liveness() {
+    return this.observability.liveness();
+  }
+
+  @Get('health/ready')
+  readiness() {
+    return this.observability.assertReady();
+  }
+
+  @Get('metrics')
+  @UseGuards(OpsTokenGuard)
+  @Header('Content-Type', 'text/plain; version=0.0.4; charset=utf-8')
+  prometheus() {
+    return this.metrics.prometheus();
+  }
+
+  @Get('metrics.json')
+  @UseGuards(OpsTokenGuard)
+  snapshot() {
+    return this.metrics.snapshot();
+  }
+}

--- a/apps/api/src/observability/observability.module.ts
+++ b/apps/api/src/observability/observability.module.ts
@@ -1,0 +1,23 @@
+import { Global, Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { ObservabilityController } from './observability.controller';
+import { ObservabilityService } from './observability.service';
+import { OperationalMetricsService } from './operational-metrics.service';
+import { OpsTokenGuard } from './ops-token.guard';
+import { RequestMetricsInterceptor } from './request-metrics.interceptor';
+
+@Global()
+@Module({
+  controllers: [ObservabilityController],
+  providers: [
+    ObservabilityService,
+    OperationalMetricsService,
+    OpsTokenGuard,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: RequestMetricsInterceptor,
+    },
+  ],
+  exports: [ObservabilityService, OperationalMetricsService],
+})
+export class ObservabilityModule {}

--- a/apps/api/src/observability/observability.service.spec.ts
+++ b/apps/api/src/observability/observability.service.spec.ts
@@ -1,0 +1,55 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { ObservabilityService } from './observability.service';
+
+function harness() {
+  const prisma = {
+    $queryRaw: jest.fn().mockResolvedValue([{ ok: 1 }]),
+  };
+  return {
+    prisma,
+    service: new ObservabilityService(prisma as unknown as PrismaService),
+  };
+}
+
+describe('ObservabilityService', () => {
+  it('keeps liveness independent from database readiness', () => {
+    const { service, prisma } = harness();
+
+    expect(service.liveness()).toEqual(
+      expect.objectContaining({ status: 'live', uptimeSeconds: expect.any(Number) })
+    );
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('reports database readiness only after a real query succeeds', async () => {
+    const { service, prisma } = harness();
+
+    await expect(service.readiness()).resolves.toEqual(
+      expect.objectContaining({
+        status: 'ready',
+        database: expect.objectContaining({
+          status: 'ready',
+          latencyMs: expect.any(Number),
+        }),
+      })
+    );
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns degraded health and fails the readiness assertion when the database is unavailable', async () => {
+    const { service, prisma } = harness();
+    prisma.$queryRaw.mockRejectedValue(new Error('database unavailable'));
+
+    await expect(service.health()).resolves.toEqual(
+      expect.objectContaining({
+        status: 'degraded',
+        readiness: expect.objectContaining({
+          status: 'not_ready',
+          database: expect.objectContaining({ status: 'unavailable' }),
+        }),
+      })
+    );
+    await expect(service.assertReady()).rejects.toBeInstanceOf(ServiceUnavailableException);
+  });
+});

--- a/apps/api/src/observability/observability.service.ts
+++ b/apps/api/src/observability/observability.service.ts
@@ -1,0 +1,57 @@
+import { Injectable, ServiceUnavailableException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class ObservabilityService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  liveness() {
+    return {
+      status: 'live' as const,
+      timestamp: new Date().toISOString(),
+      uptimeSeconds: process.uptime(),
+      environment: process.env.NODE_ENV || 'development',
+    };
+  }
+
+  async readiness() {
+    const started = performance.now();
+    try {
+      await this.prisma.$queryRaw`SELECT 1`;
+      return {
+        status: 'ready' as const,
+        timestamp: new Date().toISOString(),
+        database: {
+          status: 'ready' as const,
+          latencyMs: Math.max(0, performance.now() - started),
+        },
+      };
+    } catch {
+      return {
+        status: 'not_ready' as const,
+        timestamp: new Date().toISOString(),
+        database: {
+          status: 'unavailable' as const,
+          latencyMs: Math.max(0, performance.now() - started),
+        },
+      };
+    }
+  }
+
+  async assertReady() {
+    const readiness = await this.readiness();
+    if (readiness.status !== 'ready') {
+      throw new ServiceUnavailableException(readiness);
+    }
+    return readiness;
+  }
+
+  async health() {
+    const readiness = await this.readiness();
+    return {
+      ...this.liveness(),
+      status: readiness.status === 'ready' ? ('healthy' as const) : ('degraded' as const),
+      readiness,
+    };
+  }
+}

--- a/apps/api/src/observability/operational-metrics.service.spec.ts
+++ b/apps/api/src/observability/operational-metrics.service.spec.ts
@@ -1,0 +1,70 @@
+import { OperationalMetricsService } from './operational-metrics.service';
+
+describe('OperationalMetricsService', () => {
+  it('stores only low-cardinality operational labels and aggregate timings', () => {
+    const service = new OperationalMetricsService();
+
+    service.recordRequest({
+      method: 'get',
+      operation: 'PetsController.findOwned',
+      statusCode: 200,
+      durationMs: 12.5,
+    });
+    service.recordConnectorImport({
+      provider: 'TRACTIVE',
+      kind: 'DAILY_ACTIVITY',
+      outcome: 'IMPORTED',
+      durationMs: 42,
+    });
+
+    expect(service.snapshot()).toEqual(
+      expect.objectContaining({
+        scope: 'process',
+        privacy: {
+          userIdentifiersCollected: false,
+          petIdentifiersCollected: false,
+          providerExternalIdentifiersCollected: false,
+          rawPayloadsCollected: false,
+          requestUrlsCollected: false,
+        },
+        requests: [
+          expect.objectContaining({
+            method: 'GET',
+            operation: 'PetsController.findOwned',
+            statusClass: '2xx',
+            count: 1,
+            durationMsTotal: 12.5,
+            durationMsMax: 12.5,
+          }),
+        ],
+        connectorImports: [
+          expect.objectContaining({
+            provider: 'TRACTIVE',
+            kind: 'DAILY_ACTIVITY',
+            outcome: 'IMPORTED',
+            count: 1,
+          }),
+        ],
+      })
+    );
+  });
+
+  it('exports aggregate Prometheus metrics without request URLs or entity identifiers', () => {
+    const service = new OperationalMetricsService();
+    service.recordRequest({
+      method: 'POST',
+      operation: 'ConnectorsController.disconnect',
+      statusCode: 401,
+      durationMs: 3,
+    });
+
+    const metrics = service.prometheus();
+
+    expect(metrics).toContain('operation="ConnectorsController.disconnect"');
+    expect(metrics).toContain('status_class="4xx"');
+    expect(metrics).not.toContain('/api/');
+    expect(metrics).not.toContain('userId');
+    expect(metrics).not.toContain('petId');
+    expect(metrics).not.toContain('externalObjectId');
+  });
+});

--- a/apps/api/src/observability/operational-metrics.service.ts
+++ b/apps/api/src/observability/operational-metrics.service.ts
@@ -33,6 +33,7 @@ export class OperationalMetricsService {
   private readonly startedAt = new Date();
   private readonly requests = new Map<string, RequestMetric>();
   private readonly connectorImports = new Map<string, ConnectorMetric>();
+  private deviceContractRejections = 0;
 
   recordRequest(input: {
     method: string;
@@ -79,6 +80,10 @@ export class OperationalMetricsService {
     this.connectorImports.set(key, current);
   }
 
+  recordDeviceContractRejection() {
+    this.deviceContractRejections += 1;
+  }
+
   snapshot() {
     return {
       scope: 'process' as const,
@@ -91,6 +96,7 @@ export class OperationalMetricsService {
         rawPayloadsCollected: false as const,
         requestUrlsCollected: false as const,
       },
+      deviceContractRejections: this.deviceContractRejections,
       requests: [...this.requests.values()].sort((left, right) =>
         `${left.method}:${left.operation}:${left.statusClass}`.localeCompare(
           `${right.method}:${right.operation}:${right.statusClass}`
@@ -124,6 +130,9 @@ export class OperationalMetricsService {
     }
 
     lines.push(
+      '# HELP woof_device_contract_rejections_total Device envelopes rejected before trusted provider labels are available.',
+      '# TYPE woof_device_contract_rejections_total counter',
+      `woof_device_contract_rejections_total ${this.deviceContractRejections}`,
       '# HELP woof_connector_imports_total Verified device imports by provider, kind and outcome.',
       '# TYPE woof_connector_imports_total counter'
     );

--- a/apps/api/src/observability/operational-metrics.service.ts
+++ b/apps/api/src/observability/operational-metrics.service.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@nestjs/common';
+import type { ConnectorProvider } from '../connectors/connectors.types';
+
+type RequestMetric = {
+  method: string;
+  operation: string;
+  statusClass: string;
+  count: number;
+  durationMsTotal: number;
+  durationMsMax: number;
+};
+
+type ConnectorMetric = {
+  provider: ConnectorProvider;
+  kind: 'DAILY_ACTIVITY' | 'DEVICE_STATUS';
+  outcome: 'IMPORTED' | 'DUPLICATE' | 'REJECTED';
+  count: number;
+  durationMsTotal: number;
+  durationMsMax: number;
+};
+
+function escapePrometheus(value: string) {
+  return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', '\\n');
+}
+
+function statusClass(statusCode: number) {
+  const normalized = Number.isFinite(statusCode) ? Math.max(0, Math.floor(statusCode)) : 500;
+  return `${Math.floor(normalized / 100)}xx`;
+}
+
+@Injectable()
+export class OperationalMetricsService {
+  private readonly startedAt = new Date();
+  private readonly requests = new Map<string, RequestMetric>();
+  private readonly connectorImports = new Map<string, ConnectorMetric>();
+
+  recordRequest(input: {
+    method: string;
+    operation: string;
+    statusCode: number;
+    durationMs: number;
+  }) {
+    const method = input.method.toUpperCase().slice(0, 12);
+    const operation = input.operation.slice(0, 160);
+    const bucket = statusClass(input.statusCode);
+    const key = `${method}\u0000${operation}\u0000${bucket}`;
+    const current = this.requests.get(key) ?? {
+      method,
+      operation,
+      statusClass: bucket,
+      count: 0,
+      durationMsTotal: 0,
+      durationMsMax: 0,
+    };
+    current.count += 1;
+    current.durationMsTotal += input.durationMs;
+    current.durationMsMax = Math.max(current.durationMsMax, input.durationMs);
+    this.requests.set(key, current);
+  }
+
+  recordConnectorImport(input: {
+    provider: ConnectorProvider;
+    kind: 'DAILY_ACTIVITY' | 'DEVICE_STATUS';
+    outcome: 'IMPORTED' | 'DUPLICATE' | 'REJECTED';
+    durationMs: number;
+  }) {
+    const key = `${input.provider}\u0000${input.kind}\u0000${input.outcome}`;
+    const current = this.connectorImports.get(key) ?? {
+      provider: input.provider,
+      kind: input.kind,
+      outcome: input.outcome,
+      count: 0,
+      durationMsTotal: 0,
+      durationMsMax: 0,
+    };
+    current.count += 1;
+    current.durationMsTotal += input.durationMs;
+    current.durationMsMax = Math.max(current.durationMsMax, input.durationMs);
+    this.connectorImports.set(key, current);
+  }
+
+  snapshot() {
+    return {
+      scope: 'process' as const,
+      startedAt: this.startedAt.toISOString(),
+      uptimeSeconds: process.uptime(),
+      privacy: {
+        userIdentifiersCollected: false as const,
+        petIdentifiersCollected: false as const,
+        providerExternalIdentifiersCollected: false as const,
+        rawPayloadsCollected: false as const,
+        requestUrlsCollected: false as const,
+      },
+      requests: [...this.requests.values()].sort((left, right) =>
+        `${left.method}:${left.operation}:${left.statusClass}`.localeCompare(
+          `${right.method}:${right.operation}:${right.statusClass}`
+        )
+      ),
+      connectorImports: [...this.connectorImports.values()].sort((left, right) =>
+        `${left.provider}:${left.kind}:${left.outcome}`.localeCompare(
+          `${right.provider}:${right.kind}:${right.outcome}`
+        )
+      ),
+    };
+  }
+
+  prometheus() {
+    const lines = [
+      '# HELP woof_process_uptime_seconds Process uptime in seconds.',
+      '# TYPE woof_process_uptime_seconds gauge',
+      `woof_process_uptime_seconds ${process.uptime()}`,
+      '# HELP woof_http_requests_total Requests handled by operation and status class.',
+      '# TYPE woof_http_requests_total counter',
+    ];
+
+    for (const metric of this.requests.values()) {
+      const labels = `method="${escapePrometheus(metric.method)}",operation="${escapePrometheus(
+        metric.operation
+      )}",status_class="${escapePrometheus(metric.statusClass)}"`;
+      lines.push(`woof_http_requests_total{${labels}} ${metric.count}`);
+      lines.push(`woof_http_request_duration_ms_sum{${labels}} ${metric.durationMsTotal}`);
+      lines.push(`woof_http_request_duration_ms_count{${labels}} ${metric.count}`);
+      lines.push(`woof_http_request_duration_ms_max{${labels}} ${metric.durationMsMax}`);
+    }
+
+    lines.push(
+      '# HELP woof_connector_imports_total Verified device imports by provider, kind and outcome.',
+      '# TYPE woof_connector_imports_total counter'
+    );
+    for (const metric of this.connectorImports.values()) {
+      const labels = `provider="${metric.provider}",kind="${metric.kind}",outcome="${metric.outcome}"`;
+      lines.push(`woof_connector_imports_total{${labels}} ${metric.count}`);
+      lines.push(`woof_connector_import_duration_ms_sum{${labels}} ${metric.durationMsTotal}`);
+      lines.push(`woof_connector_import_duration_ms_count{${labels}} ${metric.count}`);
+      lines.push(`woof_connector_import_duration_ms_max{${labels}} ${metric.durationMsMax}`);
+    }
+
+    return `${lines.join('\n')}\n`;
+  }
+}

--- a/apps/api/src/observability/ops-token.guard.spec.ts
+++ b/apps/api/src/observability/ops-token.guard.spec.ts
@@ -1,0 +1,45 @@
+import {
+  ServiceUnavailableException,
+  UnauthorizedException,
+  type ExecutionContext,
+} from '@nestjs/common';
+import { OpsTokenGuard } from './ops-token.guard';
+
+function context(token?: string) {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ headers: token ? { 'x-woof-ops-token': token } : {} }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('OpsTokenGuard', () => {
+  const original = process.env.OPS_METRICS_TOKEN;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.OPS_METRICS_TOKEN;
+    else process.env.OPS_METRICS_TOKEN = original;
+  });
+
+  it('fails closed when operational metrics authentication is not configured', () => {
+    delete process.env.OPS_METRICS_TOKEN;
+    const guard = new OpsTokenGuard();
+
+    expect(() => guard.canActivate(context())).toThrow(ServiceUnavailableException);
+  });
+
+  it('rejects missing and incorrect credentials', () => {
+    process.env.OPS_METRICS_TOKEN = 'correct-secret';
+    const guard = new OpsTokenGuard();
+
+    expect(() => guard.canActivate(context())).toThrow(UnauthorizedException);
+    expect(() => guard.canActivate(context('wrong'))).toThrow(UnauthorizedException);
+  });
+
+  it('accepts only the configured credential', () => {
+    process.env.OPS_METRICS_TOKEN = 'correct-secret';
+    const guard = new OpsTokenGuard();
+
+    expect(guard.canActivate(context('correct-secret'))).toBe(true);
+  });
+});

--- a/apps/api/src/observability/ops-token.guard.ts
+++ b/apps/api/src/observability/ops-token.guard.ts
@@ -1,0 +1,32 @@
+import { timingSafeEqual } from 'node:crypto';
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  ServiceUnavailableException,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+function constantTimeEqual(left: string, right: string) {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  if (leftBuffer.length !== rightBuffer.length) return false;
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+@Injectable()
+export class OpsTokenGuard implements CanActivate {
+  canActivate(context: ExecutionContext) {
+    const configured = process.env.OPS_METRICS_TOKEN?.trim();
+    if (!configured) {
+      throw new ServiceUnavailableException('Operational metrics are not configured');
+    }
+
+    const request = context.switchToHttp().getRequest<{ headers?: Record<string, unknown> }>();
+    const supplied = request.headers?.['x-woof-ops-token'];
+    if (typeof supplied !== 'string' || !constantTimeEqual(supplied, configured)) {
+      throw new UnauthorizedException('Invalid operational metrics credential');
+    }
+    return true;
+  }
+}

--- a/apps/api/src/observability/ops-token.guard.ts
+++ b/apps/api/src/observability/ops-token.guard.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from 'node:crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
 import {
   CanActivate,
   ExecutionContext,
@@ -7,11 +7,12 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 
+function tokenDigest(value: string) {
+  return createHash('sha256').update(value, 'utf8').digest();
+}
+
 function constantTimeEqual(left: string, right: string) {
-  const leftBuffer = Buffer.from(left);
-  const rightBuffer = Buffer.from(right);
-  if (leftBuffer.length !== rightBuffer.length) return false;
-  return timingSafeEqual(leftBuffer, rightBuffer);
+  return timingSafeEqual(tokenDigest(left), tokenDigest(right));
 }
 
 @Injectable()

--- a/apps/api/src/observability/request-metrics.interceptor.ts
+++ b/apps/api/src/observability/request-metrics.interceptor.ts
@@ -1,0 +1,52 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+  type HttpException,
+} from '@nestjs/common';
+import type { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { OperationalMetricsService } from './operational-metrics.service';
+
+function exceptionStatus(error: unknown) {
+  if (error && typeof error === 'object' && 'getStatus' in error) {
+    const getStatus = (error as Pick<HttpException, 'getStatus'>).getStatus;
+    if (typeof getStatus === 'function') return getStatus.call(error);
+  }
+  return 500;
+}
+
+@Injectable()
+export class RequestMetricsInterceptor implements NestInterceptor {
+  constructor(private readonly metrics: OperationalMetricsService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (context.getType() !== 'http') return next.handle();
+
+    const request = context.switchToHttp().getRequest<{ method?: string }>();
+    const response = context.switchToHttp().getResponse<{ statusCode?: number }>();
+    const operation = `${context.getClass().name}.${context.getHandler().name}`;
+    const method = request.method ?? 'UNKNOWN';
+    const started = performance.now();
+    let recorded = false;
+
+    const record = (statusCode: number) => {
+      if (recorded) return;
+      recorded = true;
+      this.metrics.recordRequest({
+        method,
+        operation,
+        statusCode,
+        durationMs: Math.max(0, performance.now() - started),
+      });
+    };
+
+    return next.handle().pipe(
+      tap({
+        next: () => record(response.statusCode ?? 200),
+        error: (error) => record(exceptionStatus(error)),
+      })
+    );
+  }
+}

--- a/docs/DOGOS_OBSERVABILITY_DEVICE_CONTRACTS.md
+++ b/docs/DOGOS_OBSERVABILITY_DEVICE_CONTRACTS.md
@@ -1,0 +1,118 @@
+# dogOS Observability + Device Partner Contracts v1
+
+## Purpose
+
+This release makes dogOS operationally measurable and partner-integration-ready without creating a second source of pet truth or expanding location collection.
+
+It has three jobs:
+
+1. report real service liveness/readiness rather than optimistic placeholders;
+2. expose low-cardinality operational metrics that do not contain user, pet, provider-object, payload, or request-URL identifiers;
+3. define a bounded, versioned wearable transport envelope that enters the already-qualified Connectors → Autopilot → CareEvent import path.
+
+## Health semantics
+
+`GET /api/v1/ops/health/live` reports process liveness only. It does not query Postgres.
+
+`GET /api/v1/ops/health/ready` performs a real `SELECT 1` through the canonical Prisma client. A database failure returns HTTP 503 through `ServiceUnavailableException`.
+
+The legacy `GET /api/v1/health` surface now uses the same real readiness probe and reports `healthy` or `degraded`; it no longer hard-codes a connected database.
+
+## Operational metrics
+
+`GET /api/v1/ops/metrics` exposes Prometheus text and `GET /api/v1/ops/metrics.json` exposes the same process-local aggregates as JSON.
+
+Both endpoints fail closed unless `OPS_METRICS_TOKEN` is configured and the caller supplies the exact value in `x-woof-ops-token`. Token comparison hashes both values to fixed-length SHA-256 digests before `timingSafeEqual`. A configured token must contain at least 32 characters.
+
+Metrics are deliberately process-local. Horizontal deployments should scrape and aggregate externally rather than persisting per-request telemetry in the application database.
+
+### Allowed labels
+
+HTTP metrics may contain only:
+
+- HTTP method;
+- Nest controller/handler operation name;
+- HTTP status class (`2xx`, `4xx`, `5xx`, etc.);
+- aggregate count, total duration, and max duration.
+
+Verified device-import metrics may contain only:
+
+- provider from the closed connector registry;
+- event kind from the closed wearable event enum;
+- outcome (`IMPORTED`, `DUPLICATE`, `REJECTED`);
+- aggregate count and timing.
+
+Malformed envelopes rejected before a trusted provider/kind exists increment one unlabeled counter: `woof_device_contract_rejections_total`.
+
+Operational metrics must not contain:
+
+- user IDs;
+- pet IDs;
+- provider account/pet/object IDs;
+- raw provider payloads;
+- request URLs, query strings, or route parameters;
+- precise location data.
+
+Product analytics remains a separate subsystem. Operational metrics are not behavioral analytics and must not be repurposed as one.
+
+## Device partner envelope
+
+The internal transport contract is `woof-device-partner-v1`.
+
+Required fields:
+
+- `schemaVersion` exactly `woof-device-partner-v1`;
+- wearable `provider` (`FI` or `TRACTIVE` in v1);
+- bounded `externalPetId` and `externalObjectId` identifiers;
+- `kind` of `DAILY_ACTIVITY` or `DEVICE_STATUS`;
+- valid `observedAt` timestamp;
+- JSON-object `payload`.
+
+V1 limits:
+
+- maximum payload: 16 KiB after JSON serialization;
+- maximum future clock skew: 5 minutes;
+- maximum historical backfill: 35 days;
+- identifiers: non-empty, no control characters, at most 160 characters;
+- recursive precise-location keys are rejected before provider normalization.
+
+The contract is an **internal verified-transport seam**. No public browser controller accepts provider-originated wearable events.
+
+## Authority and source truth
+
+The partner envelope does not gain new product authority.
+
+After validation, it is reduced to the existing `VerifiedWearableTransportEvent` and sent through `ConnectorsService.ingestWearableFromTransport()`. That path still requires:
+
+1. a connected provider account;
+2. a usable encrypted connector credential;
+3. a provider pet mapped to a dogOS pet owned by the user;
+4. deterministic provider normalization with precise-location rejection;
+5. idempotency/hash replay checks;
+6. delegation to Autopilot/CareEvent canonical source truth;
+7. hash-only connector import provenance.
+
+Device partner v1 does **not** permit:
+
+- direct canonical Pet mutation;
+- raw provider payload persistence;
+- precise GPS/location import;
+- browser provider impersonation;
+- autonomous purchases;
+- wearable-derived reward farming.
+
+## Scaling posture
+
+The first operational metrics implementation is intentionally in-memory and bounded by closed label sets. It is suitable for normal Prometheus-style scraping and avoids adding a telemetry write on every API request.
+
+A later scaling release may add distributed tracing/export aggregation, queue-depth/worker metrics, connection-pool saturation, or provider-specific verified webhook transports. Those additions must preserve the same identifier and authority boundaries.
+
+## Qualification
+
+This release requires one exact head to pass:
+
+1. `dogOS Observability + Device Contracts CI`;
+2. root `CI`;
+3. `dogOS Connectors CI`, because the release changes the qualified Connectors service and configuration surface.
+
+Any other inherited dogOS workflow that is triggered by a changed owned path also becomes required for that exact head. Diagnostic heads do not count.


### PR DESCRIPTION
## dogOS Observability + Device Partner Contracts v1

Base: exact Behavior Moments Shadow v1 merge SHA `9113bf8b229c2d0c5279a9e009a1caa992e94de4`.

This release makes dogOS operationally measurable and partner-integration-ready without introducing another source of pet truth or expanding location collection.

### Real readiness

- replaces the old hard-coded `database: connected` health claim with a real Prisma `SELECT 1` readiness probe
- adds process liveness and 503-capable database readiness endpoints under `/api/v1/ops/health/*`
- keeps the legacy health surface but now reports real `healthy` / `degraded` state

### Privacy-safe operational metrics

- adds bounded process-local request and connector-import aggregates suitable for Prometheus scraping
- HTTP labels are limited to method, Nest controller/handler operation, status class, count and aggregate latency
- verified device labels are limited to closed provider/kind/outcome enums
- malformed pre-parse envelopes increment one unlabeled rejection counter
- metrics explicitly exclude user IDs, pet IDs, provider-owned IDs, raw payloads, URLs, route params, query strings and precise location
- metrics endpoints fail closed unless a distinct `OPS_METRICS_TOKEN` is configured
- configured ops tokens must be at least 32 characters
- comparison hashes both supplied/configured tokens to fixed-length SHA-256 digests before `timingSafeEqual`, avoiding a length-dependent comparison path

### Versioned device partner contract

`woof-device-partner-v1` adds a bounded internal verified-transport envelope for FI / Tractive wearable observations:

- 16 KiB maximum JSON payload
- 160-character bounded identifiers with control-character rejection
- five-minute future skew limit
- 35-day historical backfill limit
- recursive precise-location-key rejection
- no public browser ingestion endpoint

After validation, the event still delegates to the already-qualified Connectors → Autopilot → CareEvent source-of-truth path with encrypted credentials, mapped pet identity, replay hashes and import receipts. No direct canonical Pet writes or raw provider payload persistence are added.

### Executable boundaries

`dogOS Observability + Device Contracts CI` enforces:

- no schema or migration ownership in this release
- full inherited migration deployment
- real database probing and 503 readiness behavior
- no user/pet/provider-object identifiers, raw payloads, URLs, query strings or route params in operational metrics
- fail-closed protected metrics access
- private-only wearable partner transport
- no direct canonical Pet/Activity/CareEvent/Media writes from Connectors
- API TypeScript, focused observability/device/config tests, Autopilot source-truth regression and production API build

See `docs/DOGOS_OBSERVABILITY_DEVICE_CONTRACTS.md`.

### Qualification receipts

Qualified exact head: `d0260250cea8338e5edf2c9ef352f445bc000a29`

All nine workflows triggered by the owned surface completed successfully on that exact SHA:

1. **dogOS Observability + Device Contracts CI** — run `32670302315`
2. **dogOS Connectors CI** — run `32670302398`
3. **root CI** — run `32670302411`
4. **dogOS Foundation CI** — run `32670302349`
5. **Adventure System CI** — run `32670302362`
6. **dogOS Autopilot CI** — run `32670302332`
7. **dogOS Our Story CI** — run `32670302439`
8. **dogOS Concierge CI** — run `32670302321`
9. **dogOS Trust + Discovery CI** — run `32670302333`

The owning Observability lane passed real readiness, identifier-free metrics, fail-closed ops authentication, private wearable transport, canonical connector delegation, strict lint/type-check, focused observability/device/config contracts, the Autopilot source-truth regression, all 16 inherited migrations, and an API production build.

Connectors independently passed schema validation/formatting, the full migration chain with zero Prisma drift, direct-canonical-mutation/browser-impersonation/raw-payload-persistence guards, API/web TypeScript, connector crypto/lifecycle/operational contracts, Autopilot and Our Story regressions, Connected Services web contracts, and API/web production builds.

Root CI independently passed full backend unit/API tests, release-critical formatting, zero-warning lint, full monorepo TypeScript, ML compilation/policy contracts, frontend unit tests, the full Chromium smoke/accessibility/visual suite, and independent API/web production builds.

Foundation, Adventure, Autopilot, Our Story, Concierge, and Trust + Discovery all passed their inherited exact-head qualification graphs as well.

Diagnostic heads do not count.