### PR TITLE
dogOS Realtime: enforce runtime payload integrity

### DIFF
--- a/.github/workflows/dogos-realtime-payload-integrity-ci.yml
+++ b/.github/workflows/dogos-realtime-payload-integrity-ci.yml
@@ -1,0 +1,374 @@
+name: dogOS Realtime Payload Integrity CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/chat/chat-input-contract.ts'
+      - 'apps/api/src/chat/chat-input-contract.spec.ts'
+      - 'apps/api/src/chat/chat.gateway.ts'
+      - 'apps/api/src/chat/chat.gateway.spec.ts'
+      - 'apps/api/src/chat/chat-security.service.ts'
+      - 'apps/api/src/chat/chat-security.service.spec.ts'
+      - '.github/workflows/dogos-realtime-payload-integrity-ci.yml'
+      - 'docs/DOGOS_REALTIME_PAYLOAD_INTEGRITY.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-realtime-payload-integrity-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  JWT_SECRET: ci-only-realtime-payload-secret-12345678901234567890
+  NODE_ENV: test
+  ML_SERVICE_ENABLED: 'false'
+
+jobs:
+  qualify:
+    name: Runtime payload boundary + production image qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject schema and migration ownership changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
+            echo 'Realtime Payload Integrity v1 does not own database schema or migration changes.'
+            exit 1
+          fi
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check Realtime Payload Integrity formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/chat/chat-input-contract.ts
+          apps/api/src/chat/chat-input-contract.spec.ts
+          apps/api/src/chat/chat.gateway.ts
+          apps/api/src/chat/chat.gateway.spec.ts
+          apps/api/src/chat/chat-security.service.ts
+          apps/api/src/chat/chat-security.service.spec.ts
+          .github/workflows/dogos-realtime-payload-integrity-ci.yml
+          docs/DOGOS_REALTIME_PAYLOAD_INTEGRITY.md
+
+      - name: Lint Realtime Payload Integrity API surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/chat/chat-input-contract.ts
+          src/chat/chat-input-contract.spec.ts
+          src/chat/chat.gateway.ts
+          src/chat/chat.gateway.spec.ts
+          src/chat/chat-security.service.ts
+          src/chat/chat-security.service.spec.ts
+
+      - name: Enforce validation before admission and chat work
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          contract = Path('apps/api/src/chat/chat-input-contract.ts').read_text()
+          gateway = Path('apps/api/src/chat/chat.gateway.ts').read_text()
+          security = Path('apps/api/src/chat/chat-security.service.ts').read_text()
+
+          required_contract = [
+              'MAX_CHAT_MESSAGE_LENGTH = 4_000',
+              'MAX_CHAT_IDENTIFIER_LENGTH = 128',
+              'MAX_REALTIME_PACKET_BYTES = 32 * 1024',
+              'parseSendChatMessagePayload',
+              'parseConversationPayload',
+              'normalizeChatMessageText',
+              "value.includes('\\u0000')",
+          ]
+          missing = [token for token in required_contract if token not in contract]
+          if missing:
+              raise SystemExit(f'missing realtime input contract: {missing}')
+
+          if 'maxHttpBufferSize: MAX_REALTIME_PACKET_BYTES' not in gateway:
+              raise SystemExit('Socket.IO must enforce the bounded packet ceiling')
+          if 'data.conversationId' in gateway:
+              raise SystemExit('gateway must never dereference unvalidated message-body shapes directly')
+
+          message_start = gateway.index("@SubscribeMessage('message:send')")
+          join_start = gateway.index("@SubscribeMessage('conversation:join')")
+          leave_start = gateway.index("@SubscribeMessage('conversation:leave')")
+          typing_start = gateway.index("@SubscribeMessage('typing:start')")
+          typing_impl = gateway.index('private async emitTyping')
+
+          message = gateway[message_start:join_start]
+          join = gateway[join_start:leave_start]
+          leave = gateway[leave_start:typing_start]
+          typing = gateway[typing_impl:]
+
+          checks = [
+              (
+                  'message',
+                  message,
+                  'parseSendChatMessagePayload(data)',
+                  "realtimeAdmission.consume(userId, 'message')",
+                  'chatSecurity.persistMessage',
+              ),
+              (
+                  'join',
+                  join,
+                  'parseConversationPayload(data)',
+                  "realtimeAdmission.consume(userId, 'membership')",
+                  'chatSecurity.assertConversationAccess',
+              ),
+              (
+                  'leave',
+                  leave,
+                  'parseConversationPayload(data)',
+                  "realtimeAdmission.consume(userId, 'membership')",
+                  'chatSecurity.assertConversationAccess',
+              ),
+              (
+                  'typing',
+                  typing,
+                  'parseConversationPayload(data)',
+                  "realtimeAdmission.consume(userId, 'typing')",
+                  'chatSecurity.withAuthorizedRealtimeRecipients',
+              ),
+          ]
+          for label, handler, parser, admission_call, expensive_call in checks:
+              identity = handler.find('connectedUsers.get(client.id)')
+              parsed = handler.find(parser)
+              invalid = handler.find("error: 'invalid_payload'")
+              admission = handler.find(admission_call)
+              expensive = handler.find(expensive_call)
+              if min(identity, parsed, invalid, admission, expensive) < 0:
+                  raise SystemExit(f'{label} handler is missing a payload-ordering invariant')
+              if not identity < parsed < invalid < admission < expensive:
+                  raise SystemExit(
+                      f'{label} must authenticate, validate, reject invalid input, admit, then perform chat work'
+                  )
+
+          persist_start = security.index('async persistMessage')
+          access = security.index('await this.assertConversationAccess', persist_start)
+          validation_tokens = [
+              'isChatIdentifier(input.conversationId)',
+              'isClientMessageId(input.clientMessageId)',
+              'input.text.length > MAX_CHAT_MESSAGE_LENGTH',
+              "input.text.includes('\\u0000')",
+              'normalizeChatMessageText(input.text)',
+          ]
+          for token in validation_tokens:
+              location = security.find(token, persist_start, access)
+              if location < 0:
+                  raise SystemExit(f'persistMessage must validate before its first database read: {token}')
+          PY
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Run payload, gateway, persistence, and admission contracts
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/chat/chat-input-contract.spec.ts
+          src/chat/chat.gateway.spec.ts
+          src/chat/chat-security.service.spec.ts
+          src/chat/realtime-admission.service.spec.ts
+
+      - name: Run existing PostgreSQL authorization race regressions
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/chat/chat-realtime-authorization.integration.spec.ts
+          src/chat/chat-block-atomicity.integration.spec.ts
+          src/chat/chat.service.integration.spec.ts
+
+      - name: Build API
+        run: pnpm --filter @woof/api build
+
+      - name: Build production API image
+        run: docker build --pull -f infra/docker/Dockerfile.api -t woof-api-realtime-payload:ci .
+
+      - name: Boot production image
+        run: |
+          docker rm -f woof-api-realtime-payload-ci >/dev/null 2>&1 || true
+          docker run -d --name woof-api-realtime-payload-ci --network host \
+            -e DATABASE_URL="$DATABASE_URL" \
+            -e SHADOW_DATABASE_URL="$SHADOW_DATABASE_URL" \
+            -e JWT_SECRET="$JWT_SECRET" \
+            -e NODE_ENV=production \
+            -e API_DOCS_ENABLED=false \
+            -e CORS_ORIGIN=http://localhost:3000 \
+            woof-api-realtime-payload:ci
+
+          live=0
+          for attempt in $(seq 1 30); do
+            status=$(curl --silent --show-error --output /tmp/realtime-payload-live.json --write-out '%{http_code}' \
+              http://127.0.0.1:4000/api/v1/ops/health/live || true)
+            if [ "$status" = '200' ]; then
+              live=1
+              break
+            fi
+            if ! docker ps --format '{{.Names}}' | grep -Fxq woof-api-realtime-payload-ci; then
+              echo "Production image exited before liveness; status=$status"
+              cat /tmp/realtime-payload-live.json 2>/dev/null || true
+              docker logs woof-api-realtime-payload-ci || true
+              exit 1
+            fi
+            sleep 1
+          done
+          if [ "$live" -ne 1 ]; then
+            echo 'Production image never reached liveness.'
+            docker logs woof-api-realtime-payload-ci || true
+            exit 1
+          fi
+
+      - name: Prove malformed payload rejection and transport ceiling
+        run: |
+          pnpm --filter @woof/web exec node <<'NODE'
+          const crypto = require('node:crypto');
+          const { io } = require('socket.io-client');
+
+          const secret = process.env.JWT_SECRET;
+          if (!secret) throw new Error('JWT_SECRET is required');
+
+          function jwt(sub) {
+            const now = Math.floor(Date.now() / 1000);
+            const encode = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
+            const header = encode({ alg: 'HS256', typ: 'JWT' });
+            const payload = encode({ sub, iat: now, exp: now + 300 });
+            const unsigned = `${header}.${payload}`;
+            const signature = crypto.createHmac('sha256', secret).update(unsigned).digest('base64url');
+            return `${unsigned}.${signature}`;
+          }
+
+          function connect(sub) {
+            return new Promise((resolve, reject) => {
+              const socket = io('http://127.0.0.1:4000', {
+                auth: { token: jwt(sub) },
+                transports: ['websocket'],
+                reconnection: false,
+                timeout: 4_000,
+              });
+              socket.once('connect', () => resolve(socket));
+              socket.once('connect_error', reject);
+            });
+          }
+
+          function ack(socket, event, payload) {
+            return new Promise((resolve, reject) => {
+              socket.timeout(4_000).emit(event, payload, (error, response) => {
+                if (error) reject(error);
+                else resolve(response);
+              });
+            });
+          }
+
+          function expectInvalid(response, label) {
+            if (!response || response.success !== false || response.error !== 'invalid_payload') {
+              throw new Error(`${label} expected invalid_payload, got ${JSON.stringify(response)}`);
+            }
+          }
+
+          (async () => {
+            const socket = await connect('socket-payload-user-1');
+
+            expectInvalid(await ack(socket, 'message:send', null), 'null message');
+            expectInvalid(
+              await ack(socket, 'message:send', {
+                conversationId: 'conversation-1',
+                clientMessageId: 'short',
+                text: 'hello',
+              }),
+              'short retry id'
+            );
+            expectInvalid(
+              await ack(socket, 'message:send', {
+                conversationId: 'conversation-1',
+                clientMessageId: 'client-message-oversized',
+                text: 'x'.repeat(4_001),
+              }),
+              'oversized text'
+            );
+            expectInvalid(await ack(socket, 'typing:start', null), 'null typing');
+            expectInvalid(
+              await ack(socket, 'conversation:join', { conversationId: 'bad id' }),
+              'malformed membership id'
+            );
+
+            for (let index = 0; index < 10; index += 1) {
+              expectInvalid(await ack(socket, 'message:send', null), `invalid message ${index}`);
+            }
+
+            const ordinary = await ack(socket, 'message:send', {
+              conversationId: 'missing-conversation',
+              clientMessageId: 'client-message-after-invalids',
+              text: 'ordinary bounded payload',
+            });
+            if (!ordinary || ordinary.error !== 'message_rejected') {
+              throw new Error(
+                `invalid payloads must not consume admission budget; got ${JSON.stringify(ordinary)}`
+              );
+            }
+            socket.disconnect();
+
+            const oversized = await connect('socket-payload-user-2');
+            const disconnected = new Promise((resolve, reject) => {
+              const timer = setTimeout(
+                () => reject(new Error('over-ceiling Socket.IO frame did not disconnect')),
+                4_000
+              );
+              oversized.once('disconnect', (reason) => {
+                clearTimeout(timer);
+                resolve(reason);
+              });
+            });
+
+            oversized.emit('typing:start', { conversationId: 'x'.repeat(40_000) });
+            await disconnected;
+            if (oversized.connected) {
+              throw new Error('over-ceiling Socket.IO frame must leave the socket disconnected');
+            }
+          })().catch((error) => {
+            console.error(error);
+            process.exitCode = 1;
+          });
+          NODE
+
+      - name: Stop production image
+        if: always()
+        run: docker rm -f woof-api-realtime-payload-ci >/dev/null 2>&1 || true

--- a/.github/workflows/dogos-trust-discovery-ci.yml
+++ b/.github/workflows/dogos-trust-discovery-ci.yml
@@ -187,14 +187,27 @@ jobs:
           typing_handler = source[private_typing:user_rooms]
 
           room_checks = [
-              ('conversation join', join_handler, 'client.join(`conversation:${data.conversationId}`)'),
-              ('conversation leave', leave_handler, 'client.leave(`conversation:${data.conversationId}`)'),
+              (
+                  'conversation join',
+                  join_handler,
+                  'parseConversationPayload(data)',
+                  'client.join(`conversation:${payload.conversationId}`)',
+              ),
+              (
+                  'conversation leave',
+                  leave_handler,
+                  'parseConversationPayload(data)',
+                  'client.leave(`conversation:${payload.conversationId}`)',
+              ),
           ]
-          for label, handler, room_operation in room_checks:
+          for label, handler, parser, room_operation in room_checks:
+              validation = handler.find(parser)
               authorization = handler.find('chatSecurity.assertConversationAccess')
               operation = handler.find(room_operation)
-              if authorization < 0 or operation < 0 or authorization > operation:
-                  raise SystemExit(f'{label} must authorize conversation access before its room operation')
+              if min(validation, authorization, operation) < 0 or not validation < authorization < operation:
+                  raise SystemExit(
+                      f'{label} must validate payload, authorize conversation access, then mutate its room'
+                  )
 
           typing_required = [
               'chatSecurity.withAuthorizedRealtimeRecipients',
@@ -215,6 +228,8 @@ jobs:
           forbidden_typing = [
               'client.to(`conversation:${conversationId}`)',
               'this.server.to(`conversation:${conversationId}`)',
+              'client.to(`conversation:${payload.conversationId}`)',
+              'this.server.to(`conversation:${payload.conversationId}`)',
           ]
           present = [token for token in forbidden_typing if token in typing_handler]
           if present:

--- a/apps/api/src/chat/chat-input-contract.spec.ts
+++ b/apps/api/src/chat/chat-input-contract.spec.ts
@@ -1,0 +1,72 @@
+import {
+  MAX_CHAT_MESSAGE_LENGTH,
+  MAX_REALTIME_PACKET_BYTES,
+  normalizeChatMessageText,
+  parseConversationPayload,
+  parseSendChatMessagePayload,
+} from './chat-input-contract';
+
+describe('chat input contract', () => {
+  it('normalizes a valid message payload', () => {
+    expect(
+      parseSendChatMessagePayload({
+        conversationId: 'conversation-1',
+        clientMessageId: 'client-message-123',
+        text: '  hello  ',
+      })
+    ).toEqual({
+      conversationId: 'conversation-1',
+      clientMessageId: 'client-message-123',
+      text: 'hello',
+    });
+  });
+
+  it.each([null, [], 'message', 42])('rejects non-object message payloads: %p', (payload) => {
+    expect(parseSendChatMessagePayload(payload)).toBeNull();
+  });
+
+  it('rejects oversized raw text before normalization', () => {
+    expect(
+      parseSendChatMessagePayload({
+        conversationId: 'conversation-1',
+        clientMessageId: 'client-message-123',
+        text: 'x'.repeat(MAX_CHAT_MESSAGE_LENGTH + 1),
+      })
+    ).toBeNull();
+  });
+
+  it('rejects empty and PostgreSQL-incompatible NUL text', () => {
+    expect(normalizeChatMessageText('   ')).toBeNull();
+    expect(normalizeChatMessageText('hello\u0000world')).toBeNull();
+  });
+
+  it('rejects malformed conversation and retry identifiers', () => {
+    expect(
+      parseSendChatMessagePayload({
+        conversationId: 'bad id',
+        clientMessageId: 'client-message-123',
+        text: 'hello',
+      })
+    ).toBeNull();
+    expect(
+      parseSendChatMessagePayload({
+        conversationId: 'conversation-1',
+        clientMessageId: 'short',
+        text: 'hello',
+      })
+    ).toBeNull();
+  });
+
+  it('accepts only bounded conversation payloads', () => {
+    expect(parseConversationPayload({ conversationId: 'conversation-1' })).toEqual({
+      conversationId: 'conversation-1',
+    });
+    expect(parseConversationPayload(null)).toBeNull();
+    expect(parseConversationPayload({ conversationId: 'x'.repeat(129) })).toBeNull();
+  });
+
+  it('keeps the transport ceiling comfortably above the application message contract', () => {
+    expect(MAX_REALTIME_PACKET_BYTES).toBe(32 * 1024);
+    expect(MAX_REALTIME_PACKET_BYTES).toBeGreaterThan(MAX_CHAT_MESSAGE_LENGTH * 4);
+  });
+});

--- a/apps/api/src/chat/chat-input-contract.ts
+++ b/apps/api/src/chat/chat-input-contract.ts
@@ -1,0 +1,56 @@
+export const MAX_CHAT_MESSAGE_LENGTH = 4_000;
+export const MAX_CHAT_IDENTIFIER_LENGTH = 128;
+export const MAX_REALTIME_PACKET_BYTES = 32 * 1024;
+
+const CHAT_IDENTIFIER_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
+const CLIENT_MESSAGE_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
+
+export type SendChatMessage = {
+  conversationId: string;
+  clientMessageId: string;
+  text: string;
+};
+
+export type ConversationPayload = {
+  conversationId: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isChatIdentifier(value: unknown): value is string {
+  return typeof value === 'string' && CHAT_IDENTIFIER_PATTERN.test(value);
+}
+
+export function isClientMessageId(value: unknown): value is string {
+  return typeof value === 'string' && CLIENT_MESSAGE_ID_PATTERN.test(value);
+}
+
+export function normalizeChatMessageText(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  if (value.length > MAX_CHAT_MESSAGE_LENGTH || value.includes('\u0000')) return null;
+
+  const text = value.trim();
+  return text.length > 0 ? text : null;
+}
+
+export function parseSendChatMessagePayload(value: unknown): SendChatMessage | null {
+  if (!isRecord(value)) return null;
+  if (!isChatIdentifier(value.conversationId)) return null;
+  if (!isClientMessageId(value.clientMessageId)) return null;
+
+  const text = normalizeChatMessageText(value.text);
+  if (text === null) return null;
+
+  return {
+    conversationId: value.conversationId,
+    clientMessageId: value.clientMessageId,
+    text,
+  };
+}
+
+export function parseConversationPayload(value: unknown): ConversationPayload | null {
+  if (!isRecord(value) || !isChatIdentifier(value.conversationId)) return null;
+  return { conversationId: value.conversationId };
+}

--- a/apps/api/src/chat/chat-security.service.spec.ts
+++ b/apps/api/src/chat/chat-security.service.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { MAX_CHAT_MESSAGE_LENGTH } from './chat-input-contract';
 import { ChatSecurityService } from './chat-security.service';
 
 describe('ChatSecurityService', () => {
@@ -154,19 +155,62 @@ describe('ChatSecurityService', () => {
     expect(prisma.message.create).not.toHaveBeenCalled();
   });
 
-  it('rejects empty text before any message persistence transaction begins', async () => {
-    const { prisma, service } = build();
-    prisma.conversationParticipant.findUnique.mockResolvedValue(participant());
-    prisma.blockedUser.findFirst.mockResolvedValue(null);
-
-    await expect(
-      service.persistMessage({
+  it.each([
+    [
+      'empty text',
+      {
         userId: 'user-1',
         conversationId: 'conversation-1',
         clientMessageId: 'client-message-123',
         text: '   ',
-      })
-    ).rejects.toBeInstanceOf(BadRequestException);
+      },
+    ],
+    [
+      'oversized raw text',
+      {
+        userId: 'user-1',
+        conversationId: 'conversation-1',
+        clientMessageId: 'client-message-123',
+        text: 'x'.repeat(MAX_CHAT_MESSAGE_LENGTH + 1),
+      },
+    ],
+    [
+      'a malformed conversation id',
+      {
+        userId: 'user-1',
+        conversationId: 'bad id',
+        clientMessageId: 'client-message-123',
+        text: 'hello',
+      },
+    ],
+    [
+      'a malformed client retry id',
+      {
+        userId: 'user-1',
+        conversationId: 'conversation-1',
+        clientMessageId: 'short',
+        text: 'hello',
+      },
+    ],
+    [
+      'PostgreSQL-incompatible NUL text',
+      {
+        userId: 'user-1',
+        conversationId: 'conversation-1',
+        clientMessageId: 'client-message-123',
+        text: 'hello\u0000world',
+      },
+    ],
+  ])('rejects %s before any database work begins', async (_label, input) => {
+    const { prisma, service } = build();
+
+    await expect(service.persistMessage(input)).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(prisma.conversationParticipant.findUnique).not.toHaveBeenCalled();
+    expect(prisma.blockedUser.findFirst).not.toHaveBeenCalled();
+    expect(prisma.$queryRaw).not.toHaveBeenCalled();
     expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.message.findUnique).not.toHaveBeenCalled();
+    expect(prisma.message.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/chat/chat-security.service.ts
+++ b/apps/api/src/chat/chat-security.service.ts
@@ -5,9 +5,12 @@ import {
   acquireParticipantRelationshipLocks,
   acquireRelationshipLocks,
 } from '../trust-safety/relationship-lock';
-
-const MAX_MESSAGE_LENGTH = 4_000;
-const CLIENT_MESSAGE_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
+import {
+  isChatIdentifier,
+  isClientMessageId,
+  MAX_CHAT_MESSAGE_LENGTH,
+  normalizeChatMessageText,
+} from './chat-input-contract';
 
 class DuplicateReceiptRaceError extends Error {}
 
@@ -96,18 +99,28 @@ export class ChatSecurityService {
     clientMessageId: string;
     text: string;
   }): Promise<{ message: PersistedChatMessage; duplicate: boolean }> {
-    await this.assertConversationAccess(input.userId, input.conversationId);
-
-    const text = input.text.trim();
-    if (!text) throw new BadRequestException('Message text is required');
-    if (text.length > MAX_MESSAGE_LENGTH) {
-      throw new BadRequestException(
-        `Message text must be ${MAX_MESSAGE_LENGTH} characters or fewer`
-      );
+    if (!isChatIdentifier(input.conversationId)) {
+      throw new BadRequestException('conversationId is invalid');
     }
-    if (!CLIENT_MESSAGE_ID_PATTERN.test(input.clientMessageId)) {
+    if (!isClientMessageId(input.clientMessageId)) {
       throw new BadRequestException('clientMessageId is invalid');
     }
+    if (typeof input.text !== 'string') {
+      throw new BadRequestException('Message text is required');
+    }
+    if (input.text.length > MAX_CHAT_MESSAGE_LENGTH) {
+      throw new BadRequestException(
+        `Message text must be ${MAX_CHAT_MESSAGE_LENGTH} characters or fewer`
+      );
+    }
+    if (input.text.includes('\u0000')) {
+      throw new BadRequestException('Message text is invalid');
+    }
+
+    const text = normalizeChatMessageText(input.text);
+    if (!text) throw new BadRequestException('Message text is required');
+
+    await this.assertConversationAccess(input.userId, input.conversationId);
 
     const existing = await this.getReceipt(input.userId, input.clientMessageId);
     if (existing) {

--- a/apps/api/src/chat/chat.gateway.spec.ts
+++ b/apps/api/src/chat/chat.gateway.spec.ts
@@ -1,4 +1,5 @@
 import { ForbiddenException } from '@nestjs/common';
+import { MAX_CHAT_MESSAGE_LENGTH } from './chat-input-contract';
 import { ChatGateway } from './chat.gateway';
 
 describe('ChatGateway realtime authorization', () => {
@@ -76,11 +77,17 @@ describe('ChatGateway realtime authorization', () => {
       gateway.handleMessage(client as never, {
         conversationId: 'conversation-1',
         clientMessageId: 'client-message-123',
-        text: 'hello',
+        text: '  hello  ',
       })
     ).resolves.toMatchObject({ success: true, duplicate: false });
 
     expect(realtimeAdmission.consume).toHaveBeenCalledWith('user-1', 'message');
+    expect(chatSecurity.persistMessage).toHaveBeenCalledWith({
+      userId: 'user-1',
+      conversationId: 'conversation-1',
+      clientMessageId: 'client-message-123',
+      text: 'hello',
+    });
     expect(chatSecurity.withAuthorizedRealtimeRecipients).toHaveBeenCalledWith(
       'conversation-1',
       expect.any(Function)
@@ -101,6 +108,34 @@ describe('ChatGateway realtime authorization', () => {
           : String(rooms).startsWith('conversation:')
       )
     ).toBe(false);
+  });
+
+  it('rejects malformed messages before admission or persistence work begins', async () => {
+    const { gateway, client, chatSecurity, realtimeAdmission } = build();
+    await gateway.handleConnection(client as never);
+
+    const invalidPayloads = [
+      null,
+      [],
+      { conversationId: 'bad id', clientMessageId: 'client-message-123', text: 'hello' },
+      { conversationId: 'conversation-1', clientMessageId: 'short', text: 'hello' },
+      {
+        conversationId: 'conversation-1',
+        clientMessageId: 'client-message-123',
+        text: 'x'.repeat(MAX_CHAT_MESSAGE_LENGTH + 1),
+      },
+    ];
+
+    for (const payload of invalidPayloads) {
+      await expect(gateway.handleMessage(client as never, payload)).resolves.toEqual({
+        success: false,
+        error: 'invalid_payload',
+      });
+    }
+
+    expect(realtimeAdmission.consume).not.toHaveBeenCalled();
+    expect(chatSecurity.persistMessage).not.toHaveBeenCalled();
+    expect(chatSecurity.withAuthorizedRealtimeRecipients).not.toHaveBeenCalled();
   });
 
   it('rejects message floods before persistence work begins', async () => {
@@ -146,6 +181,20 @@ describe('ChatGateway realtime authorization', () => {
     expect(emit).toHaveBeenCalledWith('typing:start', { userId: 'user-1' });
   });
 
+  it('rejects malformed typing payloads before admission or relationship work', async () => {
+    const { gateway, client, chatSecurity, realtimeAdmission, to } = build();
+    await gateway.handleConnection(client as never);
+
+    await expect(gateway.handleTypingStart(client as never, null)).resolves.toEqual({
+      success: false,
+      error: 'invalid_payload',
+    });
+
+    expect(realtimeAdmission.consume).not.toHaveBeenCalled();
+    expect(chatSecurity.withAuthorizedRealtimeRecipients).not.toHaveBeenCalled();
+    expect(to).not.toHaveBeenCalled();
+  });
+
   it('rejects typing floods before relationship authorization work begins', async () => {
     const { gateway, client, chatSecurity, realtimeAdmission, to } = build();
     await gateway.handleConnection(client as never);
@@ -157,6 +206,20 @@ describe('ChatGateway realtime authorization', () => {
 
     expect(chatSecurity.withAuthorizedRealtimeRecipients).not.toHaveBeenCalled();
     expect(to).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed membership payloads before admission or access checks', async () => {
+    const { gateway, client, chatSecurity, realtimeAdmission } = build();
+    await gateway.handleConnection(client as never);
+    client.join.mockClear();
+
+    await expect(
+      gateway.handleJoinConversation(client as never, { conversationId: 'bad id' })
+    ).resolves.toEqual({ success: false, error: 'invalid_payload' });
+
+    expect(realtimeAdmission.consume).not.toHaveBeenCalled();
+    expect(chatSecurity.assertConversationAccess).not.toHaveBeenCalled();
+    expect(client.join).not.toHaveBeenCalled();
   });
 
   it('rate-limits room membership churn before access checks', async () => {

--- a/apps/api/src/chat/chat.gateway.ts
+++ b/apps/api/src/chat/chat.gateway.ts
@@ -11,16 +11,16 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { NudgesService } from '../nudges/nudges.service';
+import {
+  MAX_REALTIME_PACKET_BYTES,
+  parseConversationPayload,
+  parseSendChatMessagePayload,
+} from './chat-input-contract';
 import { ChatSecurityService } from './chat-security.service';
 import { RealtimeAdmissionService } from './realtime-admission.service';
 
-interface SendChatMessage {
-  conversationId: string;
-  clientMessageId: string;
-  text: string;
-}
-
 @WebSocketGateway({
+  maxHttpBufferSize: MAX_REALTIME_PACKET_BYTES,
   cors: {
     origin: process.env.CORS_ORIGIN?.split(',') || ['http://localhost:3000'],
     credentials: true,
@@ -67,9 +67,12 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   @SubscribeMessage('message:send')
-  async handleMessage(@ConnectedSocket() client: Socket, @MessageBody() data: SendChatMessage) {
+  async handleMessage(@ConnectedSocket() client: Socket, @MessageBody() data: unknown) {
     const userId = this.connectedUsers.get(client.id);
     if (!userId) return { success: false, error: 'unauthorized' };
+
+    const payload = parseSendChatMessagePayload(data);
+    if (!payload) return { success: false, error: 'invalid_payload' };
 
     const admission = this.realtimeAdmission.consume(userId, 'message');
     if (!admission.allowed) {
@@ -77,12 +80,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
 
     try {
-      const result = await this.chatSecurity.persistMessage({
-        userId,
-        conversationId: data.conversationId,
-        clientMessageId: data.clientMessageId,
-        text: data.text,
-      });
+      const result = await this.chatSecurity.persistMessage({ userId, ...payload });
 
       const message = {
         id: result.message.id,
@@ -95,13 +93,13 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
       if (!result.duplicate) {
         await this.chatSecurity.withAuthorizedRealtimeRecipients(
-          data.conversationId,
+          payload.conversationId,
           (authorizedUserIds) => {
             this.server.to(this.userRooms(authorizedUserIds)).emit('message:received', message);
           }
         );
         void this.nudgesService
-          .checkChatActivityNudges(data.conversationId, userId)
+          .checkChatActivityNudges(payload.conversationId, userId)
           .catch((error) => {
             this.logger.warn(`Chat nudge check failed: ${this.errorName(error)}`);
           });
@@ -115,12 +113,12 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   @SubscribeMessage('conversation:join')
-  async handleJoinConversation(
-    @ConnectedSocket() client: Socket,
-    @MessageBody() data: { conversationId: string }
-  ) {
+  async handleJoinConversation(@ConnectedSocket() client: Socket, @MessageBody() data: unknown) {
     const userId = this.connectedUsers.get(client.id);
     if (!userId) return { success: false, error: 'unauthorized' };
+
+    const payload = parseConversationPayload(data);
+    if (!payload) return { success: false, error: 'invalid_payload' };
 
     const admission = this.realtimeAdmission.consume(userId, 'membership');
     if (!admission.allowed) {
@@ -128,8 +126,8 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
 
     try {
-      await this.chatSecurity.assertConversationAccess(userId, data.conversationId);
-      await client.join(`conversation:${data.conversationId}`);
+      await this.chatSecurity.assertConversationAccess(userId, payload.conversationId);
+      await client.join(`conversation:${payload.conversationId}`);
       return { success: true };
     } catch {
       return { success: false, error: 'conversation_unavailable' };
@@ -137,12 +135,12 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   @SubscribeMessage('conversation:leave')
-  async handleLeaveConversation(
-    @ConnectedSocket() client: Socket,
-    @MessageBody() data: { conversationId: string }
-  ) {
+  async handleLeaveConversation(@ConnectedSocket() client: Socket, @MessageBody() data: unknown) {
     const userId = this.connectedUsers.get(client.id);
     if (!userId) return { success: false, error: 'unauthorized' };
+
+    const payload = parseConversationPayload(data);
+    if (!payload) return { success: false, error: 'invalid_payload' };
 
     const admission = this.realtimeAdmission.consume(userId, 'membership');
     if (!admission.allowed) {
@@ -150,8 +148,8 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
 
     try {
-      await this.chatSecurity.assertConversationAccess(userId, data.conversationId);
-      await client.leave(`conversation:${data.conversationId}`);
+      await this.chatSecurity.assertConversationAccess(userId, payload.conversationId);
+      await client.leave(`conversation:${payload.conversationId}`);
       return { success: true };
     } catch {
       return { success: false, error: 'conversation_unavailable' };
@@ -159,28 +157,21 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   @SubscribeMessage('typing:start')
-  async handleTypingStart(
-    @ConnectedSocket() client: Socket,
-    @MessageBody() data: { conversationId: string }
-  ) {
-    return this.emitTyping(client, data.conversationId, 'typing:start');
+  async handleTypingStart(@ConnectedSocket() client: Socket, @MessageBody() data: unknown) {
+    return this.emitTyping(client, data, 'typing:start');
   }
 
   @SubscribeMessage('typing:stop')
-  async handleTypingStop(
-    @ConnectedSocket() client: Socket,
-    @MessageBody() data: { conversationId: string }
-  ) {
-    return this.emitTyping(client, data.conversationId, 'typing:stop');
+  async handleTypingStop(@ConnectedSocket() client: Socket, @MessageBody() data: unknown) {
+    return this.emitTyping(client, data, 'typing:stop');
   }
 
-  private async emitTyping(
-    client: Socket,
-    conversationId: string,
-    event: 'typing:start' | 'typing:stop'
-  ) {
+  private async emitTyping(client: Socket, data: unknown, event: 'typing:start' | 'typing:stop') {
     const userId = this.connectedUsers.get(client.id);
     if (!userId) return { success: false, error: 'unauthorized' };
+
+    const payload = parseConversationPayload(data);
+    if (!payload) return { success: false, error: 'invalid_payload' };
 
     const admission = this.realtimeAdmission.consume(userId, 'typing');
     if (!admission.allowed) {
@@ -189,7 +180,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     try {
       await this.chatSecurity.withAuthorizedRealtimeRecipients(
-        conversationId,
+        payload.conversationId,
         (authorizedUserIds) => {
           this.server
             .to(this.userRooms(authorizedUserIds))

--- a/docs/DOGOS_REALTIME_PAYLOAD_INTEGRITY.md
+++ b/docs/DOGOS_REALTIME_PAYLOAD_INTEGRITY.md
@@ -1,0 +1,66 @@
+# dogOS Realtime Payload Integrity
+
+## Purpose
+
+Socket.IO payload types are untrusted runtime input. TypeScript annotations on `@MessageBody()` do not validate network data, and authenticated traffic must not reach database authorization or relationship-lock work when its shape or size is already invalid.
+
+This release establishes an explicit runtime input boundary for dogOS chat events.
+
+## Transport ceiling
+
+The chat gateway configures Socket.IO with a `32 KiB` maximum packet size through `maxHttpBufferSize`.
+
+The application message contract remains much smaller:
+
+- message text: at most 4,000 raw JavaScript characters;
+- conversation identifier: 8–128 ASCII alphanumeric, underscore, or hyphen characters;
+- client message identifier: 8–128 ASCII alphanumeric, underscore, or hyphen characters;
+- NUL characters are rejected because PostgreSQL text cannot represent them.
+
+The transport ceiling is intentionally above the valid application envelope while remaining far below Socket.IO's default megabyte-scale allowance.
+
+## Ordering contract
+
+For every authenticated realtime chat event, work is ordered as:
+
+1. resolve the authenticated socket user;
+2. validate and normalize the payload in process memory;
+3. consume the existing authenticated-user admission bucket;
+4. perform conversation authorization, relationship locking, persistence, or delivery work.
+
+Malformed input returns `{ success: false, error: 'invalid_payload' }` and does not consume the authenticated user's message, typing, or membership admission budget.
+
+Unauthenticated sockets still fail before payload parsing.
+
+## Persistence defense in depth
+
+`ChatSecurityService.persistMessage()` repeats the shared message contract before its first database access. This protects the persistence seam from future non-Socket.IO callers and makes the zero-database-on-invalid-input property independent of the gateway.
+
+The write-time block-dominance and idempotent receipt contracts remain unchanged after validation succeeds.
+
+## Runtime shapes
+
+The gateway treats all `@MessageBody()` values as `unknown` and explicitly parses:
+
+- `message:send` with `conversationId`, `clientMessageId`, and `text`;
+- `conversation:join` and `conversation:leave` with `conversationId`;
+- `typing:start` and `typing:stop` with `conversationId`.
+
+`null`, arrays, primitive values, malformed identifiers, empty messages, oversized messages, and NUL-containing messages are rejected without dereferencing unsafe shapes.
+
+## Qualification
+
+The dedicated realtime payload integrity workflow must prove on one exact head SHA:
+
+- shared parser unit contracts;
+- gateway validation before admission and authorization work;
+- persistence validation before any database call;
+- inherited chat authorization and block-ordering regressions on PostgreSQL;
+- API type-check, lint, and production build;
+- production Docker image boot;
+- malformed Socket.IO events return stable `invalid_payload` responses;
+- repeated invalid messages do not consume the user's message admission bucket;
+- a valid-sized structurally valid message still enters ordinary chat rejection behavior; and
+- an over-ceiling Socket.IO frame causes the server to close the connection.
+
+No schema or migration changes are owned by this release.


### PR DESCRIPTION
## dogOS Realtime Payload Integrity

Base production merge: `fefed499aca6c5b634e429936891e8b0456452ed`.

**Qualified exact head:** `6705a4746c7a12caa3bdc2bb03e4bee5f999de94`.

### Observed production defect

Socket.IO `@MessageBody()` TypeScript annotations are compile-time only. The production gateway accepted unvalidated runtime payload shapes, and `ChatSecurityService.persistMessage()` performed `assertConversationAccess()` before checking message text or `clientMessageId` validity.

That created two concrete failure modes:

- malformed typing payloads such as `null` could be dereferenced at the handler boundary instead of returning a stable rejection;
- authenticated invalid or oversized messages could spend database authorization reads before being rejected by constraints the server already knew locally.

Socket.IO also retained its much larger default packet ceiling despite Woof's 4,000-character application message contract.

### Runtime input boundary

A new shared `chat-input-contract.ts` owns the realtime chat input contract:

- message text: maximum 4,000 raw JavaScript characters, trimmed non-empty;
- PostgreSQL-incompatible NUL text rejected;
- conversation identifiers: 8–128 ASCII alphanumeric/underscore/hyphen characters;
- client retry identifiers: 8–128 ASCII alphanumeric/underscore/hyphen characters;
- Socket.IO packet ceiling: 32 KiB.

All `@MessageBody()` values are now `unknown` at the gateway boundary and are explicitly parsed before use.

### Ordering

Authenticated event handling now follows:

1. resolve authenticated socket user;
2. validate and normalize payload in memory;
3. return `{ success: false, error: 'invalid_payload' }` on malformed input;
4. consume the existing authenticated-user admission bucket;
5. perform database authorization, relationship-lock, persistence, or delivery work.

Malformed payloads do not consume admission budget and cannot reach chat persistence or relationship authorization.

`persistMessage()` independently repeats the same contract **before its first database call**, protecting the persistence seam from future non-Socket.IO callers.

The existing rate limits, block-dominance ordering, private-user-room delivery authority, idempotent receipts, and reconnect-resistant admission semantics are otherwise unchanged.

### Transport fuse

The gateway now sets `maxHttpBufferSize` to 32 KiB. This is comfortably above a valid 4,000-character application message envelope but far below Socket.IO's previous megabyte-scale default.

### Inherited trust contract modernization

The existing Trust + Discovery static room check still required the retired raw expression `data.conversationId`. That would have forced the gateway to reintroduce the unsafe unvalidated access pattern this release intentionally removes.

The inherited gate is strengthened to require this exact ordering for join and leave:

1. `parseConversationPayload(data)`;
2. `chatSecurity.assertConversationAccess(...)`;
3. room join/leave using `payload.conversationId`.

Typing continues to require lock-bound private-user-room fanout, and the forbidden conversation-room fanout checks cover both raw and validated-payload expression forms.

### Exact-head qualification receipts

All **9 workflows actually triggered by this release** completed successfully on exact head `6705a4746c7a12caa3bdc2bb03e4bee5f999de94`:

- CI Action Runtime Qualification — run `32772791010`
- root CI — run `32772790768`
- dogOS Chat Delivery Integrity CI — run `32772790729`
- dogOS Network Integrity + Scale CI — run `32772790749`
- dogOS Live Authorization CI — run `32772790709`
- dogOS Trust Enforcement Atomicity CI — run `32772790728`
- dogOS Trust + Discovery CI — run `32772790711`
- dogOS Realtime Abuse Control CI — run `32772790654`
- dogOS Realtime Payload Integrity CI — run `32772790730`

### Deep production proof receipts

Realtime Payload Integrity job `97576823778` passed every release gate, including:

- all 16 committed migrations;
- touched-file Prettier and zero-warning ESLint;
- static validation-before-admission/chat-work ordering;
- API TypeScript;
- parser, gateway, persistence, and admission unit contracts;
- all three PostgreSQL authorization/integrity regressions;
- API build;
- production Docker build and boot; and
- the real Socket.IO production-image malformed-payload + transport-ceiling experiment.

That final experiment proved malformed message/typing/membership payloads return `invalid_payload`, repeated invalid messages do not consume the authenticated user's message admission budget, a subsequent valid-sized payload reaches ordinary `message_rejected` semantics rather than `rate_limited`, and a 40k over-ceiling Socket.IO frame disconnects the socket.

Realtime Abuse job `97576837099` independently passed its complete source/unit/PostgreSQL suite, production Docker build/boot, and authenticated Socket.IO flood, distinct-user isolation, and reconnect-retention proof. This verifies the new payload boundary composes cleanly with the previously qualified abuse-control layer.

Trust + Discovery job `97576967931` passed the strengthened validated-payload → authorization → room-mutation invariant, privacy guards, API/web type-checks, backend and web transport contracts, privacy-safe Playwright browser contract, and both API/web production builds.

Root CI run `32772790768` passed static quality gates, backend unit/API tests, frontend unit/Playwright contracts, and API/web production builds.

### Diagnostic history

`f75675f9a7ecca0d9afabbf798bab9c18a177043` is diagnostic only. The new runtime workflow and broad repository gates were healthy, but the dedicated lane exposed one Prettier-only difference in `chat.gateway.ts`. Trust + Discovery's formatter oracle proved the exact canonical change: collapse the `emitTyping(...)` signature onto one line. Every other touched chat file was unchanged.

`eee725ac449cd5c4685c0c99e3bd49aded02e64c` is also diagnostic only. It passed the new payload source/unit/PostgreSQL gates through API build and inherited Live Authorization / Trust Enforcement, but Trust + Discovery correctly vetoed it because its own static check was stale and still required raw `data.conversationId`. That inherited contract was repaired in the stricter direction described above.

No diagnostic-head result counts as release evidence.

### Scope

The qualified branch is exactly one commit ahead of production and zero behind. It changes exactly nine files:

- shared input contract + unit tests;
- gateway + gateway tests;
- persistence service + persistence tests;
- dedicated qualification workflow;
- strengthened inherited Trust + Discovery workflow contract;
- runtime-boundary documentation.

No schema, migration, lockfile, product UI, or unrelated application surface is changed.