### PR TITLE
dogOS Runtime: proxy-safe production throttling

### DIFF
--- a/.github/workflows/dogos-proxy-safe-throttling-ci.yml
+++ b/.github/workflows/dogos-proxy-safe-throttling-ci.yml
@@ -1,0 +1,210 @@
+name: dogOS Proxy-Safe Throttling CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/app.module.ts'
+      - 'apps/api/src/common/http/client-ip.ts'
+      - 'apps/api/src/common/http/client-ip.spec.ts'
+      - '.github/workflows/dogos-proxy-safe-throttling-ci.yml'
+      - 'docs/DOGOS_PROXY_SAFE_THROTTLING.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-proxy-safe-throttling-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  JWT_SECRET: ci-only-proxy-safe-throttle-secret-1234567890
+  NODE_ENV: test
+  ML_SERVICE_ENABLED: 'false'
+
+jobs:
+  qualify:
+    name: Fly client isolation + production image qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject schema and migration ownership changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
+            echo 'Proxy-Safe Throttling v1 does not own database schema or migration changes.'
+            exit 1
+          fi
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check Proxy-Safe Throttling formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/app.module.ts
+          apps/api/src/common/http/client-ip.ts
+          apps/api/src/common/http/client-ip.spec.ts
+          .github/workflows/dogos-proxy-safe-throttling-ci.yml
+          docs/DOGOS_PROXY_SAFE_THROTTLING.md
+
+      - name: Lint Proxy-Safe Throttling API surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/app.module.ts
+          src/common/http/client-ip.ts
+          src/common/http/client-ip.spec.ts
+
+      - name: Enforce narrow proxy trust boundary
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          app = Path('apps/api/src/app.module.ts').read_text()
+          tracker = Path('apps/api/src/common/http/client-ip.ts').read_text()
+          main = Path('apps/api/src/main.ts').read_text()
+
+          required_tracker = [
+              "request.headers?.['fly-client-ip']",
+              'isTrustedFlyRuntime(env)',
+              'env.FLY_APP_NAME',
+              'env.FLY_MACHINE_ID',
+              'isIP(candidate)',
+              '`fly:${proxyIp}`',
+              '`fly-fallback:${directIp}`',
+              '`direct:${directIp}`',
+          ]
+          missing = [token for token in required_tracker if token not in tracker]
+          if missing:
+              raise SystemExit(f'missing proxy-safe tracker invariant: {missing}')
+
+          if 'getTracker: clientIpTracker' not in app:
+              raise SystemExit('global throttler must use clientIpTracker')
+          if 'trust proxy' in main.lower() or 'trust proxy' in app.lower():
+              raise SystemExit('broad Express trust proxy is forbidden for throttle identity')
+          if 'x-forwarded-for' in tracker.lower():
+              raise SystemExit('throttle tracker must not parse spoofable X-Forwarded-For chains')
+          PY
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Run proxy tracker contracts
+        run: pnpm --filter @woof/api exec jest --runInBand src/common/http/client-ip.spec.ts
+
+      - name: Build API
+        run: pnpm --filter @woof/api build
+
+      - name: Build production API image
+        run: docker build --pull -f infra/docker/Dockerfile.api -t woof-api-proxy-throttle:ci .
+
+      - name: Boot production image in Fly runtime mode
+        run: |
+          docker rm -f woof-api-proxy-throttle-ci >/dev/null 2>&1 || true
+          docker run -d --name woof-api-proxy-throttle-ci --network host \
+            -e DATABASE_URL="$DATABASE_URL" \
+            -e SHADOW_DATABASE_URL="$SHADOW_DATABASE_URL" \
+            -e JWT_SECRET="$JWT_SECRET" \
+            -e NODE_ENV=production \
+            -e API_DOCS_ENABLED=false \
+            -e CORS_ORIGIN=http://localhost:3000 \
+            -e FLY_APP_NAME=woof-api-ci \
+            -e FLY_MACHINE_ID=machine-ci \
+            woof-api-proxy-throttle:ci
+
+          live=0
+          for attempt in $(seq 1 30); do
+            status=$(curl --silent --show-error --output /tmp/proxy-live.json --write-out '%{http_code}' \
+              --header 'Fly-Client-IP: 198.51.100.250' \
+              http://127.0.0.1:4000/api/v1/ops/health/live || true)
+            if [ "$status" = '200' ]; then
+              live=1
+              break
+            fi
+            if ! docker ps --format '{{.Names}}' | grep -Fxq woof-api-proxy-throttle-ci; then
+              echo "Production image exited before liveness; status=$status"
+              cat /tmp/proxy-live.json 2>/dev/null || true
+              docker logs woof-api-proxy-throttle-ci || true
+              exit 1
+            fi
+            sleep 1
+          done
+          if [ "$live" -ne 1 ]; then
+            echo 'Production image never reached liveness.'
+            docker logs woof-api-proxy-throttle-ci || true
+            exit 1
+          fi
+
+      - name: Prove distinct Fly clients have isolated short buckets
+        run: |
+          sleep 2
+          endpoint=http://127.0.0.1:4000/api/v1/ops/health/live
+
+          for attempt in 1 2 3; do
+            status=$(curl --silent --show-error --output "/tmp/client-a-$attempt.json" --write-out '%{http_code}' \
+              --header 'Fly-Client-IP: 203.0.113.10' "$endpoint")
+            test "$status" = '200' || {
+              echo "Fly client A request $attempt expected 200, got $status"
+              cat "/tmp/client-a-$attempt.json" || true
+              exit 1
+            }
+          done
+
+          status=$(curl --silent --show-error --output /tmp/client-a-throttled.json --write-out '%{http_code}' \
+            --header 'Fly-Client-IP: 203.0.113.10' "$endpoint")
+          test "$status" = '429' || {
+            echo "Fly client A fourth request expected 429, got $status"
+            cat /tmp/client-a-throttled.json || true
+            exit 1
+          }
+
+          status=$(curl --silent --show-error --output /tmp/client-b.json --write-out '%{http_code}' \
+            --header 'Fly-Client-IP: 203.0.113.11' "$endpoint")
+          test "$status" = '200' || {
+            echo "Distinct Fly client B must have an independent bucket; got $status"
+            cat /tmp/client-b.json || true
+            exit 1
+          }
+
+      - name: Stop production image
+        if: always()
+        run: docker rm -f woof-api-proxy-throttle-ci >/dev/null 2>&1 || true

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -15,6 +15,7 @@ import { BehaviorVisionModule } from './behavior-vision/behavior-vision.module';
 import { ChatModule } from './chat/chat.module';
 import { CoActivityModule } from './co-activity/co-activity.module';
 import { CoachingModule } from './coaching/coaching.module';
+import { clientIpTracker } from './common/http/client-ip';
 import { CompatibilityModule } from './compatibility/compatibility.module';
 import { ConciergeModule } from './concierge/concierge.module';
 import { validateEnvironment } from './config/env.validation';
@@ -47,6 +48,7 @@ import { VerificationModule } from './verification/verification.module';
 
 export const throttlerOptions: ThrottlerModuleOptions = {
   skipIf: () => process.env.NODE_ENV === 'test',
+  getTracker: clientIpTracker,
   throttlers: [
     { name: 'short', ttl: 1000, limit: 3 },
     { name: 'medium', ttl: 10000, limit: 20 },

--- a/apps/api/src/common/http/client-ip.spec.ts
+++ b/apps/api/src/common/http/client-ip.spec.ts
@@ -1,4 +1,8 @@
-import { clientIpTracker, flyClientIp, isTrustedFlyRuntime } from './client-ip';
+import {
+  clientIpTrackerForEnv,
+  flyClientIp,
+  isTrustedFlyRuntime,
+} from './client-ip';
 
 describe('clientIpTracker', () => {
   const flyEnv = {
@@ -8,7 +12,7 @@ describe('clientIpTracker', () => {
 
   it('trusts a single valid Fly-Client-IP only inside a proven Fly runtime', async () => {
     await expect(
-      clientIpTracker(
+      clientIpTrackerForEnv(
         {
           headers: { 'fly-client-ip': '203.0.113.10' },
           ip: '172.16.0.10',
@@ -20,8 +24,14 @@ describe('clientIpTracker', () => {
 
   it('keeps distinct Fly clients in distinct throttle identities', async () => {
     const [clientA, clientB] = await Promise.all([
-      clientIpTracker({ headers: { 'fly-client-ip': '203.0.113.10' }, ip: '172.16.0.10' }, flyEnv),
-      clientIpTracker({ headers: { 'fly-client-ip': '203.0.113.11' }, ip: '172.16.0.10' }, flyEnv),
+      clientIpTrackerForEnv(
+        { headers: { 'fly-client-ip': '203.0.113.10' }, ip: '172.16.0.10' },
+        flyEnv
+      ),
+      clientIpTrackerForEnv(
+        { headers: { 'fly-client-ip': '203.0.113.11' }, ip: '172.16.0.10' },
+        flyEnv
+      ),
     ]);
 
     expect(clientA).toBe('fly:203.0.113.10');
@@ -30,7 +40,7 @@ describe('clientIpTracker', () => {
 
   it('ignores a spoofed Fly-Client-IP outside a Fly runtime', async () => {
     await expect(
-      clientIpTracker(
+      clientIpTrackerForEnv(
         {
           headers: { 'fly-client-ip': '203.0.113.99' },
           ip: '198.51.100.20',
@@ -42,7 +52,7 @@ describe('clientIpTracker', () => {
 
   it('requires both Fly runtime identity variables before trusting the proxy header', async () => {
     await expect(
-      clientIpTracker(
+      clientIpTrackerForEnv(
         {
           headers: { 'fly-client-ip': '203.0.113.99' },
           ip: '198.51.100.20',
@@ -54,7 +64,7 @@ describe('clientIpTracker', () => {
 
   it('fails safe to the direct peer when the Fly header is missing or malformed', async () => {
     await expect(
-      clientIpTracker(
+      clientIpTrackerForEnv(
         {
           headers: { 'fly-client-ip': '203.0.113.10, 198.51.100.7' },
           ip: '172.16.0.10',
@@ -64,7 +74,7 @@ describe('clientIpTracker', () => {
     ).resolves.toBe('fly-fallback:172.16.0.10');
 
     await expect(
-      clientIpTracker(
+      clientIpTrackerForEnv(
         {
           headers: { 'fly-client-ip': ['203.0.113.10', '203.0.113.11'] },
           socket: { remoteAddress: '172.16.0.11' },

--- a/apps/api/src/common/http/client-ip.spec.ts
+++ b/apps/api/src/common/http/client-ip.spec.ts
@@ -1,8 +1,4 @@
-import {
-  clientIpTrackerForEnv,
-  flyClientIp,
-  isTrustedFlyRuntime,
-} from './client-ip';
+import { clientIpTrackerForEnv, flyClientIp, isTrustedFlyRuntime } from './client-ip';
 
 describe('clientIpTracker', () => {
   const flyEnv = {

--- a/apps/api/src/common/http/client-ip.spec.ts
+++ b/apps/api/src/common/http/client-ip.spec.ts
@@ -1,0 +1,86 @@
+import { clientIpTracker, flyClientIp, isTrustedFlyRuntime } from './client-ip';
+
+describe('clientIpTracker', () => {
+  const flyEnv = {
+    FLY_APP_NAME: 'woof-api-ci',
+    FLY_MACHINE_ID: 'machine-ci',
+  } as NodeJS.ProcessEnv;
+
+  it('trusts a single valid Fly-Client-IP only inside a proven Fly runtime', async () => {
+    await expect(
+      clientIpTracker(
+        {
+          headers: { 'fly-client-ip': '203.0.113.10' },
+          ip: '172.16.0.10',
+        },
+        flyEnv
+      )
+    ).resolves.toBe('fly:203.0.113.10');
+  });
+
+  it('keeps distinct Fly clients in distinct throttle identities', async () => {
+    const [clientA, clientB] = await Promise.all([
+      clientIpTracker({ headers: { 'fly-client-ip': '203.0.113.10' }, ip: '172.16.0.10' }, flyEnv),
+      clientIpTracker({ headers: { 'fly-client-ip': '203.0.113.11' }, ip: '172.16.0.10' }, flyEnv),
+    ]);
+
+    expect(clientA).toBe('fly:203.0.113.10');
+    expect(clientB).toBe('fly:203.0.113.11');
+  });
+
+  it('ignores a spoofed Fly-Client-IP outside a Fly runtime', async () => {
+    await expect(
+      clientIpTracker(
+        {
+          headers: { 'fly-client-ip': '203.0.113.99' },
+          ip: '198.51.100.20',
+        },
+        {}
+      )
+    ).resolves.toBe('direct:198.51.100.20');
+  });
+
+  it('requires both Fly runtime identity variables before trusting the proxy header', async () => {
+    await expect(
+      clientIpTracker(
+        {
+          headers: { 'fly-client-ip': '203.0.113.99' },
+          ip: '198.51.100.20',
+        },
+        { FLY_APP_NAME: 'woof-api-ci' }
+      )
+    ).resolves.toBe('direct:198.51.100.20');
+  });
+
+  it('fails safe to the direct peer when the Fly header is missing or malformed', async () => {
+    await expect(
+      clientIpTracker(
+        {
+          headers: { 'fly-client-ip': '203.0.113.10, 198.51.100.7' },
+          ip: '172.16.0.10',
+        },
+        flyEnv
+      )
+    ).resolves.toBe('fly-fallback:172.16.0.10');
+
+    await expect(
+      clientIpTracker(
+        {
+          headers: { 'fly-client-ip': ['203.0.113.10', '203.0.113.11'] },
+          socket: { remoteAddress: '172.16.0.11' },
+        },
+        flyEnv
+      )
+    ).resolves.toBe('fly-fallback:172.16.0.11');
+  });
+
+  it('accepts valid IPv6 client addresses', () => {
+    expect(flyClientIp({ headers: { 'fly-client-ip': '2001:db8::1' } })).toBe('2001:db8::1');
+  });
+
+  it('detects only complete Fly runtime identity', () => {
+    expect(isTrustedFlyRuntime(flyEnv)).toBe(true);
+    expect(isTrustedFlyRuntime({ FLY_APP_NAME: 'woof-api-ci' })).toBe(false);
+    expect(isTrustedFlyRuntime({ FLY_MACHINE_ID: 'machine-ci' })).toBe(false);
+  });
+});

--- a/apps/api/src/common/http/client-ip.ts
+++ b/apps/api/src/common/http/client-ip.ts
@@ -25,9 +25,9 @@ export function flyClientIp(request: ThrottlerRequestLike) {
   return normalizeIp(header);
 }
 
-export async function clientIpTracker(
+export async function clientIpTrackerForEnv(
   request: ThrottlerRequestLike,
-  env: NodeJS.ProcessEnv = process.env
+  env: NodeJS.ProcessEnv
 ): Promise<string> {
   const directIp =
     normalizeIp(request.ip) ?? normalizeIp(request.socket?.remoteAddress) ?? 'unknown';
@@ -38,4 +38,8 @@ export async function clientIpTracker(
 
   const proxyIp = flyClientIp(request);
   return proxyIp ? `fly:${proxyIp}` : `fly-fallback:${directIp}`;
+}
+
+export async function clientIpTracker(request: ThrottlerRequestLike): Promise<string> {
+  return clientIpTrackerForEnv(request, process.env);
 }

--- a/apps/api/src/common/http/client-ip.ts
+++ b/apps/api/src/common/http/client-ip.ts
@@ -1,0 +1,40 @@
+import { isIP } from 'node:net';
+
+type HeaderValue = string | string[] | undefined;
+
+export type ThrottlerRequestLike = {
+  headers?: Record<string, HeaderValue>;
+  ip?: string;
+  socket?: {
+    remoteAddress?: string | null;
+  };
+};
+
+function normalizeIp(value: string | null | undefined) {
+  const candidate = value?.trim();
+  return candidate && isIP(candidate) ? candidate : null;
+}
+
+export function isTrustedFlyRuntime(env: NodeJS.ProcessEnv = process.env) {
+  return Boolean(env.FLY_APP_NAME?.trim() && env.FLY_MACHINE_ID?.trim());
+}
+
+export function flyClientIp(request: ThrottlerRequestLike) {
+  const header = request.headers?.['fly-client-ip'];
+  if (typeof header !== 'string') return null;
+  return normalizeIp(header);
+}
+
+export async function clientIpTracker(
+  request: ThrottlerRequestLike,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<string> {
+  const directIp = normalizeIp(request.ip) ?? normalizeIp(request.socket?.remoteAddress) ?? 'unknown';
+
+  if (!isTrustedFlyRuntime(env)) {
+    return `direct:${directIp}`;
+  }
+
+  const proxyIp = flyClientIp(request);
+  return proxyIp ? `fly:${proxyIp}` : `fly-fallback:${directIp}`;
+}

--- a/apps/api/src/common/http/client-ip.ts
+++ b/apps/api/src/common/http/client-ip.ts
@@ -29,7 +29,8 @@ export async function clientIpTracker(
   request: ThrottlerRequestLike,
   env: NodeJS.ProcessEnv = process.env
 ): Promise<string> {
-  const directIp = normalizeIp(request.ip) ?? normalizeIp(request.socket?.remoteAddress) ?? 'unknown';
+  const directIp =
+    normalizeIp(request.ip) ?? normalizeIp(request.socket?.remoteAddress) ?? 'unknown';
 
   if (!isTrustedFlyRuntime(env)) {
     return `direct:${directIp}`;

--- a/docs/DOGOS_PROXY_SAFE_THROTTLING.md
+++ b/docs/DOGOS_PROXY_SAFE_THROTTLING.md
@@ -1,0 +1,63 @@
+# dogOS Proxy-Safe Throttling v1
+
+This release hardens the existing global API throttler for production behind Fly Proxy without changing throttle limits, database schema, product authority, or user-facing feature semantics.
+
+## Problem
+
+Nest's default throttler tracks HTTP clients using the request IP. Behind a reverse proxy, the direct peer address can represent the proxy rather than the original client. If multiple public users collapse onto the same proxy address, they can unintentionally share one throttle bucket.
+
+Woof deploys its API behind Fly Proxy. Fly documents `Fly-Client-IP` as the client address observed by Fly Proxy and recommends it over manually parsing `X-Forwarded-For` when Fly is the direct edge. Fly also documents `FLY_APP_NAME` and `FLY_MACHINE_ID` as runtime environment values supplied to Machines.
+
+## Trust boundary
+
+Woof does not enable broad Express `trust proxy=true` and does not parse `X-Forwarded-For` for throttling.
+
+The throttle tracker trusts `Fly-Client-IP` only when both Fly runtime identity variables are present:
+
+- `FLY_APP_NAME`
+- `FLY_MACHINE_ID`
+
+The header must be exactly one valid IPv4 or IPv6 address. Arrays, comma-separated chains, empty values, and malformed addresses are rejected.
+
+When the runtime is not demonstrably Fly-hosted, `Fly-Client-IP` is ignored even if a caller supplies it.
+
+When the runtime is Fly-hosted but the Fly client header is absent or invalid, the tracker falls back to the direct request/socket address. This can conservatively merge clients into a proxy bucket, but it cannot create arbitrary attacker-controlled identities or bypass rate limiting.
+
+## Tracker identities
+
+Tracker keys are source-prefixed so trust domains cannot collide accidentally:
+
+- `fly:<validated-client-ip>` for a validated Fly client address in a Fly runtime;
+- `fly-fallback:<direct-peer-ip>` when Fly runtime is proven but the client header is unusable;
+- `direct:<direct-peer-ip>` everywhere else.
+
+The value is used only as the internal throttler tracker. This release does not add client IPs to telemetry or application logs.
+
+## Existing policy remains unchanged
+
+The global limits remain:
+
+- short: 3 requests per 1 second;
+- medium: 20 requests per 10 seconds;
+- long: 100 requests per 60 seconds.
+
+Test environments continue to skip throttling under the existing policy. Production behavior keeps the global `ThrottlerGuard` and changes only its tracker source.
+
+## Qualification
+
+One exact candidate head must pass every workflow triggered by this ownership surface.
+
+The dedicated Proxy-Safe Throttling lane must remain schema-free and prove:
+
+1. all inherited migrations still apply to PostgreSQL;
+2. formatting, zero-warning lint, API TypeScript, focused unit tests, and API build pass;
+3. `throttlerOptions` uses the narrow `clientIpTracker`;
+4. production source does not enable broad `trust proxy` or use `X-Forwarded-For` for throttle identity;
+5. a spoofed Fly client header is ignored outside a complete Fly runtime identity;
+6. malformed or multi-value Fly client headers fail safe to the direct peer;
+7. valid IPv4 and IPv6 Fly client addresses are accepted only inside a proven Fly runtime;
+8. the real production Docker image boots against PostgreSQL with simulated Fly runtime identity;
+9. three rapid requests from Fly client A succeed and the fourth is throttled with HTTP 429;
+10. a request from distinct Fly client B immediately succeeds, proving A and B do not share the short bucket.
+
+Diagnostic heads do not qualify a release.


### PR DESCRIPTION
## dogOS Proxy-Safe Throttling v1

Base: exact Live Authorization production merge `dfbd2e341c58fc766fa8a029c8a8a9b3261412dd`.

Qualified exact head: `97338f01c60efe73df486bbfd99e7a516f142f93`.

This release fixes a production rate-limit identity seam without changing throttle limits, database schema, product authority, or user-facing semantics.

### Problem closed

Woof's API runs behind Fly Proxy, while the global Nest throttler previously used its default request-IP tracker. Unrelated public users could therefore collapse onto the same direct proxy peer and unintentionally share one throttle bucket.

### Narrow trust boundary

Woof does **not** enable broad Express `trust proxy=true` and does not parse `X-Forwarded-For` for throttle identity.

The tracker trusts `Fly-Client-IP` only when both Fly runtime identity variables are present (`FLY_APP_NAME` + `FLY_MACHINE_ID`) and the header is exactly one valid IPv4 or IPv6 address.

- proven Fly runtime + valid header -> `fly:<client-ip>`
- proven Fly runtime + missing/malformed header -> `fly-fallback:<direct-peer-ip>`
- every other runtime -> `direct:<direct-peer-ip>`

Spoofed Fly headers are ignored outside Fly. Multi-value, comma-separated, and malformed headers fail safe to the direct peer rather than creating attacker-controlled identities.

### Existing abuse controls remain unchanged

- short: 3 requests / 1 second
- medium: 20 requests / 10 seconds
- long: 100 requests / 60 seconds
- global `ThrottlerGuard` remains authoritative
- test skip behavior remains unchanged

Only tracker identity changes.

### Diagnostic defects caught before qualification

The stronger release lane found two contained implementation defects before runtime qualification:

1. the first candidate had a Prettier mismatch in the new tracker;
2. the next candidate exposed a real Nest type-contract error because the tracker used its second parameter for injected environment state while `ThrottlerGetTrackerFunction` reserves that parameter for `ExecutionContext`.

The type defect was fixed without casts or weakening: production now exposes the exact one-request callback, while deterministic tests use a separate environment-aware helper. A later touched-file formatting mismatch in that test was normalized without behavioral changes.

All earlier heads are diagnostic only and do not count as release evidence.

### Exact-head qualification receipts

Every workflow actually triggered by this global `AppModule` ownership surface completed successfully on the same frozen SHA `97338f01c60efe73df486bbfd99e7a516f142f93`:

- dogOS Proxy-Safe Throttling CI — `32700955821`
- dogOS Production Runtime CI — `32700955888`
- dogOS Observability + Device Contracts CI — `32700955912`
- dogOS Foundation CI — `32700955832`
- dogOS Concierge CI — `32700955860`
- dogOS Autopilot CI — `32700955816`
- dogOS Connectors CI — `32700955865`
- dogOS Our Story CI — `32700955805`
- Adventure System CI — `32700955864`
- dogOS Trust + Discovery CI — `32700955822`
- root CI — `32700955995`

### Production-image proof

The dedicated Proxy-Safe lane proves on the exact qualified head:

- all 16 inherited migrations apply to real PostgreSQL;
- no schema/migration ownership was added;
- touched-file Prettier and zero-warning lint pass;
- broad `trust proxy` and `X-Forwarded-For` tracker parsing remain forbidden;
- API TypeScript and proxy tracker unit contracts pass;
- the API builds;
- the actual production Docker image builds and boots with simulated Fly runtime identity;
- Fly client A receives three rapid successful requests and its fourth is throttled;
- distinct Fly client B immediately remains successful, proving separate short-window buckets.

Production Runtime independently rebuilds and boots the production image and revalidates privacy-safe error telemetry, request correlation, liveness, readiness, docs-disabled behavior, migration/runtime packaging, and production throttle presence.

Root CI independently passes static quality, backend unit/API tests, frontend unit/browser/accessibility/visual contracts, and production API/Web builds. The remaining composition owners independently pass their schema, type, test, authority, privacy, and production-build contracts.

No database schema or migration changes are owned by this release.

See `docs/DOGOS_PROXY_SAFE_THROTTLING.md`.

Diagnostic heads do not qualify a release.