### PR TITLE
dogOS Chat Delivery Integrity: stable retries and ACK-safe drafts

### DIFF
--- a/.github/workflows/dogos-chat-delivery-integrity-ci.yml
+++ b/.github/workflows/dogos-chat-delivery-integrity-ci.yml
@@ -1,0 +1,150 @@
+name: dogOS Chat Delivery Integrity CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/web/src/components/inbox/chat-window.tsx'
+      - 'apps/web/src/lib/socket.ts'
+      - 'apps/web/src/lib/chat-delivery.ts'
+      - 'apps/web/src/lib/chat-delivery.spec.ts'
+      - 'apps/api/src/chat/**'
+      - '.github/workflows/dogos-chat-delivery-integrity-ci.yml'
+      - 'docs/DOGOS_CHAT_DELIVERY_INTEGRITY.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-chat-delivery-integrity-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  NODE_ENV: test
+  JWT_SECRET: ci-only-chat-delivery-secret
+  ML_SERVICE_ENABLED: 'false'
+
+jobs:
+  qualify:
+    name: Stable retry identity + canonical receipt qualification
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject schema and migration ownership changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
+            echo 'Chat Delivery Integrity v1 does not own database schema or migration changes.'
+            exit 1
+          fi
+
+      - name: Check Chat Delivery formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/web/src/components/inbox/chat-window.tsx
+          apps/web/src/lib/socket.ts
+          apps/web/src/lib/chat-delivery.ts
+          apps/web/src/lib/chat-delivery.spec.ts
+          .github/workflows/dogos-chat-delivery-integrity-ci.yml
+          docs/DOGOS_CHAT_DELIVERY_INTEGRITY.md
+
+      - name: Lint Chat Delivery web surface
+        run: >-
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/components/inbox/chat-window.tsx
+          src/lib/socket.ts
+          src/lib/chat-delivery.ts
+          src/lib/chat-delivery.spec.ts
+
+      - name: Enforce caller-owned retry identity
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          socket = Path('apps/web/src/lib/socket.ts').read_text()
+          composer = Path('apps/web/src/components/inbox/chat-window.tsx').read_text()
+          delivery = Path('apps/web/src/lib/chat-delivery.ts').read_text()
+
+          for forbidden in ['randomUUID', 'Date.now()', 'Math.random()']:
+              if forbidden in socket:
+                  raise SystemExit(f'socket transport must not generate message identity: {forbidden}')
+
+          socket_required = [
+              'sendMessage: (conversationId: string, text: string, clientMessageId: string)',
+              "'message:send'",
+              '{ conversationId, clientMessageId, text }',
+          ]
+          missing = [token for token in socket_required if token not in socket]
+          if missing:
+              raise SystemExit(f'missing socket retry-identity contract: {missing}')
+
+          composer_required = [
+              'getOrCreateChatSendAttempt',
+              'pendingSendRef.current = attempt',
+              'attempt.clientMessageId',
+              'invalidateAttemptForEditedDraft',
+              'reconcileDraftAfterAcknowledgedSend',
+          ]
+          missing = [token for token in composer_required if token not in composer]
+          if missing:
+              raise SystemExit(f'missing composer delivery contract: {missing}')
+
+          delivery_required = [
+              'existing.conversationId === conversationId',
+              'existing.text === text',
+              'clientMessageId: createId()',
+          ]
+          missing = [token for token in delivery_required if token not in delivery]
+          if missing:
+              raise SystemExit(f'missing stable-attempt contract: {missing}')
+          PY
+
+      - name: Enforce canonical server receipt boundary
+        run: |
+          grep -q 'dogos_chat.message_receipts' apps/api/src/chat/chat-security.service.ts
+          grep -q 'ON CONFLICT (user_id, client_message_id) DO NOTHING' apps/api/src/chat/chat-security.service.ts
+          grep -q 'if (!result.duplicate)' apps/api/src/chat/chat.gateway.ts
+          grep -q 'chatSecurity.persistMessage' apps/api/src/chat/chat.gateway.ts
+
+      - name: Type-check web
+        run: pnpm --filter @woof/web type-check
+
+      - name: Run stable retry-state contracts
+        run: pnpm --filter @woof/web exec vitest run src/lib/chat-delivery.spec.ts
+
+      - name: Run canonical server receipt regressions
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/chat/chat-security.service.spec.ts
+          src/chat/chat.gateway.spec.ts
+
+      - name: Build API
+        run: pnpm --filter @woof/api build
+
+      - name: Build web
+        env:
+          NEXT_PUBLIC_API_URL: https://api.example.com/api/v1
+        run: pnpm --filter @woof/web build

