### PR TITLE
dogOS Network Integrity + Scale: race-safe direct chat and bounded Inbox

### DIFF
--- a/.github/workflows/dogos-network-integrity-ci.yml
+++ b/.github/workflows/dogos-network-integrity-ci.yml
@@ -77,16 +77,14 @@ jobs:
       - name: Apply full database migration chain
         run: pnpm --filter @woof/database db:migrate:deploy
 
-      - name: Print exact Network Integrity formatter patch
-        run: |
-          files=(
-            apps/api/src/chat/chat.service.ts
-            apps/api/src/chat/chat.service.spec.ts
-            apps/api/src/chat/chat.service.integration.spec.ts
-          )
-          pnpm exec prettier --write "${files[@]}"
-          git diff -- "${files[@]}"
-          git diff --exit-code -- "${files[@]}"
+      - name: Check Network Integrity formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/chat/chat.service.ts
+          apps/api/src/chat/chat.service.spec.ts
+          apps/api/src/chat/chat.service.integration.spec.ts
+          .github/workflows/dogos-network-integrity-ci.yml
+          docs/DOGOS_NETWORK_INTEGRITY_SCALE.md
 
       - name: Lint Network Integrity API surface
         run: >-

--- a/.github/workflows/dogos-network-integrity-ci.yml
+++ b/.github/workflows/dogos-network-integrity-ci.yml
@@ -77,14 +77,16 @@ jobs:
       - name: Apply full database migration chain
         run: pnpm --filter @woof/database db:migrate:deploy
 
-      - name: Check Network Integrity formatting
-        run: >-
-          pnpm exec prettier --check
-          apps/api/src/chat/chat.service.ts
-          apps/api/src/chat/chat.service.spec.ts
-          apps/api/src/chat/chat.service.integration.spec.ts
-          .github/workflows/dogos-network-integrity-ci.yml
-          docs/DOGOS_NETWORK_INTEGRITY_SCALE.md
+      - name: Print exact Network Integrity formatter patch
+        run: |
+          files=(
+            apps/api/src/chat/chat.service.ts
+            apps/api/src/chat/chat.service.spec.ts
+            apps/api/src/chat/chat.service.integration.spec.ts
+          )
+          pnpm exec prettier --write "${files[@]}"
+          git diff -- "${files[@]}"
+          git diff --exit-code -- "${files[@]}"
 
       - name: Lint Network Integrity API surface
         run: >-

