### PR TITLE
dogOS Realtime: enforce finite session lifetime

### DIFF
--- a/.github/workflows/dogos-realtime-session-lifetime-ci.yml
+++ b/.github/workflows/dogos-realtime-session-lifetime-ci.yml
@@ -1,0 +1,318 @@
+name: dogOS Realtime Session Lifetime CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/chat/chat.gateway.ts'
+      - 'apps/api/src/chat/chat.gateway.spec.ts'
+      - 'apps/web/src/lib/socket.ts'
+      - '.github/workflows/dogos-realtime-session-lifetime-ci.yml'
+      - 'docs/DOGOS_REALTIME_SESSION_LIFETIME.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-realtime-session-lifetime-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  JWT_SECRET: ci-only-realtime-session-secret-12345678901234567890
+  NODE_ENV: test
+  ML_SERVICE_ENABLED: 'false'
+
+jobs:
+  qualify:
+    name: Finite realtime lease + production image qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject schema and migration ownership changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
+            echo 'Realtime Session Lifetime v1 does not own database schema or migration changes.'
+            exit 1
+          fi
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check touched-file formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/chat/chat.gateway.ts
+          apps/api/src/chat/chat.gateway.spec.ts
+          apps/web/src/lib/socket.ts
+          .github/workflows/dogos-realtime-session-lifetime-ci.yml
+          docs/DOGOS_REALTIME_SESSION_LIFETIME.md
+
+      - name: Lint realtime session surfaces
+        run: |
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish src/chat/chat.gateway.ts src/chat/chat.gateway.spec.ts
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish src/lib/socket.ts
+
+      - name: Enforce finite session lifetime before realtime work
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          gateway = Path('apps/api/src/chat/chat.gateway.ts').read_text()
+          web = Path('apps/web/src/lib/socket.ts').read_text()
+
+          required_gateway = [
+              'exp?: unknown',
+              'sessionExpiries = new Map<string, number>()',
+              'sessionExpiryTimers = new Map<string, NodeJS.Timeout>()',
+              'expiryFromPayload(payload.exp)',
+              'scheduleSessionExpiry(client, expiresAtMs)',
+              'this.clearSession(client.id)',
+              "client.emit('session:expired', { reason: 'token_expired' })",
+              'client.disconnect()',
+              'MAX_SESSION_TIMER_DELAY_MS = 2_147_483_647',
+          ]
+          missing = [token for token in required_gateway if token not in gateway]
+          if missing:
+              raise SystemExit(f'missing realtime lifetime contract: {missing}')
+
+          if "logger.warn(`Rejected socket connection: ${this.errorName(error)}`)" not in gateway:
+              raise SystemExit('socket rejection logging must remain identifier-free')
+          if 'logger.warn(token' in gateway or 'logger.error(token' in gateway:
+              raise SystemExit('raw JWT values must never be logged')
+
+          message_start = gateway.index("@SubscribeMessage('message:send')")
+          join_start = gateway.index("@SubscribeMessage('conversation:join')")
+          leave_start = gateway.index("@SubscribeMessage('conversation:leave')")
+          typing_start = gateway.index("@SubscribeMessage('typing:start')")
+          typing_impl = gateway.index('private async emitTyping')
+
+          message = gateway[message_start:join_start]
+          join = gateway[join_start:leave_start]
+          leave = gateway[leave_start:typing_start]
+          typing = gateway[typing_impl:gateway.index('private hasActiveSession')]
+
+          checks = [
+              (
+                  'message',
+                  message,
+                  'parseSendChatMessagePayload(data)',
+                  "realtimeAdmission.consume(userId, 'message')",
+                  'chatSecurity.persistMessage',
+              ),
+              (
+                  'join',
+                  join,
+                  'parseConversationPayload(data)',
+                  "realtimeAdmission.consume(userId, 'membership')",
+                  'chatSecurity.assertConversationAccess',
+              ),
+              (
+                  'leave',
+                  leave,
+                  'parseConversationPayload(data)',
+                  "realtimeAdmission.consume(userId, 'membership')",
+                  'chatSecurity.assertConversationAccess',
+              ),
+              (
+                  'typing',
+                  typing,
+                  'parseConversationPayload(data)',
+                  "realtimeAdmission.consume(userId, 'typing')",
+                  'chatSecurity.withAuthorizedRealtimeRecipients',
+              ),
+          ]
+
+          for label, handler, parser, admission_call, expensive_call in checks:
+              identity = handler.find('connectedUsers.get(client.id)')
+              lifetime = handler.find('this.hasActiveSession(client, userId)')
+              parsed = handler.find(parser)
+              admission = handler.find(admission_call)
+              expensive = handler.find(expensive_call)
+              if min(identity, lifetime, parsed, admission, expensive) < 0:
+                  raise SystemExit(f'{label} handler is missing a session-lifetime ordering invariant')
+              if not identity < lifetime < parsed < admission < expensive:
+                  raise SystemExit(
+                      f'{label} must resolve identity, verify lifetime, validate, admit, then perform chat work'
+                  )
+
+          if "socket.on('session:expired'" not in web:
+              raise SystemExit('web socket transport must observe explicit session expiry')
+          if 'useAuthStore.getState().logout()' not in web:
+              raise SystemExit('web session expiry must clear persisted auth state through the auth store')
+          PY
+
+      - name: Type-check API and web
+        run: |
+          pnpm --filter @woof/api type-check
+          pnpm --filter @woof/web type-check
+
+      - name: Run realtime lifetime and inherited chat contracts
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/chat/chat.gateway.spec.ts
+          src/chat/chat-input-contract.spec.ts
+          src/chat/realtime-admission.service.spec.ts
+
+      - name: Build API and web
+        run: |
+          pnpm --filter @woof/api build
+          pnpm --filter @woof/web build
+
+      - name: Build production API image
+        run: docker build --pull -f infra/docker/Dockerfile.api -t woof-api-realtime-session:ci .
+
+      - name: Boot production image
+        run: |
+          docker rm -f woof-api-realtime-session-ci >/dev/null 2>&1 || true
+          docker run -d --name woof-api-realtime-session-ci --network host \
+            -e DATABASE_URL="$DATABASE_URL" \
+            -e SHADOW_DATABASE_URL="$SHADOW_DATABASE_URL" \
+            -e JWT_SECRET="$JWT_SECRET" \
+            -e NODE_ENV=production \
+            -e API_DOCS_ENABLED=false \
+            -e CORS_ORIGIN=http://localhost:3000 \
+            woof-api-realtime-session:ci
+
+          live=0
+          for attempt in $(seq 1 30); do
+            status=$(curl --silent --show-error --output /tmp/realtime-session-live.json --write-out '%{http_code}' \
+              http://127.0.0.1:4000/api/v1/ops/health/live || true)
+            if [ "$status" = '200' ]; then
+              live=1
+              break
+            fi
+            if ! docker ps --format '{{.Names}}' | grep -Fxq woof-api-realtime-session-ci; then
+              echo "Production image exited before liveness; status=$status"
+              cat /tmp/realtime-session-live.json 2>/dev/null || true
+              docker logs woof-api-realtime-session-ci || true
+              exit 1
+            fi
+            sleep 1
+          done
+          if [ "$live" -ne 1 ]; then
+            echo 'Production image never reached liveness.'
+            docker logs woof-api-realtime-session-ci || true
+            exit 1
+          fi
+
+      - name: Prove JWT expiry ejects a real production Socket.IO session
+        run: |
+          pnpm --filter @woof/web exec node <<'NODE'
+          const crypto = require('node:crypto');
+          const { io } = require('socket.io-client');
+
+          const secret = process.env.JWT_SECRET;
+          if (!secret) throw new Error('JWT_SECRET is required');
+
+          function jwt(sub, expiresInSeconds) {
+            const now = Math.floor(Date.now() / 1000);
+            const encode = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
+            const header = encode({ alg: 'HS256', typ: 'JWT' });
+            const payload = encode({ sub, iat: now, exp: now + expiresInSeconds });
+            const unsigned = `${header}.${payload}`;
+            const signature = crypto.createHmac('sha256', secret).update(unsigned).digest('base64url');
+            return `${unsigned}.${signature}`;
+          }
+
+          (async () => {
+            const socket = io('http://127.0.0.1:4000', {
+              auth: { token: jwt('socket-session-user-1', 5) },
+              transports: ['websocket'],
+              reconnection: false,
+              autoConnect: false,
+              timeout: 4_000,
+            });
+
+            let sawExpiry = false;
+            const connected = new Promise((resolve, reject) => {
+              const timer = setTimeout(() => reject(new Error('socket did not connect')), 4_000);
+              socket.once('connect', () => {
+                clearTimeout(timer);
+                resolve();
+              });
+              socket.once('connect_error', (error) => {
+                clearTimeout(timer);
+                reject(error);
+              });
+            });
+
+            const expired = new Promise((resolve, reject) => {
+              const timer = setTimeout(
+                () => reject(new Error('socket remained connected beyond JWT expiry')),
+                9_000
+              );
+              socket.once('session:expired', (payload) => {
+                if (!payload || payload.reason !== 'token_expired') {
+                  clearTimeout(timer);
+                  reject(new Error(`unexpected expiry payload: ${JSON.stringify(payload)}`));
+                  return;
+                }
+                sawExpiry = true;
+              });
+              socket.once('disconnect', (reason) => {
+                clearTimeout(timer);
+                if (!sawExpiry) {
+                  reject(new Error(`socket disconnected before session:expired; reason=${reason}`));
+                  return;
+                }
+                resolve(reason);
+              });
+            });
+
+            socket.connect();
+            await connected;
+            const reason = await expired;
+            if (reason !== 'io server disconnect') {
+              throw new Error(`expected server-driven disconnect, got ${reason}`);
+            }
+          })().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
+
+      - name: Cleanup production image
+        if: always()
+        run: |
+          docker logs woof-api-realtime-session-ci || true
+          docker rm -f woof-api-realtime-session-ci >/dev/null 2>&1 || true

--- a/apps/api/src/chat/chat.gateway.spec.ts
+++ b/apps/api/src/chat/chat.gateway.spec.ts
@@ -5,7 +5,10 @@ import { ChatGateway } from './chat.gateway';
 describe('ChatGateway realtime authorization', () => {
   function build() {
     const jwtService = {
-      verifyAsync: jest.fn().mockResolvedValue({ sub: 'user-1' }),
+      verifyAsync: jest.fn().mockResolvedValue({
+        sub: 'user-1',
+        exp: Math.floor(Date.now() / 1_000) + 300,
+      }),
     };
     const chatSecurity = {
       persistMessage: jest.fn(),
@@ -34,6 +37,7 @@ describe('ChatGateway realtime authorization', () => {
       handshake: { auth: { token: 'token-1' } },
       join: jest.fn().mockResolvedValue(undefined),
       leave: jest.fn().mockResolvedValue(undefined),
+      emit: jest.fn(),
       disconnect: jest.fn(),
     };
 
@@ -49,6 +53,103 @@ describe('ChatGateway realtime authorization', () => {
       to,
     };
   }
+
+  it('requires a finite JWT expiry before granting realtime membership', async () => {
+    const { gateway, client, jwtService } = build();
+    jwtService.verifyAsync.mockResolvedValueOnce({ sub: 'user-1' });
+
+    await gateway.handleConnection(client as never);
+
+    expect(client.join).not.toHaveBeenCalled();
+    expect(client.emit).not.toHaveBeenCalled();
+    expect(client.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('actively expires the socket lease and removes event authority at token expiry', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-24T20:30:00.000Z'));
+
+    try {
+      const { gateway, client, jwtService, chatSecurity, realtimeAdmission } = build();
+      jwtService.verifyAsync.mockResolvedValueOnce({
+        sub: 'user-1',
+        exp: Math.floor(Date.now() / 1_000) + 2,
+      });
+
+      await gateway.handleConnection(client as never);
+      expect(client.join).toHaveBeenCalledWith('user:user-1');
+      expect(client.disconnect).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1_999);
+      expect(client.disconnect).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1);
+      expect(client.emit).toHaveBeenCalledWith('session:expired', { reason: 'token_expired' });
+      expect(client.disconnect).toHaveBeenCalledTimes(1);
+
+      await expect(
+        gateway.handleMessage(client as never, {
+          conversationId: 'conversation-1',
+          clientMessageId: 'client-message-after-expiry',
+          text: 'hello',
+        })
+      ).resolves.toEqual({ success: false, error: 'unauthorized' });
+
+      expect(realtimeAdmission.consume).not.toHaveBeenCalled();
+      expect(chatSecurity.persistMessage).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('rechecks expiry at event ingress even before the disconnect timer gets a turn', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-24T20:35:00.000Z'));
+
+    try {
+      const { gateway, client, jwtService, chatSecurity, realtimeAdmission } = build();
+      jwtService.verifyAsync.mockResolvedValueOnce({
+        sub: 'user-1',
+        exp: Math.floor(Date.now() / 1_000) + 2,
+      });
+      await gateway.handleConnection(client as never);
+
+      jest.setSystemTime(new Date('2026-08-24T20:35:03.000Z'));
+
+      await expect(
+        gateway.handleTypingStart(client as never, { conversationId: 'conversation-1' })
+      ).resolves.toEqual({ success: false, error: 'unauthorized' });
+
+      expect(client.emit).toHaveBeenCalledWith('session:expired', { reason: 'token_expired' });
+      expect(client.disconnect).toHaveBeenCalledTimes(1);
+      expect(realtimeAdmission.consume).not.toHaveBeenCalled();
+      expect(chatSecurity.withAuthorizedRealtimeRecipients).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('cancels the token-expiry timer when a socket disconnects normally', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-24T20:40:00.000Z'));
+
+    try {
+      const { gateway, client, jwtService } = build();
+      jwtService.verifyAsync.mockResolvedValueOnce({
+        sub: 'user-1',
+        exp: Math.floor(Date.now() / 1_000) + 2,
+      });
+      await gateway.handleConnection(client as never);
+
+      gateway.handleDisconnect(client as never);
+      jest.advanceTimersByTime(3_000);
+
+      expect(client.emit).not.toHaveBeenCalledWith('session:expired', expect.anything());
+      expect(client.disconnect).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 
   it('delivers persisted messages only through authorized private user rooms', async () => {
     const { gateway, client, chatSecurity, realtimeAdmission, to, emit } = build();

--- a/apps/api/src/chat/chat.gateway.ts
+++ b/apps/api/src/chat/chat.gateway.ts
@@ -19,6 +19,13 @@ import {
 import { ChatSecurityService } from './chat-security.service';
 import { RealtimeAdmissionService } from './realtime-admission.service';
 
+const MAX_SESSION_TIMER_DELAY_MS = 2_147_483_647;
+
+type RealtimeJwtPayload = {
+  sub?: unknown;
+  exp?: unknown;
+};
+
 @WebSocketGateway({
   maxHttpBufferSize: MAX_REALTIME_PACKET_BYTES,
   cors: {
@@ -32,6 +39,8 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   private readonly logger = new Logger(ChatGateway.name);
   private readonly connectedUsers = new Map<string, string>();
+  private readonly sessionExpiries = new Map<string, number>();
+  private readonly sessionExpiryTimers = new Map<string, NodeJS.Timeout>();
 
   constructor(
     private readonly jwtService: JwtService,
@@ -42,34 +51,42 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   async handleConnection(client: Socket) {
     try {
-      const token = client.handshake.auth.token;
-      if (!token) {
+      const token = client.handshake.auth?.token;
+      if (typeof token !== 'string' || token.length === 0) {
         client.disconnect();
         return;
       }
 
-      const payload = await this.jwtService.verifyAsync<{ sub?: string }>(token);
-      if (!payload.sub) {
+      const payload = await this.jwtService.verifyAsync<RealtimeJwtPayload>(token);
+      const userId = this.userIdFromPayload(payload.sub);
+      const expiresAtMs = this.expiryFromPayload(payload.exp);
+      if (!userId || !expiresAtMs) {
         client.disconnect();
         return;
       }
 
-      this.connectedUsers.set(client.id, payload.sub);
-      await client.join(`user:${payload.sub}`);
+      this.connectedUsers.set(client.id, userId);
+      this.sessionExpiries.set(client.id, expiresAtMs);
+      this.scheduleSessionExpiry(client, expiresAtMs);
+      if (!this.hasActiveSession(client, userId)) return;
+      await client.join(`user:${userId}`);
     } catch (error) {
+      this.clearSession(client.id);
       this.logger.warn(`Rejected socket connection: ${this.errorName(error)}`);
       client.disconnect();
     }
   }
 
   handleDisconnect(client: Socket) {
-    this.connectedUsers.delete(client.id);
+    this.clearSession(client.id);
   }
 
   @SubscribeMessage('message:send')
   async handleMessage(@ConnectedSocket() client: Socket, @MessageBody() data: unknown) {
     const userId = this.connectedUsers.get(client.id);
-    if (!userId) return { success: false, error: 'unauthorized' };
+    if (!userId || !this.hasActiveSession(client, userId)) {
+      return { success: false, error: 'unauthorized' };
+    }
 
     const payload = parseSendChatMessagePayload(data);
     if (!payload) return { success: false, error: 'invalid_payload' };
@@ -115,7 +132,9 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @SubscribeMessage('conversation:join')
   async handleJoinConversation(@ConnectedSocket() client: Socket, @MessageBody() data: unknown) {
     const userId = this.connectedUsers.get(client.id);
-    if (!userId) return { success: false, error: 'unauthorized' };
+    if (!userId || !this.hasActiveSession(client, userId)) {
+      return { success: false, error: 'unauthorized' };
+    }
 
     const payload = parseConversationPayload(data);
     if (!payload) return { success: false, error: 'invalid_payload' };
@@ -137,7 +156,9 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @SubscribeMessage('conversation:leave')
   async handleLeaveConversation(@ConnectedSocket() client: Socket, @MessageBody() data: unknown) {
     const userId = this.connectedUsers.get(client.id);
-    if (!userId) return { success: false, error: 'unauthorized' };
+    if (!userId || !this.hasActiveSession(client, userId)) {
+      return { success: false, error: 'unauthorized' };
+    }
 
     const payload = parseConversationPayload(data);
     if (!payload) return { success: false, error: 'invalid_payload' };
@@ -168,7 +189,9 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   private async emitTyping(client: Socket, data: unknown, event: 'typing:start' | 'typing:stop') {
     const userId = this.connectedUsers.get(client.id);
-    if (!userId) return { success: false, error: 'unauthorized' };
+    if (!userId || !this.hasActiveSession(client, userId)) {
+      return { success: false, error: 'unauthorized' };
+    }
 
     const payload = parseConversationPayload(data);
     if (!payload) return { success: false, error: 'invalid_payload' };
@@ -193,6 +216,79 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     } catch {
       return { success: false, error: 'conversation_unavailable' };
     }
+  }
+
+  private hasActiveSession(client: Socket, userId: string) {
+    const expiresAtMs = this.sessionExpiries.get(client.id);
+    if (!expiresAtMs || this.connectedUsers.get(client.id) !== userId) return false;
+
+    if (expiresAtMs <= Date.now()) {
+      this.expireSession(client, expiresAtMs);
+      return false;
+    }
+
+    return true;
+  }
+
+  private scheduleSessionExpiry(client: Socket, expiresAtMs: number) {
+    this.clearSessionTimer(client.id);
+
+    const remainingMs = expiresAtMs - Date.now();
+    if (remainingMs <= 0) {
+      this.expireSession(client, expiresAtMs);
+      return;
+    }
+
+    const timer = setTimeout(
+      () => {
+        if (this.sessionExpiries.get(client.id) !== expiresAtMs) return;
+
+        if (Date.now() < expiresAtMs) {
+          this.scheduleSessionExpiry(client, expiresAtMs);
+          return;
+        }
+
+        this.expireSession(client, expiresAtMs);
+      },
+      Math.min(remainingMs, MAX_SESSION_TIMER_DELAY_MS)
+    );
+    timer.unref();
+    this.sessionExpiryTimers.set(client.id, timer);
+  }
+
+  private expireSession(client: Socket, expectedExpiresAtMs: number) {
+    if (this.sessionExpiries.get(client.id) !== expectedExpiresAtMs) return;
+
+    this.clearSession(client.id);
+    client.emit('session:expired', { reason: 'token_expired' });
+    client.disconnect();
+  }
+
+  private clearSession(socketId: string) {
+    this.connectedUsers.delete(socketId);
+    this.sessionExpiries.delete(socketId);
+    this.clearSessionTimer(socketId);
+  }
+
+  private clearSessionTimer(socketId: string) {
+    const timer = this.sessionExpiryTimers.get(socketId);
+    if (!timer) return;
+
+    clearTimeout(timer);
+    this.sessionExpiryTimers.delete(socketId);
+  }
+
+  private userIdFromPayload(value: unknown) {
+    return typeof value === 'string' && value.length > 0 ? value : null;
+  }
+
+  private expiryFromPayload(value: unknown) {
+    if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) return null;
+
+    const expiresAtMs = value * 1_000;
+    if (!Number.isSafeInteger(expiresAtMs) || expiresAtMs <= Date.now()) return null;
+
+    return expiresAtMs;
   }
 
   private userRooms(userIds: string[]) {

--- a/apps/web/src/lib/socket.ts
+++ b/apps/web/src/lib/socket.ts
@@ -14,6 +14,9 @@ export function getSocket(): Socket {
       auth: { token },
       autoConnect: false,
     });
+    socket.on('session:expired', () => {
+      useAuthStore.getState().logout();
+    });
   }
 
   return socket;

--- a/docs/DOGOS_REALTIME_SESSION_LIFETIME.md
+++ b/docs/DOGOS_REALTIME_SESSION_LIFETIME.md
@@ -1,0 +1,84 @@
+# dogOS Realtime Session Lifetime v1
+
+This release makes JWT lifetime an active realtime authorization boundary. It changes no database schema, chat persistence authority, block semantics, rate limits, or product-visible chat behavior beyond ending an expired session.
+
+## Problem closed
+
+HTTP authentication validates JWT expiry on every request. Socket.IO previously validated the JWT only during `handleConnection()`, then stored `sub` in an in-memory `connectedUsers` map for the lifetime of the socket.
+
+That meant a socket established shortly before JWT expiry could remain connected after the token expired. The stale connection could continue attempting message, membership, and typing events, and because it remained in `user:<userId>`, it could also remain eligible for passive realtime delivery.
+
+A signed token without a finite `exp` claim was likewise acceptable to the Socket.IO handshake even though dogOS access tokens are intended to be finite leases.
+
+## Finite session lease
+
+A realtime connection now requires both:
+
+- a non-empty string JWT `sub` claim; and
+- a positive, safe-integer JWT NumericDate `exp` claim that is still in the future.
+
+`JwtService.verifyAsync()` remains the signature and standard JWT verification boundary. The gateway additionally requires the expiry claim because realtime authorization must have an explicit end time.
+
+The server stores only the authenticated user ID and expiry timestamp for the active socket. It does not store or log the raw token.
+
+## Active expiry
+
+Each authenticated socket receives a server-side expiry timer tied to the verified JWT deadline.
+
+At expiry the gateway:
+
+1. removes the socket's user and expiry authority from process memory;
+2. clears its expiry timer;
+3. emits `session:expired` with the bounded reason `token_expired`; and
+4. server-disconnects the socket.
+
+Disconnecting removes the stale socket from its private `user:<userId>` room, so an expired connection cannot remain a passive realtime recipient.
+
+Node timers have a maximum single delay. Tokens whose expiry is farther away than that limit are handled by a bounded timer that re-arms until the actual JWT deadline rather than overflowing into an early or immediate timeout.
+
+Normal disconnect cleanup clears the stored session and timer, preventing timer retention after a socket is gone.
+
+## Event-ingress recheck
+
+Timer delivery is not treated as the sole security boundary. Every authenticated Socket.IO action still begins by resolving `connectedUsers.get(client.id)`, and now also verifies that the stored JWT deadline remains in the future before payload parsing, admission accounting, database authorization, relationship locking, persistence, or delivery work.
+
+This closes the event-loop edge where the wall clock has crossed expiry but the scheduled timer has not yet received a turn.
+
+The established ordering becomes:
+
+1. resolve the authenticated socket identity;
+2. require an active finite JWT lease;
+3. validate and normalize the event payload;
+4. consume the existing authenticated-user admission budget;
+5. perform canonical authorization, locking, persistence, or delivery work.
+
+The prior payload-integrity, abuse-control, block-dominance, live-recipient authorization, idempotent delivery, and private-user-room contracts remain unchanged.
+
+## Web behavior
+
+The web transport listens for the explicit `session:expired` event and clears the persisted Woof auth state through the existing auth-store logout boundary. A later login can reuse the singleton Socket.IO client because `connectSocket()` always refreshes `socket.auth` from the current auth store before connecting.
+
+This release does not introduce refresh tokens, a server-side token revocation table, or a new session database. It enforces the lifetime already encoded in the signed access token. Explicit server-side revocation is a separate authority problem and should not be implied by this release.
+
+## Privacy
+
+Operational logging remains identifier-free at this boundary. Rejected connections log only the error class name already used by the gateway. Raw JWTs, user IDs, socket auth objects, and token claims are not logged.
+
+## Qualification contract
+
+The dedicated Realtime Session Lifetime lane must prove one exact candidate head and must:
+
+1. reject schema and migration ownership;
+2. apply the full inherited migration chain;
+3. pass touched-file Prettier and zero-warning API/web lint;
+4. require finite future `exp` at the realtime handshake;
+5. require session-lifetime validation before payload/admission/chat work for message, membership, and typing handlers;
+6. prove normal disconnect clears expiry state;
+7. prove an expired lease rejects event work even if its timer has not run yet;
+8. pass API and web TypeScript;
+9. pass the focused gateway regression suite;
+10. build API and web production bundles;
+11. build and boot the real production API image; and
+12. use a real Socket.IO client against that image to prove a short-lived signed JWT receives `session:expired` and is server-disconnected at its deadline.
+
+Diagnostic heads do not qualify the release.


### PR DESCRIPTION
## dogOS Realtime Session Lifetime v1

Base production merge: `d017682d9a98d20065603f74dbfe42ecb17c8258` (merged PR #27 Realtime Payload Integrity).

Qualified exact head: `67763ab5ea7f1278035bbbf3a628b4fb1273c000`.

### Production defect closed

The realtime gateway verified JWTs only once during `handleConnection()` and then cached `sub` in `connectedUsers` for the lifetime of the Socket.IO connection. HTTP requests correctly reject expired JWTs on every request, but an already-connected socket could outlive its token and retain both event authority and membership in its private `user:<userId>` delivery room.

A signed JWT without a finite `exp` claim could also establish an effectively unbounded realtime lease.

### Finite realtime lease

Realtime authentication now requires:

- a non-empty string `sub`;
- a positive safe-integer JWT NumericDate `exp`;
- that expiry to still be in the future after ordinary `JwtService.verifyAsync()` verification.

The raw token is never retained or logged. The gateway stores only user ID + expiry for the active socket.

Every authenticated socket receives a bounded server-side expiry timer. At the verified deadline the gateway clears cached authority and the timer, emits `session:expired { reason: 'token_expired' }`, and server-disconnects the socket. That disconnect removes the stale connection from its private user room, closing passive delivery as well as inbound actions.

Long-lived tokens beyond Node's maximum single timer delay are re-armed in bounded chunks rather than overflowing the timer. Normal disconnect clears all lifetime state.

The handshake also rechecks the lease immediately before joining `user:<userId>`, so a socket that crosses expiry between signature verification and room mutation cannot enter the private delivery room.

### Event-ingress fail closed

Message, join, leave and typing paths each recheck the stored lease immediately after resolving the authenticated socket identity and before payload parsing, admission accounting, database authorization, relationship locking, persistence, or delivery work.

The ordering is now:

`identity -> active JWT lease -> payload validation -> realtime admission -> canonical chat work`

Payload integrity, block dominance, live recipient authorization, idempotent receipts, reconnect-resistant admission and private-user-room fanout remain unchanged.

### Web behavior

The web Socket.IO transport handles `session:expired` through the existing persisted auth-store logout boundary. A later login can reuse the singleton socket because `connectSocket()` refreshes `socket.auth` from current auth state before connecting.

### Honest scope

This release does **not** add refresh tokens, a server-side revocation table, or claim immediate logout/password-change revocation. It enforces the finite lifetime already encoded in the signed access token. Explicit server-side revocation remains a separate authority problem.

No schema, migration, lockfile, recommendation, Adventure, Autopilot, connector, health, or ML semantics are changed.

### Exact-head qualification receipt

All workflows triggered by this ownership surface completed successfully on `67763ab5ea7f1278035bbbf3a628b4fb1273c000`:

- root `CI` run `32790514184`: static gates, frontend unit + Playwright smoke/accessibility/visual contracts, backend unit/API tests, API + web production builds;
- `dogOS Realtime Session Lifetime CI` run `32790514177`: full migration chain, formatting, zero-warning lint, structural ordering checks, API/web type-checks, focused regressions, production API/web builds, Docker boot, and a real short-lived Socket.IO JWT expiry/ejection proof;
- `dogOS Live Authorization CI` run `32790514207`;
- `dogOS Realtime Payload Integrity CI` run `32790514234`;
- `dogOS Realtime Abuse Control CI` run `32790514205`;
- `dogOS Trust Enforcement Atomicity CI` run `32790514185`;
- `dogOS Chat Delivery Integrity CI` run `32790514193`;
- `dogOS Network Integrity + Scale CI` run `32790514181`;
- `dogOS Trust + Discovery CI` run `32790514250`;
- `CI Action Runtime Qualification` run `32790514214`.

The production transport proof used the real Dockerized API and a real Socket.IO client with a short-lived HMAC-signed JWT. The client observed the bounded `session:expired` event at the token deadline followed by a server-driven disconnect.

### Diagnostic history

`5163ecef7b480f60d10daaa066ff9047088f6858` is diagnostic only. It applied all inherited migrations successfully but was rejected by read-only Prettier before semantic checks ran. The source was normalized, the handshake-to-private-room clock edge was additionally closed, and the branch was rebuilt as one commit directly on the unchanged production base.

This exact head is qualified and ready for review. It is intentionally not merged here.