### PR TITLE
CI: modernize GitHub Action runtimes

### DIFF
--- a/.github/workflows/adventure-system-ci.yml
+++ b/.github/workflows/adventure-system-ci.yml
@@ -66,13 +66,13 @@ jobs:
       ENABLE_ADVENTURE_SYSTEM: 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/behavior-vision-branch-ci.yml
+++ b/.github/workflows/behavior-vision-branch-ci.yml
@@ -22,13 +22,13 @@ jobs:
       NEXT_PUBLIC_API_URL: http://127.0.0.1:59999/api/v1
       ML_SERVICE_ENABLED: 'false'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/ci-action-runtime-ci.yml
+++ b/.github/workflows/ci-action-runtime-ci.yml
@@ -1,0 +1,110 @@
+name: CI Action Runtime Qualification
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'docs/CI_ACTION_RUNTIME.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-action-runtime-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  qualify:
+    name: Maintained action runtime + project toolchain qualification
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Verify project runtime stays pinned
+        run: |
+          test "$(node --version)" = "v${NODE_VERSION}"
+          test "$(pnpm --version)" = "${PNPM_VERSION}"
+
+      - name: Install from committed lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Enforce maintained action majors across every workflow
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          allowed = {
+              'actions/checkout': 'v7',
+              'actions/setup-node': 'v7',
+              'pnpm/action-setup': 'v6',
+              'actions/upload-artifact': 'v7',
+          }
+
+          workflows = sorted(Path('.github/workflows').glob('*.yml'))
+          if not workflows:
+              raise SystemExit('no GitHub Actions workflows found')
+
+          seen = {action: 0 for action in allowed}
+          violations = []
+          for workflow in workflows:
+              for line_number, line in enumerate(workflow.read_text().splitlines(), start=1):
+                  stripped = line.strip()
+                  if not stripped.startswith('- uses:') and not stripped.startswith('uses:'):
+                      continue
+                  for action, expected_version in allowed.items():
+                      marker = f'{action}@'
+                      if marker not in stripped:
+                          continue
+                      seen[action] += 1
+                      actual_version = stripped.split(marker, 1)[1].split()[0].strip("'\"")
+                      if actual_version != expected_version:
+                          violations.append(
+                              f'{workflow}:{line_number}: {action}@{actual_version} '
+                              f'must be {action}@{expected_version}'
+                          )
+
+          if violations:
+              raise SystemExit('\n'.join(violations))
+
+          required = ['actions/checkout', 'actions/setup-node', 'pnpm/action-setup']
+          missing = [action for action in required if seen[action] == 0]
+          if missing:
+              raise SystemExit(f'missing required maintained action families: {missing}')
+          PY
+
+      - name: Parse and format-check the complete workflow inventory
+        run: pnpm exec prettier --check .github/workflows docs/CI_ACTION_RUNTIME.md
+
+      - name: Record qualification proof
+        run: |
+          {
+            echo "node=$(node --version)"
+            echo "pnpm=$(pnpm --version)"
+            echo "workflows=$(find .github/workflows -maxdepth 1 -type f -name '*.yml' | wc -l | tr -d ' ')"
+          } > /tmp/ci-action-runtime-proof.txt
+          cat /tmp/ci-action-runtime-proof.txt
+
+      - name: Exercise maintained artifact upload runtime
+        uses: actions/upload-artifact@v7
+        with:
+          name: ci-action-runtime-${{ github.run_id }}
+          path: /tmp/ci-action-runtime-proof.txt
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,15 @@ jobs:
     name: Static quality gates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -120,15 +120,15 @@ jobs:
       ML_SERVICE_ENABLED: 'false'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -155,15 +155,15 @@ jobs:
       NEXT_PUBLIC_API_URL: http://127.0.0.1:59999/api/v1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-${{ github.run_id }}
           path: apps/web/playwright-report
@@ -198,15 +198,15 @@ jobs:
       ML_SERVICE_ENABLED: 'false'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install pinned Fly.io CLI
         uses: superfly/flyctl-actions/setup-flyctl@v1.5
@@ -48,7 +48,7 @@ jobs:
     environment: production
     needs: deploy-api-production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install pinned Vercel CLI
         run: npm install --global vercel@58.4.4

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install pinned Fly.io CLI
         uses: superfly/flyctl-actions/setup-flyctl@v1.5
@@ -39,7 +39,7 @@ jobs:
     environment: staging
     needs: deploy-api-staging
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install pinned Vercel CLI
         run: npm install --global vercel@58.4.4

--- a/.github/workflows/dogos-autopilot-ci.yml
+++ b/.github/workflows/dogos-autopilot-ci.yml
@@ -59,13 +59,13 @@ jobs:
       ENABLE_DOGOS_AUTOPILOT: 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-behavior-moments-ci.yml