--- a/.github/workflows/dogos-network-integrity-ci.yml
+++ b/.github/workflows/dogos-network-integrity-ci.yml
@@ -1,0 +1,174 @@
+name: dogOS Network Integrity + Scale CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/chat/**'
+      - '.github/workflows/dogos-network-integrity-ci.yml'
+      - 'docs/DOGOS_NETWORK_INTEGRITY_SCALE.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-network-integrity-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  qualify:
+    name: Direct-thread integrity + bounded Inbox qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+      SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_shadow
+      JWT_SECRET: ci-only-network-integrity-secret
+      NODE_ENV: test
+      ML_SERVICE_ENABLED: 'false'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject schema and migration ownership changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
+            echo 'Network Integrity + Scale v1 does not own database schema or migration changes.'
+            exit 1
+          fi
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check Network Integrity formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/chat/chat.service.ts
+          apps/api/src/chat/chat.service.spec.ts
+          apps/api/src/chat/chat.service.integration.spec.ts
+          .github/workflows/dogos-network-integrity-ci.yml
+          docs/DOGOS_NETWORK_INTEGRITY_SCALE.md
+
+      - name: Lint Network Integrity API surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/chat/chat.service.ts
+          src/chat/chat.service.spec.ts
+          src/chat/chat.service.integration.spec.ts
+
+      - name: Enforce symmetric transaction-scoped pair locking
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          source = Path('apps/api/src/chat/chat.service.ts').read_text()
+          start = source.index('async createDirectConversation')
+          end = source.index('async getMessages', start)
+          block = source[start:end]
+
+          required = [
+              '$transaction',
+              'pg_advisory_xact_lock',
+              'hashtextextended',
+              'directPairLockKey',
+              'conversation.findMany',
+              'conversation.create',
+          ]
+          missing = [token for token in required if token not in block]
+          if missing:
+              raise SystemExit(f'missing direct-thread integrity tokens: {missing}')
+
+          if source.index('.sort()', source.index('function directPairLockKey')) > source.index('class ChatService'):
+              raise SystemExit('direct pair key must sort users before entering ChatService')
+
+          if block.index('pg_advisory_xact_lock') > block.index('conversation.findMany'):
+              raise SystemExit('pair lock must be acquired before candidate conversation lookup')
+          if block.index('pg_advisory_xact_lock') > block.index('conversation.create'):
+              raise SystemExit('pair lock must be acquired before conversation creation')
+          PY
+
+      - name: Enforce bounded set-based Inbox reads
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          source = Path('apps/api/src/chat/chat.service.ts').read_text()
+          start = source.index('async listConversations')
+          end = source.index('async createDirectConversation', start)
+          block = source[start:end]
+
+          if 'assertConversationAccess' in block:
+              raise SystemExit('Inbox list must not reintroduce per-thread authorization queries')
+          if 'message.count' in block:
+              raise SystemExit('Inbox list must not reintroduce per-thread unread counts')
+          for token in ['blockedUser.findMany', 'getUnreadCounts', 'directConversations']:
+              if token not in block:
+                  raise SystemExit(f'missing bounded Inbox token: {token}')
+
+          unread_start = source.index('private async getUnreadCounts')
+          unread = source[unread_start:]
+          for token in ['conversation_participants', 'LEFT JOIN messages', 'last_read_at', 'Prisma.join(conversationIds)']:
+              if token not in unread:
+                  raise SystemExit(f'missing set-based unread token: {token}')
+          PY
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Run chat unit contracts
+        run: >-
+          pnpm --filter @woof/api exec jest
+          src/chat/chat.service.spec.ts
+          src/chat/chat-security.service.spec.ts
+          --runInBand
+
+      - name: Run real PostgreSQL network integrity contracts
+        run: pnpm --filter @woof/api exec jest src/chat/chat.service.integration.spec.ts --runInBand
+
+      - name: Run Trust + Discovery backend regression
+        run: >-
+          pnpm --filter @woof/api exec jest
+          src/chat/chat.gateway.spec.ts
+          src/discovery/discovery.service.spec.ts
+          src/meetup-proposals/meetup-proposals.service.spec.ts
+          --runInBand
+
+      - name: Build API
+        run: pnpm --filter @woof/api build

--- a/apps/api/src/chat/chat.service.integration.spec.ts
+++ b/apps/api/src/chat/chat.service.integration.spec.ts
@@ -1,19 +1,23 @@
 import { randomUUID } from 'node:crypto';
+import { PrismaService } from '../prisma/prisma.service';
 import { ChatSecurityService } from './chat-security.service';
 import { ChatService } from './chat.service';
-import { PrismaService } from '../prisma/prisma.service';
 
 describe('ChatService integration', () => {
   const prisma = new PrismaService();
   const security = { assertConversationAccess: jest.fn() } as unknown as ChatSecurityService;
   const service = new ChatService(prisma, security);
   const usersToDelete: string[] = [];
+  const conversationsToDelete: string[] = [];
 
   beforeAll(async () => {
     await prisma.$connect();
   });
 
   afterAll(async () => {
+    if (conversationsToDelete.length > 0) {
+      await prisma.conversation.deleteMany({ where: { id: { in: conversationsToDelete } } });
+    }
     if (usersToDelete.length > 0) {
       await prisma.telemetry.deleteMany({ where: { userId: { in: usersToDelete } } });
       await prisma.user.deleteMany({ where: { id: { in: usersToDelete } } });
@@ -48,6 +52,7 @@ describe('ChatService integration', () => {
 
     expect(attempts.filter((attempt) => attempt.created)).toHaveLength(1);
     expect(new Set(attempts.map((attempt) => attempt.id)).size).toBe(1);
+    conversationsToDelete.push(attempts[0]!.id);
 
     const conversations = await prisma.conversation.findMany({
       where: {
@@ -95,6 +100,7 @@ describe('ChatService integration', () => {
       },
       select: { id: true },
     });
+    conversationsToDelete.push(conversation.id);
 
     await prisma.message.createMany({
       data: [

--- a/apps/api/src/chat/chat.service.integration.spec.ts
+++ b/apps/api/src/chat/chat.service.integration.spec.ts
@@ -1,0 +1,131 @@
+import { randomUUID } from 'node:crypto';
+import { ChatSecurityService } from './chat-security.service';
+import { ChatService } from './chat.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('ChatService integration', () => {
+  const prisma = new PrismaService();
+  const security = { assertConversationAccess: jest.fn() } as unknown as ChatSecurityService;
+  const service = new ChatService(prisma, security);
+  const usersToDelete: string[] = [];
+
+  beforeAll(async () => {
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    if (usersToDelete.length > 0) {
+      await prisma.telemetry.deleteMany({ where: { userId: { in: usersToDelete } } });
+      await prisma.user.deleteMany({ where: { id: { in: usersToDelete } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  async function userFixture(label: string) {
+    const suffix = randomUUID().slice(0, 8);
+    const user = await prisma.user.create({
+      data: {
+        handle: `chat-${label}-${suffix}`,
+        email: `chat-${label}-${suffix}@example.test`,
+        visibility: 'PUBLIC',
+      },
+      select: { id: true },
+    });
+    usersToDelete.push(user.id);
+    return user;
+  }
+
+  it('creates exactly one direct thread under concurrent opposite-direction requests', async () => {
+    const [left, right] = await Promise.all([userFixture('left'), userFixture('right')]);
+
+    const attempts = await Promise.all(
+      Array.from({ length: 8 }, (_, index) =>
+        index % 2 === 0
+          ? service.createDirectConversation(left.id, right.id)
+          : service.createDirectConversation(right.id, left.id)
+      )
+    );
+
+    expect(attempts.filter((attempt) => attempt.created)).toHaveLength(1);
+    expect(new Set(attempts.map((attempt) => attempt.id)).size).toBe(1);
+
+    const conversations = await prisma.conversation.findMany({
+      where: {
+        AND: [
+          { participants: { some: { userId: left.id } } },
+          { participants: { some: { userId: right.id } } },
+        ],
+      },
+      select: {
+        id: true,
+        participants: { select: { userId: true } },
+      },
+    });
+
+    const direct = conversations.filter(
+      (conversation) =>
+        conversation.participants.length === 2 &&
+        conversation.participants.some((participant) => participant.userId === left.id) &&
+        conversation.participants.some((participant) => participant.userId === right.id)
+    );
+    expect(direct).toHaveLength(1);
+
+    await expect(
+      prisma.telemetry.count({
+        where: {
+          userId: { in: [left.id, right.id] },
+          source: 'chat',
+          event: 'CONVERSATION_STARTED',
+        },
+      })
+    ).resolves.toBe(1);
+  });
+
+  it('computes unread direct-message counts in one batched query using lastReadAt', async () => {
+    const [owner, other] = await Promise.all([userFixture('owner'), userFixture('other')]);
+    const lastReadAt = new Date('2026-08-23T20:00:00.000Z');
+    const conversation = await prisma.conversation.create({
+      data: {
+        participants: {
+          create: [
+            { userId: owner.id, lastReadAt },
+            { userId: other.id },
+          ],
+        },
+      },
+      select: { id: true },
+    });
+
+    await prisma.message.createMany({
+      data: [
+        {
+          conversationId: conversation.id,
+          senderId: other.id,
+          text: 'old message',
+          createdAt: new Date('2026-08-23T19:59:00.000Z'),
+        },
+        {
+          conversationId: conversation.id,
+          senderId: other.id,
+          text: 'new unread message',
+          createdAt: new Date('2026-08-23T20:01:00.000Z'),
+        },
+        {
+          conversationId: conversation.id,
+          senderId: owner.id,
+          text: 'my reply',
+          createdAt: new Date('2026-08-23T20:02:00.000Z'),
+        },
+      ],
+    });
+
+    await expect(service.listConversations(owner.id)).resolves.toEqual([
+      expect.objectContaining({
+        id: conversation.id,
+        participant: expect.objectContaining({ id: other.id }),
+        unreadCount: 1,
+        lastMessage: expect.objectContaining({ content: 'my reply' }),
+      }),
+    ]);
+  });
+});

--- a/apps/api/src/chat/chat.service.integration.spec.ts
+++ b/apps/api/src/chat/chat.service.integration.spec.ts
@@ -92,10 +92,7 @@ describe('ChatService integration', () => {
     const conversation = await prisma.conversation.create({
       data: {
         participants: {
-          create: [
-            { userId: owner.id, lastReadAt },
-            { userId: other.id },
-          ],
+          create: [{ userId: owner.id, lastReadAt }, { userId: other.id }],
         },
       },
       select: { id: true },

--- a/apps/api/src/chat/chat.service.spec.ts
+++ b/apps/api/src/chat/chat.service.spec.ts
@@ -138,9 +138,7 @@ describe('ChatService', () => {
         inboxConversation({ id: 'conversation-1', otherUserId: 'user-2', name: 'luna-human' }),
         inboxConversation({ id: 'conversation-2', otherUserId: 'user-3', name: 'milo-human' }),
       ]);
-      prisma.blockedUser.findMany.mockResolvedValue([
-        { userId: 'user-3', blockedId: 'user-1' },
-      ]);
+      prisma.blockedUser.findMany.mockResolvedValue([{ userId: 'user-3', blockedId: 'user-1' }]);
       prisma.$queryRaw.mockResolvedValue([{ conversation_id: 'conversation-1', unread_count: 3n }]);
 
       await expect(service.listConversations('user-1')).resolves.toEqual([

--- a/apps/api/src/chat/chat.service.spec.ts
+++ b/apps/api/src/chat/chat.service.spec.ts
@@ -6,82 +6,164 @@ const directConversation = {
   participants: [{ userId: 'user-1' }, { userId: 'user-2' }],
 };
 
-describe('ChatService direct conversation privacy', () => {
+function inboxConversation(input: { id: string; otherUserId: string; name: string }) {
+  return {
+    id: input.id,
+    updatedAt: new Date('2026-08-23T20:00:00.000Z'),
+    participants: [
+      {
+        userId: 'user-1',
+        user: { id: 'user-1', handle: 'me', avatarUrl: null, pets: [] },
+      },
+      {
+        userId: input.otherUserId,
+        user: {
+          id: input.otherUserId,
+          handle: input.name,
+          avatarUrl: null,
+          pets: [{ id: `pet-${input.otherUserId}`, name: `${input.name} dog`, avatarUrl: null }],
+        },
+      },
+    ],
+    messages: [
+      {
+        id: `message-${input.id}`,
+        senderId: input.otherUserId,
+        text: 'hello',
+        mediaUrls: [],
+        createdAt: new Date('2026-08-23T19:59:00.000Z'),
+      },
+    ],
+  };
+}
+
+describe('ChatService', () => {
   function build() {
     const prisma = {
       user: { findUnique: jest.fn() },
-      blockedUser: { findFirst: jest.fn() },
+      blockedUser: { findFirst: jest.fn(), findMany: jest.fn() },
       conversation: { findMany: jest.fn(), create: jest.fn() },
       telemetry: { create: jest.fn() },
+      $queryRaw: jest.fn().mockResolvedValue([]),
+      $transaction: jest.fn(),
     };
+    prisma.$transaction.mockImplementation(async (callback: (tx: typeof prisma) => unknown) =>
+      callback(prisma)
+    );
     const security = { assertConversationAccess: jest.fn() };
     return {
       prisma,
+      security,
       service: new ChatService(prisma as never, security as never),
     };
   }
 
-  it('rejects a brand-new conversation with a FRIENDS_ONLY profile', async () => {
-    const { prisma, service } = build();
-    prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'FRIENDS_ONLY' });
-    prisma.blockedUser.findFirst.mockResolvedValue(null);
-    prisma.conversation.findMany.mockResolvedValue([]);
+  describe('direct conversation privacy and integrity', () => {
+    it('rejects a brand-new conversation with a FRIENDS_ONLY profile', async () => {
+      const { prisma, service } = build();
+      prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'FRIENDS_ONLY' });
+      prisma.blockedUser.findFirst.mockResolvedValue(null);
+      prisma.conversation.findMany.mockResolvedValue([]);
 
-    await expect(service.createDirectConversation('user-1', 'user-2')).rejects.toBeInstanceOf(
-      NotFoundException
-    );
-    expect(prisma.conversation.create).not.toHaveBeenCalled();
-  });
-
-  it('rejects a brand-new conversation with a PRIVATE profile', async () => {
-    const { prisma, service } = build();
-    prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'PRIVATE' });
-    prisma.blockedUser.findFirst.mockResolvedValue(null);
-    prisma.conversation.findMany.mockResolvedValue([]);
-
-    await expect(service.createDirectConversation('user-1', 'user-2')).rejects.toBeInstanceOf(
-      NotFoundException
-    );
-    expect(prisma.conversation.create).not.toHaveBeenCalled();
-  });
-
-  it('reuses an established direct conversation after profile visibility becomes restricted', async () => {
-    const { prisma, service } = build();
-    prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'FRIENDS_ONLY' });
-    prisma.blockedUser.findFirst.mockResolvedValue(null);
-    prisma.conversation.findMany.mockResolvedValue([directConversation]);
-
-    await expect(service.createDirectConversation('user-1', 'user-2')).resolves.toEqual({
-      id: 'conversation-1',
-      created: false,
+      await expect(service.createDirectConversation('user-1', 'user-2')).rejects.toBeInstanceOf(
+        NotFoundException
+      );
+      expect(prisma.conversation.create).not.toHaveBeenCalled();
     });
-    expect(prisma.conversation.create).not.toHaveBeenCalled();
-  });
 
-  it('does not reuse an established conversation when either participant has blocked the other', async () => {
-    const { prisma, service } = build();
-    prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'PUBLIC' });
-    prisma.blockedUser.findFirst.mockResolvedValue({ id: 'block-1' });
-    prisma.conversation.findMany.mockResolvedValue([directConversation]);
+    it('rejects a brand-new conversation with a PRIVATE profile', async () => {
+      const { prisma, service } = build();
+      prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'PRIVATE' });
+      prisma.blockedUser.findFirst.mockResolvedValue(null);
+      prisma.conversation.findMany.mockResolvedValue([]);
 
-    await expect(service.createDirectConversation('user-1', 'user-2')).rejects.toBeInstanceOf(
-      ForbiddenException
-    );
-    expect(prisma.conversation.create).not.toHaveBeenCalled();
-  });
-
-  it('creates a conversation only for a public, unblocked profile with no existing direct thread', async () => {
-    const { prisma, service } = build();
-    prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'PUBLIC' });
-    prisma.blockedUser.findFirst.mockResolvedValue(null);
-    prisma.conversation.findMany.mockResolvedValue([]);
-    prisma.conversation.create.mockResolvedValue({ id: 'conversation-2' });
-    prisma.telemetry.create.mockResolvedValue({ id: 'telemetry-1' });
-
-    await expect(service.createDirectConversation('user-1', 'user-2')).resolves.toEqual({
-      id: 'conversation-2',
-      created: true,
+      await expect(service.createDirectConversation('user-1', 'user-2')).rejects.toBeInstanceOf(
+        NotFoundException
+      );
+      expect(prisma.conversation.create).not.toHaveBeenCalled();
     });
-    expect(prisma.conversation.create).toHaveBeenCalledTimes(1);
+
+    it('reuses an established direct conversation after profile visibility becomes restricted', async () => {
+      const { prisma, service } = build();
+      prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'FRIENDS_ONLY' });
+      prisma.blockedUser.findFirst.mockResolvedValue(null);
+      prisma.conversation.findMany.mockResolvedValue([directConversation]);
+
+      await expect(service.createDirectConversation('user-1', 'user-2')).resolves.toEqual({
+        id: 'conversation-1',
+        created: false,
+      });
+      expect(prisma.conversation.create).not.toHaveBeenCalled();
+    });
+
+    it('does not reuse an established conversation when either participant has blocked the other', async () => {
+      const { prisma, service } = build();
+      prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'PUBLIC' });
+      prisma.blockedUser.findFirst.mockResolvedValue({ id: 'block-1' });
+      prisma.conversation.findMany.mockResolvedValue([directConversation]);
+
+      await expect(service.createDirectConversation('user-1', 'user-2')).rejects.toBeInstanceOf(
+        ForbiddenException
+      );
+      expect(prisma.conversation.create).not.toHaveBeenCalled();
+    });
+
+    it('serializes pair lookup and creation behind a transaction-scoped advisory lock', async () => {
+      const { prisma, service } = build();
+      prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'PUBLIC' });
+      prisma.blockedUser.findFirst.mockResolvedValue(null);
+      prisma.conversation.findMany.mockResolvedValue([]);
+      prisma.conversation.create.mockResolvedValue({ id: 'conversation-2' });
+      prisma.telemetry.create.mockResolvedValue({ id: 'telemetry-1' });
+
+      await expect(service.createDirectConversation('user-1', 'user-2')).resolves.toEqual({
+        id: 'conversation-2',
+        created: true,
+      });
+
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+      expect(prisma.$queryRaw.mock.invocationCallOrder[0]).toBeLessThan(
+        prisma.conversation.findMany.mock.invocationCallOrder[0]!
+      );
+      expect(prisma.conversation.create).toHaveBeenCalledTimes(1);
+      expect(prisma.telemetry.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('inbox batching', () => {
+    it('filters blocked direct threads and computes unread counts with bounded set queries', async () => {
+      const { prisma, security, service } = build();
+      prisma.conversation.findMany.mockResolvedValue([
+        inboxConversation({ id: 'conversation-1', otherUserId: 'user-2', name: 'luna-human' }),
+        inboxConversation({ id: 'conversation-2', otherUserId: 'user-3', name: 'milo-human' }),
+      ]);
+      prisma.blockedUser.findMany.mockResolvedValue([
+        { userId: 'user-3', blockedId: 'user-1' },
+      ]);
+      prisma.$queryRaw.mockResolvedValue([{ conversation_id: 'conversation-1', unread_count: 3n }]);
+
+      await expect(service.listConversations('user-1')).resolves.toEqual([
+        expect.objectContaining({
+          id: 'conversation-1',
+          participant: expect.objectContaining({ id: 'user-2', name: 'luna-human' }),
+          unreadCount: 3,
+        }),
+      ]);
+
+      expect(prisma.conversation.findMany).toHaveBeenCalledTimes(1);
+      expect(prisma.blockedUser.findMany).toHaveBeenCalledTimes(1);
+      expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+      expect(security.assertConversationAccess).not.toHaveBeenCalled();
+    });
+
+    it('does not issue block or unread queries when no direct conversations are present', async () => {
+      const { prisma, service } = build();
+      prisma.conversation.findMany.mockResolvedValue([]);
+
+      await expect(service.listConversations('user-1')).resolves.toEqual([]);
+      expect(prisma.blockedUser.findMany).not.toHaveBeenCalled();
+      expect(prisma.$queryRaw).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -112,9 +112,7 @@ export class ChatService {
     );
 
     return visible.map((conversation) => {
-      const other = conversation.participants.find(
-        (participant) => participant.userId !== userId
-      )!;
+      const other = conversation.participants.find((participant) => participant.userId !== userId)!;
       const lastMessage = conversation.messages[0] ?? null;
 
       return {

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -11,6 +11,15 @@ import { ChatSecurityService } from './chat-security.service';
 const MAX_CONVERSATIONS = 50;
 const MAX_MESSAGES = 100;
 
+type UnreadCountRow = {
+  conversation_id: string;
+  unread_count: bigint | number;
+};
+
+function directPairLockKey(userId: string, participantId: string) {
+  return `woof:direct-chat:${[userId, participantId].sort().join(':')}`;
+}
+
 @Injectable()
 export class ChatService {
   constructor(
@@ -29,7 +38,6 @@ export class ChatService {
         participants: {
           select: {
             userId: true,
-            lastReadAt: true,
             user: {
               select: {
                 id: true,
@@ -58,30 +66,58 @@ export class ChatService {
       },
     });
 
-    const visible = [];
-    for (const conversation of conversations) {
-      try {
-        await this.security.assertConversationAccess(userId, conversation.id);
-      } catch {
-        continue;
-      }
+    const directConversations = conversations.filter((conversation) => {
+      if (conversation.participants.length !== 2) return false;
+      return conversation.participants.some((participant) => participant.userId === userId);
+    });
+    if (directConversations.length === 0) return [];
 
-      const self = conversation.participants.find((participant) => participant.userId === userId);
-      const others = conversation.participants.filter(
+    const otherUserIds = [
+      ...new Set(
+        directConversations.flatMap((conversation) =>
+          conversation.participants
+            .filter((participant) => participant.userId !== userId)
+            .map((participant) => participant.userId)
+        )
+      ),
+    ];
+
+    const blockedRelations =
+      otherUserIds.length === 0
+        ? []
+        : await this.prisma.blockedUser.findMany({
+            where: {
+              OR: [
+                { userId, blockedId: { in: otherUserIds } },
+                { userId: { in: otherUserIds }, blockedId: userId },
+              ],
+            },
+            select: { userId: true, blockedId: true },
+          });
+    const blockedOtherUserIds = new Set(
+      blockedRelations.map((relation) =>
+        relation.userId === userId ? relation.blockedId : relation.userId
+      )
+    );
+
+    const visible = directConversations.filter((conversation) => {
+      const other = conversation.participants.find((participant) => participant.userId !== userId);
+      return Boolean(other && !blockedOtherUserIds.has(other.userId));
+    });
+    if (visible.length === 0) return [];
+
+    const unreadCounts = await this.getUnreadCounts(
+      userId,
+      visible.map((conversation) => conversation.id)
+    );
+
+    return visible.map((conversation) => {
+      const other = conversation.participants.find(
         (participant) => participant.userId !== userId
-      );
-      if (others.length !== 1) continue;
-      const other = others[0]!;
+      )!;
       const lastMessage = conversation.messages[0] ?? null;
-      const unreadCount = await this.prisma.message.count({
-        where: {
-          conversationId: conversation.id,
-          senderId: { not: userId },
-          ...(self?.lastReadAt ? { createdAt: { gt: self.lastReadAt } } : {}),
-        },
-      });
 
-      visible.push({
+      return {
         id: conversation.id,
         participant: {
           id: other.user.id,
@@ -100,12 +136,10 @@ export class ChatService {
               createdAt: lastMessage.createdAt,
             }
           : null,
-        unreadCount,
+        unreadCount: unreadCounts.get(conversation.id) ?? 0,
         updatedAt: conversation.updatedAt,
-      });
-    }
-
-    return visible;
+      };
+    });
   }
 
   async createDirectConversation(userId: string, participantId: string) {
@@ -113,56 +147,70 @@ export class ChatService {
       throw new BadRequestException('Choose another member');
     }
 
-    const [target, blocked, candidates] = await Promise.all([
-      this.prisma.user.findUnique({
-        where: { id: participantId },
-        select: { id: true, visibility: true },
-      }),
-      this.prisma.blockedUser.findFirst({
-        where: {
-          OR: [
-            { userId, blockedId: participantId },
-            { userId: participantId, blockedId: userId },
-          ],
+    const pairKey = directPairLockKey(userId, participantId);
+    return this.prisma.$transaction(async (tx) => {
+      await tx.$queryRaw(Prisma.sql`
+        SELECT pg_advisory_xact_lock(hashtextextended(${pairKey}, 0))
+      `);
+
+      const [target, blocked, candidates] = await Promise.all([
+        tx.user.findUnique({
+          where: { id: participantId },
+          select: { id: true, visibility: true },
+        }),
+        tx.blockedUser.findFirst({
+          where: {
+            OR: [
+              { userId, blockedId: participantId },
+              { userId: participantId, blockedId: userId },
+            ],
+          },
+          select: { id: true },
+        }),
+        tx.conversation.findMany({
+          where: {
+            AND: [
+              { participants: { some: { userId } } },
+              { participants: { some: { userId: participantId } } },
+            ],
+          },
+          select: { id: true, participants: { select: { userId: true } } },
+          take: 20,
+        }),
+      ]);
+
+      if (blocked) throw new ForbiddenException('Conversation is unavailable');
+
+      const existing = candidates.find(
+        (conversation) =>
+          conversation.participants.length === 2 &&
+          conversation.participants.some((participant) => participant.userId === userId) &&
+          conversation.participants.some((participant) => participant.userId === participantId)
+      );
+      if (existing) return { id: existing.id, created: false };
+
+      if (!target || target.visibility !== 'PUBLIC') {
+        throw new NotFoundException('Member not found');
+      }
+
+      const conversation = await tx.conversation.create({
+        data: {
+          participants: {
+            create: [{ userId }, { userId: participantId }],
+          },
         },
         select: { id: true },
-      }),
-      this.prisma.conversation.findMany({
-        where: {
-          AND: [
-            { participants: { some: { userId } } },
-            { participants: { some: { userId: participantId } } },
-          ],
+      });
+      await tx.telemetry.create({
+        data: {
+          userId,
+          source: 'chat',
+          event: 'CONVERSATION_STARTED',
+          data: { conversationId: conversation.id },
         },
-        select: { id: true, participants: { select: { userId: true } } },
-        take: 20,
-      }),
-    ]);
-
-    if (blocked) throw new ForbiddenException('Conversation is unavailable');
-
-    const existing = candidates.find(
-      (conversation) =>
-        conversation.participants.length === 2 &&
-        conversation.participants.some((participant) => participant.userId === userId) &&
-        conversation.participants.some((participant) => participant.userId === participantId)
-    );
-    if (existing) return { id: existing.id, created: false };
-
-    if (!target || target.visibility !== 'PUBLIC') {
-      throw new NotFoundException('Member not found');
-    }
-
-    const conversation = await this.prisma.conversation.create({
-      data: {
-        participants: {
-          create: [{ userId }, { userId: participantId }],
-        },
-      },
-      select: { id: true },
+      });
+      return { id: conversation.id, created: true };
     });
-    await this.recordTelemetry(userId, 'CONVERSATION_STARTED', { conversationId: conversation.id });
-    return { id: conversation.id, created: true };
   }
 
   async getMessages(userId: string, conversationId: string, page = 1, limit = 50) {
@@ -213,9 +261,23 @@ export class ChatService {
     return { ok: true };
   }
 
-  private async recordTelemetry(userId: string, event: string, data: Prisma.InputJsonObject) {
-    await this.prisma.telemetry.create({
-      data: { userId, source: 'chat', event, data },
-    });
+  private async getUnreadCounts(userId: string, conversationIds: string[]) {
+    if (conversationIds.length === 0) return new Map<string, number>();
+
+    const rows = await this.prisma.$queryRaw<UnreadCountRow[]>(Prisma.sql`
+      SELECT
+        cp.conversation_id,
+        COUNT(m.id) AS unread_count
+      FROM conversation_participants cp
+      LEFT JOIN messages m
+        ON m.conversation_id = cp.conversation_id
+       AND m.sender_id <> ${userId}
+       AND (cp.last_read_at IS NULL OR m.created_at > cp.last_read_at)
+      WHERE cp.user_id = ${userId}
+        AND cp.conversation_id IN (${Prisma.join(conversationIds)})
+      GROUP BY cp.conversation_id
+    `);
+
+    return new Map(rows.map((row) => [row.conversation_id, Number(row.unread_count)]));
   }
 }

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -150,7 +150,10 @@ export class ChatService {
     const pairKey = directPairLockKey(userId, participantId);
     return this.prisma.$transaction(async (tx) => {
       await tx.$queryRaw(Prisma.sql`
-        SELECT pg_advisory_xact_lock(hashtextextended(${pairKey}, 0))
+        SELECT 1 AS locked
+        FROM (
+          SELECT pg_advisory_xact_lock(hashtextextended(${pairKey}, 0))
+        ) AS pair_lock
       `);
 
       const [target, blocked, candidates] = await Promise.all([

--- a/docs/DOGOS_NETWORK_INTEGRITY_SCALE.md
+++ b/docs/DOGOS_NETWORK_INTEGRITY_SCALE.md
@@ -1,0 +1,75 @@
+# dogOS Network Integrity + Scale v1
+
+## Purpose
+
+This release hardens the direct-message network without changing its privacy model or adding a new schema.
+
+It addresses two concrete production seams:
+
+1. simultaneous attempts to start the same direct conversation could race through the previous check-then-create flow and create duplicate threads;
+2. Inbox conversation loading performed authorization and unread-count work once per conversation after the initial list query.
+
+## Direct-thread uniqueness under concurrency
+
+`ChatService.createDirectConversation()` now runs the pair lookup and create path inside one Prisma transaction.
+
+Before reading candidate conversations, the transaction acquires a PostgreSQL transaction-scoped advisory lock derived from a symmetric pair key:
+
+`woof:direct-chat:<sorted-user-a>:<sorted-user-b>`
+
+Because the user IDs are sorted before hashing, A → B and B → A serialize on the same lock. The lock is released automatically when the transaction commits or rolls back.
+
+After the lock is held, the existing privacy rules remain authoritative:
+
+- either-direction blocks reject the request;
+- an established exact two-person conversation is reused even if the target later becomes non-public;
+- a brand-new conversation can only be created for a `PUBLIC` target;
+- conversation creation and `CONVERSATION_STARTED` telemetry commit atomically.
+
+This release intentionally uses no schema migration. Advisory-lock hash collisions can only serialize unrelated pairs unnecessarily; they cannot create duplicate conversations or merge identities.
+
+A real PostgreSQL integration contract fires concurrent requests in both directions and requires:
+
+- exactly one response with `created: true`;
+- one shared conversation ID across all responses;
+- exactly one persisted two-person direct conversation;
+- exactly one `CONVERSATION_STARTED` telemetry record.
+
+## Bounded Inbox loading
+
+`ChatService.listConversations()` no longer runs `assertConversationAccess()` and `message.count()` once per thread.
+
+The Inbox path is bounded to three data operations for up to 50 candidate conversations:
+
+1. one conversation query containing participants and latest message;
+2. one block-edge query covering every other participant in both directions;
+3. one set-based PostgreSQL unread-count query across all visible conversation IDs.
+
+The unread query joins `conversation_participants` to `messages`, respects the caller's `last_read_at`, excludes the caller's own messages, and returns zero for conversations without unread messages.
+
+The privacy semantics are preserved because the initial conversation query already requires the caller to be a participant, only exact two-person threads are surfaced, and the batched block query checks both block directions before any thread is returned.
+
+`getMessages()`, `markRead()`, realtime room joins/leaves, typing, and message persistence continue to use the authoritative `ChatSecurityService.assertConversationAccess()` path.
+
+## Non-goals
+
+This release does not:
+
+- change chat visibility or block policy;
+- create group-chat semantics;
+- weaken realtime server authorization;
+- change idempotent message receipts;
+- add a chat migration or uniqueness column;
+- expose conversation identifiers through operational metrics.
+
+## Qualification
+
+One exact head must pass every workflow triggered by the changed ownership surface. At minimum:
+
+1. `dogOS Network Integrity + Scale CI`;
+2. `dogOS Trust + Discovery CI`;
+3. root `CI`.
+
+The dedicated lane verifies formatting/lint/type safety, prohibits schema ownership, structurally requires the symmetric advisory lock and set-based Inbox path, runs unit contracts, runs the real PostgreSQL concurrency/unread integration suite, replays chat-security tests, and builds the API.
+
+Diagnostic heads do not count.


### PR DESCRIPTION
## dogOS Network Integrity + Scale v1

Base: exact Observability + Device Contracts merge SHA `1bd1124747643d6750f6833e3b09634a48144cfe`.

This release hardens the direct-message network without changing the established Trust + Discovery privacy model or adding a database migration.

### Race-safe direct conversations

`createDirectConversation()` now serializes the same unordered user pair inside a Prisma transaction using PostgreSQL `pg_advisory_xact_lock(hashtextextended(...))` and a symmetric sorted pair key.

The lock is acquired before candidate-thread lookup or creation, so simultaneous A→B and B→A requests cannot both pass the old check-then-create gap.

Existing policy remains unchanged:

- blocks win in either direction
- established exact two-person conversations remain reusable after visibility changes
- new conversations require a `PUBLIC` target
- conversation creation and `CONVERSATION_STARTED` telemetry commit atomically

A real PostgreSQL integration test fires eight concurrent opposite-direction requests and requires one persisted direct thread, one created response, one shared conversation ID, and one start-telemetry event.

During qualification Prisma 5.22 exposed one concrete interoperability issue: selecting `pg_advisory_xact_lock()` directly returns PostgreSQL `void`, which Prisma cannot deserialize. The final implementation preserves the same transaction lock semantics while executing the lock in a subquery whose outer SELECT returns a normal integer.

### Bounded Inbox reads

Inbox loading no longer performs per-thread authorization and unread-count queries after the initial list.

For up to 50 candidate conversations it now uses three bounded data operations:

1. one conversation/participant/latest-message query
2. one both-direction block-edge query for all counterpart users
3. one set-based unread-count query across every visible conversation

The unread query respects `last_read_at`, excludes self-sent messages, and returns zero when no unread messages exist. A real PostgreSQL integration test covers the timestamp semantics.

`getMessages()`, `markRead()`, realtime room authorization, typing, and persist-before-emit message delivery continue to use `ChatSecurityService.assertConversationAccess()`.

### Exact-head qualification

Qualified head: `35b01a8ccabec0b351bf6fa62a20793168c2f14d`

All workflows triggered by this ownership surface completed successfully on that exact SHA:

1. `dogOS Network Integrity + Scale CI` — run `32671118520`
2. `dogOS Trust + Discovery CI` — run `32671118549`
3. root `CI` — run `32671118533`

The dedicated lane passed:

- no schema/migration ownership
- full 16-migration chain
- read-only Prettier check
- zero-warning API lint
- symmetric transaction-lock structural invariant
- bounded set-based Inbox invariant
- API TypeScript
- chat/security unit contracts
- real PostgreSQL eight-way direct-thread concurrency contract
- real PostgreSQL `lastReadAt` unread-count contract
- Trust + Discovery backend regressions
- production API build

Root CI independently passed formatting, lint, monorepo TypeScript, ML policy contracts, full backend unit/API tests, frontend unit/browser/accessibility/visual contracts, and production builds. Trust + Discovery independently passed its authorization, privacy, realtime, transport, browser, type, and production-build gates.

See `docs/DOGOS_NETWORK_INTEGRITY_SCALE.md`.

Diagnostic heads do not count; only the exact qualified head above is merge-authoritative.