### PR TITLE
dogOS Realtime: authenticated socket abuse control

### DIFF
--- a/.github/workflows/dogos-realtime-abuse-ci.yml
+++ b/.github/workflows/dogos-realtime-abuse-ci.yml
@@ -1,0 +1,331 @@
+name: dogOS Realtime Abuse Control CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/chat/chat.gateway.ts'
+      - 'apps/api/src/chat/chat.gateway.spec.ts'
+      - 'apps/api/src/chat/chat.module.ts'
+      - 'apps/api/src/chat/realtime-admission.service.ts'
+      - 'apps/api/src/chat/realtime-admission.service.spec.ts'
+      - '.github/workflows/dogos-realtime-abuse-ci.yml'
+      - 'docs/DOGOS_REALTIME_ABUSE_CONTROL.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-realtime-abuse-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  JWT_SECRET: ci-only-realtime-abuse-secret-12345678901234567890
+  NODE_ENV: test
+  ML_SERVICE_ENABLED: 'false'
+
+jobs:
+  qualify:
+    name: Authenticated socket admission + production image qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject schema and migration ownership changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
+            echo 'Realtime Abuse Control v1 does not own database schema or migration changes.'
+            exit 1
+          fi
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check Realtime Abuse Control formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/chat/chat.gateway.ts
+          apps/api/src/chat/chat.gateway.spec.ts
+          apps/api/src/chat/chat.module.ts
+          apps/api/src/chat/realtime-admission.service.ts
+          apps/api/src/chat/realtime-admission.service.spec.ts
+          .github/workflows/dogos-realtime-abuse-ci.yml
+          docs/DOGOS_REALTIME_ABUSE_CONTROL.md
+
+      - name: Lint Realtime Abuse Control API surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/chat/chat.gateway.ts
+          src/chat/chat.gateway.spec.ts
+          src/chat/chat.module.ts
+          src/chat/realtime-admission.service.ts
+          src/chat/realtime-admission.service.spec.ts
+
+      - name: Enforce bounded authenticated admission before chat work
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          gateway = Path('apps/api/src/chat/chat.gateway.ts').read_text()
+          limiter = Path('apps/api/src/chat/realtime-admission.service.ts').read_text()
+          module = Path('apps/api/src/chat/chat.module.ts').read_text()
+
+          required_limiter = [
+              "export type RealtimeAction = 'message' | 'typing' | 'membership'",
+              'MAX_REALTIME_BUCKETS = 10_000',
+              'PRUNE_INTERVAL = 256',
+              'this.pruneExpired(now)',
+              'this.ensureCapacity(now)',
+              'const key = `${action}:${userId}`',
+          ]
+          missing = [token for token in required_limiter if token not in limiter]
+          if missing:
+              raise SystemExit(f'missing bounded realtime admission invariant: {missing}')
+
+          if 'RealtimeAdmissionService' not in module:
+              raise SystemExit('ChatModule must own the realtime admission singleton')
+          if 'socket.id' in limiter or 'client.id' in limiter:
+              raise SystemExit('rate identity must be the authenticated user, never the socket id')
+
+          message_start = gateway.index("@SubscribeMessage('message:send')")
+          join_start = gateway.index("@SubscribeMessage('conversation:join')")
+          leave_start = gateway.index("@SubscribeMessage('conversation:leave')")
+          typing_start = gateway.index("@SubscribeMessage('typing:start')")
+          typing_impl = gateway.index('private async emitTyping')
+
+          message = gateway[message_start:join_start]
+          join = gateway[join_start:leave_start]
+          leave = gateway[leave_start:typing_start]
+          typing = gateway[typing_impl:]
+
+          checks = [
+              ('message', message, "realtimeAdmission.consume(userId, 'message')", 'chatSecurity.persistMessage'),
+              ('join', join, "realtimeAdmission.consume(userId, 'membership')", 'chatSecurity.assertConversationAccess'),
+              ('leave', leave, "realtimeAdmission.consume(userId, 'membership')", 'chatSecurity.assertConversationAccess'),
+              ('typing', typing, "realtimeAdmission.consume(userId, 'typing')", 'chatSecurity.withAuthorizedRealtimeRecipients'),
+          ]
+          for label, handler, admission_call, expensive_call in checks:
+              identity = handler.find('connectedUsers.get(client.id)')
+              admission = handler.find(admission_call)
+              expensive = handler.find(expensive_call)
+              denial = handler.find("error: 'rate_limited'")
+              if min(identity, admission, expensive, denial) < 0:
+                  raise SystemExit(f'{label} handler is missing an admission invariant')
+              if not identity < admission < denial < expensive:
+                  raise SystemExit(f'{label} must authenticate, admit, deny if needed, then perform chat work')
+
+          disconnect_start = gateway.index('handleDisconnect')
+          message_start = gateway.index("@SubscribeMessage('message:send')")
+          disconnect = gateway[disconnect_start:message_start]
+          if 'realtimeAdmission' in disconnect:
+              raise SystemExit('disconnect must not reset authenticated-user admission state')
+          PY
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Run realtime admission and gateway contracts
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/chat/realtime-admission.service.spec.ts
+          src/chat/chat.gateway.spec.ts
+          src/chat/chat-security.service.spec.ts
+
+      - name: Run existing PostgreSQL authorization race regressions
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/chat/chat-realtime-authorization.integration.spec.ts
+          src/chat/chat-block-atomicity.integration.spec.ts
+
+      - name: Build API
+        run: pnpm --filter @woof/api build
+
+      - name: Build production API image
+        run: docker build --pull -f infra/docker/Dockerfile.api -t woof-api-realtime-abuse:ci .
+
+      - name: Boot production image
+        run: |
+          docker rm -f woof-api-realtime-abuse-ci >/dev/null 2>&1 || true
+          docker run -d --name woof-api-realtime-abuse-ci --network host \
+            -e DATABASE_URL="$DATABASE_URL" \
+            -e SHADOW_DATABASE_URL="$SHADOW_DATABASE_URL" \
+            -e JWT_SECRET="$JWT_SECRET" \
+            -e NODE_ENV=production \
+            -e API_DOCS_ENABLED=false \
+            -e CORS_ORIGIN=http://localhost:3000 \
+            woof-api-realtime-abuse:ci
+
+          live=0
+          for attempt in $(seq 1 30); do
+            status=$(curl --silent --show-error --output /tmp/realtime-live.json --write-out '%{http_code}' \
+              http://127.0.0.1:4000/api/v1/ops/health/live || true)
+            if [ "$status" = '200' ]; then
+              live=1
+              break
+            fi
+            if ! docker ps --format '{{.Names}}' | grep -Fxq woof-api-realtime-abuse-ci; then
+              echo "Production image exited before liveness; status=$status"
+              cat /tmp/realtime-live.json 2>/dev/null || true
+              docker logs woof-api-realtime-abuse-ci || true
+              exit 1
+            fi
+            sleep 1
+          done
+          if [ "$live" -ne 1 ]; then
+            echo 'Production image never reached liveness.'
+            docker logs woof-api-realtime-abuse-ci || true
+            exit 1
+          fi
+
+      - name: Prove authenticated Socket.IO flood admission and reconnect retention
+        run: |
+          pnpm --filter @woof/web exec node <<'NODE'
+          const crypto = require('node:crypto');
+          const { io } = require('socket.io-client');
+
+          const secret = process.env.JWT_SECRET;
+          if (!secret) throw new Error('JWT_SECRET is required');
+
+          function jwt(sub) {
+            const now = Math.floor(Date.now() / 1000);
+            const encode = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
+            const header = encode({ alg: 'HS256', typ: 'JWT' });
+            const payload = encode({ sub, iat: now, exp: now + 300 });
+            const unsigned = `${header}.${payload}`;
+            const signature = crypto.createHmac('sha256', secret).update(unsigned).digest('base64url');
+            return `${unsigned}.${signature}`;
+          }
+
+          function connect(sub) {
+            return new Promise((resolve, reject) => {
+              const socket = io('http://127.0.0.1:4000', {
+                auth: { token: jwt(sub) },
+                transports: ['websocket'],
+                reconnection: false,
+                timeout: 4_000,
+              });
+              socket.once('connect', () => resolve(socket));
+              socket.once('connect_error', reject);
+            });
+          }
+
+          function ack(socket, event, payload) {
+            return new Promise((resolve, reject) => {
+              socket.timeout(4_000).emit(event, payload, (error, response) => {
+                if (error) reject(error);
+                else resolve(response);
+              });
+            });
+          }
+
+          function expectRateLimited(response, label) {
+            if (!response || response.success !== false || response.error !== 'rate_limited') {
+              throw new Error(`${label} expected rate_limited, got ${JSON.stringify(response)}`);
+            }
+            if (!Number.isFinite(response.retryAfterMs) || response.retryAfterMs <= 0) {
+              throw new Error(`${label} must include a positive retryAfterMs`);
+            }
+          }
+
+          (async () => {
+            const userOne = await connect('socket-abuse-user-1');
+
+            for (let index = 0; index < 5; index += 1) {
+              userOne.emit('message:send', {
+                conversationId: 'missing-conversation',
+                clientMessageId: `flood-message-${index}`,
+                text: 'flood probe',
+              });
+            }
+            const messageDenied = await ack(userOne, 'message:send', {
+              conversationId: 'missing-conversation',
+              clientMessageId: 'flood-message-denied',
+              text: 'flood probe',
+            });
+            expectRateLimited(messageDenied, 'message flood');
+
+            userOne.disconnect();
+            const reconnected = await connect('socket-abuse-user-1');
+            const reconnectDenied = await ack(reconnected, 'message:send', {
+              conversationId: 'missing-conversation',
+              clientMessageId: 'reconnect-message-denied',
+              text: 'reconnect probe',
+            });
+            expectRateLimited(reconnectDenied, 'reconnect flood');
+
+            for (let index = 0; index < 8; index += 1) {
+              reconnected.emit('typing:start', { conversationId: 'missing-conversation' });
+            }
+            const typingDenied = await ack(reconnected, 'typing:start', {
+              conversationId: 'missing-conversation',
+            });
+            expectRateLimited(typingDenied, 'typing flood');
+
+            for (let index = 0; index < 10; index += 1) {
+              reconnected.emit('conversation:join', { conversationId: 'missing-conversation' });
+            }
+            const membershipDenied = await ack(reconnected, 'conversation:join', {
+              conversationId: 'missing-conversation',
+            });
+            expectRateLimited(membershipDenied, 'membership flood');
+
+            const userTwo = await connect('socket-abuse-user-2');
+            const independent = await ack(userTwo, 'message:send', {
+              conversationId: 'missing-conversation',
+              clientMessageId: 'independent-user-message',
+              text: 'independent probe',
+            });
+            if (!independent || independent.error === 'rate_limited') {
+              throw new Error(`distinct user must have an independent bucket: ${JSON.stringify(independent)}`);
+            }
+
+            userTwo.disconnect();
+            reconnected.disconnect();
+          })().catch((error) => {
+            console.error(error);
+            process.exitCode = 1;
+          });
+          NODE
+
+      - name: Stop production image
+        if: always()
+        run: docker rm -f woof-api-realtime-abuse-ci >/dev/null 2>&1 || true

--- a/apps/api/src/chat/chat.gateway.spec.ts
+++ b/apps/api/src/chat/chat.gateway.spec.ts
@@ -11,6 +11,9 @@ describe('ChatGateway realtime authorization', () => {
       assertConversationAccess: jest.fn(),
       withAuthorizedRealtimeRecipients: jest.fn(),
     };
+    const realtimeAdmission = {
+      consume: jest.fn().mockReturnValue({ allowed: true }),
+    };
     const nudgesService = {
       checkChatActivityNudges: jest.fn().mockResolvedValue({ created: false }),
     };
@@ -20,6 +23,7 @@ describe('ChatGateway realtime authorization', () => {
     const gateway = new ChatGateway(
       jwtService as never,
       chatSecurity as never,
+      realtimeAdmission as never,
       nudgesService as never
     );
     gateway.server = { to } as never;
@@ -37,6 +41,7 @@ describe('ChatGateway realtime authorization', () => {
       client,
       jwtService,
       chatSecurity,
+      realtimeAdmission,
       nudgesService,
       emit,
       except,
@@ -45,7 +50,7 @@ describe('ChatGateway realtime authorization', () => {
   }
 
   it('delivers persisted messages only through authorized private user rooms', async () => {
-    const { gateway, client, chatSecurity, to, emit } = build();
+    const { gateway, client, chatSecurity, realtimeAdmission, to, emit } = build();
     await gateway.handleConnection(client as never);
 
     const createdAt = new Date('2026-08-24T04:00:00.000Z');
@@ -75,6 +80,7 @@ describe('ChatGateway realtime authorization', () => {
       })
     ).resolves.toMatchObject({ success: true, duplicate: false });
 
+    expect(realtimeAdmission.consume).toHaveBeenCalledWith('user-1', 'message');
     expect(chatSecurity.withAuthorizedRealtimeRecipients).toHaveBeenCalledWith(
       'conversation-1',
       expect.any(Function)
@@ -97,8 +103,25 @@ describe('ChatGateway realtime authorization', () => {
     ).toBe(false);
   });
 
+  it('rejects message floods before persistence work begins', async () => {
+    const { gateway, client, chatSecurity, realtimeAdmission } = build();
+    await gateway.handleConnection(client as never);
+    realtimeAdmission.consume.mockReturnValueOnce({ allowed: false, retryAfterMs: 750 });
+
+    await expect(
+      gateway.handleMessage(client as never, {
+        conversationId: 'conversation-1',
+        clientMessageId: 'client-message-123',
+        text: 'hello',
+      })
+    ).resolves.toEqual({ success: false, error: 'rate_limited', retryAfterMs: 750 });
+
+    expect(chatSecurity.persistMessage).not.toHaveBeenCalled();
+    expect(chatSecurity.withAuthorizedRealtimeRecipients).not.toHaveBeenCalled();
+  });
+
   it('requires the typing actor to remain authorized and excludes only the current socket', async () => {
-    const { gateway, client, chatSecurity, to, except, emit } = build();
+    const { gateway, client, chatSecurity, realtimeAdmission, to, except, emit } = build();
     await gateway.handleConnection(client as never);
 
     chatSecurity.withAuthorizedRealtimeRecipients.mockImplementation(
@@ -117,9 +140,37 @@ describe('ChatGateway realtime authorization', () => {
       gateway.handleTypingStart(client as never, { conversationId: 'conversation-1' })
     ).resolves.toEqual({ success: true });
 
+    expect(realtimeAdmission.consume).toHaveBeenCalledWith('user-1', 'typing');
     expect(to).toHaveBeenCalledWith(['user:user-1', 'user:user-2', 'user:user-3']);
     expect(except).toHaveBeenCalledWith('socket-1');
     expect(emit).toHaveBeenCalledWith('typing:start', { userId: 'user-1' });
+  });
+
+  it('rejects typing floods before relationship authorization work begins', async () => {
+    const { gateway, client, chatSecurity, realtimeAdmission, to } = build();
+    await gateway.handleConnection(client as never);
+    realtimeAdmission.consume.mockReturnValueOnce({ allowed: false, retryAfterMs: 500 });
+
+    await expect(
+      gateway.handleTypingStart(client as never, { conversationId: 'conversation-1' })
+    ).resolves.toEqual({ success: false, error: 'rate_limited', retryAfterMs: 500 });
+
+    expect(chatSecurity.withAuthorizedRealtimeRecipients).not.toHaveBeenCalled();
+    expect(to).not.toHaveBeenCalled();
+  });
+
+  it('rate-limits room membership churn before access checks', async () => {
+    const { gateway, client, chatSecurity, realtimeAdmission } = build();
+    await gateway.handleConnection(client as never);
+    client.join.mockClear();
+    realtimeAdmission.consume.mockReturnValueOnce({ allowed: false, retryAfterMs: 400 });
+
+    await expect(
+      gateway.handleJoinConversation(client as never, { conversationId: 'conversation-1' })
+    ).resolves.toEqual({ success: false, error: 'rate_limited', retryAfterMs: 400 });
+
+    expect(chatSecurity.assertConversationAccess).not.toHaveBeenCalled();
+    expect(client.join).not.toHaveBeenCalled();
   });
 
   it('does not emit typing after relationship authorization is revoked', async () => {

--- a/apps/api/src/chat/chat.gateway.ts
+++ b/apps/api/src/chat/chat.gateway.ts
@@ -12,6 +12,7 @@ import {
 import { Server, Socket } from 'socket.io';
 import { NudgesService } from '../nudges/nudges.service';
 import { ChatSecurityService } from './chat-security.service';
+import { RealtimeAdmissionService } from './realtime-admission.service';
 
 interface SendChatMessage {
   conversationId: string;
@@ -35,6 +36,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   constructor(
     private readonly jwtService: JwtService,
     private readonly chatSecurity: ChatSecurityService,
+    private readonly realtimeAdmission: RealtimeAdmissionService,
     private readonly nudgesService: NudgesService
   ) {}
 
@@ -68,6 +70,11 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   async handleMessage(@ConnectedSocket() client: Socket, @MessageBody() data: SendChatMessage) {
     const userId = this.connectedUsers.get(client.id);
     if (!userId) return { success: false, error: 'unauthorized' };
+
+    const admission = this.realtimeAdmission.consume(userId, 'message');
+    if (!admission.allowed) {
+      return { success: false, error: 'rate_limited', retryAfterMs: admission.retryAfterMs };
+    }
 
     try {
       const result = await this.chatSecurity.persistMessage({
@@ -115,6 +122,11 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const userId = this.connectedUsers.get(client.id);
     if (!userId) return { success: false, error: 'unauthorized' };
 
+    const admission = this.realtimeAdmission.consume(userId, 'membership');
+    if (!admission.allowed) {
+      return { success: false, error: 'rate_limited', retryAfterMs: admission.retryAfterMs };
+    }
+
     try {
       await this.chatSecurity.assertConversationAccess(userId, data.conversationId);
       await client.join(`conversation:${data.conversationId}`);
@@ -131,6 +143,11 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   ) {
     const userId = this.connectedUsers.get(client.id);
     if (!userId) return { success: false, error: 'unauthorized' };
+
+    const admission = this.realtimeAdmission.consume(userId, 'membership');
+    if (!admission.allowed) {
+      return { success: false, error: 'rate_limited', retryAfterMs: admission.retryAfterMs };
+    }
 
     try {
       await this.chatSecurity.assertConversationAccess(userId, data.conversationId);
@@ -164,6 +181,11 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   ) {
     const userId = this.connectedUsers.get(client.id);
     if (!userId) return { success: false, error: 'unauthorized' };
+
+    const admission = this.realtimeAdmission.consume(userId, 'typing');
+    if (!admission.allowed) {
+      return { success: false, error: 'rate_limited', retryAfterMs: admission.retryAfterMs };
+    }
 
     try {
       await this.chatSecurity.withAuthorizedRealtimeRecipients(

--- a/apps/api/src/chat/chat.module.ts
+++ b/apps/api/src/chat/chat.module.ts
@@ -7,6 +7,7 @@ import { ChatController } from './chat.controller';
 import { ChatGateway } from './chat.gateway';
 import { ChatSecurityService } from './chat-security.service';
 import { ChatService } from './chat.service';
+import { RealtimeAdmissionService } from './realtime-admission.service';
 
 @Module({
   imports: [
@@ -21,6 +22,6 @@ import { ChatService } from './chat.service';
     PrismaModule,
   ],
   controllers: [ChatController],
-  providers: [ChatGateway, ChatSecurityService, ChatService],
+  providers: [ChatGateway, ChatSecurityService, ChatService, RealtimeAdmissionService],
 })
 export class ChatModule {}

--- a/apps/api/src/chat/realtime-admission.service.spec.ts
+++ b/apps/api/src/chat/realtime-admission.service.spec.ts
@@ -1,0 +1,89 @@
+import { RealtimeAdmissionService } from './realtime-admission.service';
+
+describe('RealtimeAdmissionService', () => {
+  it('limits rapid message attempts before persistence work', () => {
+    const limiter = new RealtimeAdmissionService();
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(limiter.consume('user-1', 'message', 1_000)).toEqual({ allowed: true });
+    }
+
+    expect(limiter.consume('user-1', 'message', 1_000)).toEqual({
+      allowed: false,
+      retryAfterMs: 1_000,
+    });
+    expect(limiter.consume('user-1', 'message', 2_000)).toEqual({ allowed: true });
+  });
+
+  it('keeps authenticated users in independent realtime buckets', () => {
+    const limiter = new RealtimeAdmissionService();
+
+    for (let index = 0; index < 5; index += 1) {
+      expect(limiter.consume('user-1', 'message', 1_000)).toEqual({ allowed: true });
+    }
+
+    expect(limiter.consume('user-1', 'message', 1_000).allowed).toBe(false);
+    expect(limiter.consume('user-2', 'message', 1_000)).toEqual({ allowed: true });
+  });
+
+  it('bounds sustained message volume across the long window', () => {
+    const limiter = new RealtimeAdmissionService();
+
+    for (let index = 0; index < 60; index += 1) {
+      expect(limiter.consume('user-1', 'message', index * 1_001)).toEqual({ allowed: true });
+    }
+
+    const denied = limiter.consume('user-1', 'message', 59_060);
+    expect(denied.allowed).toBe(false);
+    if (!denied.allowed) {
+      expect(denied.retryAfterMs).toBeGreaterThan(0);
+    }
+  });
+
+  it('cuts off typing floods before repeated authorization work', () => {
+    const limiter = new RealtimeAdmissionService();
+
+    for (let index = 0; index < 8; index += 1) {
+      expect(limiter.consume('user-1', 'typing', 5_000)).toEqual({ allowed: true });
+    }
+
+    expect(limiter.consume('user-1', 'typing', 5_000)).toEqual({
+      allowed: false,
+      retryAfterMs: 5_000,
+    });
+  });
+
+  it('shares one user bucket across reconnect-style repeated calls', () => {
+    const limiter = new RealtimeAdmissionService();
+
+    for (let index = 0; index < 10; index += 1) {
+      expect(limiter.consume('user-1', 'membership', 10_000)).toEqual({ allowed: true });
+    }
+
+    expect(limiter.consume('user-1', 'membership', 10_000).allowed).toBe(false);
+  });
+
+  it('evicts old identities when the bounded bucket cap is reached', () => {
+    const limiter = new RealtimeAdmissionService();
+
+    for (let index = 0; index < 5; index += 1) {
+      limiter.consume('old-user', 'message', 0);
+    }
+
+    for (let index = 0; index < 10_000; index += 1) {
+      limiter.consume(`user-${index}`, 'message', 0);
+    }
+
+    expect(limiter.consume('old-user', 'message', 0)).toEqual({ allowed: true });
+  });
+
+  it('expires inactive window state', () => {
+    const limiter = new RealtimeAdmissionService();
+
+    for (let index = 0; index < 5; index += 1) {
+      limiter.consume('user-1', 'message', 0);
+    }
+
+    expect(limiter.consume('user-1', 'message', 60_001)).toEqual({ allowed: true });
+  });
+});

--- a/apps/api/src/chat/realtime-admission.service.ts
+++ b/apps/api/src/chat/realtime-admission.service.ts
@@ -3,8 +3,7 @@ import { Injectable } from '@nestjs/common';
 export type RealtimeAction = 'message' | 'typing' | 'membership';
 
 export type RealtimeAdmissionDecision =
-  | { allowed: true }
-  | { allowed: false; retryAfterMs: number };
+  { allowed: true } | { allowed: false; retryAfterMs: number };
 
 type WindowPolicy = {
   limit: number;

--- a/apps/api/src/chat/realtime-admission.service.ts
+++ b/apps/api/src/chat/realtime-admission.service.ts
@@ -44,11 +44,7 @@ export class RealtimeAdmissionService {
   private readonly buckets = new Map<string, Bucket>();
   private operations = 0;
 
-  consume(
-    userId: string,
-    action: RealtimeAction,
-    now = Date.now()
-  ): RealtimeAdmissionDecision {
+  consume(userId: string, action: RealtimeAction, now = Date.now()): RealtimeAdmissionDecision {
     this.operations += 1;
     if (this.operations % PRUNE_INTERVAL === 0) {
       this.pruneExpired(now);
@@ -102,9 +98,7 @@ export class RealtimeAdmissionService {
 
   private pruneExpired(now: number) {
     for (const [key, bucket] of this.buckets) {
-      bucket.timestamps = bucket.timestamps.filter(
-        (timestamp) => timestamp > now - MAX_WINDOW_MS
-      );
+      bucket.timestamps = bucket.timestamps.filter((timestamp) => timestamp > now - MAX_WINDOW_MS);
       if (bucket.timestamps.length === 0) {
         this.buckets.delete(key);
       }

--- a/apps/api/src/chat/realtime-admission.service.ts
+++ b/apps/api/src/chat/realtime-admission.service.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@nestjs/common';
+
+export type RealtimeAction = 'message' | 'typing' | 'membership';
+
+export type RealtimeAdmissionDecision =
+  | { allowed: true }
+  | { allowed: false; retryAfterMs: number };
+
+type WindowPolicy = {
+  limit: number;
+  windowMs: number;
+};
+
+type Bucket = {
+  timestamps: number[];
+  lastSeenAt: number;
+};
+
+export const REALTIME_ADMISSION_POLICIES: Record<RealtimeAction, WindowPolicy[]> = {
+  message: [
+    { limit: 5, windowMs: 1_000 },
+    { limit: 60, windowMs: 60_000 },
+  ],
+  typing: [
+    { limit: 8, windowMs: 5_000 },
+    { limit: 60, windowMs: 60_000 },
+  ],
+  membership: [
+    { limit: 10, windowMs: 5_000 },
+    { limit: 60, windowMs: 60_000 },
+  ],
+};
+
+const MAX_REALTIME_BUCKETS = 10_000;
+const PRUNE_INTERVAL = 256;
+const MAX_WINDOW_MS = Math.max(
+  ...Object.values(REALTIME_ADMISSION_POLICIES).flatMap((policies) =>
+    policies.map((policy) => policy.windowMs)
+  )
+);
+
+@Injectable()
+export class RealtimeAdmissionService {
+  private readonly buckets = new Map<string, Bucket>();
+  private operations = 0;
+
+  consume(
+    userId: string,
+    action: RealtimeAction,
+    now = Date.now()
+  ): RealtimeAdmissionDecision {
+    this.operations += 1;
+    if (this.operations % PRUNE_INTERVAL === 0) {
+      this.pruneExpired(now);
+    }
+
+    const key = `${action}:${userId}`;
+    let bucket = this.buckets.get(key);
+    if (!bucket) {
+      this.ensureCapacity(now);
+      bucket = { timestamps: [], lastSeenAt: now };
+      this.buckets.set(key, bucket);
+    }
+
+    bucket.timestamps = bucket.timestamps.filter((timestamp) => timestamp > now - MAX_WINDOW_MS);
+    bucket.lastSeenAt = now;
+
+    for (const policy of REALTIME_ADMISSION_POLICIES[action]) {
+      const windowStart = now - policy.windowMs;
+      const recent = bucket.timestamps.filter((timestamp) => timestamp > windowStart);
+      if (recent.length >= policy.limit) {
+        return {
+          allowed: false,
+          retryAfterMs: Math.max(1, recent[0]! + policy.windowMs - now),
+        };
+      }
+    }
+
+    bucket.timestamps.push(now);
+    return { allowed: true };
+  }
+
+  private ensureCapacity(now: number) {
+    if (this.buckets.size < MAX_REALTIME_BUCKETS) return;
+    this.pruneExpired(now);
+
+    while (this.buckets.size >= MAX_REALTIME_BUCKETS) {
+      let oldestKey: string | null = null;
+      let oldestSeenAt = Number.POSITIVE_INFINITY;
+
+      for (const [key, bucket] of this.buckets) {
+        if (bucket.lastSeenAt < oldestSeenAt) {
+          oldestSeenAt = bucket.lastSeenAt;
+          oldestKey = key;
+        }
+      }
+
+      if (!oldestKey) return;
+      this.buckets.delete(oldestKey);
+    }
+  }
+
+  private pruneExpired(now: number) {
+    for (const [key, bucket] of this.buckets) {
+      bucket.timestamps = bucket.timestamps.filter(
+        (timestamp) => timestamp > now - MAX_WINDOW_MS
+      );
+      if (bucket.timestamps.length === 0) {
+        this.buckets.delete(key);
+      }
+    }
+  }
+}

--- a/docs/DOGOS_REALTIME_ABUSE_CONTROL.md
+++ b/docs/DOGOS_REALTIME_ABUSE_CONTROL.md
@@ -1,0 +1,92 @@
+# dogOS Realtime Abuse Control v1
+
+## Release intent
+
+Woof's HTTP API has global throttling, but Socket.IO event handlers do not pass through that HTTP guard. Realtime chat therefore needs an explicit admission boundary before authenticated events can create database writes, conversation-access reads, or relationship-lock work.
+
+This release adds that boundary without changing canonical chat persistence, block policy, message idempotency, realtime recipient authorization, or database schema.
+
+## Admission authority
+
+`RealtimeAdmissionService` is a singleton inside `ChatModule` and keys buckets by authenticated user ID plus event class.
+
+The gateway consumes admission only after socket authentication has established the user identity, and before expensive work:
+
+- `message:send` before `persistMessage`
+- `conversation:join` and `conversation:leave` before `assertConversationAccess`
+- `typing:start` and `typing:stop` before `withAuthorizedRealtimeRecipients`
+
+A rejected event returns:
+
+- `success: false`
+- `error: rate_limited`
+- bounded `retryAfterMs`
+
+Rate limiting does not masquerade as an authorization failure and does not mutate canonical chat state.
+
+## v1 policies
+
+Message attempts:
+
+- 5 per 1 second
+- 60 per 60 seconds
+
+Typing events, with start and stop sharing one bucket:
+
+- 8 per 5 seconds
+- 60 per 60 seconds
+
+Conversation join/leave events, sharing one membership bucket:
+
+- 10 per 5 seconds
+- 60 per 60 seconds
+
+The current web client emits typing only on focus and blur, not for every keystroke. These limits therefore leave substantial room above normal product behavior while cutting off automated event floods.
+
+## Reconnect behavior
+
+Admission state is keyed by authenticated user rather than socket ID and is not cleared on disconnect.
+
+Reconnecting the same user to the same API process cannot reset an exhausted bucket. Socket presence state remains separate and is still removed normally on disconnect.
+
+## Bounded memory
+
+The limiter retains at most 10,000 active action/user buckets per API process.
+
+Expired timestamps are pruned periodically. When the cap is reached, stale state is removed first and the least recently seen remaining bucket is evicted if capacity is still required. One authenticated client therefore cannot grow limiter memory without bound by manufacturing socket IDs.
+
+## Scale boundary
+
+Realtime Abuse Control v1 is process-local, matching the current in-memory storage model used by the Nest HTTP throttler.
+
+It guarantees bounded work per API process and prevents reconnect resets on that process. It is not a claim of a globally distributed user quota across arbitrary API machines or regions. If Woof later requires a fleet-wide abuse budget, the admission storage can move to a shared atomic backend while preserving the gateway's admission-first contract and public error semantics.
+
+## Hard boundaries
+
+This release must preserve:
+
+- no database schema or migration changes
+- no weakening of PR #20 message retry/idempotency behavior
+- no weakening of PR #21 write-time block dominance
+- no weakening of PR #23 lock-bound realtime authorization
+- no use of socket ID as the rate-limit identity
+- no clearing a user's admission state on disconnect
+- no database or relationship-lock work before a denied event returns
+- no unbounded limiter map
+- no per-keystroke requirement in the web client
+
+## Qualification
+
+The dedicated CI lane must prove on one exact head:
+
+1. all inherited migrations still apply to real PostgreSQL;
+2. touched-file formatting, zero-warning lint, API TypeScript, unit contracts, and API build pass;
+3. message, typing, and membership admission occurs before downstream chat work;
+4. the limiter is user-keyed, expiry-pruned, and bounded;
+5. prior chat authorization, persistence, retry, and block-dominance regressions remain green;
+6. the production Docker image boots;
+7. an authenticated Socket.IO client is cut off for message, typing, and membership floods;
+8. reconnecting the same user does not reset an exhausted message bucket;
+9. a distinct authenticated user retains an independent message bucket.
+
+Earlier diagnostic heads never count as release evidence.


### PR DESCRIPTION
## dogOS Realtime Abuse Control v1

Base: exact Proxy-Safe Throttling production merge `b38a86d77ca1775d0680f25c4c09e08c86e83ee6`.

Qualified exact head: `93a7a9e241549ee667e75a81fe39b488b0314d53`.

This release closes an abuse-control gap in Woof's realtime chat transport without changing database schema, canonical chat persistence, block semantics, message idempotency, or realtime recipient authorization.

### Problem closed

The global Nest `ThrottlerGuard` protects HTTP requests, but Socket.IO handlers do not pass through that HTTP guard. An authenticated client could therefore repeatedly invoke `message:send`, typing, or conversation join/leave events and force database writes, access reads, or participant relationship-lock work without a realtime admission budget.

Typing is especially important because each accepted event can invoke lock-bound current recipient authorization. The production web client emits typing only on focus/blur, not per keystroke, so legitimate product traffic is far below the selected ceilings.

### Admission-first boundary

A singleton `RealtimeAdmissionService` now admits authenticated event classes before expensive chat work:

- `message:send` before `persistMessage`
- `conversation:join` and `conversation:leave` before `assertConversationAccess`
- `typing:start` and `typing:stop` before `withAuthorizedRealtimeRecipients`

Denied events return `success: false`, `error: rate_limited`, and a positive `retryAfterMs` without entering canonical persistence or authorization work.

### Policies

Message attempts:
- 5 / 1 second
- 60 / 60 seconds

Typing start/stop share one bucket:
- 8 / 5 seconds
- 60 / 60 seconds

Conversation join/leave share one membership bucket:
- 10 / 5 seconds
- 60 / 60 seconds

### Identity, reconnects, and memory

Buckets are keyed by authenticated `action:userId`, never socket ID. Disconnect removes socket presence but does not clear admission state, so reconnecting the same authenticated user to the same API process cannot reset an exhausted bucket.

The process-local limiter is bounded to 10,000 active action/user buckets, periodically prunes expired state, and evicts least-recently-seen state when the cap remains full.

This v1 intentionally matches the current process-local storage model of Woof's HTTP throttler. It is a per-process abuse boundary, not a claim of a globally distributed quota. A future shared atomic backend can replace storage without changing the gateway contract.

### Diagnostic heads

The first two candidate heads were rejected only by touched-file formatting before semantic qualification:

- `64a34385a17565bf8e9cb08d1306069ee54db2e9` — initial Prettier rejection
- `713a52fd9d08c04163006f600cc2ef7e3a059460` — remaining union-type formatting delta

The second correction was copied from the exact `prettier --write` diff emitted by the inherited Trust + Discovery lane. Neither diagnostic correction changed runtime behavior. Diagnostic heads do not qualify the release.

### Exact-head qualification receipts

Every workflow actually triggered by this chat ownership surface completed successfully on the same frozen SHA `93a7a9e241549ee667e75a81fe39b488b0314d53`:

- dogOS Realtime Abuse Control CI — `32702409889`
- dogOS Live Authorization CI — `32702409892`
- dogOS Trust Enforcement Atomicity CI — `32702409869`
- dogOS Network Integrity + Scale CI — `32702409864`
- dogOS Chat Delivery Integrity CI — `32702409887`
- dogOS Trust + Discovery CI — `32702409888`
- root CI — `32702409855`

### Production-image and concurrency proof

The dedicated Realtime Abuse Control lane passed, on the exact qualified head:

1. all 16 inherited migrations apply to real PostgreSQL;
2. no schema or migration ownership is introduced;
3. touched-file formatting and zero-warning lint pass;
4. admission is structurally before persistence, access checks, and lock-bound realtime authorization;
5. API TypeScript passes;
6. realtime limiter and gateway unit contracts pass;
7. inherited PostgreSQL block-dominance and live-authorization race regressions pass;
8. the API builds;
9. the actual production Docker image builds and boots;
10. a real authenticated Socket.IO client is rate-limited for message, typing, and membership floods;
11. reconnecting the same authenticated user does not reset its exhausted message bucket;
12. a distinct authenticated user retains an independent message bucket.

The inherited owner lanes independently preserve caller-owned retry identity, canonical delivery receipts, block atomicity, participant relationship-lock ordering, authorized private-room fanout, network/privacy contracts, backend tests, frontend tests, browser contracts, and production builds.

No database schema or migration changes are owned by this release.

See `docs/DOGOS_REALTIME_ABUSE_CONTROL.md`.