+++ b/.github/workflows/dogos-behavior-moments-ci.yml
@@ -33,15 +33,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-chat-delivery-integrity-ci.yml
+++ b/.github/workflows/dogos-chat-delivery-integrity-ci.yml
@@ -32,15 +32,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-concierge-ci.yml
+++ b/.github/workflows/dogos-concierge-ci.yml
@@ -39,15 +39,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-connectors-ci.yml
+++ b/.github/workflows/dogos-connectors-ci.yml
@@ -61,13 +61,13 @@ jobs:
       CONNECTOR_CREDENTIALS_KEY: BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-foundation-ci.yml
+++ b/.github/workflows/dogos-foundation-ci.yml
@@ -57,13 +57,13 @@ jobs:
       ENABLE_ADVENTURE_SYSTEM: 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-live-authorization-ci.yml
+++ b/.github/workflows/dogos-live-authorization-ci.yml
@@ -46,15 +46,15 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-network-integrity-ci.yml
+++ b/.github/workflows/dogos-network-integrity-ci.yml
@@ -45,15 +45,15 @@ jobs:
       ML_SERVICE_ENABLED: 'false'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-observability-device-ci.yml
+++ b/.github/workflows/dogos-observability-device-ci.yml
@@ -56,15 +56,15 @@ jobs:
       OPS_METRICS_TOKEN: ci-only-ops-metrics-secret-0123456789abcdef
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-our-story-ci.yml
+++ b/.github/workflows/dogos-our-story-ci.yml
@@ -58,13 +58,13 @@ jobs:
       ENABLE_DOGOS_OUR_STORY: 'true'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-production-runtime-ci.yml
+++ b/.github/workflows/dogos-production-runtime-ci.yml
@@ -57,15 +57,15 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-proxy-safe-throttling-ci.yml
+++ b/.github/workflows/dogos-proxy-safe-throttling-ci.yml
@@ -46,15 +46,15 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-realtime-abuse-ci.yml
+++ b/.github/workflows/dogos-realtime-abuse-ci.yml
@@ -48,15 +48,15 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-release-polish-ci.yml
+++ b/.github/workflows/dogos-release-polish-ci.yml
@@ -46,15 +46,15 @@ jobs:
       NEXT_PUBLIC_API_URL: http://127.0.0.1:59999/api/v1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-trust-discovery-ci.yml
+++ b/.github/workflows/dogos-trust-discovery-ci.yml
@@ -70,15 +70,15 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/dogos-trust-enforcement-atomicity-ci.yml
+++ b/.github/workflows/dogos-trust-enforcement-atomicity-ci.yml
@@ -45,15 +45,15 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/media-library-branch-ci.yml
+++ b/.github/workflows/media-library-branch-ci.yml
@@ -41,13 +41,13 @@ jobs:
       ML_SERVICE_ENABLED: 'false'
       MEDIA_DERIVATIVES_ENABLED: 'false'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/docs/CI_ACTION_RUNTIME.md
+++ b/docs/CI_ACTION_RUNTIME.md
@@ -1,0 +1,46 @@
+# CI Action Runtime Contract
+
+Woof keeps the runtime used by GitHub Actions themselves separate from the Node.js runtime used to build and test the product.
+
+## Maintained action executors
+
+Repository workflows standardize on these action majors:
+
+- `actions/checkout@v7`
+- `actions/setup-node@v7`
+- `pnpm/action-setup@v6`
+- `actions/upload-artifact@v7`
+
+These maintained action lines use the current GitHub Actions Node 24 execution generation instead of the deprecated Node 20 action runtime that GitHub-hosted runners were already forcing forward during qualification runs.
+
+The repository does not use removed `actions/setup-node` inputs such as `always-auth`, and it does not depend on an `actions/download-artifact@v4` workflow contract.
+
+## Product toolchain remains unchanged
+
+This release does **not** migrate the application runtime.
+
+Woof continues to build and test with:
+
+- Node.js `20.20.2`
+- pnpm `8.15.1`
+
+`actions/setup-node@v7` installs that exact project Node version. `pnpm/action-setup@v6` installs that exact pnpm version.
+
+The release also leaves Fly CLI, Vercel CLI, Docker image Node, database migrations, dependency lockfiles, and deployment behavior unchanged.
+
+## Executable drift guard
+
+`.github/workflows/ci-action-runtime-ci.yml` runs for workflow changes and:
+
+1. uses the maintained checkout, pnpm, setup-node, and artifact-upload actions itself;
+2. proves the project runtime resolves to Node `20.20.2` and pnpm `8.15.1`;
+3. scans every workflow and rejects an unapproved major for the four standardized action families;
+4. runs Prettier over the complete workflow inventory so malformed YAML cannot pass silently;
+5. performs a frozen lockfile install; and
+6. uploads a one-day qualification artifact so `actions/upload-artifact@v7` is exercised on a successful path.
+
+A future action-major change should be an explicit, qualified infrastructure release rather than silent version drift.
+
+## Release qualification
+
+Changing shared workflow infrastructure has a wide ownership surface. A release is qualified only when every workflow actually triggered by the PR completes successfully on one frozen exact head SHA. Earlier diagnostic heads do not count.


