### PR TITLE
dogOS Live Authorization: atomic realtime block enforcement

### DIFF
--- a/.github/workflows/dogos-live-authorization-ci.yml
+++ b/.github/workflows/dogos-live-authorization-ci.yml
@@ -1,0 +1,207 @@
+name: dogOS Live Authorization CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/chat/**'
+      - 'apps/api/src/trust-safety/relationship-lock.ts'
+      - 'apps/api/src/trust-safety/relationship-lock.spec.ts'
+      - '.github/workflows/dogos-live-authorization-ci.yml'
+      - 'docs/DOGOS_LIVE_AUTHORIZATION.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-live-authorization-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  JWT_SECRET: ci-only-live-authorization-secret
+  NODE_ENV: test
+  ML_SERVICE_ENABLED: 'false'
+
+jobs:
+  qualify:
+    name: Realtime block ordering + recipient qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject schema and migration ownership changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
+            echo 'Live Authorization v1 does not own database schema or migration changes.'
+            exit 1
+          fi
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check Live Authorization formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/trust-safety/relationship-lock.ts
+          apps/api/src/trust-safety/relationship-lock.spec.ts
+          apps/api/src/chat/chat-security.service.ts
+          apps/api/src/chat/chat-security.service.spec.ts
+          apps/api/src/chat/chat.gateway.ts
+          apps/api/src/chat/chat.gateway.spec.ts
+          apps/api/src/chat/chat-live-authorization.integration.spec.ts
+          .github/workflows/dogos-live-authorization-ci.yml
+          docs/DOGOS_LIVE_AUTHORIZATION.md
+
+      - name: Lint Live Authorization API surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/trust-safety/relationship-lock.ts
+          src/trust-safety/relationship-lock.spec.ts
+          src/chat/chat-security.service.ts
+          src/chat/chat-security.service.spec.ts
+          src/chat/chat.gateway.ts
+          src/chat/chat.gateway.spec.ts
+          src/chat/chat-live-authorization.integration.spec.ts
+
+      - name: Enforce participant relationship lock graph
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          lock = Path('apps/api/src/trust-safety/relationship-lock.ts').read_text()
+          required = [
+              'relationshipLockKeysForParticipants',
+              'for (let index = 0;',
+              'for (let otherIndex = index + 1;',
+              'acquireParticipantRelationshipLocks',
+              'acquireRelationshipLockKeys',
+              'pg_advisory_xact_lock',
+              'hashtextextended',
+          ]
+          missing = [token for token in required if token not in lock]
+          if missing:
+              raise SystemExit(f'missing participant relationship-lock invariant: {missing}')
+          PY
+
+      - name: Enforce lock-bound realtime authorization
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          security = Path('apps/api/src/chat/chat-security.service.ts').read_text()
+          start = security.index('async withAuthorizedRealtimeRecipients')
+          end = security.index('async persistMessage', start)
+          body = security[start:end]
+
+          required = [
+              'this.prisma.$transaction',
+              'conversationParticipant.findMany',
+              'acquireParticipantRelationshipLocks',
+              'blockedUser.findMany',
+              'blockedEndpoints.add(block.userId)',
+              'blockedEndpoints.add(block.blockedId)',
+              'requiredUserId',
+              'await deliver(authorizedUserIds)',
+          ]
+          missing = [token for token in required if token not in body]
+          if missing:
+              raise SystemExit(f'missing realtime authorization invariant: {missing}')
+          if body.index('acquireParticipantRelationshipLocks') > body.index('blockedUser.findMany'):
+              raise SystemExit('realtime block policy must be read after participant relationship locks')
+          if body.index('blockedUser.findMany') > body.index('await deliver(authorizedUserIds)'):
+              raise SystemExit('delivery must happen only after the locked block-policy read')
+          PY
+
+      - name: Reject conversation-room fanout authority
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          gateway = Path('apps/api/src/chat/chat.gateway.ts').read_text()
+          required = [
+              'withAuthorizedRealtimeRecipients',
+              'this.server.to(this.userRooms(authorizedUserIds))',
+              '.except(client.id)',
+              'userRooms(userIds: string[])',
+              '`user:${userId}`',
+          ]
+          missing = [token for token in required if token not in gateway]
+          if missing:
+              raise SystemExit(f'missing authorized user-room fanout invariant: {missing}')
+          forbidden = [
+              ".to(`conversation:${data.conversationId}`)",
+              ".to(`conversation:${conversationId}`)",
+              "client.to(`conversation:${conversationId}`)",
+          ]
+          present = [token for token in forbidden if token in gateway]
+          if present:
+              raise SystemExit(f'conversation room cannot be realtime delivery authority: {present}')
+          PY
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Run realtime authorization unit contracts
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/trust-safety/relationship-lock.spec.ts
+          src/chat/chat-security.service.spec.ts
+          src/chat/chat.gateway.spec.ts
+
+      - name: Run real PostgreSQL realtime ordering contracts
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/chat/chat-live-authorization.integration.spec.ts
+
+      - name: Run write-time block dominance regression
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/chat/chat-block-atomicity.integration.spec.ts
+
+      - name: Run chat persistence regressions
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/chat/chat.service.integration.spec.ts
+          src/chat/chat.service.spec.ts
+
+      - name: Build API
+        run: pnpm --filter @woof/api build

--- a/.github/workflows/dogos-trust-discovery-ci.yml
+++ b/.github/workflows/dogos-trust-discovery-ci.yml
@@ -180,21 +180,45 @@ jobs:
           leave_start = source.index("@SubscribeMessage('conversation:leave')")
           typing_start = source.index("@SubscribeMessage('typing:start')")
           private_typing = source.index('private async emitTyping')
+          user_rooms = source.index('private userRooms')
 
           join_handler = source[join_start:leave_start]
           leave_handler = source[leave_start:typing_start]
-          typing_handler = source[private_typing:]
+          typing_handler = source[private_typing:user_rooms]
 
-          checks = [
+          room_checks = [
               ('conversation join', join_handler, 'client.join(`conversation:${data.conversationId}`)'),
               ('conversation leave', leave_handler, 'client.leave(`conversation:${data.conversationId}`)'),
-              ('typing emit', typing_handler, 'client.to(`conversation:${conversationId}`).emit'),
           ]
-          for label, handler, room_operation in checks:
+          for label, handler, room_operation in room_checks:
               authorization = handler.find('chatSecurity.assertConversationAccess')
               operation = handler.find(room_operation)
               if authorization < 0 or operation < 0 or authorization > operation:
                   raise SystemExit(f'{label} must authorize conversation access before its room operation')
+
+          typing_required = [
+              'chatSecurity.withAuthorizedRealtimeRecipients',
+              'this.server',
+              'this.userRooms(authorizedUserIds)',
+              '.except(client.id)',
+              ',\n        userId\n      );',
+          ]
+          missing = [token for token in typing_required if token not in typing_handler]
+          if missing:
+              raise SystemExit(f'typing must use lock-bound authorized private user-room fanout: {missing}')
+
+          authorization = typing_handler.find('chatSecurity.withAuthorizedRealtimeRecipients')
+          operation = typing_handler.find('this.userRooms(authorizedUserIds)')
+          if authorization > operation:
+              raise SystemExit('typing must authorize realtime recipients before private-room fanout')
+
+          forbidden_typing = [
+              'client.to(`conversation:${conversationId}`)',
+              'this.server.to(`conversation:${conversationId}`)',
+          ]
+          present = [token for token in forbidden_typing if token in typing_handler]
+          if present:
+              raise SystemExit(f'conversation room cannot authorize typing delivery: {present}')
           PY
           grep -q 'chatSecurity.persistMessage' apps/api/src/chat/chat.gateway.ts
           grep -q 'clientMessageId' apps/web/src/lib/socket.ts

--- a/apps/api/src/chat/chat-live-authorization.integration.spec.ts
+++ b/apps/api/src/chat/chat-live-authorization.integration.spec.ts
@@ -1,0 +1,153 @@
+import { randomUUID } from 'node:crypto';
+import { PrismaService } from '../prisma/prisma.service';
+import { acquireRelationshipLocks } from '../trust-safety/relationship-lock';
+import { ChatSecurityService } from './chat-security.service';
+
+describe('chat realtime authorization integration', () => {
+  const prisma = new PrismaService();
+  const service = new ChatSecurityService(prisma);
+  const usersToDelete: string[] = [];
+  const conversationsToDelete: string[] = [];
+
+  beforeAll(async () => {
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    if (conversationsToDelete.length > 0) {
+      await prisma.conversation.deleteMany({ where: { id: { in: conversationsToDelete } } });
+    }
+    if (usersToDelete.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: usersToDelete } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  async function userFixture(label: string) {
+    const suffix = randomUUID().slice(0, 8);
+    const user = await prisma.user.create({
+      data: {
+        handle: `realtime-${label}-${suffix}`,
+        email: `realtime-${label}-${suffix}@example.test`,
+        visibility: 'PUBLIC',
+      },
+      select: { id: true },
+    });
+    usersToDelete.push(user.id);
+    return user;
+  }
+
+  async function groupFixture(label: string) {
+    const [userA, userB, userC] = await Promise.all([
+      userFixture(`${label}-a`),
+      userFixture(`${label}-b`),
+      userFixture(`${label}-c`),
+    ]);
+    const conversation = await prisma.conversation.create({
+      data: {
+        participants: {
+          create: [{ userId: userA.id }, { userId: userB.id }, { userId: userC.id }],
+        },
+      },
+      select: { id: true },
+    });
+    conversationsToDelete.push(conversation.id);
+    return { userA, userB, userC, conversation };
+  }
+
+  it('waits for a relationship block and excludes both blocked endpoints when the block commits first', async () => {
+    const { userA, userB, userC, conversation } = await groupFixture('block-first');
+
+    let blockWrittenResolve!: () => void;
+    const blockWritten = new Promise<void>((resolve) => {
+      blockWrittenResolve = resolve;
+    });
+    let releaseBlockResolve!: () => void;
+    const releaseBlock = new Promise<void>((resolve) => {
+      releaseBlockResolve = resolve;
+    });
+
+    const blockTransaction = prisma.$transaction(async (tx) => {
+      await acquireRelationshipLocks(tx, userA.id, [userB.id]);
+      await tx.blockedUser.create({
+        data: { userId: userA.id, blockedId: userB.id, reason: 'realtime-block-first' },
+      });
+      blockWrittenResolve();
+      await releaseBlock;
+    });
+
+    await blockWritten;
+
+    let delivered = false;
+    const deliveryPromise = service.withAuthorizedRealtimeRecipients(
+      conversation.id,
+      (authorizedUserIds) => {
+        delivered = true;
+        expect(authorizedUserIds).toEqual([userC.id]);
+      }
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(delivered).toBe(false);
+
+    releaseBlockResolve();
+    await blockTransaction;
+
+    await expect(deliveryPromise).resolves.toEqual({ authorizedUserIds: [userC.id] });
+    expect(delivered).toBe(true);
+  });
+
+  it('holds block commit behind realtime delivery when delivery acquires the relationship graph first', async () => {
+    const { userA, userB, userC, conversation } = await groupFixture('delivery-first');
+
+    let deliveryEnteredResolve!: () => void;
+    const deliveryEntered = new Promise<void>((resolve) => {
+      deliveryEnteredResolve = resolve;
+    });
+    let releaseDeliveryResolve!: () => void;
+    const releaseDelivery = new Promise<void>((resolve) => {
+      releaseDeliveryResolve = resolve;
+    });
+    let deliveredUserIds: string[] = [];
+
+    const deliveryPromise = service.withAuthorizedRealtimeRecipients(
+      conversation.id,
+      async (authorizedUserIds) => {
+        deliveredUserIds = authorizedUserIds;
+        deliveryEnteredResolve();
+        await releaseDelivery;
+      }
+    );
+
+    await deliveryEntered;
+
+    let blockSettled = false;
+    const blockPromise = prisma
+      .$transaction(async (tx) => {
+        await acquireRelationshipLocks(tx, userA.id, [userB.id]);
+        await tx.blockedUser.create({
+          data: { userId: userA.id, blockedId: userB.id, reason: 'realtime-delivery-first' },
+        });
+      })
+      .finally(() => {
+        blockSettled = true;
+      });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(blockSettled).toBe(false);
+
+    releaseDeliveryResolve();
+    await expect(deliveryPromise).resolves.toEqual({
+      authorizedUserIds: [...deliveredUserIds],
+    });
+    await blockPromise;
+
+    expect([...deliveredUserIds].sort()).toEqual([userA.id, userB.id, userC.id].sort());
+    await expect(
+      prisma.blockedUser.findUnique({
+        where: { userId_blockedId: { userId: userA.id, blockedId: userB.id } },
+        select: { id: true },
+      })
+    ).resolves.toBeTruthy();
+  });
+});

--- a/apps/api/src/chat/chat-security.service.spec.ts
+++ b/apps/api/src/chat/chat-security.service.spec.ts
@@ -64,9 +64,7 @@ describe('ChatSecurityService', () => {
       { userId: 'user-2' },
       { userId: 'user-3' },
     ]);
-    prisma.blockedUser.findMany.mockResolvedValue([
-      { userId: 'user-1', blockedId: 'user-2' },
-    ]);
+    prisma.blockedUser.findMany.mockResolvedValue([{ userId: 'user-1', blockedId: 'user-2' }]);
     prisma.$queryRaw.mockResolvedValue([{ locked: 1 }]);
     const deliver = jest.fn();
 
@@ -91,9 +89,7 @@ describe('ChatSecurityService', () => {
       { userId: 'user-2' },
       { userId: 'user-3' },
     ]);
-    prisma.blockedUser.findMany.mockResolvedValue([
-      { userId: 'user-1', blockedId: 'user-2' },
-    ]);
+    prisma.blockedUser.findMany.mockResolvedValue([{ userId: 'user-1', blockedId: 'user-2' }]);
     prisma.$queryRaw.mockResolvedValue([{ locked: 1 }]);
     const deliver = jest.fn();
 

--- a/apps/api/src/chat/chat-security.service.spec.ts
+++ b/apps/api/src/chat/chat-security.service.spec.ts
@@ -10,8 +10,8 @@ describe('ChatSecurityService', () => {
 
   function build() {
     const prisma = {
-      conversationParticipant: { findUnique: jest.fn() },
-      blockedUser: { findFirst: jest.fn() },
+      conversationParticipant: { findUnique: jest.fn(), findMany: jest.fn() },
+      blockedUser: { findFirst: jest.fn(), findMany: jest.fn() },
       message: { findUnique: jest.fn(), create: jest.fn() },
       $queryRaw: jest.fn(),
       $transaction: jest.fn(),
@@ -55,6 +55,52 @@ describe('ChatSecurityService', () => {
     await expect(service.assertConversationAccess('user-1', 'conversation-1')).resolves.toEqual({
       otherUserIds: ['user-2', 'user-3'],
     });
+  });
+
+  it('filters both endpoints of a blocked relationship from group realtime delivery', async () => {
+    const { prisma, service } = build();
+    prisma.conversationParticipant.findMany.mockResolvedValue([
+      { userId: 'user-1' },
+      { userId: 'user-2' },
+      { userId: 'user-3' },
+    ]);
+    prisma.blockedUser.findMany.mockResolvedValue([
+      { userId: 'user-1', blockedId: 'user-2' },
+    ]);
+    prisma.$queryRaw.mockResolvedValue([{ locked: 1 }]);
+    const deliver = jest.fn();
+
+    await expect(
+      service.withAuthorizedRealtimeRecipients('conversation-1', deliver)
+    ).resolves.toEqual({ authorizedUserIds: ['user-3'] });
+
+    expect(deliver).toHaveBeenCalledWith(['user-3']);
+    expect(prisma.$queryRaw).toHaveBeenCalledTimes(3);
+    expect(prisma.$queryRaw.mock.invocationCallOrder[2]).toBeLessThan(
+      prisma.blockedUser.findMany.mock.invocationCallOrder[0]!
+    );
+    expect(prisma.blockedUser.findMany.mock.invocationCallOrder[0]).toBeLessThan(
+      deliver.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it('rejects ephemeral realtime delivery when the required actor is no longer authorized', async () => {
+    const { prisma, service } = build();
+    prisma.conversationParticipant.findMany.mockResolvedValue([
+      { userId: 'user-1' },
+      { userId: 'user-2' },
+      { userId: 'user-3' },
+    ]);
+    prisma.blockedUser.findMany.mockResolvedValue([
+      { userId: 'user-1', blockedId: 'user-2' },
+    ]);
+    prisma.$queryRaw.mockResolvedValue([{ locked: 1 }]);
+    const deliver = jest.fn();
+
+    await expect(
+      service.withAuthorizedRealtimeRecipients('conversation-1', deliver, 'user-1')
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(deliver).not.toHaveBeenCalled();
   });
 
   it('replays an idempotent persisted message without creating or emitting a second record', async () => {

--- a/apps/api/src/chat/chat-security.service.ts
+++ b/apps/api/src/chat/chat-security.service.ts
@@ -1,7 +1,10 @@
 import { BadRequestException, ForbiddenException, Injectable } from '@nestjs/common';
 import { Prisma } from '@woof/database';
 import { PrismaService } from '../prisma/prisma.service';
-import { acquireRelationshipLocks } from '../trust-safety/relationship-lock';
+import {
+  acquireParticipantRelationshipLocks,
+  acquireRelationshipLocks,
+} from '../trust-safety/relationship-lock';
 
 const MAX_MESSAGE_LENGTH = 4_000;
 const CLIENT_MESSAGE_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
@@ -18,6 +21,8 @@ type ConversationAccessClient = Pick<
   'conversationParticipant' | 'blockedUser' | '$queryRaw'
 >;
 
+type RealtimeDelivery = (authorizedUserIds: string[]) => void | Promise<void>;
+
 export type PersistedChatMessage = {
   id: string;
   conversationId: string;
@@ -33,6 +38,56 @@ export class ChatSecurityService {
 
   async assertConversationAccess(userId: string, conversationId: string) {
     return this.assertConversationAccessWithClient(this.prisma, userId, conversationId, false);
+  }
+
+  async withAuthorizedRealtimeRecipients(
+    conversationId: string,
+    deliver: RealtimeDelivery,
+    requiredUserId?: string
+  ) {
+    return this.prisma.$transaction(async (tx) => {
+      const participants = await tx.conversationParticipant.findMany({
+        where: { conversationId },
+        select: { userId: true },
+        orderBy: { userId: 'asc' },
+      });
+      const participantUserIds = [...new Set(participants.map((entry) => entry.userId))];
+
+      if (participantUserIds.length < 2) {
+        throw new ForbiddenException('Conversation is unavailable');
+      }
+
+      await acquireParticipantRelationshipLocks(tx, participantUserIds);
+
+      const blocks = await tx.blockedUser.findMany({
+        where: {
+          userId: { in: participantUserIds },
+          blockedId: { in: participantUserIds },
+        },
+        select: { userId: true, blockedId: true },
+      });
+
+      const blockedEndpoints = new Set<string>();
+      for (const block of blocks) {
+        if (block.userId === block.blockedId) continue;
+        blockedEndpoints.add(block.userId);
+        blockedEndpoints.add(block.blockedId);
+      }
+
+      const authorizedUserIds = participantUserIds.filter(
+        (participantUserId) => !blockedEndpoints.has(participantUserId)
+      );
+
+      if (requiredUserId && !authorizedUserIds.includes(requiredUserId)) {
+        throw new ForbiddenException('Conversation is unavailable');
+      }
+
+      if (authorizedUserIds.length > 0) {
+        await deliver(authorizedUserIds);
+      }
+
+      return { authorizedUserIds };
+    });
   }
 
   async persistMessage(input: {

--- a/apps/api/src/chat/chat.gateway.spec.ts
+++ b/apps/api/src/chat/chat.gateway.spec.ts
@@ -1,0 +1,138 @@
+import { ForbiddenException } from '@nestjs/common';
+import { ChatGateway } from './chat.gateway';
+
+describe('ChatGateway realtime authorization', () => {
+  function build() {
+    const jwtService = {
+      verifyAsync: jest.fn().mockResolvedValue({ sub: 'user-1' }),
+    };
+    const chatSecurity = {
+      persistMessage: jest.fn(),
+      assertConversationAccess: jest.fn(),
+      withAuthorizedRealtimeRecipients: jest.fn(),
+    };
+    const nudgesService = {
+      checkChatActivityNudges: jest.fn().mockResolvedValue({ created: false }),
+    };
+    const emit = jest.fn();
+    const except = jest.fn().mockReturnValue({ emit });
+    const to = jest.fn().mockReturnValue({ emit, except });
+    const gateway = new ChatGateway(
+      jwtService as never,
+      chatSecurity as never,
+      nudgesService as never
+    );
+    gateway.server = { to } as never;
+
+    const client = {
+      id: 'socket-1',
+      handshake: { auth: { token: 'token-1' } },
+      join: jest.fn().mockResolvedValue(undefined),
+      leave: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn(),
+    };
+
+    return {
+      gateway,
+      client,
+      jwtService,
+      chatSecurity,
+      nudgesService,
+      emit,
+      except,
+      to,
+    };
+  }
+
+  it('delivers persisted messages only through authorized private user rooms', async () => {
+    const { gateway, client, chatSecurity, to, emit } = build();
+    await gateway.handleConnection(client as never);
+
+    const createdAt = new Date('2026-08-24T04:00:00.000Z');
+    chatSecurity.persistMessage.mockResolvedValue({
+      duplicate: false,
+      message: {
+        id: 'message-1',
+        conversationId: 'conversation-1',
+        senderId: 'user-1',
+        text: 'hello',
+        mediaUrls: [],
+        createdAt,
+      },
+    });
+    chatSecurity.withAuthorizedRealtimeRecipients.mockImplementation(
+      async (_conversationId: string, deliver: (userIds: string[]) => void) => {
+        deliver(['user-1', 'user-3']);
+        return { authorizedUserIds: ['user-1', 'user-3'] };
+      }
+    );
+
+    await expect(
+      gateway.handleMessage(client as never, {
+        conversationId: 'conversation-1',
+        clientMessageId: 'client-message-123',
+        text: 'hello',
+      })
+    ).resolves.toMatchObject({ success: true, duplicate: false });
+
+    expect(chatSecurity.withAuthorizedRealtimeRecipients).toHaveBeenCalledWith(
+      'conversation-1',
+      expect.any(Function)
+    );
+    expect(to).toHaveBeenCalledWith(['user:user-1', 'user:user-3']);
+    expect(emit).toHaveBeenCalledWith('message:received', {
+      id: 'message-1',
+      conversationId: 'conversation-1',
+      senderId: 'user-1',
+      text: 'hello',
+      mediaUrls: [],
+      timestamp: createdAt,
+    });
+    expect(
+      to.mock.calls.some(([rooms]) =>
+        Array.isArray(rooms)
+          ? rooms.some((room) => String(room).startsWith('conversation:'))
+          : String(rooms).startsWith('conversation:')
+      )
+    ).toBe(false);
+  });
+
+  it('requires the typing actor to remain authorized and excludes only the current socket', async () => {
+    const { gateway, client, chatSecurity, to, except, emit } = build();
+    await gateway.handleConnection(client as never);
+
+    chatSecurity.withAuthorizedRealtimeRecipients.mockImplementation(
+      async (
+        _conversationId: string,
+        deliver: (userIds: string[]) => void,
+        requiredUserId?: string
+      ) => {
+        expect(requiredUserId).toBe('user-1');
+        deliver(['user-1', 'user-2', 'user-3']);
+        return { authorizedUserIds: ['user-1', 'user-2', 'user-3'] };
+      }
+    );
+
+    await expect(
+      gateway.handleTypingStart(client as never, { conversationId: 'conversation-1' })
+    ).resolves.toEqual({ success: true });
+
+    expect(to).toHaveBeenCalledWith(['user:user-1', 'user:user-2', 'user:user-3']);
+    expect(except).toHaveBeenCalledWith('socket-1');
+    expect(emit).toHaveBeenCalledWith('typing:start', { userId: 'user-1' });
+  });
+
+  it('does not emit typing after relationship authorization is revoked', async () => {
+    const { gateway, client, chatSecurity, to } = build();
+    await gateway.handleConnection(client as never);
+    chatSecurity.withAuthorizedRealtimeRecipients.mockRejectedValue(
+      new ForbiddenException('Conversation is unavailable')
+    );
+
+    await expect(
+      gateway.handleTypingStop(client as never, { conversationId: 'conversation-1' })
+    ).resolves.toEqual({ success: false, error: 'conversation_unavailable' });
+
+    expect(to).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/chat/chat.gateway.ts
+++ b/apps/api/src/chat/chat.gateway.ts
@@ -87,7 +87,12 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       };
 
       if (!result.duplicate) {
-        this.server.to(`conversation:${data.conversationId}`).emit('message:received', message);
+        await this.chatSecurity.withAuthorizedRealtimeRecipients(
+          data.conversationId,
+          (authorizedUserIds) => {
+            this.server.to(this.userRooms(authorizedUserIds)).emit('message:received', message);
+          }
+        );
         void this.nudgesService
           .checkChatActivityNudges(data.conversationId, userId)
           .catch((error) => {
@@ -161,12 +166,24 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     if (!userId) return { success: false, error: 'unauthorized' };
 
     try {
-      await this.chatSecurity.assertConversationAccess(userId, conversationId);
-      client.to(`conversation:${conversationId}`).emit(event, { userId });
+      await this.chatSecurity.withAuthorizedRealtimeRecipients(
+        conversationId,
+        (authorizedUserIds) => {
+          this.server
+            .to(this.userRooms(authorizedUserIds))
+            .except(client.id)
+            .emit(event, { userId });
+        },
+        userId
+      );
       return { success: true };
     } catch {
       return { success: false, error: 'conversation_unavailable' };
     }
+  }
+
+  private userRooms(userIds: string[]) {
+    return userIds.map((userId) => `user:${userId}`);
   }
 
   private errorName(error: unknown) {

--- a/apps/api/src/trust-safety/relationship-lock.spec.ts
+++ b/apps/api/src/trust-safety/relationship-lock.spec.ts
@@ -1,4 +1,8 @@
-import { relationshipLockKey, relationshipLockKeys } from './relationship-lock';
+import {
+  relationshipLockKey,
+  relationshipLockKeys,
+  relationshipLockKeysForParticipants,
+} from './relationship-lock';
 
 describe('relationship lock keys', () => {
   it('is symmetric for the same unordered user pair', () => {
@@ -9,6 +13,16 @@ describe('relationship lock keys', () => {
     expect(relationshipLockKeys('user-a', ['user-c', 'user-b', 'user-c', 'user-a'])).toEqual([
       relationshipLockKey('user-a', 'user-b'),
       relationshipLockKey('user-a', 'user-c'),
+    ]);
+  });
+
+  it('builds every unique unordered relationship pair for conversation participants', () => {
+    expect(
+      relationshipLockKeysForParticipants(['user-c', 'user-a', 'user-b', 'user-c', ''])
+    ).toEqual([
+      relationshipLockKey('user-a', 'user-b'),
+      relationshipLockKey('user-a', 'user-c'),
+      relationshipLockKey('user-b', 'user-c'),
     ]);
   });
 });

--- a/apps/api/src/trust-safety/relationship-lock.ts
+++ b/apps/api/src/trust-safety/relationship-lock.ts
@@ -16,12 +16,20 @@ export function relationshipLockKeys(userId: string, otherUserIds: string[]) {
   ].sort();
 }
 
-export async function acquireRelationshipLocks(
-  tx: RelationshipLockClient,
-  userId: string,
-  otherUserIds: string[]
-) {
-  const keys = relationshipLockKeys(userId, otherUserIds);
+export function relationshipLockKeysForParticipants(userIds: string[]) {
+  const uniqueUserIds = [...new Set(userIds.filter(Boolean))].sort();
+  const keys: string[] = [];
+
+  for (let index = 0; index < uniqueUserIds.length; index += 1) {
+    for (let otherIndex = index + 1; otherIndex < uniqueUserIds.length; otherIndex += 1) {
+      keys.push(relationshipLockKey(uniqueUserIds[index]!, uniqueUserIds[otherIndex]!));
+    }
+  }
+
+  return keys.sort();
+}
+
+async function acquireRelationshipLockKeys(tx: RelationshipLockClient, keys: string[]) {
   for (const key of keys) {
     await tx.$queryRaw<Array<{ locked: number }>>(Prisma.sql`
       SELECT 1 AS locked
@@ -31,4 +39,19 @@ export async function acquireRelationshipLocks(
     `);
   }
   return keys;
+}
+
+export async function acquireRelationshipLocks(
+  tx: RelationshipLockClient,
+  userId: string,
+  otherUserIds: string[]
+) {
+  return acquireRelationshipLockKeys(tx, relationshipLockKeys(userId, otherUserIds));
+}
+
+export async function acquireParticipantRelationshipLocks(
+  tx: RelationshipLockClient,
+  userIds: string[]
+) {
+  return acquireRelationshipLockKeys(tx, relationshipLockKeysForParticipants(userIds));
 }

--- a/docs/DOGOS_LIVE_AUTHORIZATION.md
+++ b/docs/DOGOS_LIVE_AUTHORIZATION.md
@@ -1,0 +1,67 @@
+# dogOS Live Authorization v1
+
+This release closes a realtime authorization gap without changing database schema, canonical block semantics, conversation membership, or message persistence authority.
+
+## Problem
+
+A Socket.IO client may join a `conversation:<id>` room after an access check. Relationship policy can change after that join. Before this release, message and typing broadcasts targeted the conversation room directly, so an already-connected socket could remain a passive recipient after a block even though new writes were correctly rejected.
+
+Room membership is therefore no longer treated as authorization.
+
+## Delivery authority
+
+Every authenticated socket joins its private `user:<userId>` room at connection time. Conversation rooms may remain for compatibility and explicit join/leave behavior, but production message and typing fanout must never use them as a permission boundary.
+
+Before a realtime event is emitted, `ChatSecurityService.withAuthorizedRealtimeRecipients`:
+
+1. reads the current conversation participants;
+2. constructs every unique unordered relationship pair across those participants;
+3. acquires the same PostgreSQL transaction-scoped advisory-lock keys used by canonical block/unblock and write-time chat enforcement, in one deterministic global order;
+4. re-reads blocked relationships after those locks are held;
+5. removes both endpoints of every blocked participant relationship from the realtime recipient set;
+6. executes the delivery callback while the authorization transaction and relationship locks are still active.
+
+The callback runs while locks are held deliberately. Returning a recipient list and emitting afterward would reintroduce a check-then-act race where a block could commit between authorization and delivery.
+
+## Persisted messages
+
+Message persistence keeps its existing write-time locked access recheck and idempotent delivery receipt contract.
+
+Realtime fanout is a second, recipient-side policy boundary. If a message was canonically persisted and then a block commits before fanout, the blocked relationship endpoints are excluded from realtime delivery while unaffected participants in a group conversation may still receive the already-accepted message.
+
+If fanout acquires the relationship graph first, the block waits until the delivery callback completes. The event is therefore ordered before the block commit.
+
+## Ephemeral typing events
+
+Typing events have no persisted linearization point. The actor must still appear in the authorized realtime recipient set under the participant relationship locks. If the actor is an endpoint of a currently blocked participant relationship, the typing event is rejected and nothing is emitted.
+
+When authorized, typing fanout targets authorized private user rooms and excludes only the current socket, preserving delivery to another active socket owned by the same user.
+
+## Group conversations
+
+If A and B are participants in a group with C and either A blocks B or B blocks A:
+
+- A is excluded from realtime events for that conversation;
+- B is excluded from realtime events for that conversation;
+- C remains eligible if C has no blocked relationship with another participant.
+
+This matches the existing conversation-access policy, where a participant cannot access a conversation containing someone with whom they have an active block in either direction.
+
+## Qualification
+
+One exact candidate head must pass every workflow triggered by this ownership surface.
+
+The dedicated Live Authorization lane must remain schema-free and prove:
+
+- all inherited migrations apply to real PostgreSQL;
+- strict formatting, lint and API TypeScript checks pass;
+- the complete participant relationship lock graph is deterministic;
+- message and typing delivery use authorized private user rooms rather than conversation-room fanout;
+- blocked endpoints are filtered from group delivery;
+- a blocked typing actor cannot emit;
+- when a block transaction owns the relationship lock first, realtime delivery waits and then excludes both blocked endpoints;
+- when realtime delivery owns the participant relationship graph first, the block transaction waits until delivery completes;
+- the prior write-time block-dominance contract remains green;
+- the API builds successfully.
+
+Diagnostic heads do not qualify a release.

--- a/docs/DOGOS_TRUST_DISCOVERY.md
+++ b/docs/DOGOS_TRUST_DISCOVERY.md
@@ -46,7 +46,9 @@ Every realtime operation now checks current server-side conversation membership 
 - typing start
 - typing stop
 
-Messages are emitted only after the canonical `Message` row has committed.
+Conversation-room membership is not delivery authority. A socket may retain a `conversation:<id>` room for compatibility after joining, but message and typing fanout must target private `user:<userId>` rooms selected from current server-side policy. Realtime recipient selection runs under the same deterministic relationship advisory-lock namespace used by canonical block enforcement so a block commit and an event delivery have a defined order rather than a check-then-act gap.
+
+Messages are emitted only after the canonical `Message` row has committed. Recipient eligibility is then rechecked before realtime fanout, so a relationship block that commits before delivery removes both blocked endpoints without deleting or rewriting already-persisted message history.
 
 Every send carries a client-generated `clientMessageId`. A receipt is unique per user and message ID and is bound to one conversation. Retrying the same accepted send returns the persisted message without emitting a duplicate.
 
@@ -147,6 +149,7 @@ Trust + Discovery v1 must preserve all of the following:
 - no precise discovery coordinate persistence
 - no precise-coordinate telemetry
 - no chat room access based only on caller-supplied IDs
+- no conversation-room membership as realtime delivery authority
 - no global presence broadcasts
 - no message emit before persistence
 - no duplicate sends on idempotent retry


### PR DESCRIPTION
## dogOS Live Authorization v1

Base: exact Production Runtime Hardening production merge `292fa050843a5908bbcfcd2506c986ccc75f2f21`.

Qualified exact head: `ca6017cd460929378d2fad260a251173c270493a`.

This release closes a realtime authorization gap without changing database schema, canonical block semantics, conversation membership, or message persistence authority.

### Problem closed

Conversation-room membership outlived the access check that created it. Before this release, a socket that joined `conversation:<id>` before a relationship block could remain a passive realtime recipient even though new sends and typing attempts were rejected after the block.

Conversation rooms are now compatibility state only, never realtime delivery authority.

### Lock-bound realtime delivery

- Every authenticated socket already joins its private `user:<userId>` room.
- Message and typing fanout target only private user rooms selected by current server-side policy.
- `ChatSecurityService.withAuthorizedRealtimeRecipients` reads current participants, acquires every unique participant-pair relationship advisory lock in one deterministic global order, then reads block policy.
- Both endpoints of every blocked participant relationship are excluded from the recipient set.
- The delivery callback executes while the authorization transaction and relationship locks are still held, eliminating the check-then-emit gap.

### Ordering semantics

Persisted messages keep PR #20/#21's existing write-time authorization, idempotent `clientMessageId`, canonical receipt, and block-dominance contracts.

If a message persisted before a block but the block commits before realtime fanout, blocked endpoints are filtered while unaffected group participants may still receive the already-canonical message. If delivery owns the relationship lock graph first, the block waits until emission completes, so the event is ordered before the block commit.

Typing is ephemeral and passes the actor as a required authorized participant. A blocked actor cannot emit typing at all.

### Group behavior

If A and B share a conversation with C and either A blocks B or B blocks A, A and B stop receiving that conversation's realtime events while C remains eligible if C has no blocked relationship with another participant. This matches the existing conversation-access policy.

### Inherited contract upgrade

The Trust + Discovery qualification gate previously encoded the older `client.to(conversation)` typing implementation. This PR strengthens that inherited gate rather than bypassing it:

- join and leave still require server authorization before room mutation;
- global presence broadcasts remain forbidden;
- typing now must use lock-bound authorized recipient selection;
- typing must use private user-room fanout and exclude only the current socket;
- the current actor must be an authorized participant;
- conversation-room typing fanout is explicitly forbidden.

`docs/DOGOS_TRUST_DISCOVERY.md` now also states that conversation-room membership is never realtime delivery authority.

### Exact-head qualification receipts

All workflows actually triggered by this ownership surface completed successfully on the same frozen SHA `ca6017cd460929378d2fad260a251173c270493a`:

- dogOS Live Authorization CI — `32694231301`
- dogOS Trust Enforcement Atomicity CI — `32694231428`
- dogOS Network Integrity + Scale CI — `32694231334`
- dogOS Chat Delivery Integrity CI — `32694231310`
- dogOS Trust + Discovery CI — `32694231307`
- root CI — `32694231303`

The dedicated Live Authorization lane proves in one exact-head run:

- all 16 inherited migrations apply to real PostgreSQL;
- schema/migration ownership remains unchanged;
- touched-file formatting, zero-warning lint, and API TypeScript pass;
- the complete participant relationship-lock graph is deterministic;
- conversation-room fanout is absent from message/typing delivery authority;
- group recipient filtering removes both endpoints of a blocked relationship;
- a blocked typing actor cannot emit;
- **block-first PostgreSQL race:** delivery waits for the block and then excludes both blocked endpoints;
- **delivery-first PostgreSQL race:** block commit waits while the authorized delivery callback holds the relationship graph;
- the prior write-time block-dominance PostgreSQL regression remains green;
- chat persistence/idempotency regressions remain green;
- the API builds successfully.

Trust + Discovery independently passes current room/presence policy, precise-location protections, network transport contracts, the real Chromium privacy-safe discovery contract, and API/Web builds. Root CI independently passes static quality, backend unit/API tests, frontend unit/browser/accessibility/visual contracts, and production API/Web builds.

No database schema or migration changes are owned by this release.

See `docs/DOGOS_LIVE_AUTHORIZATION.md`.

Diagnostic heads do not qualify a release.