### PR TITLE
dogOS Trust Enforcement: atomic block dominance over chat writes

### DIFF
--- a/.github/workflows/dogos-trust-enforcement-atomicity-ci.yml
+++ b/.github/workflows/dogos-trust-enforcement-atomicity-ci.yml
@@ -77,18 +77,20 @@ jobs:
       - name: Apply full database migration chain
         run: pnpm --filter @woof/database db:migrate:deploy
 
-      - name: Print exact Trust Enforcement formatter patch
-        run: |
-          files=(
-            apps/api/src/trust-safety/relationship-lock.spec.ts
-            apps/api/src/trust-safety/trust-safety.service.ts
-            apps/api/src/trust-safety/trust-safety.service.spec.ts
-            apps/api/src/chat/chat-security.service.ts
-            apps/api/src/chat/chat-security.service.spec.ts
-          )
-          pnpm exec prettier --write "${files[@]}"
-          git diff -- "${files[@]}"
-          git diff --exit-code -- "${files[@]}"
+      - name: Check Trust Enforcement formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/trust-safety/relationship-lock.ts
+          apps/api/src/trust-safety/relationship-lock.spec.ts
+          apps/api/src/trust-safety/trust-safety.service.ts
+          apps/api/src/trust-safety/trust-safety.service.spec.ts
+          apps/api/src/chat/chat-security.service.ts
+          apps/api/src/chat/chat-security.service.spec.ts
+          apps/api/src/chat/chat.service.ts
+          apps/api/src/chat/chat.service.spec.ts
+          apps/api/src/chat/chat-block-atomicity.integration.spec.ts
+          .github/workflows/dogos-trust-enforcement-atomicity-ci.yml
+          docs/DOGOS_TRUST_ENFORCEMENT_ATOMICITY.md
 
       - name: Lint Trust Enforcement API surface
         run: >-
@@ -117,12 +119,11 @@ jobs:
               'SELECT 1 AS locked',
               'pg_advisory_xact_lock',
               'hashtextextended',
+              ') AS relationship_lock',
           ]
           missing = [token for token in required if token not in lock]
           if missing:
               raise SystemExit(f'missing relationship-lock invariant: {missing}')
-          if 'SELECT pg_advisory_xact_lock' in lock:
-              raise SystemExit('Prisma must not deserialize the advisory lock void return directly')
           PY
 
       - name: Enforce block and unblock serialization
@@ -162,9 +163,10 @@ jobs:
           persist = security[persist_start:access_helper_start]
           helper = security[access_helper_start:]
 
-          if "input.conversationId,\n          true" not in persist:
+          locked_recheck = 'assertConversationAccessWithClient(tx, input.userId, input.conversationId, true)'
+          if locked_recheck not in persist:
               raise SystemExit('message transaction must request a locked write-time access recheck')
-          if persist.index('assertConversationAccessWithClient') > persist.index('tx.message.create'):
+          if persist.index(locked_recheck) > persist.index('tx.message.create'):
               raise SystemExit('message access recheck must precede canonical message creation')
           if helper.index('acquireRelationshipLocks') > helper.index('blockedUser.findFirst'):
               raise SystemExit('message block policy must be checked after relationship lock acquisition')