### PR DESCRIPTION
## CI Action Runtime Modernization

Base production merge: `50920b9c5e0cf7df33eda6804422d3db676df5dd`.

**Qualified exact head:** `4675951c596d206258bd79e930deba25ba3c8199`.

This release removes the repository-wide implicit Node 20 action-runtime fallback by moving the complete current workflow inventory to maintained GitHub Action generations while deliberately leaving Woof's application runtime unchanged.

### Repository-wide executor modernization

All 22 pre-existing workflow files now standardize on:

- `actions/checkout@v7`
- `actions/setup-node@v7`
- `pnpm/action-setup@v6`
- `actions/upload-artifact@v7` where artifact upload is used

Every ordinary owner workflow otherwise preserves its path ownership, checkout depth, PostgreSQL services, structural gates, tests, Docker proofs, deployment commands, and qualification semantics.

### Product runtime remains intentionally unchanged

This is **not** an application Node migration. Woof still builds and tests with exactly:

- Node.js `20.20.2`
- pnpm `8.15.1`

The release does not change dependency lockfiles, database schema or migrations, Docker image Node or pnpm versions, Fly/Vercel configuration, deployment semantics, or product behavior.

### Permanent drift guard

New `.github/workflows/ci-action-runtime-ci.yml` runs on workflow changes and proves:

1. checkout v7, setup-node v7, pnpm/action-setup v6, and upload-artifact v7 execute successfully;
2. the project still resolves to Node `20.20.2` and pnpm `8.15.1`;
3. the frozen lockfile install succeeds;
4. every workflow is scanned and the standardized action families must use the approved majors;
5. the complete workflow inventory and runtime-contract document pass Prettier parsing/checking; and
6. `actions/upload-artifact@v7` executes on a successful path and produces a qualification artifact.

The contract is documented in `docs/CI_ACTION_RUNTIME.md`.

### Exact-head qualification receipts

All **19 workflows actually triggered by this PR** completed successfully on the same exact head `4675951c596d206258bd79e930deba25ba3c8199`:

- CI Action Runtime Qualification — run `32705066341`
- root CI — run `32705066553`
- Adventure System CI — run `32705066462`
- dogOS Autopilot CI — run `32705066303`
- dogOS Behavior Moments Shadow CI — run `32705066313`
- dogOS Chat Delivery Integrity CI — run `32705066298`
- dogOS Concierge CI — run `32705066556`
- dogOS Connectors CI — run `32705066403`
- dogOS Foundation CI — run `32705066486`
- dogOS Live Authorization CI — run `32705066283`
- dogOS Network Integrity + Scale CI — run `32705066527`
- dogOS Observability + Device Contracts CI — run `32705066402`
- dogOS Our Story CI — run `32705066455`
- dogOS Production Runtime CI — run `32705066444`
- dogOS Proxy-Safe Throttling CI — run `32705066657`
- dogOS Realtime Abuse Control CI — run `32705066466`
- dogOS Release Polish CI — run `32705066343`
- dogOS Trust + Discovery CI — run `32705066472`
- dogOS Trust Enforcement Atomicity CI — run `32705066357`

The two branch-only workflows and two push-only deployment workflows correctly do not trigger as PR workflows; their workflow files are still included in the repository-wide action-major and Prettier inventory checks.

### Deep proof receipts

The Action Runtime job `97364277104` passed every terminal proof, including exact project-runtime verification, frozen install, repository-wide action-major enforcement, whole-workflow formatting/parsing, and the successful artifact-v7 execution. The emitted artifact is `ci-action-runtime-32705066341` (`9511932541`), tied to this exact head.

Production Runtime job `97364277461` passed the full migration chain, runtime/privacy invariants, API type/tests/build, production Docker build, image contract verification, and live production-image HTTP contract boot.

Realtime Abuse job `97364293055` passed its bounded-admission structural gates, unit and real PostgreSQL authorization races, production Docker build/boot, and the authenticated Socket.IO flood + reconnect-retention proof.

### Diagnostic history

The earlier candidate `d00ebc0d905ec6dbb860d9d39e331bdd5b2a982b` is diagnostic only. It proved the new action executors, exact Node/pnpm resolution, frozen install, and repository-wide major scan, but the new full-inventory Prettier gate surfaced one inherited missing final newline in `behavior-vision-branch-ci.yml`.

That single formatting byte was normalized without changing workflow behavior and the release was re-squashed to one commit directly on the production base. No earlier head counts as release evidence.

### Scope audit

The qualified branch is exactly one commit ahead of production and zero behind. The diff contains exactly 24 files:

- 22 existing workflow YAML files;
- 1 new action-runtime qualification workflow;
- 1 new documentation file.

Every existing workflow is a pure action-major substitution except the Behavior Vision branch workflow, which additionally receives the verified inherited EOF normalization. No application, schema, migration, lockfile, or infrastructure configuration file is changed.