--- a/apps/web/src/components/inbox/chat-window.tsx
+++ b/apps/web/src/components/inbox/chat-window.tsx
@@ -14,6 +14,12 @@ import {
   type ChatMessage,
   type ChatMessagePage,
 } from '@/lib/api/chat';
+import {
+  getOrCreateChatSendAttempt,
+  invalidateAttemptForEditedDraft,
+  reconcileDraftAfterAcknowledgedSend,
+  type ChatSendAttempt,
+} from '@/lib/chat-delivery';
 import { meetupProposalsApi } from '@/lib/api/meetup-proposals';
 import { chatSocket, connectSocket } from '@/lib/socket';
 import { cn } from '@/lib/utils';
@@ -33,6 +39,7 @@ export function ChatWindow({ conversation, currentUserId, onBack }: ChatWindowPr
   const [sending, setSending] = useState(false);
   const [proposalMessage, setProposalMessage] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const pendingSendRef = useRef<ChatSendAttempt | null>(null);
 
   const messages = useQuery({
     queryKey: ['chat', 'messages', conversation.id],
@@ -66,6 +73,7 @@ export function ChatWindow({ conversation, currentUserId, onBack }: ChatWindowPr
     });
 
     return () => {
+      pendingSendRef.current = null;
       removeMessageListener();
       chatSocket.leaveConversation(conversation.id);
       if (activeSocket.connected) {
@@ -81,10 +89,21 @@ export function ChatWindow({ conversation, currentUserId, onBack }: ChatWindowPr
   const handleSend = async () => {
     const text = inputValue.trim();
     if (!text || sending) return;
+
+    const attempt = getOrCreateChatSendAttempt(pendingSendRef.current, conversation.id, text);
+    pendingSendRef.current = attempt;
     setSending(true);
     setSendError(null);
+
     try {
-      const persisted = await chatSocket.sendMessage(conversation.id, text);
+      const persisted = await chatSocket.sendMessage(
+        conversation.id,
+        attempt.text,
+        attempt.clientMessageId
+      );
+      if (pendingSendRef.current?.clientMessageId === attempt.clientMessageId) {
+        pendingSendRef.current = null;
+      }
       queryClient.setQueryData<ChatMessagePage>(
         ['chat', 'messages', conversation.id],
         (current) => {
@@ -92,10 +111,12 @@ export function ChatWindow({ conversation, currentUserId, onBack }: ChatWindowPr
           return { ...current, data: [...current.data, persisted], total: current.total + 1 };
         }
       );
-      setInputValue('');
-      await queryClient.invalidateQueries({ queryKey: ['chat', 'conversations'] });
+      setInputValue((current) => reconcileDraftAfterAcknowledgedSend(current, attempt.text));
+      void queryClient.invalidateQueries({ queryKey: ['chat', 'conversations'] });
     } catch {
-      setSendError('That message was not saved. Your draft is still here.');
+      setSendError(
+        'Delivery was not confirmed. Your draft is still here, and retrying it will not duplicate it.'
+      );
     } finally {
       setSending(false);
     }
@@ -251,7 +272,15 @@ export function ChatWindow({ conversation, currentUserId, onBack }: ChatWindowPr
             placeholder="Message…"
             value={inputValue}
             maxLength={4000}
-            onChange={(event) => setInputValue(event.target.value)}
+            onChange={(event) => {
+              const nextDraft = event.target.value;
+              pendingSendRef.current = invalidateAttemptForEditedDraft(
+                pendingSendRef.current,
+                nextDraft
+              );
+              setInputValue(nextDraft);
+              setSendError(null);
+            }}
             onKeyDown={(event) => {
               if (event.key === 'Enter' && !event.shiftKey) {
                 event.preventDefault();

--- a/apps/web/src/lib/chat-delivery.spec.ts
+++ b/apps/web/src/lib/chat-delivery.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getOrCreateChatSendAttempt,
+  invalidateAttemptForEditedDraft,
+  reconcileDraftAfterAcknowledgedSend,
+} from './chat-delivery';
+
+describe('chat delivery attempt identity', () => {
+  it('reuses the same clientMessageId for an uncertain retry of the same draft', () => {
+    const createId = vi.fn().mockReturnValueOnce('client-message-1');
+    const first = getOrCreateChatSendAttempt(null, 'conversation-1', ' hello ', createId);
+    const retry = getOrCreateChatSendAttempt(first, 'conversation-1', 'hello', createId);
+
+    expect(first).toEqual({
+      conversationId: 'conversation-1',
+      text: 'hello',
+      clientMessageId: 'client-message-1',
+    });
+    expect(retry).toBe(first);
+    expect(createId).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a new identity when the draft changes or the conversation changes', () => {
+    const createId = vi
+      .fn()
+      .mockReturnValueOnce('client-message-1')
+      .mockReturnValueOnce('client-message-2')
+      .mockReturnValueOnce('client-message-3');
+    const first = getOrCreateChatSendAttempt(null, 'conversation-1', 'hello', createId);
+    const edited = getOrCreateChatSendAttempt(first, 'conversation-1', 'hello again', createId);
+    const moved = getOrCreateChatSendAttempt(edited, 'conversation-2', 'hello again', createId);
+
+    expect(edited.clientMessageId).toBe('client-message-2');
+    expect(moved.clientMessageId).toBe('client-message-3');
+    expect(createId).toHaveBeenCalledTimes(3);
+  });
+
+  it('invalidates retry identity after an intentional draft edit', () => {
+    const attempt = {
+      conversationId: 'conversation-1',
+      text: 'hello',
+      clientMessageId: 'client-message-1',
+    };
+
+    expect(invalidateAttemptForEditedDraft(attempt, ' hello ')).toBe(attempt);
+    expect(invalidateAttemptForEditedDraft(attempt, 'hello there')).toBeNull();
+  });
+
+  it('does not erase text typed after the acknowledged send started', () => {
+    expect(reconcileDraftAfterAcknowledgedSend('hello', 'hello')).toBe('');
+    expect(reconcileDraftAfterAcknowledgedSend('hello again', 'hello')).toBe('hello again');
+  });
+});

--- a/apps/web/src/lib/chat-delivery.ts
+++ b/apps/web/src/lib/chat-delivery.ts
@@ -1,0 +1,41 @@
+export type ChatSendAttempt = {
+  conversationId: string;
+  text: string;
+  clientMessageId: string;
+};
+
+export function createChatClientMessageId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `msg_${Date.now()}_${Math.random().toString(36).slice(2, 14)}`;
+}
+
+export function getOrCreateChatSendAttempt(
+  existing: ChatSendAttempt | null,
+  conversationId: string,
+  draft: string,
+  createId: () => string = createChatClientMessageId
+): ChatSendAttempt {
+  const text = draft.trim();
+  if (existing && existing.conversationId === conversationId && existing.text === text) {
+    return existing;
+  }
+  return {
+    conversationId,
+    text,
+    clientMessageId: createId(),
+  };
+}
+
+export function invalidateAttemptForEditedDraft(
+  existing: ChatSendAttempt | null,
+  nextDraft: string
+): ChatSendAttempt | null {
+  if (!existing) return null;
+  return nextDraft.trim() === existing.text ? existing : null;
+}
+
+export function reconcileDraftAfterAcknowledgedSend(currentDraft: string, sentText: string) {
+  return currentDraft.trim() === sentText ? '' : currentDraft;
+}

--- a/apps/web/src/lib/socket.ts
+++ b/apps/web/src/lib/socket.ts
@@ -30,13 +30,6 @@ export function disconnectSocket() {
   if (socket?.connected) socket.disconnect();
 }
 
-export function createChatClientMessageId() {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-  return `msg_${Date.now()}_${Math.random().toString(36).slice(2, 14)}`;
-}
-
 type SendAck = {
   success: boolean;
   duplicate?: boolean;

--- a/apps/web/src/lib/socket.ts
+++ b/apps/web/src/lib/socket.ts
@@ -30,7 +30,7 @@ export function disconnectSocket() {
   if (socket?.connected) socket.disconnect();
 }
 
-function newClientMessageId() {
+export function createChatClientMessageId() {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
   }
@@ -58,13 +58,13 @@ export const chatSocket = {
   leaveConversation: (conversationId: string) => {
     getSocket().emit('conversation:leave', { conversationId });
   },
-  sendMessage: (conversationId: string, text: string) =>
+  sendMessage: (conversationId: string, text: string, clientMessageId: string) =>
     new Promise<ChatMessage>((resolve, reject) => {
       getSocket()
         .timeout(8_000)
         .emit(
           'message:send',
-          { conversationId, clientMessageId: newClientMessageId(), text },
+          { conversationId, clientMessageId, text },
           (timeoutError: Error | null, ack?: SendAck) => {
             if (timeoutError || !ack?.success || !ack.message) {
               reject(timeoutError ?? new Error(ack?.error ?? 'Message was not accepted'));

--- a/docs/DOGOS_CHAT_DELIVERY_INTEGRITY.md
+++ b/docs/DOGOS_CHAT_DELIVERY_INTEGRITY.md
@@ -1,0 +1,59 @@
+# dogOS Chat Delivery Integrity v1
+
+## Goal
+
+Make an uncertain client retry idempotent end to end.
+
+The server already persists a `(user_id, client_message_id)` delivery receipt and suppresses duplicate realtime emission. This release closes the client-side half of that contract so a lost or delayed Socket.IO ACK cannot turn a user retry into a second canonical message.
+
+## Client send identity
+
+The socket transport does not create `clientMessageId` values.
+
+The chat composer owns a `ChatSendAttempt` containing:
+
+- `conversationId`
+- normalized message text
+- `clientMessageId`
+
+The first send creates the ID. If delivery is not confirmed and the user retries the same unchanged draft in the same conversation, the exact same ID is reused. The existing server receipt therefore resolves the retry to the already-persisted canonical message instead of creating another one.
+
+Editing the draft invalidates the uncertain attempt identity. A changed draft is a new send intent and receives a new ID.
+
+## ACK semantics
+
+A transport timeout is not proof that the server failed to save the message. The UI therefore says delivery was not confirmed instead of claiming the message was not saved.
+
+After an acknowledged send, the composer clears the draft only when the current input still matches the text that was sent. Text typed while the request was in flight is preserved.
+
+Conversation-list cache refresh is non-authoritative UI maintenance. A cache invalidation failure cannot turn a successfully acknowledged canonical save into a false send failure.
+
+## Existing server authority
+
+This release does not change the database schema or server source of truth.
+
+Server guarantees remain:
+
+- messages are persisted before realtime emission
+- `(user_id, client_message_id)` is unique
+- a duplicate receipt returns the existing canonical message
+- a reused client ID cannot be moved to a different conversation
+- duplicate retries do not emit a second `message:received` event
+- conversation membership and block policy remain server-authorized
+
+## Qualification
+
+The dedicated Chat Delivery Integrity lane must prove:
+
+- no schema or migration ownership
+- read-only formatting and zero-warning lint
+- socket transport cannot generate message IDs
+- `clientMessageId` is required by `sendMessage`
+- the composer owns and reuses uncertain retry identity
+- draft edits invalidate retry identity
+- late ACK reconciliation preserves newer draft text
+- web TypeScript and focused delivery-state tests pass
+- existing API receipt and gateway regressions pass
+- web and API production builds pass
+
+Trust + Discovery CI and root CI remain independently authoritative whenever their owned paths trigger.


### PR DESCRIPTION
## dogOS Chat Delivery Integrity v1

Base: exact Network Integrity + Scale merge SHA `4745fc11c6ec737e774d3198dcddd74d791f6993`.

This release closes the client-side half of the existing server message-receipt contract without changing the database schema or server source of truth.

### Stable retry identity

The socket transport no longer creates `clientMessageId` values. The chat composer owns a `ChatSendAttempt` containing the conversation, normalized text, and client message ID.

If delivery is not confirmed and the user retries the same unchanged draft in the same conversation, the exact same `clientMessageId` is reused. The existing `(user_id, client_message_id)` server receipt therefore resolves the retry to the already-persisted canonical message instead of creating another one after a lost or delayed ACK.

Editing the draft invalidates the uncertain retry identity and becomes a new send intent.

### ACK-safe draft behavior

A transport timeout is not proof that the server failed to save the message. The UI now reports that delivery was not confirmed and keeps the draft available for a safe retry.

A successful ACK clears the composer only when the current input still matches the text that was sent. Text typed after the send began is preserved.

Conversation-list cache invalidation is non-authoritative UI maintenance and no longer participates in the send-failure path after a canonical ACK.

### Existing server authority preserved

- persist before realtime emit
- unique `(user_id, client_message_id)` receipt
- duplicate retry returns existing canonical message
- client ID cannot be moved to another conversation
- duplicate receipt does not emit a second `message:received`
- membership/block authorization remains server-side

### Exact-head qualification

Qualified head: `77198964cae8d719bad1cbfd62e0bf91884b339d`

All workflows triggered by this ownership surface completed successfully on that exact SHA:

1. `dogOS Chat Delivery Integrity CI` — run `32674721262`
2. `dogOS Trust + Discovery CI` — run `32674721209`
3. root `CI` — run `32674721276`

The dedicated lane passed:

- no schema/migration ownership
- read-only Prettier check
- zero-warning web lint
- structural prohibition on socket-generated message IDs
- caller-owned retry-identity invariant
- canonical server receipt boundary invariant
- web TypeScript
- focused stable retry-state tests
- existing server receipt and gateway regressions
- production API build
- production web build

Root CI independently passed formatting, lint, monorepo TypeScript, ML policy contracts, full backend unit/API tests, frontend unit/browser/accessibility/visual contracts, and independent API/web production builds. Trust + Discovery independently passed its migration, authorization, privacy, realtime, transport, focused browser, type, and production-build gates.

See `docs/DOGOS_CHAT_DELIVERY_INTEGRITY.md`.

Diagnostic heads do not count; only the exact qualified head above is merge-authoritative.