--- a/.github/workflows/dogos-trust-enforcement-atomicity-ci.yml
+++ b/.github/workflows/dogos-trust-enforcement-atomicity-ci.yml
@@ -1,0 +1,213 @@
+name: dogOS Trust Enforcement Atomicity CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/chat/**'
+      - 'apps/api/src/trust-safety/**'
+      - '.github/workflows/dogos-trust-enforcement-atomicity-ci.yml'
+      - 'docs/DOGOS_TRUST_ENFORCEMENT_ATOMICITY.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-trust-enforcement-atomicity-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  JWT_SECRET: ci-only-trust-atomicity-secret
+  NODE_ENV: test
+  ML_SERVICE_ENABLED: 'false'
+
+jobs:
+  qualify:
+    name: Atomic block dominance qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject schema and migration ownership changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
+            echo 'Trust Enforcement Atomicity v1 does not own database schema or migration changes.'
+            exit 1
+          fi
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check Trust Enforcement formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/trust-safety/relationship-lock.ts
+          apps/api/src/trust-safety/relationship-lock.spec.ts
+          apps/api/src/trust-safety/trust-safety.service.ts
+          apps/api/src/trust-safety/trust-safety.service.spec.ts
+          apps/api/src/chat/chat-security.service.ts
+          apps/api/src/chat/chat-security.service.spec.ts
+          apps/api/src/chat/chat.service.ts
+          apps/api/src/chat/chat.service.spec.ts
+          apps/api/src/chat/chat-block-atomicity.integration.spec.ts
+          .github/workflows/dogos-trust-enforcement-atomicity-ci.yml
+          docs/DOGOS_TRUST_ENFORCEMENT_ATOMICITY.md
+
+      - name: Lint Trust Enforcement API surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/trust-safety/relationship-lock.ts
+          src/trust-safety/relationship-lock.spec.ts
+          src/trust-safety/trust-safety.service.ts
+          src/trust-safety/trust-safety.service.spec.ts
+          src/chat/chat-security.service.ts
+          src/chat/chat-security.service.spec.ts
+          src/chat/chat.service.ts
+          src/chat/chat.service.spec.ts
+          src/chat/chat-block-atomicity.integration.spec.ts
+
+      - name: Enforce deterministic shared relationship locks
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          lock = Path('apps/api/src/trust-safety/relationship-lock.ts').read_text()
+          required = [
+              '[userAId, userBId].sort()',
+              'relationshipLockKeys',
+              '].sort()',
+              'for (const key of keys)',
+              'SELECT 1 AS locked',
+              'pg_advisory_xact_lock',
+              'hashtextextended',
+          ]
+          missing = [token for token in required if token not in lock]
+          if missing:
+              raise SystemExit(f'missing relationship-lock invariant: {missing}')
+          if 'SELECT pg_advisory_xact_lock' in lock:
+              raise SystemExit('Prisma must not deserialize the advisory lock void return directly')
+          PY
+
+      - name: Enforce block and unblock serialization
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          source = Path('apps/api/src/trust-safety/trust-safety.service.ts').read_text()
+          block_start = source.index('async blockUser')
+          unblock_start = source.index('async unblockUser', block_start)
+          get_blocked_start = source.index('async getBlockedUsers', unblock_start)
+          block = source[block_start:unblock_start]
+          unblock = source[unblock_start:get_blocked_start]
+
+          for label, body, mutation in [
+              ('block', block, 'tx.blockedUser.upsert'),
+              ('unblock', unblock, 'tx.blockedUser.deleteMany'),
+          ]:
+              for token in ['$transaction', 'acquireRelationshipLocks', mutation]:
+                  if token not in body:
+                      raise SystemExit(f'{label} missing transactional trust token: {token}')
+              if body.index('acquireRelationshipLocks') > body.index(mutation):
+                  raise SystemExit(f'{label} must acquire relationship lock before canonical mutation')
+
+          if block.index('await Promise.all') < block.index('this.prisma.$transaction'):
+              raise SystemExit('ancillary block effects must run only after the canonical block transaction')
+          PY
+
+      - name: Enforce write-time chat trust rechecks
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          security = Path('apps/api/src/chat/chat-security.service.ts').read_text()
+          persist_start = security.index('async persistMessage')
+          access_helper_start = security.index('private async assertConversationAccessWithClient')
+          persist = security[persist_start:access_helper_start]
+          helper = security[access_helper_start:]
+
+          if "input.conversationId,\n          true" not in persist:
+              raise SystemExit('message transaction must request a locked write-time access recheck')
+          if persist.index('assertConversationAccessWithClient') > persist.index('tx.message.create'):
+              raise SystemExit('message access recheck must precede canonical message creation')
+          if helper.index('acquireRelationshipLocks') > helper.index('blockedUser.findFirst'):
+              raise SystemExit('message block policy must be checked after relationship lock acquisition')
+
+          chat = Path('apps/api/src/chat/chat.service.ts').read_text()
+          direct_start = chat.index('async createDirectConversation')
+          direct_end = chat.index('async getMessages', direct_start)
+          direct = chat[direct_start:direct_end]
+          for token in ['directPairLockKey', 'acquireRelationshipLocks', 'blockedUser.findFirst']:
+              if token not in direct:
+                  raise SystemExit(f'direct conversation path missing trust token: {token}')
+          if direct.index('acquireRelationshipLocks') > direct.index('blockedUser.findFirst'):
+              raise SystemExit('direct conversation block policy must run after the relationship lock')
+          PY
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Run trust serialization unit contracts
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/trust-safety/relationship-lock.spec.ts
+          src/trust-safety/trust-safety.service.spec.ts
+          src/chat/chat-security.service.spec.ts
+          src/chat/chat.service.spec.ts
+
+      - name: Run real PostgreSQL block dominance contract
+        run: pnpm --filter @woof/api exec jest src/chat/chat-block-atomicity.integration.spec.ts --runInBand
+
+      - name: Run direct-thread and delivery regressions
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/chat/chat.service.integration.spec.ts
+          src/chat/chat.gateway.spec.ts
+
+      - name: Run Trust + Discovery backend regressions
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/discovery/discovery.service.spec.ts
+          src/meetup-proposals/meetup-proposals.outcomes.spec.ts
+          src/compatibility/compatibility.baseline.spec.ts
+
+      - name: Build API
+        run: pnpm --filter @woof/api build

--- a/.github/workflows/dogos-trust-enforcement-atomicity-ci.yml
+++ b/.github/workflows/dogos-trust-enforcement-atomicity-ci.yml
@@ -77,20 +77,18 @@ jobs:
       - name: Apply full database migration chain
         run: pnpm --filter @woof/database db:migrate:deploy
 
-      - name: Check Trust Enforcement formatting
-        run: >-
-          pnpm exec prettier --check
-          apps/api/src/trust-safety/relationship-lock.ts
-          apps/api/src/trust-safety/relationship-lock.spec.ts
-          apps/api/src/trust-safety/trust-safety.service.ts
-          apps/api/src/trust-safety/trust-safety.service.spec.ts
-          apps/api/src/chat/chat-security.service.ts
-          apps/api/src/chat/chat-security.service.spec.ts
-          apps/api/src/chat/chat.service.ts
-          apps/api/src/chat/chat.service.spec.ts
-          apps/api/src/chat/chat-block-atomicity.integration.spec.ts
-          .github/workflows/dogos-trust-enforcement-atomicity-ci.yml
-          docs/DOGOS_TRUST_ENFORCEMENT_ATOMICITY.md
+      - name: Print exact Trust Enforcement formatter patch
+        run: |
+          files=(
+            apps/api/src/trust-safety/relationship-lock.spec.ts
+            apps/api/src/trust-safety/trust-safety.service.ts
+            apps/api/src/trust-safety/trust-safety.service.spec.ts
+            apps/api/src/chat/chat-security.service.ts
+            apps/api/src/chat/chat-security.service.spec.ts
+          )
+          pnpm exec prettier --write "${files[@]}"
+          git diff -- "${files[@]}"
+          git diff --exit-code -- "${files[@]}"
 
       - name: Lint Trust Enforcement API surface
         run: >-

--- a/apps/api/src/chat/chat-block-atomicity.integration.spec.ts
+++ b/apps/api/src/chat/chat-block-atomicity.integration.spec.ts
@@ -1,0 +1,122 @@
+import { randomUUID } from 'node:crypto';
+import { ForbiddenException } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+import { acquireRelationshipLocks } from '../trust-safety/relationship-lock';
+import { ChatSecurityService } from './chat-security.service';
+
+describe('chat block atomicity integration', () => {
+  const prisma = new PrismaService();
+  const service = new ChatSecurityService(prisma);
+  const usersToDelete: string[] = [];
+  const conversationsToDelete: string[] = [];
+
+  beforeAll(async () => {
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    if (conversationsToDelete.length > 0) {
+      await prisma.conversation.deleteMany({ where: { id: { in: conversationsToDelete } } });
+    }
+    if (usersToDelete.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: usersToDelete } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  async function userFixture(label: string) {
+    const suffix = randomUUID().slice(0, 8);
+    const user = await prisma.user.create({
+      data: {
+        handle: `atomic-${label}-${suffix}`,
+        email: `atomic-${label}-${suffix}@example.test`,
+        visibility: 'PUBLIC',
+      },
+      select: { id: true },
+    });
+    usersToDelete.push(user.id);
+    return user;
+  }
+
+  it('rejects a message that passed its outer access check when a waiting block commits first', async () => {
+    const [sender, blocker] = await Promise.all([userFixture('sender'), userFixture('blocker')]);
+    const conversation = await prisma.conversation.create({
+      data: {
+        participants: {
+          create: [{ userId: sender.id }, { userId: blocker.id }],
+        },
+      },
+      select: { id: true },
+    });
+    conversationsToDelete.push(conversation.id);
+
+    let blockWrittenResolve!: () => void;
+    const blockWritten = new Promise<void>((resolve) => {
+      blockWrittenResolve = resolve;
+    });
+    let releaseBlockResolve!: () => void;
+    const releaseBlock = new Promise<void>((resolve) => {
+      releaseBlockResolve = resolve;
+    });
+
+    const blockTransaction = prisma.$transaction(async (tx) => {
+      await acquireRelationshipLocks(tx, blocker.id, [sender.id]);
+      await tx.blockedUser.create({
+        data: { userId: blocker.id, blockedId: sender.id, reason: 'atomicity-test' },
+      });
+      blockWrittenResolve();
+      await releaseBlock;
+    });
+
+    await blockWritten;
+
+    let outerAccessPassedResolve!: () => void;
+    const outerAccessPassed = new Promise<void>((resolve) => {
+      outerAccessPassedResolve = resolve;
+    });
+    const originalAssertAccess = service.assertConversationAccess.bind(service);
+    const accessSpy = jest
+      .spyOn(service, 'assertConversationAccess')
+      .mockImplementation(async (userId, conversationId) => {
+        const result = await originalAssertAccess(userId, conversationId);
+        outerAccessPassedResolve();
+        return result;
+      });
+
+    let messageSettled = false;
+    const clientMessageId = `atomic-${randomUUID()}`;
+    const messagePromise = service
+      .persistMessage({
+        userId: sender.id,
+        conversationId: conversation.id,
+        clientMessageId,
+        text: 'must not cross a committed block',
+      })
+      .finally(() => {
+        messageSettled = true;
+      });
+
+    await outerAccessPassed;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(messageSettled).toBe(false);
+
+    releaseBlockResolve();
+    await blockTransaction;
+
+    await expect(messagePromise).rejects.toBeInstanceOf(ForbiddenException);
+    accessSpy.mockRestore();
+
+    await expect(
+      prisma.message.count({ where: { conversationId: conversation.id, senderId: sender.id } })
+    ).resolves.toBe(0);
+
+    const receipts = await prisma.$queryRaw<Array<{ count: bigint }>>(Prisma.sql`
+      SELECT COUNT(*)::bigint AS count
+      FROM dogos_chat.message_receipts
+      WHERE user_id = CAST(${sender.id} AS text)
+        AND client_message_id = ${clientMessageId}
+    `);
+    expect(Number(receipts[0]?.count ?? 0)).toBe(0);
+  });
+});

--- a/apps/api/src/chat/chat-security.service.spec.ts
+++ b/apps/api/src/chat/chat-security.service.spec.ts
@@ -88,7 +88,9 @@ describe('ChatSecurityService', () => {
   it('rechecks block policy behind the relationship lock before a new message is created', async () => {
     const { prisma, service } = build();
     prisma.conversationParticipant.findUnique.mockResolvedValue(participant());
-    prisma.blockedUser.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({ id: 'block-1' });
+    prisma.blockedUser.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'block-1' });
     prisma.$queryRaw.mockResolvedValue([]);
 
     await expect(

--- a/apps/api/src/chat/chat-security.service.spec.ts
+++ b/apps/api/src/chat/chat-security.service.spec.ts
@@ -12,10 +12,13 @@ describe('ChatSecurityService', () => {
     const prisma = {
       conversationParticipant: { findUnique: jest.fn() },
       blockedUser: { findFirst: jest.fn() },
-      message: { findUnique: jest.fn() },
+      message: { findUnique: jest.fn(), create: jest.fn() },
       $queryRaw: jest.fn(),
       $transaction: jest.fn(),
     };
+    prisma.$transaction.mockImplementation(async (callback: (tx: typeof prisma) => unknown) =>
+      callback(prisma)
+    );
     return {
       prisma,
       service: new ChatSecurityService(prisma as never),
@@ -80,6 +83,31 @@ describe('ChatSecurityService', () => {
       })
     ).resolves.toEqual({ message: persisted, duplicate: true });
     expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('rechecks block policy behind the relationship lock before a new message is created', async () => {
+    const { prisma, service } = build();
+    prisma.conversationParticipant.findUnique.mockResolvedValue(participant());
+    prisma.blockedUser.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({ id: 'block-1' });
+    prisma.$queryRaw.mockResolvedValue([]);
+
+    await expect(
+      service.persistMessage({
+        userId: 'user-1',
+        conversationId: 'conversation-1',
+        clientMessageId: 'client-message-123',
+        text: 'hello',
+      })
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.conversationParticipant.findUnique).toHaveBeenCalledTimes(2);
+    expect(prisma.blockedUser.findFirst).toHaveBeenCalledTimes(2);
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(2);
+    expect(prisma.$queryRaw.mock.invocationCallOrder[1]).toBeLessThan(
+      prisma.blockedUser.findFirst.mock.invocationCallOrder[1]!
+    );
+    expect(prisma.message.create).not.toHaveBeenCalled();
   });
 
   it('rejects empty text before any message persistence transaction begins', async () => {

--- a/apps/api/src/chat/chat-security.service.ts
+++ b/apps/api/src/chat/chat-security.service.ts
@@ -63,12 +63,7 @@ export class ChatSecurityService {
 
     try {
       const message = await this.prisma.$transaction(async (tx) => {
-        await this.assertConversationAccessWithClient(
-          tx,
-          input.userId,
-          input.conversationId,
-          true
-        );
+        await this.assertConversationAccessWithClient(tx, input.userId, input.conversationId, true);
 
         const receiptRows = await tx.$queryRaw<MessageReceiptRow[]>(Prisma.sql`
           SELECT message_id, conversation_id

--- a/apps/api/src/chat/chat-security.service.ts
+++ b/apps/api/src/chat/chat-security.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
 import { Prisma } from '@woof/database';
 import { PrismaService } from '../prisma/prisma.service';
+import { acquireRelationshipLocks } from '../trust-safety/relationship-lock';
 
 const MAX_MESSAGE_LENGTH = 4_000;
 const CLIENT_MESSAGE_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
@@ -11,6 +12,11 @@ type MessageReceiptRow = {
   message_id: string;
   conversation_id: string;
 };
+
+type ConversationAccessClient = Pick<
+  Prisma.TransactionClient,
+  'conversationParticipant' | 'blockedUser' | '$queryRaw'
+>;
 
 export type PersistedChatMessage = {
   id: string;
@@ -26,44 +32,7 @@ export class ChatSecurityService {
   constructor(private readonly prisma: PrismaService) {}
 
   async assertConversationAccess(userId: string, conversationId: string) {
-    const participant = await this.prisma.conversationParticipant.findUnique({
-      where: { conversationId_userId: { conversationId, userId } },
-      select: {
-        conversation: {
-          select: {
-            participants: { select: { userId: true } },
-          },
-        },
-      },
-    });
-
-    if (!participant) {
-      throw new ForbiddenException('Conversation is unavailable');
-    }
-
-    const otherUserIds = participant.conversation.participants
-      .map((entry) => entry.userId)
-      .filter((participantUserId) => participantUserId !== userId);
-
-    if (otherUserIds.length === 0) {
-      throw new ForbiddenException('Conversation is unavailable');
-    }
-
-    const blocked = await this.prisma.blockedUser.findFirst({
-      where: {
-        OR: otherUserIds.flatMap((otherUserId) => [
-          { userId, blockedId: otherUserId },
-          { userId: otherUserId, blockedId: userId },
-        ]),
-      },
-      select: { id: true },
-    });
-
-    if (blocked) {
-      throw new ForbiddenException('Conversation is unavailable');
-    }
-
-    return { otherUserIds };
+    return this.assertConversationAccessWithClient(this.prisma, userId, conversationId, false);
   }
 
   async persistMessage(input: {
@@ -94,6 +63,13 @@ export class ChatSecurityService {
 
     try {
       const message = await this.prisma.$transaction(async (tx) => {
+        await this.assertConversationAccessWithClient(
+          tx,
+          input.userId,
+          input.conversationId,
+          true
+        );
+
         const receiptRows = await tx.$queryRaw<MessageReceiptRow[]>(Prisma.sql`
           SELECT message_id, conversation_id
           FROM dogos_chat.message_receipts
@@ -145,6 +121,56 @@ export class ChatSecurityService {
       if (!message) throw error;
       return { message, duplicate: true };
     }
+  }
+
+  private async assertConversationAccessWithClient(
+    client: ConversationAccessClient,
+    userId: string,
+    conversationId: string,
+    lockRelationships: boolean
+  ) {
+    const participant = await client.conversationParticipant.findUnique({
+      where: { conversationId_userId: { conversationId, userId } },
+      select: {
+        conversation: {
+          select: {
+            participants: { select: { userId: true } },
+          },
+        },
+      },
+    });
+
+    if (!participant) {
+      throw new ForbiddenException('Conversation is unavailable');
+    }
+
+    const otherUserIds = participant.conversation.participants
+      .map((entry) => entry.userId)
+      .filter((participantUserId) => participantUserId !== userId);
+
+    if (otherUserIds.length === 0) {
+      throw new ForbiddenException('Conversation is unavailable');
+    }
+
+    if (lockRelationships) {
+      await acquireRelationshipLocks(client, userId, otherUserIds);
+    }
+
+    const blocked = await client.blockedUser.findFirst({
+      where: {
+        OR: otherUserIds.flatMap((otherUserId) => [
+          { userId, blockedId: otherUserId },
+          { userId: otherUserId, blockedId: userId },
+        ]),
+      },
+      select: { id: true },
+    });
+
+    if (blocked) {
+      throw new ForbiddenException('Conversation is unavailable');
+    }
+
+    return { otherUserIds };
   }
 
   private assertReceiptConversation(receipt: MessageReceiptRow, conversationId: string) {

--- a/apps/api/src/chat/chat.service.spec.ts
+++ b/apps/api/src/chat/chat.service.spec.ts
@@ -108,7 +108,7 @@ describe('ChatService', () => {
       expect(prisma.conversation.create).not.toHaveBeenCalled();
     });
 
-    it('serializes pair lookup and creation behind a transaction-scoped advisory lock', async () => {
+    it('serializes pair lookup and block policy behind transaction-scoped advisory locks', async () => {
       const { prisma, service } = build();
       prisma.user.findUnique.mockResolvedValue({ id: 'user-2', visibility: 'PUBLIC' });
       prisma.blockedUser.findFirst.mockResolvedValue(null);
@@ -122,9 +122,12 @@ describe('ChatService', () => {
       });
 
       expect(prisma.$transaction).toHaveBeenCalledTimes(1);
-      expect(prisma.$queryRaw).toHaveBeenCalledTimes(1);
+      expect(prisma.$queryRaw).toHaveBeenCalledTimes(2);
       expect(prisma.$queryRaw.mock.invocationCallOrder[0]).toBeLessThan(
         prisma.conversation.findMany.mock.invocationCallOrder[0]!
+      );
+      expect(prisma.$queryRaw.mock.invocationCallOrder[1]).toBeLessThan(
+        prisma.blockedUser.findFirst.mock.invocationCallOrder[0]!
       );
       expect(prisma.conversation.create).toHaveBeenCalledTimes(1);
       expect(prisma.telemetry.create).toHaveBeenCalledTimes(1);

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { Prisma } from '@woof/database';
 import { PrismaService } from '../prisma/prisma.service';
+import { acquireRelationshipLocks } from '../trust-safety/relationship-lock';
 import { ChatSecurityService } from './chat-security.service';
 
 const MAX_CONVERSATIONS = 50;
@@ -153,6 +154,7 @@ export class ChatService {
           SELECT pg_advisory_xact_lock(hashtextextended(${pairKey}, 0))
         ) AS pair_lock
       `);
+      await acquireRelationshipLocks(tx, userId, [participantId]);
 
       const [target, blocked, candidates] = await Promise.all([
         tx.user.findUnique({

--- a/apps/api/src/trust-safety/relationship-lock.spec.ts
+++ b/apps/api/src/trust-safety/relationship-lock.spec.ts
@@ -1,0 +1,16 @@
+import { relationshipLockKey, relationshipLockKeys } from './relationship-lock';
+
+describe('relationship lock keys', () => {
+  it('is symmetric for the same unordered user pair', () => {
+    expect(relationshipLockKey('user-b', 'user-a')).toBe(
+      relationshipLockKey('user-a', 'user-b')
+    );
+  });
+
+  it('deduplicates and sorts multi-party relationship locks deterministically', () => {
+    expect(relationshipLockKeys('user-a', ['user-c', 'user-b', 'user-c', 'user-a'])).toEqual([
+      relationshipLockKey('user-a', 'user-b'),
+      relationshipLockKey('user-a', 'user-c'),
+    ]);
+  });
+});

--- a/apps/api/src/trust-safety/relationship-lock.spec.ts
+++ b/apps/api/src/trust-safety/relationship-lock.spec.ts
@@ -2,9 +2,7 @@ import { relationshipLockKey, relationshipLockKeys } from './relationship-lock';
 
 describe('relationship lock keys', () => {
   it('is symmetric for the same unordered user pair', () => {
-    expect(relationshipLockKey('user-b', 'user-a')).toBe(
-      relationshipLockKey('user-a', 'user-b')
-    );
+    expect(relationshipLockKey('user-b', 'user-a')).toBe(relationshipLockKey('user-a', 'user-b'));
   });
 
   it('deduplicates and sorts multi-party relationship locks deterministically', () => {

--- a/apps/api/src/trust-safety/relationship-lock.ts
+++ b/apps/api/src/trust-safety/relationship-lock.ts
@@ -1,0 +1,34 @@
+import { Prisma } from '@woof/database';
+
+type RelationshipLockClient = Pick<Prisma.TransactionClient, '$queryRaw'>;
+
+export function relationshipLockKey(userAId: string, userBId: string) {
+  return `woof:relationship:${[userAId, userBId].sort().join(':')}`;
+}
+
+export function relationshipLockKeys(userId: string, otherUserIds: string[]) {
+  return [
+    ...new Set(
+      otherUserIds
+        .filter((otherUserId) => otherUserId && otherUserId !== userId)
+        .map((otherUserId) => relationshipLockKey(userId, otherUserId))
+    ),
+  ].sort();
+}
+
+export async function acquireRelationshipLocks(
+  tx: RelationshipLockClient,
+  userId: string,
+  otherUserIds: string[]
+) {
+  const keys = relationshipLockKeys(userId, otherUserIds);
+  for (const key of keys) {
+    await tx.$queryRaw<Array<{ locked: number }>>(Prisma.sql`
+      SELECT 1 AS locked
+      FROM (
+        SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0))
+      ) AS relationship_lock
+    `);
+  }
+  return keys;
+}

--- a/apps/api/src/trust-safety/trust-safety.service.spec.ts
+++ b/apps/api/src/trust-safety/trust-safety.service.spec.ts
@@ -30,12 +30,14 @@ describe('TrustSafetyService relationship serialization', () => {
         findUnique: jest.fn().mockResolvedValue({ id: 'user-b' }),
         findMany: jest.fn(),
       },
-      $transaction: jest.fn().mockImplementation(async (callback: (client: typeof tx) => unknown) => {
-        events.push('transaction:start');
-        const result = await callback(tx);
-        events.push('transaction:commit');
-        return result;
-      }),
+      $transaction: jest
+        .fn()
+        .mockImplementation(async (callback: (client: typeof tx) => unknown) => {
+          events.push('transaction:start');
+          const result = await callback(tx);
+          events.push('transaction:commit');
+          return result;
+        }),
       meetupProposal: {
         updateMany: jest.fn().mockImplementation(async () => {
           events.push('meetup-cleanup');
@@ -69,10 +71,7 @@ describe('TrustSafetyService relationship serialization', () => {
     const { events, prisma, tx, service } = build();
 
     await expect(
-      service.blockUser(
-        'user-a',
-        { blockedUserId: 'user-b', reason: 'safety boundary' } as never
-      )
+      service.blockUser('user-a', { blockedUserId: 'user-b', reason: 'safety boundary' } as never)
     ).resolves.toEqual({
       id: 'block-1',
       blockedUserId: 'user-b',

--- a/apps/api/src/trust-safety/trust-safety.service.spec.ts
+++ b/apps/api/src/trust-safety/trust-safety.service.spec.ts
@@ -1,0 +1,101 @@
+import { TrustSafetyService } from './trust-safety.service';
+
+describe('TrustSafetyService relationship serialization', () => {
+  function build() {
+    const events: string[] = [];
+    const block = {
+      id: 'block-1',
+      userId: 'user-a',
+      blockedId: 'user-b',
+      createdAt: new Date('2026-08-23T20:00:00.000Z'),
+    };
+    const tx = {
+      $queryRaw: jest.fn().mockImplementation(async () => {
+        events.push('lock');
+        return [{ locked: 1 }];
+      }),
+      blockedUser: {
+        upsert: jest.fn().mockImplementation(async () => {
+          events.push('block-upsert');
+          return block;
+        }),
+        deleteMany: jest.fn().mockImplementation(async () => {
+          events.push('block-delete');
+          return { count: 1 };
+        }),
+      },
+    };
+    const prisma = {
+      user: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'user-b' }),
+        findMany: jest.fn(),
+      },
+      $transaction: jest.fn().mockImplementation(async (callback: (client: typeof tx) => unknown) => {
+        events.push('transaction:start');
+        const result = await callback(tx);
+        events.push('transaction:commit');
+        return result;
+      }),
+      meetupProposal: {
+        updateMany: jest.fn().mockImplementation(async () => {
+          events.push('meetup-cleanup');
+          return { count: 0 };
+        }),
+      },
+      pet: {
+        findMany: jest.fn().mockImplementation(async () => {
+          events.push('pet-read');
+          return [];
+        }),
+      },
+      petEdge: { updateMany: jest.fn() },
+      telemetry: {
+        create: jest.fn().mockImplementation(async () => {
+          events.push('telemetry');
+          return { id: 'telemetry-1' };
+        }),
+      },
+      blockedUser: {
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+      },
+      reportFlag: { create: jest.fn(), findMany: jest.fn() },
+    };
+
+    return { events, prisma, tx, service: new TrustSafetyService(prisma as never) };
+  }
+
+  it('commits the block behind the shared relationship lock before ancillary cleanup', async () => {
+    const { events, prisma, tx, service } = build();
+
+    await expect(
+      service.blockUser(
+        'user-a',
+        { blockedUserId: 'user-b', reason: 'safety boundary' } as never
+      )
+    ).resolves.toEqual({
+      id: 'block-1',
+      blockedUserId: 'user-b',
+      createdAt: new Date('2026-08-23T20:00:00.000Z'),
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(tx.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(tx.blockedUser.upsert).toHaveBeenCalledTimes(1);
+    expect(events.indexOf('lock')).toBeLessThan(events.indexOf('block-upsert'));
+    expect(events.indexOf('block-upsert')).toBeLessThan(events.indexOf('transaction:commit'));
+    expect(events.indexOf('transaction:commit')).toBeLessThan(events.indexOf('meetup-cleanup'));
+    expect(events.indexOf('transaction:commit')).toBeLessThan(events.indexOf('telemetry'));
+  });
+
+  it('serializes unblock through the same relationship lock', async () => {
+    const { events, tx, service } = build();
+
+    await expect(service.unblockUser('user-a', 'user-b')).resolves.toEqual({ unblocked: true });
+
+    expect(events.indexOf('lock')).toBeLessThan(events.indexOf('block-delete'));
+    expect(tx.blockedUser.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 'user-a', blockedId: 'user-b' },
+    });
+  });
+});

--- a/apps/api/src/trust-safety/trust-safety.service.ts
+++ b/apps/api/src/trust-safety/trust-safety.service.ts
@@ -151,7 +151,7 @@ export class TrustSafetyService {
           ],
         },
         select: { id: true },
-      }),
+      })
     );
   }
 

--- a/apps/api/src/trust-safety/trust-safety.service.ts
+++ b/apps/api/src/trust-safety/trust-safety.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { BlockUserDto, ReportUserDto } from './dto/trust-safety.dto';
+import { acquireRelationshipLocks } from './relationship-lock';
 
 @Injectable()
 export class TrustSafetyService {
@@ -16,16 +17,19 @@ export class TrustSafetyService {
     });
     if (!target) throw new NotFoundException('Member not found');
 
-    const block = await this.prisma.blockedUser.upsert({
-      where: {
-        userId_blockedId: { userId, blockedId: dto.blockedUserId },
-      },
-      create: {
-        userId,
-        blockedId: dto.blockedUserId,
-        reason: dto.reason?.trim() || null,
-      },
-      update: { reason: dto.reason?.trim() || null },
+    const block = await this.prisma.$transaction(async (tx) => {
+      await acquireRelationshipLocks(tx, userId, [dto.blockedUserId]);
+      return tx.blockedUser.upsert({
+        where: {
+          userId_blockedId: { userId, blockedId: dto.blockedUserId },
+        },
+        create: {
+          userId,
+          blockedId: dto.blockedUserId,
+          reason: dto.reason?.trim() || null,
+        },
+        update: { reason: dto.reason?.trim() || null },
+      });
     });
 
     await Promise.all([
@@ -54,8 +58,11 @@ export class TrustSafetyService {
   }
 
   async unblockUser(userId: string, blockedUserId: string) {
-    const result = await this.prisma.blockedUser.deleteMany({
-      where: { userId, blockedId: blockedUserId },
+    const result = await this.prisma.$transaction(async (tx) => {
+      await acquireRelationshipLocks(tx, userId, [blockedUserId]);
+      return tx.blockedUser.deleteMany({
+        where: { userId, blockedId: blockedUserId },
+      });
     });
     return { unblocked: result.count > 0 };
   }

--- a/docs/DOGOS_TRUST_ENFORCEMENT_ATOMICITY.md
+++ b/docs/DOGOS_TRUST_ENFORCEMENT_ATOMICITY.md
@@ -1,0 +1,71 @@
+# dogOS Trust Enforcement Atomicity v1
+
+## Goal
+
+Make committed trust-safety state dominate relationship writes at the database ordering boundary.
+
+Before this release, chat access was checked before message persistence began. A block could therefore commit after the access check but before the message row, allowing a message to cross an already-committed block. New direct-conversation creation had the same ordering gap.
+
+## Shared relationship lock
+
+Blocking, unblocking, new direct-conversation creation, and new message persistence now share a symmetric PostgreSQL transaction advisory lock for each unordered user pair.
+
+The key is derived from sorted canonical user IDs. Multi-party message authorization derives one pair lock for every other conversation participant, deduplicates the keys, sorts them, and acquires them sequentially to provide deterministic lock ordering.
+
+The advisory lock query returns a normal integer row around `pg_advisory_xact_lock(...)`; Prisma never has to deserialize PostgreSQL's `void` return type.
+
+## Block dominance
+
+`blockUser()` acquires the relationship lock inside the same transaction that upserts the canonical block row. The lock is held through commit.
+
+A message or new direct-conversation transaction ordered after that commit acquires the same relationship lock and checks the block row only after the lock is obtained. It therefore sees the committed block and rejects the write.
+
+`unblockUser()` uses the same serialization boundary so trust-state transitions have one consistent relationship ordering primitive.
+
+## Message writes
+
+The existing outer conversation-access check remains as an early authorization gate. It is not the authoritative write-time boundary.
+
+For any new canonical message, the persistence transaction:
+
+1. reloads conversation membership;
+2. acquires all relationship locks in deterministic order;
+3. rechecks block policy;
+4. rechecks the delivery receipt;
+5. creates the message;
+6. creates the idempotency receipt.
+
+Persist-before-emit and the Chat Delivery Integrity client retry contract remain unchanged.
+
+## Direct conversations
+
+PR #19's dedicated direct-pair advisory lock remains in place for duplicate-thread prevention. The relationship lock is acquired after that pair lock and before block lookup. This preserves the proven direct-thread uniqueness mechanism while also serializing conversation creation against trust-state changes.
+
+## Ancillary block effects
+
+The canonical block transaction commits before ancillary effects run:
+
+- pending/accepted meetup cancellation;
+- pet-edge `AVOID` updates;
+- trust-safety telemetry.
+
+These effects remain important, but failure in an ancillary subsystem must not roll back or delay the canonical safety boundary.
+
+## Qualification
+
+The dedicated Trust Enforcement Atomicity lane must prove:
+
+- no schema or migration ownership;
+- the full existing migration chain applies;
+- read-only formatting and zero-warning API lint;
+- symmetric deterministic relationship lock keys;
+- no direct Prisma deserialization of advisory-lock `void`;
+- block/unblock acquire the shared lock inside their transactions;
+- block commit precedes ancillary cleanup;
+- message persistence reacquires and rechecks block policy behind the lock;
+- new direct-conversation creation checks block policy behind the same relationship lock;
+- a real PostgreSQL race where outer chat access succeeds but a block commits first rejects the message with zero message rows and zero receipts;
+- existing direct-thread concurrency, delivery-receipt, gateway, and trust regressions remain green;
+- the API production build succeeds.
+
+Triggered inherited workflows remain independently authoritative on the same exact PR head.


### PR DESCRIPTION
## dogOS Trust Enforcement Atomicity v1

Base: exact Chat Delivery Integrity merge SHA `5d79d39f39ad0f0adbfa3653b342b48a5f5647e5`.

This release closes a database-ordering race between trust-safety blocks and relationship writes without changing the schema.

### Shared relationship serialization

Blocking, unblocking, new direct-conversation creation, and new message persistence now share a symmetric transaction-scoped PostgreSQL advisory lock for each unordered user pair.

Multi-party message authorization derives one lock per counterpart, deduplicates and sorts those keys, and acquires them sequentially for deterministic ordering.

The lock query uses an outer integer `SELECT` so Prisma never has to deserialize PostgreSQL's `void` return from `pg_advisory_xact_lock()`.

### Block dominance

`blockUser()` acquires the relationship lock in the same transaction as the canonical block upsert and holds it through commit. Ancillary meetup cancellation, pet-edge updates, and telemetry execute after that canonical safety transaction.

Message persistence keeps the existing early access check, but any new canonical write now reloads membership, acquires the relationship locks, rechecks block policy, then proceeds to receipt/message persistence.

PR #19's direct-pair lock remains in place for duplicate-thread prevention. New direct-conversation creation additionally acquires the shared relationship lock before its block check.

### Real race proof

A PostgreSQL integration contract deliberately:

1. holds an uncommitted block behind the shared relationship lock;
2. starts a message and proves its outer access check already succeeded;
3. keeps that message unsettled while the block is uncommitted;
4. commits the block first;
5. requires the waiting message to reject with `ForbiddenException`;
6. requires zero message rows and zero delivery receipts for that send.

### Exact-head qualification

Qualified head: `3b9af6746d77f9354082b5d18b4ca577eec59f70`.

Every workflow triggered by the changed ownership surface completed successfully on that exact SHA:

- Trust Enforcement Atomicity CI — run `32675632313`
  - full 16-migration chain
  - read-only formatting + strict lint
  - deterministic shared relationship-lock structural contracts
  - API typecheck
  - trust serialization unit contracts
  - real PostgreSQL block-dominance race
  - direct-thread + delivery regressions
  - Trust + Discovery backend regressions
  - API production build
- Network Integrity + Scale CI — run `32675632293`
  - direct-thread lock/bounded Inbox gates
  - real PostgreSQL concurrency contracts
  - API production build
- Chat Delivery Integrity CI — run `32675632355`
  - stable client retry identity
  - canonical server receipt/gateway regressions
  - API + web production builds
- Trust + Discovery CI — run `32675632241`
  - full migration chain
  - API/web lint + typecheck
  - room/presence authorization and precise-location privacy gates
  - trust/discovery/meetup/transport contracts
  - privacy-safe Chromium discovery journey
  - API + web production builds
- root CI — run `32675632278`
  - formatting/lint/typecheck/ML policy gates
  - full backend unit + API suites
  - frontend unit tests
  - Chromium smoke/accessibility/visual contracts
  - production builds

The real PostgreSQL race proof is the release veto: after the sender's outer access check succeeds, a block committed first still dominates the waiting send, which rejects with no canonical message and no delivery receipt.

See `docs/DOGOS_TRUST_ENFORCEMENT_ATOMICITY.md`.

Diagnostic heads do not count.