### PR TITLE
dogOS Auth: add persisted session authority

### DIFF
--- a/.github/scripts/assert-database-ownership.py
+++ b/.github/scripts/assert-database-ownership.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Fail closed on Prisma ownership changes, with explicit add-only exceptions."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        fail("usage: assert-database-ownership.py BASE_SHA [ALLOW_ADDED_PATH ...]")
+
+    base_sha = sys.argv[1]
+    allowed_added = set(sys.argv[2:])
+    diff = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-status",
+            "--find-renames",
+            f"{base_sha}...HEAD",
+            "--",
+            "packages/database/prisma/",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+    violations: list[str] = []
+    for raw_line in diff.splitlines():
+        if not raw_line.strip():
+            continue
+        fields = raw_line.split("\t")
+        status = fields[0]
+        paths = fields[1:]
+
+        if status == "A" and len(paths) == 1 and paths[0] in allowed_added:
+            continue
+
+        violations.append(raw_line)
+
+    if violations:
+        print("Database ownership boundary rejected these Prisma changes:", file=sys.stderr)
+        for violation in violations:
+            print(f"  {violation}", file=sys.stderr)
+        if allowed_added:
+            print("Only these newly-added paths are allowed in this lane:", file=sys.stderr)
+            for path in sorted(allowed_added):
+                print(f"  A\t{path}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/dogos-chat-delivery-integrity-ci.yml
+++ b/.github/workflows/dogos-chat-delivery-integrity-ci.yml
@@ -51,15 +51,12 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @woof/database db:generate
 
-      - name: Reject schema and migration ownership changes
+      - name: Enforce database ownership boundary
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
-            echo 'Chat Delivery Integrity v1 does not own database schema or migration changes.'
-            exit 1
-          fi
+        run: >-
+          python .github/scripts/assert-database-ownership.py "$BASE_SHA"
+          packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/migration.sql
 
       - name: Check Chat Delivery formatting
         run: >-
@@ -124,10 +121,54 @@ jobs:
 
       - name: Enforce canonical server receipt boundary
         run: |
-          grep -q 'dogos_chat.message_receipts' apps/api/src/chat/chat-security.service.ts
-          grep -q 'ON CONFLICT (user_id, client_message_id) DO NOTHING' apps/api/src/chat/chat-security.service.ts
-          grep -q 'if (!result.duplicate)' apps/api/src/chat/chat.gateway.ts
-          grep -q 'chatSecurity.persistMessage' apps/api/src/chat/chat.gateway.ts
+          python - <<'PY'
+          from pathlib import Path
+
+          gateway = Path('apps/api/src/chat/chat.gateway.ts').read_text()
+          security = Path('apps/api/src/chat/chat-security.service.ts').read_text()
+
+          receipt_required = [
+              'dogos_chat.message_receipts',
+              'ON CONFLICT (user_id, client_message_id) DO NOTHING',
+              'pg_advisory_xact_lock',
+              'woof:chat-receipt:',
+          ]
+          missing = [token for token in receipt_required if token not in security]
+          if missing:
+              raise SystemExit(f'missing canonical receipt invariant: {missing}')
+
+          message = gateway[
+              gateway.index("@SubscribeMessage('message:send')"):
+              gateway.index("@SubscribeMessage('conversation:join')")
+          ]
+          authority = message.index('this.withAuthoritativeSession(client, userId, async (tx) =>')
+          persistence = message.index('chatSecurity.persistMessageInTransaction(tx')
+          postcommit = message.index('if (response?.success && !response.duplicate)')
+          fanout = message.index('chatSecurity.withAuthorizedRealtimeRecipients', postcommit)
+          if not authority < persistence < postcommit < fanout:
+              raise SystemExit(
+                  'message delivery must persist with the authority transaction before post-commit fanout'
+              )
+
+          tx_start = security.index('async persistMessageInTransaction')
+          tx_end = security.index('private normalizePersistMessageInput', tx_start)
+          tx_path = security[tx_start:tx_end]
+          tx_required = [
+              'this.normalizePersistMessageInput(input)',
+              'this.acquireReceiptIdentityLock(tx',
+              'this.assertConversationAccessWithClient(tx',
+              'this.getReceiptWithClient(tx',
+              'tx.message.create',
+              'this.insertReceipt(tx',
+          ]
+          missing = [token for token in tx_required if token not in tx_path]
+          if missing:
+              raise SystemExit(f'transaction-bound persistence is incomplete: {missing}')
+          if 'this.prisma.' in tx_path or '$transaction' in tx_path:
+              raise SystemExit(
+                  'transaction-bound persistence must reuse the authority transaction, never acquire Prisma again'
+              )
+          PY
 
       - name: Type-check web
         run: pnpm --filter @woof/web type-check

--- a/.github/workflows/dogos-live-authorization-ci.yml
+++ b/.github/workflows/dogos-live-authorization-ci.yml
@@ -65,15 +65,12 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @woof/database db:generate
 
-      - name: Reject schema and migration ownership changes
+      - name: Enforce database ownership boundary
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
-            echo 'Live Authorization v1 does not own database schema or migration changes.'
-            exit 1
-          fi
+        run: >-
+          python .github/scripts/assert-database-ownership.py "$BASE_SHA"
+          packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/migration.sql
 
       - name: Apply full database migration chain
         run: pnpm --filter @woof/database db:migrate:deploy

--- a/.github/workflows/dogos-network-integrity-ci.yml
+++ b/.github/workflows/dogos-network-integrity-ci.yml
@@ -64,15 +64,12 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @woof/database db:generate
 
-      - name: Reject schema and migration ownership changes
+      - name: Enforce database ownership boundary
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
-            echo 'Network Integrity + Scale v1 does not own database schema or migration changes.'
-            exit 1
-          fi
+        run: >-
+          python .github/scripts/assert-database-ownership.py "$BASE_SHA"
+          packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/migration.sql
 
       - name: Apply full database migration chain
         run: pnpm --filter @woof/database db:migrate:deploy

--- a/.github/workflows/dogos-realtime-abuse-ci.yml
+++ b/.github/workflows/dogos-realtime-abuse-ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'apps/api/src/chat/chat.gateway.ts'
       - 'apps/api/src/chat/chat.gateway.spec.ts'
+      - 'apps/api/src/chat/chat-session-ready.spec.ts'
       - 'apps/api/src/chat/chat.module.ts'
       - 'apps/api/src/chat/realtime-admission.service.ts'
       - 'apps/api/src/chat/realtime-admission.service.spec.ts'
@@ -67,15 +68,12 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @woof/database db:generate
 
-      - name: Reject schema and migration ownership changes
+      - name: Enforce database ownership boundary
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
-            echo 'Realtime Abuse Control v1 does not own database schema or migration changes.'
-            exit 1
-          fi
+        run: >-
+          python .github/scripts/assert-database-ownership.py "$BASE_SHA"
+          packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/migration.sql
 
       - name: Apply full database migration chain
         run: pnpm --filter @woof/database db:migrate:deploy
@@ -85,6 +83,7 @@ jobs:
           pnpm exec prettier --check
           apps/api/src/chat/chat.gateway.ts
           apps/api/src/chat/chat.gateway.spec.ts
+          apps/api/src/chat/chat-session-ready.spec.ts
           apps/api/src/chat/chat.module.ts
           apps/api/src/chat/realtime-admission.service.ts
           apps/api/src/chat/realtime-admission.service.spec.ts
@@ -96,6 +95,7 @@ jobs:
           pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
           src/chat/chat.gateway.ts
           src/chat/chat.gateway.spec.ts
+          src/chat/chat-session-ready.spec.ts
           src/chat/chat.module.ts
           src/chat/realtime-admission.service.ts
           src/chat/realtime-admission.service.spec.ts
@@ -163,11 +163,12 @@ jobs:
       - name: Type-check API
         run: pnpm --filter @woof/api type-check
 
-      - name: Run realtime admission and gateway contracts
+      - name: Run realtime admission, readiness and gateway contracts
         run: >-
           pnpm --filter @woof/api exec jest --runInBand
           src/chat/realtime-admission.service.spec.ts
           src/chat/chat.gateway.spec.ts
+          src/chat/chat-session-ready.spec.ts
           src/chat/chat-security.service.spec.ts
 
       - name: Run existing PostgreSQL authorization race regressions
@@ -219,32 +220,58 @@ jobs:
       - name: Prove authenticated Socket.IO flood admission and reconnect retention
         run: |
           pnpm --filter @woof/web exec node <<'NODE'
-          const crypto = require('node:crypto');
           const { io } = require('socket.io-client');
+          const baseUrl = 'http://127.0.0.1:4000/api/v1';
 
-          const secret = process.env.JWT_SECRET;
-          if (!secret) throw new Error('JWT_SECRET is required');
-
-          function jwt(sub) {
-            const now = Math.floor(Date.now() / 1000);
-            const encode = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
-            const header = encode({ alg: 'HS256', typ: 'JWT' });
-            const payload = encode({ sub, iat: now, exp: now + 300 });
-            const unsigned = `${header}.${payload}`;
-            const signature = crypto.createHmac('sha256', secret).update(unsigned).digest('base64url');
-            return `${unsigned}.${signature}`;
+          async function register(label) {
+            const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+            const response = await fetch(`${baseUrl}/auth/register`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                handle: `ci-abuse-${label}-${suffix}`.slice(0, 30),
+                email: `ci-abuse-${label}-${suffix}@example.test`,
+                password: 'SessionPass123!',
+              }),
+            });
+            const payload = await response.json().catch(() => null);
+            if (response.status !== 201 || !payload?.access_token) {
+              throw new Error(`register ${label} failed: ${response.status} ${JSON.stringify(payload)}`);
+            }
+            return payload.access_token;
           }
 
-          function connect(sub) {
+          function connect(token) {
             return new Promise((resolve, reject) => {
               const socket = io('http://127.0.0.1:4000', {
-                auth: { token: jwt(sub) },
+                auth: { token },
                 transports: ['websocket'],
                 reconnection: false,
                 timeout: 4_000,
               });
-              socket.once('connect', () => resolve(socket));
-              socket.once('connect_error', reject);
+              const timer = setTimeout(() => {
+                socket.disconnect();
+                reject(new Error('socket transport connected but session:ready did not arrive'));
+              }, 5_000);
+              socket.once('session:ready', (payload) => {
+                if (!payload || payload.socketId !== socket.id) {
+                  clearTimeout(timer);
+                  socket.disconnect();
+                  reject(new Error(`session:ready socket mismatch: ${JSON.stringify(payload)}`));
+                  return;
+                }
+                clearTimeout(timer);
+                resolve(socket);
+              });
+              socket.once('connect_error', (error) => {
+                clearTimeout(timer);
+                reject(error);
+              });
+              socket.once('disconnect', (reason) => {
+                if (reason === 'io client disconnect') return;
+                clearTimeout(timer);
+                reject(new Error(`socket disconnected before session:ready: ${reason}`));
+              });
             });
           }
 
@@ -257,6 +284,12 @@ jobs:
             });
           }
 
+          function expectAdmitted(response, label) {
+            if (!response || response.error === 'rate_limited' || response.error === 'unauthorized') {
+              throw new Error(`${label} should reach canonical work: ${JSON.stringify(response)}`);
+            }
+          }
+
           function expectRateLimited(response, label) {
             if (!response || response.success !== false || response.error !== 'rate_limited') {
               throw new Error(`${label} expected rate_limited, got ${JSON.stringify(response)}`);
@@ -266,16 +299,28 @@ jobs:
             }
           }
 
-          (async () => {
-            const userOne = await connect('socket-abuse-user-1');
+          async function consumeBurst(socket, action, count, payloadForIndex, label) {
+            const responses = await Promise.all(
+              Array.from({ length: count }, (_, index) => ack(socket, action, payloadForIndex(index)))
+            );
+            responses.forEach((response, index) => expectAdmitted(response, `${label} ${index}`));
+          }
 
-            for (let index = 0; index < 5; index += 1) {
-              userOne.emit('message:send', {
+          (async () => {
+            const tokenOne = await register('one');
+            const userOne = await connect(tokenOne);
+
+            await consumeBurst(
+              userOne,
+              'message:send',
+              5,
+              (index) => ({
                 conversationId: 'missing-conversation',
                 clientMessageId: `flood-message-${index}`,
                 text: 'flood probe',
-              });
-            }
+              }),
+              'message burst'
+            );
             const messageDenied = await ack(userOne, 'message:send', {
               conversationId: 'missing-conversation',
               clientMessageId: 'flood-message-denied',
@@ -284,7 +329,7 @@ jobs:
             expectRateLimited(messageDenied, 'message flood');
 
             userOne.disconnect();
-            const reconnected = await connect('socket-abuse-user-1');
+            const reconnected = await connect(tokenOne);
             const reconnectDenied = await ack(reconnected, 'message:send', {
               conversationId: 'missing-conversation',
               clientMessageId: 'reconnect-message-denied',
@@ -292,40 +337,51 @@ jobs:
             });
             expectRateLimited(reconnectDenied, 'reconnect flood');
 
-            for (let index = 0; index < 8; index += 1) {
-              reconnected.emit('typing:start', { conversationId: 'missing-conversation' });
-            }
+            await consumeBurst(
+              reconnected,
+              'typing:start',
+              8,
+              () => ({ conversationId: 'missing-conversation' }),
+              'typing burst'
+            );
             const typingDenied = await ack(reconnected, 'typing:start', {
               conversationId: 'missing-conversation',
             });
             expectRateLimited(typingDenied, 'typing flood');
 
-            for (let index = 0; index < 10; index += 1) {
-              reconnected.emit('conversation:join', { conversationId: 'missing-conversation' });
-            }
+            await consumeBurst(
+              reconnected,
+              'conversation:join',
+              10,
+              () => ({ conversationId: 'missing-conversation' }),
+              'membership burst'
+            );
             const membershipDenied = await ack(reconnected, 'conversation:join', {
               conversationId: 'missing-conversation',
             });
             expectRateLimited(membershipDenied, 'membership flood');
 
-            const userTwo = await connect('socket-abuse-user-2');
+            const tokenTwo = await register('two');
+            const userTwo = await connect(tokenTwo);
             const independent = await ack(userTwo, 'message:send', {
               conversationId: 'missing-conversation',
               clientMessageId: 'independent-user-message',
               text: 'independent probe',
             });
-            if (!independent || independent.error === 'rate_limited') {
-              throw new Error(`distinct user must have an independent bucket: ${JSON.stringify(independent)}`);
-            }
+            expectAdmitted(independent, 'distinct user independent bucket');
 
             userTwo.disconnect();
             reconnected.disconnect();
-          })().catch((error) => {
-            console.error(error);
-            process.exitCode = 1;
-          });
+          })()
+            .then(() => process.exit(0))
+            .catch((error) => {
+              console.error(error);
+              process.exit(1);
+            });
           NODE
 
       - name: Stop production image
         if: always()
-        run: docker rm -f woof-api-realtime-abuse-ci >/dev/null 2>&1 || true
+        run: |
+          docker logs woof-api-realtime-abuse-ci || true
+          docker rm -f woof-api-realtime-abuse-ci >/dev/null 2>&1 || true

--- a/.github/workflows/dogos-realtime-payload-integrity-ci.yml
+++ b/.github/workflows/dogos-realtime-payload-integrity-ci.yml
@@ -8,6 +8,7 @@ on:
       - 'apps/api/src/chat/chat-input-contract.spec.ts'
       - 'apps/api/src/chat/chat.gateway.ts'
       - 'apps/api/src/chat/chat.gateway.spec.ts'
+      - 'apps/api/src/chat/chat-session-ready.spec.ts'
       - 'apps/api/src/chat/chat-security.service.ts'
       - 'apps/api/src/chat/chat-security.service.spec.ts'
       - '.github/workflows/dogos-realtime-payload-integrity-ci.yml'
@@ -68,15 +69,12 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @woof/database db:generate
 
-      - name: Reject schema and migration ownership changes
+      - name: Enforce database ownership boundary
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
-            echo 'Realtime Payload Integrity v1 does not own database schema or migration changes.'
-            exit 1
-          fi
+        run: >-
+          python .github/scripts/assert-database-ownership.py "$BASE_SHA"
+          packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/migration.sql
 
       - name: Apply full database migration chain
         run: pnpm --filter @woof/database db:migrate:deploy
@@ -88,6 +86,7 @@ jobs:
           apps/api/src/chat/chat-input-contract.spec.ts
           apps/api/src/chat/chat.gateway.ts
           apps/api/src/chat/chat.gateway.spec.ts
+          apps/api/src/chat/chat-session-ready.spec.ts
           apps/api/src/chat/chat-security.service.ts
           apps/api/src/chat/chat-security.service.spec.ts
           .github/workflows/dogos-realtime-payload-integrity-ci.yml
@@ -100,6 +99,7 @@ jobs:
           src/chat/chat-input-contract.spec.ts
           src/chat/chat.gateway.ts
           src/chat/chat.gateway.spec.ts
+          src/chat/chat-session-ready.spec.ts
           src/chat/chat-security.service.ts
           src/chat/chat-security.service.spec.ts
 
@@ -147,28 +147,28 @@ jobs:
                   message,
                   'parseSendChatMessagePayload(data)',
                   "realtimeAdmission.consume(userId, 'message')",
-                  'chatSecurity.persistMessage',
+                  'chatSecurity.persistMessageInTransaction(tx',
               ),
               (
                   'join',
                   join,
                   'parseConversationPayload(data)',
                   "realtimeAdmission.consume(userId, 'membership')",
-                  'chatSecurity.assertConversationAccess',
+                  'chatSecurity.assertConversationAccessInTransaction(',
               ),
               (
                   'leave',
                   leave,
                   'parseConversationPayload(data)',
                   "realtimeAdmission.consume(userId, 'membership')",
-                  'chatSecurity.assertConversationAccess',
+                  'chatSecurity.assertConversationAccessInTransaction(',
               ),
               (
                   'typing',
                   typing,
                   'parseConversationPayload(data)',
                   "realtimeAdmission.consume(userId, 'typing')",
-                  'chatSecurity.withAuthorizedRealtimeRecipients',
+                  'chatSecurity.withAuthorizedRealtimeRecipientsInTransaction(',
               ),
           ]
           for label, handler, parser, admission_call, expensive_call in checks:
@@ -184,8 +184,9 @@ jobs:
                       f'{label} must authenticate, validate, reject invalid input, admit, then perform chat work'
                   )
 
-          persist_start = security.index('async persistMessage')
-          access = security.index('await this.assertConversationAccess', persist_start)
+          normalize_start = security.index('private normalizePersistMessageInput')
+          normalize_end = security.index('private async assertConversationAccessWithClient', normalize_start)
+          normalize = security[normalize_start:normalize_end]
           validation_tokens = [
               'isChatIdentifier(input.conversationId)',
               'isClientMessageId(input.clientMessageId)',
@@ -193,20 +194,52 @@ jobs:
               "input.text.includes('\\u0000')",
               'normalizeChatMessageText(input.text)',
           ]
-          for token in validation_tokens:
-              location = security.find(token, persist_start, access)
-              if location < 0:
-                  raise SystemExit(f'persistMessage must validate before its first database read: {token}')
+          missing = [token for token in validation_tokens if token not in normalize]
+          if missing:
+              raise SystemExit(f'server persistence validation is incomplete: {missing}')
+
+          for method, end_marker in [
+              ('async persistMessage(', 'async persistMessageInTransaction'),
+              ('async persistMessageInTransaction(', 'private normalizePersistMessageInput'),
+          ]:
+              start = security.index(method)
+              end = security.index(end_marker, start + len(method))
+              body = security[start:end]
+              normalize_call = body.find('this.normalizePersistMessageInput(input)')
+              if normalize_call < 0:
+                  raise SystemExit(f'{method} must validate before database work')
+
+              db_markers = [
+                  'this.assertConversationAccess',
+                  'this.getReceipt(',
+                  'this.prisma.',
+                  'this.acquireReceiptIdentityLock(tx',
+                  'this.assertConversationAccessWithClient(tx',
+                  'this.getReceiptWithClient(tx',
+                  'tx.message.',
+              ]
+              db_positions = [body.find(marker) for marker in db_markers if body.find(marker) >= 0]
+              if db_positions and normalize_call > min(db_positions):
+                  raise SystemExit(f'{method} must validate before its first database operation')
+
+          tx_start = security.index('async persistMessageInTransaction')
+          tx_end = security.index('private normalizePersistMessageInput', tx_start)
+          tx_path = security[tx_start:tx_end]
+          if 'this.prisma.' in tx_path or '$transaction' in tx_path:
+              raise SystemExit(
+                  'transaction-bound persistence must not reacquire Prisma while session authority holds a connection'
+              )
           PY
 
       - name: Type-check API
         run: pnpm --filter @woof/api type-check
 
-      - name: Run payload, gateway, persistence, and admission contracts
+      - name: Run payload, readiness, gateway, persistence, and admission contracts
         run: >-
           pnpm --filter @woof/api exec jest --runInBand
           src/chat/chat-input-contract.spec.ts
           src/chat/chat.gateway.spec.ts
+          src/chat/chat-session-ready.spec.ts
           src/chat/chat-security.service.spec.ts
           src/chat/realtime-admission.service.spec.ts
 
@@ -260,32 +293,58 @@ jobs:
       - name: Prove malformed payload rejection and transport ceiling
         run: |
           pnpm --filter @woof/web exec node <<'NODE'
-          const crypto = require('node:crypto');
           const { io } = require('socket.io-client');
+          const baseUrl = 'http://127.0.0.1:4000/api/v1';
 
-          const secret = process.env.JWT_SECRET;
-          if (!secret) throw new Error('JWT_SECRET is required');
-
-          function jwt(sub) {
-            const now = Math.floor(Date.now() / 1000);
-            const encode = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
-            const header = encode({ alg: 'HS256', typ: 'JWT' });
-            const payload = encode({ sub, iat: now, exp: now + 300 });
-            const unsigned = `${header}.${payload}`;
-            const signature = crypto.createHmac('sha256', secret).update(unsigned).digest('base64url');
-            return `${unsigned}.${signature}`;
+          async function register(label) {
+            const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+            const response = await fetch(`${baseUrl}/auth/register`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                handle: `ci-payload-${label}-${suffix}`.slice(0, 30),
+                email: `ci-payload-${label}-${suffix}@example.test`,
+                password: 'SessionPass123!',
+              }),
+            });
+            const payload = await response.json().catch(() => null);
+            if (response.status !== 201 || !payload?.access_token) {
+              throw new Error(`register ${label} failed: ${response.status} ${JSON.stringify(payload)}`);
+            }
+            return payload.access_token;
           }
 
-          function connect(sub) {
+          function connect(token) {
             return new Promise((resolve, reject) => {
               const socket = io('http://127.0.0.1:4000', {
-                auth: { token: jwt(sub) },
+                auth: { token },
                 transports: ['websocket'],
                 reconnection: false,
                 timeout: 4_000,
               });
-              socket.once('connect', () => resolve(socket));
-              socket.once('connect_error', reject);
+              const timer = setTimeout(() => {
+                socket.disconnect();
+                reject(new Error('socket transport connected but session:ready did not arrive'));
+              }, 5_000);
+              socket.once('session:ready', (payload) => {
+                if (!payload || payload.socketId !== socket.id) {
+                  clearTimeout(timer);
+                  socket.disconnect();
+                  reject(new Error(`session:ready socket mismatch: ${JSON.stringify(payload)}`));
+                  return;
+                }
+                clearTimeout(timer);
+                resolve(socket);
+              });
+              socket.once('connect_error', (error) => {
+                clearTimeout(timer);
+                reject(error);
+              });
+              socket.once('disconnect', (reason) => {
+                if (reason === 'io client disconnect') return;
+                clearTimeout(timer);
+                reject(new Error(`socket disconnected before session:ready: ${reason}`));
+              });
             });
           }
 
@@ -305,7 +364,8 @@ jobs:
           }
 
           (async () => {
-            const socket = await connect('socket-payload-user-1');
+            const tokenOne = await register('one');
+            const socket = await connect(tokenOne);
 
             expectInvalid(await ack(socket, 'message:send', null), 'null message');
             expectInvalid(
@@ -346,7 +406,8 @@ jobs:
             }
             socket.disconnect();
 
-            const oversized = await connect('socket-payload-user-2');
+            const tokenTwo = await register('two');
+            const oversized = await connect(tokenTwo);
             const disconnected = new Promise((resolve, reject) => {
               const timer = setTimeout(
                 () => reject(new Error('over-ceiling Socket.IO frame did not disconnect')),
@@ -363,10 +424,12 @@ jobs:
             if (oversized.connected) {
               throw new Error('over-ceiling Socket.IO frame must leave the socket disconnected');
             }
-          })().catch((error) => {
-            console.error(error);
-            process.exitCode = 1;
-          });
+          })()
+            .then(() => process.exit(0))
+            .catch((error) => {
+              console.error(error);
+              process.exit(1);
+            });
           NODE
 
       - name: Stop production image

--- a/.github/workflows/dogos-realtime-session-lifetime-ci.yml
+++ b/.github/workflows/dogos-realtime-session-lifetime-ci.yml
@@ -6,7 +6,9 @@ on:
     paths:
       - 'apps/api/src/chat/chat.gateway.ts'
       - 'apps/api/src/chat/chat.gateway.spec.ts'
+      - 'apps/api/src/chat/chat-session-ready.spec.ts'
       - 'apps/web/src/lib/socket.ts'
+      - 'apps/web/src/lib/socket.spec.ts'
       - '.github/workflows/dogos-realtime-session-lifetime-ci.yml'
       - 'docs/DOGOS_REALTIME_SESSION_LIFETIME.md'
 
@@ -65,15 +67,12 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @woof/database db:generate
 
-      - name: Reject schema and migration ownership changes
+      - name: Enforce database ownership boundary
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
-            echo 'Realtime Session Lifetime v1 does not own database schema or migration changes.'
-            exit 1
-          fi
+        run: >-
+          python .github/scripts/assert-database-ownership.py "$BASE_SHA"
+          packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/migration.sql
 
       - name: Apply full database migration chain
         run: pnpm --filter @woof/database db:migrate:deploy
@@ -83,29 +82,35 @@ jobs:
           pnpm exec prettier --check
           apps/api/src/chat/chat.gateway.ts
           apps/api/src/chat/chat.gateway.spec.ts
+          apps/api/src/chat/chat-session-ready.spec.ts
           apps/web/src/lib/socket.ts
+          apps/web/src/lib/socket.spec.ts
           .github/workflows/dogos-realtime-session-lifetime-ci.yml
           docs/DOGOS_REALTIME_SESSION_LIFETIME.md
 
       - name: Lint realtime session surfaces
         run: |
-          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish src/chat/chat.gateway.ts src/chat/chat.gateway.spec.ts
-          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish src/lib/socket.ts
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish src/chat/chat.gateway.ts src/chat/chat.gateway.spec.ts src/chat/chat-session-ready.spec.ts
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish src/lib/socket.ts src/lib/socket.spec.ts
 
-      - name: Enforce finite session lifetime before realtime work
+      - name: Enforce finite lifetime and socket-bound authorization readiness before realtime work
         run: |
           python - <<'PY'
           from pathlib import Path
 
           gateway = Path('apps/api/src/chat/chat.gateway.ts').read_text()
           web = Path('apps/web/src/lib/socket.ts').read_text()
+          ready_emit = "client.emit('session:ready', { socketId: client.id })"
 
           required_gateway = [
               'exp?: unknown',
               'sessionExpiries = new Map<string, number>()',
               'sessionExpiryTimers = new Map<string, NodeJS.Timeout>()',
               'expiryFromPayload(payload.exp)',
+              'sessionAuthority.withActiveSession',
               'scheduleSessionExpiry(client, expiresAtMs)',
+              'await client.join(`user:${userId}`)',
+              ready_emit,
               'this.clearSession(client.id)',
               "client.emit('session:expired', { reason: 'token_expired' })",
               'client.disconnect()',
@@ -113,7 +118,14 @@ jobs:
           ]
           missing = [token for token in required_gateway if token not in gateway]
           if missing:
-              raise SystemExit(f'missing realtime lifetime contract: {missing}')
+              raise SystemExit(f'missing realtime lifetime/readiness contract: {missing}')
+
+          connection = gateway[gateway.index('async handleConnection'):gateway.index('handleDisconnect')]
+          authority = connection.index('sessionAuthority.withActiveSession')
+          room_join = connection.index('await client.join(`user:${userId}`)')
+          ready = connection.index(ready_emit)
+          if not authority < room_join < ready:
+              raise SystemExit('socket-bound session:ready must follow persisted authority and private room join')
 
           if "logger.warn(`Rejected socket connection: ${this.errorName(error)}`)" not in gateway:
               raise SystemExit('socket rejection logging must remain identifier-free')
@@ -175,10 +187,20 @@ jobs:
                       f'{label} must resolve identity, verify lifetime, validate, admit, then perform chat work'
                   )
 
-          if "socket.on('session:expired'" not in web:
-              raise SystemExit('web socket transport must observe explicit session expiry')
-          if 'useAuthStore.getState().logout()' not in web:
-              raise SystemExit('web session expiry must clear persisted auth state through the auth store')
+          web_required = [
+              "activeSocket.on('session:ready', (payload: SessionReadyPayload) =>",
+              'payload?.socketId !== activeSocket.id',
+              "activeSocket.on('session:expired'",
+              "activeSocket.on('session:revoked'",
+              'SESSION_READY_TIMEOUT_MS = 8_000',
+              'function waitForSessionReady(): Promise<Socket>',
+              'waitForSessionReady().then(',
+              'sessionReady = false',
+              'useAuthStore.getState().logout()',
+          ]
+          missing = [token for token in web_required if token not in web]
+          if missing:
+              raise SystemExit(f'web realtime readiness contract is incomplete: {missing}')
           PY
 
       - name: Type-check API and web
@@ -186,12 +208,14 @@ jobs:
           pnpm --filter @woof/api type-check
           pnpm --filter @woof/web type-check
 
-      - name: Run realtime lifetime and inherited chat contracts
-        run: >-
-          pnpm --filter @woof/api exec jest --runInBand
-          src/chat/chat.gateway.spec.ts
-          src/chat/chat-input-contract.spec.ts
-          src/chat/realtime-admission.service.spec.ts
+      - name: Run realtime lifetime, readiness and inherited chat contracts
+        run: |
+          pnpm --filter @woof/api exec jest --runInBand \
+            src/chat/chat.gateway.spec.ts \
+            src/chat/chat-session-ready.spec.ts \
+            src/chat/chat-input-contract.spec.ts \
+            src/chat/realtime-admission.service.spec.ts
+          pnpm --filter @woof/web exec vitest run src/lib/socket.spec.ts
 
       - name: Build API and web
         run: |
@@ -208,6 +232,7 @@ jobs:
             -e DATABASE_URL="$DATABASE_URL" \
             -e SHADOW_DATABASE_URL="$SHADOW_DATABASE_URL" \
             -e JWT_SECRET="$JWT_SECRET" \
+            -e JWT_EXPIRES_IN=5s \
             -e NODE_ENV=production \
             -e API_DOCS_ENABLED=false \
             -e CORS_ORIGIN=http://localhost:3000 \
@@ -235,28 +260,34 @@ jobs:
             exit 1
           fi
 
-      - name: Prove JWT expiry ejects a real production Socket.IO session
+      - name: Prove server-issued JWT expiry ejects an authorized production Socket.IO session
         run: |
           pnpm --filter @woof/web exec node <<'NODE'
-          const crypto = require('node:crypto');
           const { io } = require('socket.io-client');
+          const baseUrl = 'http://127.0.0.1:4000/api/v1';
 
-          const secret = process.env.JWT_SECRET;
-          if (!secret) throw new Error('JWT_SECRET is required');
-
-          function jwt(sub, expiresInSeconds) {
-            const now = Math.floor(Date.now() / 1000);
-            const encode = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
-            const header = encode({ alg: 'HS256', typ: 'JWT' });
-            const payload = encode({ sub, iat: now, exp: now + expiresInSeconds });
-            const unsigned = `${header}.${payload}`;
-            const signature = crypto.createHmac('sha256', secret).update(unsigned).digest('base64url');
-            return `${unsigned}.${signature}`;
+          async function register() {
+            const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+            const response = await fetch(`${baseUrl}/auth/register`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                handle: `ci-lifetime-${suffix}`.slice(0, 30),
+                email: `ci-lifetime-${suffix}@example.test`,
+                password: 'SessionPass123!',
+              }),
+            });
+            const payload = await response.json().catch(() => null);
+            if (response.status !== 201 || !payload?.access_token) {
+              throw new Error(`register failed: ${response.status} ${JSON.stringify(payload)}`);
+            }
+            return payload.access_token;
           }
 
           (async () => {
+            const token = await register();
             const socket = io('http://127.0.0.1:4000', {
-              auth: { token: jwt('socket-session-user-1', 5) },
+              auth: { token },
               transports: ['websocket'],
               reconnection: false,
               autoConnect: false,
@@ -264,15 +295,28 @@ jobs:
             });
 
             let sawExpiry = false;
-            const connected = new Promise((resolve, reject) => {
-              const timer = setTimeout(() => reject(new Error('socket did not connect')), 4_000);
-              socket.once('connect', () => {
+            const ready = new Promise((resolve, reject) => {
+              const timer = setTimeout(
+                () => reject(new Error('socket transport connected but session:ready did not arrive')),
+                4_000
+              );
+              socket.once('session:ready', (payload) => {
+                if (!payload || payload.socketId !== socket.id) {
+                  clearTimeout(timer);
+                  reject(new Error(`session:ready socket mismatch: ${JSON.stringify(payload)}`));
+                  return;
+                }
                 clearTimeout(timer);
                 resolve();
               });
               socket.once('connect_error', (error) => {
                 clearTimeout(timer);
                 reject(error);
+              });
+              socket.once('disconnect', (reason) => {
+                if (sawExpiry) return;
+                clearTimeout(timer);
+                reject(new Error(`socket disconnected before session:ready; reason=${reason}`));
               });
             });
 
@@ -290,25 +334,24 @@ jobs:
                 sawExpiry = true;
               });
               socket.once('disconnect', (reason) => {
+                if (!sawExpiry) return;
                 clearTimeout(timer);
-                if (!sawExpiry) {
-                  reject(new Error(`socket disconnected before session:expired; reason=${reason}`));
-                  return;
-                }
                 resolve(reason);
               });
             });
 
             socket.connect();
-            await connected;
+            await ready;
             const reason = await expired;
             if (reason !== 'io server disconnect') {
               throw new Error(`expected server-driven disconnect, got ${reason}`);
             }
-          })().catch((error) => {
-            console.error(error);
-            process.exit(1);
-          });
+          })()
+            .then(() => process.exit(0))
+            .catch((error) => {
+              console.error(error);
+              process.exit(1);
+            });
           NODE
 
       - name: Cleanup production image

--- a/.github/workflows/dogos-realtime-session-readiness-ci.yml
+++ b/.github/workflows/dogos-realtime-session-readiness-ci.yml
@@ -1,0 +1,321 @@
+name: dogOS Realtime Session Readiness CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/auth/session-authority.service.ts'
+      - 'apps/api/src/chat/chat.gateway.ts'
+      - 'apps/api/src/chat/chat.gateway.spec.ts'
+      - 'apps/api/src/chat/chat-session-ready.spec.ts'
+      - 'apps/web/src/lib/socket.ts'
+      - 'apps/web/src/lib/socket.spec.ts'
+      - 'packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/**'
+      - '.github/scripts/assert-database-ownership.py'
+      - '.github/workflows/dogos-realtime-session-readiness-ci.yml'
+      - 'docs/DOGOS_SESSION_AUTHORITY.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-realtime-session-readiness-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  JWT_SECRET: ci-only-session-readiness-secret-12345678901234567890
+  NODE_ENV: test
+  ML_SERVICE_ENABLED: 'false'
+
+jobs:
+  qualify:
+    name: Authorized-ready boundary + production transport qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Enforce database ownership boundary
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: >-
+          python .github/scripts/assert-database-ownership.py "$BASE_SHA"
+          packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/migration.sql
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check readiness formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/chat/chat.gateway.ts
+          apps/api/src/chat/chat.gateway.spec.ts
+          apps/api/src/chat/chat-session-ready.spec.ts
+          apps/web/src/lib/socket.ts
+          apps/web/src/lib/socket.spec.ts
+          .github/workflows/dogos-realtime-session-readiness-ci.yml
+
+      - name: Lint readiness surfaces
+        run: |
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish src/chat/chat.gateway.ts src/chat/chat.gateway.spec.ts src/chat/chat-session-ready.spec.ts
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish src/lib/socket.ts src/lib/socket.spec.ts
+
+      - name: Enforce authorization-ready ordering
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          gateway = Path('apps/api/src/chat/chat.gateway.ts').read_text()
+          web = Path('apps/web/src/lib/socket.ts').read_text()
+
+          connection = gateway[gateway.index('async handleConnection'):gateway.index('handleDisconnect')]
+          ready_emit = "client.emit('session:ready', { socketId: client.id })"
+          required_connection = [
+              'sessionAuthority.withActiveSession',
+              'this.connectedUsers.set(client.id, userId)',
+              'this.connectedSessions.set(client.id, sessionId)',
+              'this.sessionExpiries.set(client.id, expiresAtMs)',
+              'await client.join(`user:${userId}`)',
+              ready_emit,
+              'this.isSocketDisconnected(client)',
+          ]
+          missing = [token for token in required_connection if token not in connection]
+          if missing:
+              raise SystemExit(f'missing server readiness invariant: {missing}')
+
+          authority = connection.index('sessionAuthority.withActiveSession')
+          user_map = connection.index('this.connectedUsers.set(client.id, userId)')
+          session_map = connection.index('this.connectedSessions.set(client.id, sessionId)')
+          expiry_map = connection.index('this.sessionExpiries.set(client.id, expiresAtMs)')
+          room_join = connection.index('await client.join(`user:${userId}`)')
+          ready = connection.index(ready_emit)
+          if not authority < user_map < session_map < expiry_map < room_join < ready:
+              raise SystemExit(
+                  'server readiness order must be authority -> socket maps -> private room -> socket-bound session:ready'
+              )
+
+          if connection.count('this.isSocketDisconnected(client)') < 2:
+              raise SystemExit('server must recheck disconnect state across asynchronous admission')
+
+          required_web = [
+              'SESSION_READY_TIMEOUT_MS = 8_000',
+              'let sessionReady = false',
+              'let activeToken: string | null = null',
+              'const desiredConversations = new Set<string>()',
+              'type SessionReadyPayload',
+              'let pendingReadiness: PendingReadiness | null = null',
+              'function settleReadiness(error?: Error)',
+              'function replayDesiredConversations(activeSocket: Socket)',
+              'const activeSocket = io(apiUrl',
+              "activeSocket.on('connect', () =>",
+              "activeSocket.on('session:ready', (payload: SessionReadyPayload) =>",
+              'payload?.socketId !== activeSocket.id',
+              'replayDesiredConversations(activeSocket)',
+              "activeSocket.on('disconnect', () =>",
+              "activeSocket.on('connect_error', (error: Error) =>",
+              'const tokenChanged = activeToken !== token',
+              'desiredConversations.clear()',
+              'function waitForSessionReady(): Promise<Socket>',
+              'if (pendingReadiness) return pendingReadiness.promise',
+              "settleReadiness(new Error('Realtime session authorization timed out'))",
+              'desiredConversations.add(conversationId)',
+              'desiredConversations.delete(conversationId)',
+              'waitForSessionReady().then(',
+          ]
+          missing = [token for token in required_web if token not in web]
+          if missing:
+              raise SystemExit(f'missing web readiness invariant: {missing}')
+
+          start_typing = web[web.index('startTyping:'):web.index('stopTyping:')]
+          if 'waitForSessionReady' in start_typing:
+              raise SystemExit('ephemeral typing must be dropped while unready, never queued for replay')
+          if 'activeSocket.connected && sessionReady' not in start_typing:
+              raise SystemExit('typing may emit only from an authorized-ready transport')
+          PY
+
+      - name: Type-check API and web
+        run: |
+          pnpm --filter @woof/api type-check
+          pnpm --filter @woof/web type-check
+
+      - name: Run readiness unit contracts
+        run: |
+          pnpm --filter @woof/api exec jest --runInBand src/chat/chat-session-ready.spec.ts src/chat/chat.gateway.spec.ts
+          pnpm --filter @woof/web exec vitest run src/lib/socket.spec.ts
+
+      - name: Build API and web
+        run: |
+          pnpm --filter @woof/api build
+          pnpm --filter @woof/web build
+
+      - name: Build production API image
+        run: docker build --pull -f infra/docker/Dockerfile.api -t woof-api-session-readiness:ci .
+
+      - name: Boot production image
+        run: |
+          docker rm -f woof-api-session-readiness-ci >/dev/null 2>&1 || true
+          docker run -d --name woof-api-session-readiness-ci --network host \
+            -e DATABASE_URL="$DATABASE_URL" \
+            -e SHADOW_DATABASE_URL="$SHADOW_DATABASE_URL" \
+            -e JWT_SECRET="$JWT_SECRET" \
+            -e NODE_ENV=production \
+            -e API_DOCS_ENABLED=false \
+            -e CORS_ORIGIN=http://localhost:3000 \
+            woof-api-session-readiness:ci
+
+          live=0
+          for attempt in $(seq 1 30); do
+            status=$(curl --silent --show-error --output /tmp/session-readiness-live.json --write-out '%{http_code}' \
+              http://127.0.0.1:4000/api/v1/ops/health/live || true)
+            if [ "$status" = '200' ]; then
+              live=1
+              break
+            fi
+            if ! docker ps --format '{{.Names}}' | grep -Fxq woof-api-session-readiness-ci; then
+              echo "Production image exited before liveness; status=$status"
+              cat /tmp/session-readiness-live.json 2>/dev/null || true
+              docker logs woof-api-session-readiness-ci || true
+              exit 1
+            fi
+            sleep 1
+          done
+          if [ "$live" -ne 1 ]; then
+            echo 'Production image never reached liveness.'
+            docker logs woof-api-session-readiness-ci || true
+            exit 1
+          fi
+
+      - name: Prove first action after session ready reaches canonical authorization
+        run: |
+          pnpm --filter @woof/web exec node <<'NODE'
+          const { io } = require('socket.io-client');
+          const baseUrl = 'http://127.0.0.1:4000/api/v1';
+
+          async function register() {
+            const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+            const response = await fetch(`${baseUrl}/auth/register`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                handle: `ci-ready-${suffix}`.slice(0, 30),
+                email: `ci-ready-${suffix}@example.test`,
+                password: 'SessionPass123!',
+              }),
+            });
+            const payload = await response.json().catch(() => null);
+            if (response.status !== 201 || !payload?.access_token) {
+              throw new Error(`register failed: ${response.status} ${JSON.stringify(payload)}`);
+            }
+            return payload.access_token;
+          }
+
+          function connectReady(token) {
+            return new Promise((resolve, reject) => {
+              const socket = io('http://127.0.0.1:4000', {
+                auth: { token },
+                transports: ['websocket'],
+                reconnection: false,
+                timeout: 4_000,
+              });
+              const timer = setTimeout(() => {
+                socket.disconnect();
+                reject(new Error('session:ready did not arrive'));
+              }, 5_000);
+              socket.once('session:ready', (payload) => {
+                if (!payload || payload.socketId !== socket.id) {
+                  clearTimeout(timer);
+                  socket.disconnect();
+                  reject(
+                    new Error(
+                      `session:ready must bind to current socket: ${JSON.stringify(payload)} current=${socket.id}`
+                    )
+                  );
+                  return;
+                }
+                clearTimeout(timer);
+                resolve(socket);
+              });
+              socket.once('connect_error', (error) => {
+                clearTimeout(timer);
+                reject(error);
+              });
+              socket.once('disconnect', (reason) => {
+                if (reason === 'io client disconnect') return;
+                clearTimeout(timer);
+                reject(new Error(`socket disconnected before session:ready: ${reason}`));
+              });
+            });
+          }
+
+          function ack(socket, event, payload) {
+            return new Promise((resolve, reject) => {
+              socket.timeout(4_000).emit(event, payload, (error, response) => {
+                if (error) reject(error);
+                else resolve(response);
+              });
+            });
+          }
+
+          (async () => {
+            const token = await register();
+            const socket = await connectReady(token);
+            const firstAction = await ack(socket, 'conversation:join', {
+              conversationId: 'missing-conversation',
+            });
+            if (!firstAction || firstAction.error !== 'conversation_unavailable') {
+              throw new Error(
+                `first action after session:ready must reach canonical authorization, got ${JSON.stringify(firstAction)}`
+              );
+            }
+            if (firstAction.error === 'unauthorized') {
+              throw new Error('session:ready must never precede realtime application authority');
+            }
+            socket.disconnect();
+          })()
+            .then(() => process.exit(0))
+            .catch((error) => {
+              console.error(error);
+              process.exit(1);
+            });
+          NODE
+
+      - name: Cleanup production image
+        if: always()
+        run: |
+          docker logs woof-api-session-readiness-ci || true
+          docker rm -f woof-api-session-readiness-ci >/dev/null 2>&1 || true

--- a/.github/workflows/dogos-session-authority-ci.yml
+++ b/.github/workflows/dogos-session-authority-ci.yml
@@ -1,0 +1,578 @@
+name: dogOS Session Authority CI
+
+on:
+  pull_request:
+    branches: [main, agent/dogos-realtime-session-lifetime-v1]
+    paths:
+      - 'apps/api/src/auth/**'
+      - 'apps/api/src/chat/chat.gateway.ts'
+      - 'apps/api/src/chat/chat.gateway.spec.ts'
+      - 'apps/api/src/chat/chat-session-ready.spec.ts'
+      - 'apps/api/src/chat/chat-security.service.ts'
+      - 'apps/api/src/chat/chat-security.service.spec.ts'
+      - 'apps/api/src/chat/chat.module.ts'
+      - 'apps/web/src/lib/api.ts'
+      - 'apps/web/src/lib/socket.ts'
+      - 'apps/web/src/lib/socket.spec.ts'
+      - 'apps/mobile/src/api/auth.ts'
+      - 'packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/**'
+      - '.github/scripts/assert-database-ownership.py'
+      - '.github/workflows/dogos-session-authority-ci.yml'
+      - 'docs/DOGOS_SESSION_AUTHORITY.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-session-authority-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  JWT_SECRET: ci-only-session-authority-secret-12345678901234567890
+  NODE_ENV: test
+  ML_SERVICE_ENABLED: 'false'
+
+jobs:
+  qualify:
+    name: Persisted session revocation + realtime delivery qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Enforce exact add-only database ownership
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: >-
+          python .github/scripts/assert-database-ownership.py "$BASE_SHA"
+          packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/migration.sql
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check touched-file formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/auth/auth.controller.ts
+          apps/api/src/auth/auth.module.ts
+          apps/api/src/auth/auth.service.ts
+          apps/api/src/auth/auth.service.spec.ts
+          apps/api/src/auth/authenticated-request.ts
+          apps/api/src/auth/session-authority.service.ts
+          apps/api/src/auth/session-authority.integration.spec.ts
+          apps/api/src/auth/strategies/jwt.strategy.ts
+          apps/api/src/chat/chat.gateway.ts
+          apps/api/src/chat/chat.gateway.spec.ts
+          apps/api/src/chat/chat-session-ready.spec.ts
+          apps/api/src/chat/chat-security.service.ts
+          apps/api/src/chat/chat-security.service.spec.ts
+          apps/api/src/chat/chat.module.ts
+          apps/web/src/lib/api.ts
+          apps/web/src/lib/socket.ts
+          apps/web/src/lib/socket.spec.ts
+          apps/mobile/src/api/auth.ts
+          .github/workflows/dogos-session-authority-ci.yml
+          docs/DOGOS_SESSION_AUTHORITY.md
+
+      - name: Reject whitespace errors
+        run: git diff --check ${{ github.event.pull_request.base.sha }}...HEAD
+
+      - name: Lint Session Authority surfaces
+        run: |
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish \
+            src/auth/auth.controller.ts \
+            src/auth/auth.module.ts \
+            src/auth/auth.service.ts \
+            src/auth/auth.service.spec.ts \
+            src/auth/authenticated-request.ts \
+            src/auth/session-authority.service.ts \
+            src/auth/session-authority.integration.spec.ts \
+            src/auth/strategies/jwt.strategy.ts \
+            src/chat/chat.gateway.ts \
+            src/chat/chat.gateway.spec.ts \
+            src/chat/chat-session-ready.spec.ts \
+            src/chat/chat-security.service.ts \
+            src/chat/chat-security.service.spec.ts \
+            src/chat/chat.module.ts
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish src/lib/api.ts src/lib/socket.ts src/lib/socket.spec.ts
+          pnpm --filter @woof/mobile exec eslint --max-warnings=0 src/api/auth.ts
+
+      - name: Enforce persisted authority and transaction-bound realtime invariants
+        run: |
+          python - <<'PY'
+          import re
+          from pathlib import Path
+
+          migration = Path('packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/migration.sql').read_text()
+          service = Path('apps/api/src/auth/session-authority.service.ts').read_text()
+          auth = Path('apps/api/src/auth/auth.service.ts').read_text()
+          strategy = Path('apps/api/src/auth/strategies/jwt.strategy.ts').read_text()
+          gateway = Path('apps/api/src/chat/chat.gateway.ts').read_text()
+          security = Path('apps/api/src/chat/chat-security.service.ts').read_text()
+          web_api = Path('apps/web/src/lib/api.ts').read_text()
+          web_socket = Path('apps/web/src/lib/socket.ts').read_text()
+          mobile = Path('apps/mobile/src/api/auth.ts').read_text()
+
+          migration_required = [
+              'CREATE SCHEMA IF NOT EXISTS dogos_auth',
+              'CREATE TABLE IF NOT EXISTS dogos_auth.sessions',
+              'id TEXT PRIMARY KEY',
+              'user_id TEXT NOT NULL REFERENCES public.users(id) ON DELETE CASCADE',
+              'expires_at TIMESTAMPTZ NOT NULL',
+              'revoked_at TIMESTAMPTZ',
+              'revocation_reason TEXT',
+          ]
+          missing = [token for token in migration_required if token not in migration]
+          if missing:
+              raise SystemExit(f'missing persisted session schema invariant: {missing}')
+
+          privacy_forbidden = [
+              'ip_address', 'user_agent', 'fingerprint', 'latitude', 'longitude',
+              'raw_token', 'access_token', 'refresh_token'
+          ]
+          present = [token for token in privacy_forbidden if token in migration.lower()]
+          if present:
+              raise SystemExit(f'session authority must remain privacy-thin: {present}')
+
+          service_required = [
+              'INSERT INTO dogos_auth.sessions',
+              'type ActiveSessionWork<T> = (tx: Prisma.TransactionClient)',
+              'async withActiveSession',
+              'async revokeSession',
+              'async revokeAllSessions',
+              'async withActiveSessions',
+              'async withActiveSessionsInTransaction',
+              'ORDER BY id',
+              'FOR UPDATE',
+              'FOR SHARE',
+              'await work(tx)',
+              'await deliver(activeSessionIds)',
+          ]
+          missing = [token for token in service_required if token not in service]
+          if missing:
+              raise SystemExit(f'missing lock-bound session authority invariant: {missing}')
+          if 'await work()' in service:
+              raise SystemExit('session authority must pass its transaction client into admitted work')
+
+          active_start = service.index('async withActiveSession')
+          revoke_start = service.index('async revokeSession', active_start)
+          active_path = service[active_start:revoke_start]
+          if active_path.count('this.prisma.$transaction') != 1 or 'await work(tx)' not in active_path:
+              raise SystemExit('withActiveSession must own exactly one transaction and hand tx to canonical work')
+
+          auth_required = [
+              'const sessionId = randomUUID()',
+              'sid: sessionId',
+              'jwtService.decode(token)',
+              'sessionAuthority.createSession',
+              'sessionAuthority.revokeSession',
+              'sessionAuthority.revokeAllSessions',
+          ]
+          missing = [token for token in auth_required if token not in auth]
+          if missing:
+              raise SystemExit(f'missing auth issuance/revocation invariant: {missing}')
+          if auth.index('sessionAuthority.createSession') > auth.index('return token'):
+              raise SystemExit('server session must persist before the access token is returned')
+
+          if 'sessionAuthority.assertActive(payload.sid, payload.sub)' not in strategy:
+              raise SystemExit('protected HTTP requests must require persisted session authority')
+          if "typeof payload.sid !== 'string'" not in strategy:
+              raise SystemExit('HTTP JWT validation must fail closed without sid')
+
+          connection = gateway[gateway.index('async handleConnection'):gateway.index('handleDisconnect')]
+          ready_emit = "client.emit('session:ready', { socketId: client.id })"
+          connect_authority = connection.index('sessionAuthority.withActiveSession')
+          private_room = connection.index('await client.join(`user:${userId}`)')
+          ready = connection.index(ready_emit)
+          if not connect_authority < private_room < ready:
+              raise SystemExit(
+                  'realtime readiness must be persisted authority -> private room -> socket-bound session:ready'
+              )
+          if connection.count('this.isSocketDisconnected(client)') < 2:
+              raise SystemExit('connection admission must recheck disconnect state across async work')
+
+          message = gateway[
+              gateway.index("@SubscribeMessage('message:send')"):
+              gateway.index("@SubscribeMessage('conversation:join')")
+          ]
+          ordering = [
+              'connectedUsers.get(client.id)',
+              'this.hasActiveSession(client, userId)',
+              'parseSendChatMessagePayload(data)',
+              "realtimeAdmission.consume(userId, 'message')",
+              'this.withAuthoritativeSession(client, userId, async (tx) =>',
+              'chatSecurity.persistMessageInTransaction(tx',
+          ]
+          positions = [message.index(token) for token in ordering]
+          if positions != sorted(positions):
+              raise SystemExit(
+                  'message order must be identity -> lease -> validation -> admission -> persisted authority tx -> persistence'
+              )
+          if 'chatSecurity.persistMessage(' in message:
+              raise SystemExit('realtime messages must not reacquire Prisma through standalone persistence')
+
+          for label, start_marker, end_marker, required_call in [
+              (
+                  'join',
+                  "@SubscribeMessage('conversation:join')",
+                  "@SubscribeMessage('conversation:leave')",
+                  'chatSecurity.assertConversationAccessInTransaction',
+              ),
+              (
+                  'leave',
+                  "@SubscribeMessage('conversation:leave')",
+                  "@SubscribeMessage('typing:start')",
+                  'chatSecurity.assertConversationAccessInTransaction',
+              ),
+          ]:
+              handler = gateway[gateway.index(start_marker):gateway.index(end_marker)]
+              if 'this.withAuthoritativeSession(client, userId, async (tx) =>' not in handler:
+                  raise SystemExit(f'{label} must run under persisted session authority')
+              tx_calls = re.findall(rf'{required_call}\s*\(\s*tx\s*,', handler)
+              if len(tx_calls) != 1:
+                  raise SystemExit(f'{label} must reuse the authority transaction for relationship checks')
+
+          typing_start = gateway.index('private async emitTyping')
+          typing_end = gateway.index('private async withAuthoritativeSession', typing_start)
+          typing = gateway[typing_start:typing_end]
+          typing_required = [
+              'this.withAuthoritativeSession(client, userId, async (tx) =>',
+              'chatSecurity.withAuthorizedRealtimeRecipientsInTransaction',
+              'sessionAuthority.withActiveSessionsInTransaction',
+          ]
+          missing = [token for token in typing_required if token not in typing]
+          if missing:
+              raise SystemExit(f'typing must remain fully transaction-bound: {missing}')
+          typing_tx_calls = re.findall(r'InTransaction\s*\(\s*tx\s*,', typing)
+          if len(typing_tx_calls) < 2:
+              raise SystemExit('typing relationship and recipient-session checks must reuse the same authority tx')
+
+          tx_start = security.index('async persistMessageInTransaction')
+          tx_end = security.index('private normalizePersistMessageInput', tx_start)
+          tx_persistence = security[tx_start:tx_end]
+          tx_required = [
+              'this.normalizePersistMessageInput(input)',
+              'this.acquireReceiptIdentityLock(tx',
+              'this.assertConversationAccessWithClient(tx',
+              'this.getReceiptWithClient(tx',
+              'tx.message.create',
+              'this.insertReceipt(tx',
+          ]
+          missing = [token for token in tx_required if token not in tx_persistence]
+          if missing:
+              raise SystemExit(f'transaction-bound message persistence is incomplete: {missing}')
+          if 'this.prisma.' in tx_persistence or '$transaction' in tx_persistence:
+              raise SystemExit(
+                  'lock-bound realtime persistence must never acquire a second Prisma connection'
+              )
+
+          postcommit = message.index('if (response?.success && !response.duplicate)')
+          fanout = message.index('chatSecurity.withAuthorizedRealtimeRecipients', postcommit)
+          if fanout < postcommit:
+              raise SystemExit('message fanout must happen after canonical persistence commits')
+
+          emit_start = gateway.index('private async emitToActiveSessions')
+          emit_end = gateway.index('private sessionCandidates', emit_start)
+          postcommit_delivery = gateway[emit_start:emit_end]
+          fanout_required = [
+              'sessionAuthority.withActiveSessions(',
+              'this.server.to(this.userRooms(authorizedUserIds))',
+              'inactiveSocketIds',
+              '.except(inactiveSocketIds)',
+              "client.emit('session:revoked', { reason: 'session_revoked' })",
+          ]
+          missing = [token for token in fanout_required if token not in gateway]
+          if missing:
+              raise SystemExit(f'missing realtime session-dominance invariant: {missing}')
+          if 'sessionAuthority.withActiveSessions(' not in postcommit_delivery:
+              raise SystemExit('post-commit message fanout must still filter revoked recipient sessions')
+
+          helper_start = gateway.index('private async withAuthoritativeSession')
+          helper_end = gateway.index('private async emitToActiveSessions', helper_start)
+          helper = gateway[helper_start:helper_end]
+          helper_required = [
+              'work: (tx: Prisma.TransactionClient) => Promise<T>',
+              'sessionAuthority.withActiveSession(sessionId, userId, work)',
+          ]
+          missing = [token for token in helper_required if token not in helper]
+          if missing:
+              raise SystemExit(f'gateway authority helper must preserve tx identity: {missing}')
+
+          web_required = [
+              "activeSocket.on('session:ready', (payload: SessionReadyPayload) =>",
+              'payload?.socketId !== activeSocket.id',
+              "activeSocket.on('session:expired'",
+              "activeSocket.on('session:revoked'",
+              'SESSION_READY_TIMEOUT_MS = 8_000',
+              'function waitForSessionReady(): Promise<Socket>',
+              'waitForSessionReady().then(',
+              'desiredConversations.clear()',
+          ]
+          missing = [token for token in web_required if token not in web_socket]
+          if missing:
+              raise SystemExit(f'web session-readiness contract is incomplete: {missing}')
+
+          for label, source in [('web', web_api), ('mobile', mobile)]:
+              for endpoint in ["'/auth/logout'", "'/auth/logout-all'"]:
+                  if endpoint not in source:
+                      raise SystemExit(f'{label} client must invoke server revocation endpoint {endpoint}')
+              if 'Authorization: `Bearer ${token}`' not in source:
+                  raise SystemExit(f'{label} logout must preserve the captured token for server revocation')
+          PY
+
+      - name: Type-check API, web and mobile
+        run: |
+          pnpm --filter @woof/api type-check
+          pnpm --filter @woof/web type-check
+          pnpm --filter @woof/mobile type-check
+
+      - name: Run Session Authority unit contracts
+        run: |
+          pnpm --filter @woof/api exec jest --runInBand \
+            src/auth/auth.service.spec.ts \
+            src/chat/chat.gateway.spec.ts \
+            src/chat/chat-session-ready.spec.ts \
+            src/chat/chat-input-contract.spec.ts \
+            src/chat/realtime-admission.service.spec.ts \
+            src/chat/chat-security.service.spec.ts
+          pnpm --filter @woof/web exec vitest run src/lib/socket.spec.ts
+
+      - name: Run real PostgreSQL authority and relationship contracts
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/auth/session-authority.integration.spec.ts
+          src/chat/chat-live-authorization.integration.spec.ts
+          src/chat/chat-block-atomicity.integration.spec.ts
+          src/chat/chat.service.integration.spec.ts
+
+      - name: Build API and web
+        run: |
+          pnpm --filter @woof/api build
+          pnpm --filter @woof/web build
+
+      - name: Build production API image
+        run: docker build --pull -f infra/docker/Dockerfile.api -t woof-api-session-authority:ci .
+
+      - name: Boot production image
+        run: |
+          docker rm -f woof-api-session-authority-ci >/dev/null 2>&1 || true
+          docker run -d --name woof-api-session-authority-ci --network host \
+            -e DATABASE_URL="$DATABASE_URL" \
+            -e SHADOW_DATABASE_URL="$SHADOW_DATABASE_URL" \
+            -e JWT_SECRET="$JWT_SECRET" \
+            -e NODE_ENV=production \
+            -e API_DOCS_ENABLED=false \
+            -e CORS_ORIGIN=http://localhost:3000 \
+            woof-api-session-authority:ci
+
+          live=0
+          for attempt in $(seq 1 30); do
+            status=$(curl --silent --show-error --output /tmp/session-authority-live.json --write-out '%{http_code}' \
+              http://127.0.0.1:4000/api/v1/ops/health/live || true)
+            if [ "$status" = '200' ]; then
+              live=1
+              break
+            fi
+            if ! docker ps --format '{{.Names}}' | grep -Fxq woof-api-session-authority-ci; then
+              echo "Production image exited before liveness; status=$status"
+              cat /tmp/session-authority-live.json 2>/dev/null || true
+              docker logs woof-api-session-authority-ci || true
+              exit 1
+            fi
+            sleep 1
+          done
+          if [ "$live" -ne 1 ]; then
+            echo 'Production image never reached liveness.'
+            docker logs woof-api-session-authority-ci || true
+            exit 1
+          fi
+
+      - name: Prove current logout, realtime revocation and logout-all on production image
+        run: |
+          pnpm --filter @woof/web exec node <<'NODE'
+          const { io } = require('socket.io-client');
+          const baseUrl = 'http://127.0.0.1:4000/api/v1';
+          const HTTP_PACE_MS = 450;
+          const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+          async function request(path, { token, body } = {}) {
+            await sleep(HTTP_PACE_MS);
+            const response = await fetch(`${baseUrl}${path}`, {
+              method: body === undefined ? 'GET' : 'POST',
+              headers: {
+                ...(body === undefined ? {} : { 'content-type': 'application/json' }),
+                ...(token ? { authorization: `Bearer ${token}` } : {}),
+              },
+              ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+            });
+            let payload = null;
+            try {
+              payload = await response.json();
+            } catch {}
+            return { status: response.status, payload };
+          }
+
+          async function register(label) {
+            const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+            const credentials = {
+              handle: `ci-${label}-${suffix}`.slice(0, 30),
+              email: `ci-${label}-${suffix}@example.test`,
+              password: 'SessionPass123!',
+            };
+            const result = await request('/auth/register', { body: credentials });
+            if (result.status !== 201 || !result.payload?.access_token) {
+              throw new Error(`register ${label} failed: ${result.status} ${JSON.stringify(result.payload)}`);
+            }
+            return { credentials, token: result.payload.access_token };
+          }
+
+          async function login(credentials) {
+            const result = await request('/auth/login', {
+              body: { email: credentials.email, password: credentials.password },
+            });
+            if (result.status !== 200 || !result.payload?.access_token) {
+              throw new Error(`login failed: ${result.status} ${JSON.stringify(result.payload)}`);
+            }
+            return result.payload.access_token;
+          }
+
+          async function expectMe(token, expectedStatus, label) {
+            const result = await request('/auth/me', { token });
+            if (result.status !== expectedStatus) {
+              throw new Error(`${label}: expected /auth/me ${expectedStatus}, got ${result.status}`);
+            }
+          }
+
+          function connect(token) {
+            return new Promise((resolve, reject) => {
+              const socket = io('http://127.0.0.1:4000', {
+                auth: { token },
+                transports: ['websocket'],
+                reconnection: false,
+                timeout: 4_000,
+              });
+              const timer = setTimeout(() => {
+                socket.disconnect();
+                reject(new Error('socket transport connected but session:ready did not arrive'));
+              }, 5_000);
+              socket.once('session:ready', (payload) => {
+                if (!payload || payload.socketId !== socket.id) {
+                  clearTimeout(timer);
+                  socket.disconnect();
+                  reject(new Error(`session:ready socket mismatch: ${JSON.stringify(payload)}`));
+                  return;
+                }
+                clearTimeout(timer);
+                resolve(socket);
+              });
+              socket.once('connect_error', (error) => {
+                clearTimeout(timer);
+                reject(error);
+              });
+              socket.once('disconnect', (reason) => {
+                if (reason === 'io client disconnect') return;
+                clearTimeout(timer);
+                reject(new Error(`socket disconnected before session:ready: ${reason}`));
+              });
+            });
+          }
+
+          async function expectRealtimeRevocation(socket) {
+            const revoked = new Promise((resolve, reject) => {
+              const timer = setTimeout(() => reject(new Error('socket did not emit session:revoked')), 5_000);
+              let sawRevoked = false;
+              socket.once('session:revoked', (payload) => {
+                if (payload?.reason !== 'session_revoked') {
+                  clearTimeout(timer);
+                  reject(new Error(`unexpected revocation payload: ${JSON.stringify(payload)}`));
+                  return;
+                }
+                sawRevoked = true;
+              });
+              socket.once('disconnect', (reason) => {
+                clearTimeout(timer);
+                if (!sawRevoked || reason !== 'io server disconnect') {
+                  reject(new Error(`expected revoked server disconnect, saw=${sawRevoked}, reason=${reason}`));
+                  return;
+                }
+                resolve();
+              });
+            });
+            socket.emit('typing:start', { conversationId: 'missing-conversation' });
+            await revoked;
+          }
+
+          (async () => {
+            const primary = await register('primary');
+            await expectMe(primary.token, 200, 'fresh token');
+            const socket = await connect(primary.token);
+
+            const logout = await request('/auth/logout', { token: primary.token, body: {} });
+            if (logout.status !== 200 || logout.payload?.success !== true) {
+              throw new Error(`logout failed: ${logout.status} ${JSON.stringify(logout.payload)}`);
+            }
+            await expectMe(primary.token, 401, 'revoked current token');
+            await expectRealtimeRevocation(socket);
+
+            const tokenA = await login(primary.credentials);
+            const tokenB = await login(primary.credentials);
+            await expectMe(tokenA, 200, 'login A before logout-all');
+            await expectMe(tokenB, 200, 'login B before logout-all');
+
+            const unrelated = await register('unrelated');
+            const logoutAll = await request('/auth/logout-all', { token: tokenA, body: {} });
+            if (logoutAll.status !== 200 || logoutAll.payload?.success !== true) {
+              throw new Error(`logout-all failed: ${logoutAll.status} ${JSON.stringify(logoutAll.payload)}`);
+            }
+
+            await expectMe(tokenA, 401, 'login A after logout-all');
+            await expectMe(tokenB, 401, 'login B after logout-all');
+            await expectMe(unrelated.token, 200, 'unrelated user after logout-all');
+          })()
+            .then(() => process.exit(0))
+            .catch((error) => {
+              console.error(error);
+              process.exit(1);
+            });
+          NODE
+
+      - name: Cleanup production image
+        if: always()
+        run: |
+          docker logs woof-api-session-authority-ci || true
+          docker rm -f woof-api-session-authority-ci >/dev/null 2>&1 || true

--- a/.github/workflows/dogos-session-migration-immutability-ci.yml
+++ b/.github/workflows/dogos-session-migration-immutability-ci.yml
@@ -1,0 +1,35 @@
+name: dogOS Session Migration Immutability CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/migration.sql'
+      - '.github/scripts/assert-database-ownership.py'
+      - '.github/workflows/dogos-session-migration-immutability-ci.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-session-migration-immutability-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  qualify:
+    name: Add-only session migration ownership
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Compile ownership helper
+        run: python -m py_compile .github/scripts/assert-database-ownership.py
+
+      - name: Require add-only Session Authority migration
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: >-
+          python .github/scripts/assert-database-ownership.py "$BASE_SHA"
+          packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/migration.sql

--- a/.github/workflows/dogos-trust-discovery-ci.yml
+++ b/.github/workflows/dogos-trust-discovery-ci.yml
@@ -173,6 +173,7 @@ jobs:
             exit 1
           fi
           python - <<'PY'
+          import re
           from pathlib import Path
 
           source = Path('apps/api/src/chat/chat.gateway.ts').read_text()
@@ -211,19 +212,28 @@ jobs:
 
           typing_required = [
               'chatSecurity.withAuthorizedRealtimeRecipients',
+              'sessionAuthority.withActiveSessions',
+              'inactiveSocketIds',
               'this.server',
               'this.userRooms(authorizedUserIds)',
               '.except(client.id)',
-              ',\n        userId\n      );',
+              '.except(inactiveSocketIds)',
           ]
           missing = [token for token in typing_required if token not in typing_handler]
           if missing:
               raise SystemExit(f'typing must use lock-bound authorized private user-room fanout: {missing}')
 
           authorization = typing_handler.find('chatSecurity.withAuthorizedRealtimeRecipients')
-          operation = typing_handler.find('this.userRooms(authorizedUserIds)')
-          if authorization > operation:
-              raise SystemExit('typing must authorize realtime recipients before private-room fanout')
+          session_filter = typing_handler.find('sessionAuthority.withActiveSessions', authorization)
+          operation = typing_handler.find('this.userRooms(authorizedUserIds)', session_filter)
+          if min(authorization, session_filter, operation) < 0 or not authorization < session_filter < operation:
+              raise SystemExit(
+                  'typing must resolve relationship authorization, filter active sessions, then fan out'
+              )
+
+          authorized_call = typing_handler[authorization:]
+          if not re.search(r',\s*userId\s*\);', authorized_call):
+              raise SystemExit('typing must require the actor userId in authorized recipient resolution')
 
           forbidden_typing = [
               'client.to(`conversation:${conversationId}`)',

--- a/.github/workflows/dogos-trust-enforcement-atomicity-ci.yml
+++ b/.github/workflows/dogos-trust-enforcement-atomicity-ci.yml
@@ -64,15 +64,12 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @woof/database db:generate
 
-      - name: Reject schema and migration ownership changes
+      - name: Enforce database ownership boundary
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
-          if printf '%s\n' "$changed" | grep -E '^packages/database/prisma/(schema\.prisma|migrations/)'; then
-            echo 'Trust Enforcement Atomicity v1 does not own database schema or migration changes.'
-            exit 1
-          fi
+        run: >-
+          python .github/scripts/assert-database-ownership.py "$BASE_SHA"
+          packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/migration.sql
 
       - name: Apply full database migration chain
         run: pnpm --filter @woof/database db:migrate:deploy

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -37,6 +37,24 @@ export class AuthController {
     return this.authService.login(loginDto);
   }
 
+  @Post('logout')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Revoke the current login session' })
+  async logout(@Request() req: AuthenticatedRequest) {
+    return this.authService.logout(req.user.sub, req.user.sid);
+  }
+
+  @Post('logout-all')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Revoke every active login session for the current user' })
+  async logoutAll(@Request() req: AuthenticatedRequest) {
+    return this.authService.logoutAll(req.user.sub);
+  }
+
   @Get('me')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -2,14 +2,17 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { PrismaModule } from '../prisma/prisma.module';
 import { UsersModule } from '../users/users.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
+import { SessionAuthorityService } from './session-authority.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { LocalStrategy } from './strategies/local.strategy';
 
 @Module({
   imports: [
+    PrismaModule,
     UsersModule,
     PassportModule,
     JwtModule.registerAsync({
@@ -23,8 +26,8 @@ import { LocalStrategy } from './strategies/local.strategy';
       inject: [ConfigService],
     }),
   ],
-  providers: [AuthService, JwtStrategy, LocalStrategy],
+  providers: [AuthService, SessionAuthorityService, JwtStrategy, LocalStrategy],
   controllers: [AuthController],
-  exports: [AuthService],
+  exports: [AuthService, SessionAuthorityService],
 })
 export class AuthModule {}

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -4,14 +4,20 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { hash } from 'bcrypt';
 import { UsersService } from '../users/users.service';
 import { AuthService } from './auth.service';
+import { SessionAuthorityService } from './session-authority.service';
 
 describe('AuthService', () => {
   let service: AuthService;
-  let jwtService: { sign: jest.Mock };
+  let jwtService: { sign: jest.Mock; decode: jest.Mock };
   let usersService: {
     findByEmail: jest.Mock;
     create: jest.Mock;
     findSelfById: jest.Mock;
+  };
+  let sessionAuthority: {
+    createSession: jest.Mock;
+    revokeSession: jest.Mock;
+    revokeAllSessions: jest.Mock;
   };
 
   beforeEach(async () => {
@@ -22,6 +28,12 @@ describe('AuthService', () => {
     };
     jwtService = {
       sign: jest.fn(() => 'mock-jwt-token'),
+      decode: jest.fn(() => ({ exp: Math.floor(Date.now() / 1_000) + 3_600 })),
+    };
+    sessionAuthority = {
+      createSession: jest.fn().mockResolvedValue(undefined),
+      revokeSession: jest.fn().mockResolvedValue({ revoked: true }),
+      revokeAllSessions: jest.fn().mockResolvedValue({ revokedCount: 2 }),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -29,6 +41,7 @@ describe('AuthService', () => {
         AuthService,
         { provide: UsersService, useValue: usersService },
         { provide: JwtService, useValue: jwtService },
+        { provide: SessionAuthorityService, useValue: sessionAuthority },
       ],
     }).compile();
 
@@ -49,10 +62,7 @@ describe('AuthService', () => {
         bio: 'Test bio',
       });
 
-      const result = await service.validateUser(
-        'test@example.com',
-        'password123',
-      );
+      const result = await service.validateUser('test@example.com', 'password123');
 
       expect(result).toEqual({
         id: '123',
@@ -66,9 +76,9 @@ describe('AuthService', () => {
     it('rejects an unknown email without revealing which credential failed', async () => {
       usersService.findByEmail.mockResolvedValue(null);
 
-      await expect(
-        service.validateUser('wrong@example.com', 'password123'),
-      ).rejects.toThrow(new UnauthorizedException('Invalid credentials'));
+      await expect(service.validateUser('wrong@example.com', 'password123')).rejects.toThrow(
+        new UnauthorizedException('Invalid credentials')
+      );
     });
 
     it('rejects an incorrect password', async () => {
@@ -79,14 +89,14 @@ describe('AuthService', () => {
         handle: 'testuser',
       });
 
-      await expect(
-        service.validateUser('test@example.com', 'wrongpassword'),
-      ).rejects.toThrow(new UnauthorizedException('Invalid credentials'));
+      await expect(service.validateUser('test@example.com', 'wrongpassword')).rejects.toThrow(
+        new UnauthorizedException('Invalid credentials')
+      );
     });
   });
 
   describe('login', () => {
-    it('returns the canonical token and safe user projection', async () => {
+    it('persists a finite server-owned session before returning the canonical token', async () => {
       usersService.findByEmail.mockResolvedValue({
         id: '123',
         email: 'test@example.com',
@@ -113,16 +123,24 @@ describe('AuthService', () => {
           points: 9,
         },
       });
-      expect(jwtService.sign).toHaveBeenCalledWith({
+
+      const payload = jwtService.sign.mock.calls[0][0] as { sid: string };
+      expect(payload).toEqual({
         sub: '123',
         email: 'test@example.com',
         handle: 'testuser',
+        sid: expect.any(String),
+      });
+      expect(sessionAuthority.createSession).toHaveBeenCalledWith({
+        id: payload.sid,
+        userId: '123',
+        expiresAt: expect.any(Date),
       });
     });
   });
 
   describe('register', () => {
-    it('delegates uniqueness and persistence to UsersService', async () => {
+    it('delegates uniqueness and persists a server-owned session', async () => {
       usersService.create.mockResolvedValue({
         id: '456',
         email: 'new@example.com',
@@ -144,8 +162,14 @@ describe('AuthService', () => {
           handle: 'newuser',
           authProvider: 'EMAIL',
           passwordHash: expect.any(String),
-        }),
+        })
       );
+      const payload = jwtService.sign.mock.calls[0][0] as { sid: string };
+      expect(sessionAuthority.createSession).toHaveBeenCalledWith({
+        id: payload.sid,
+        userId: '456',
+        expiresAt: expect.any(Date),
+      });
       expect(result.access_token).toBe('mock-jwt-token');
       expect(result.user).not.toHaveProperty('passwordHash');
     });
@@ -158,8 +182,34 @@ describe('AuthService', () => {
           email: 'existing@example.com',
           handle: 'existinguser',
           password: 'password123',
-        }),
+        })
       ).rejects.toThrow('duplicate account');
+      expect(sessionAuthority.createSession).not.toHaveBeenCalled();
     });
+  });
+
+  it('revokes the current server session on logout', async () => {
+    await expect(service.logout('user-1', 'session-1')).resolves.toEqual({ success: true });
+    expect(sessionAuthority.revokeSession).toHaveBeenCalledWith('user-1', 'session-1', 'LOGOUT');
+  });
+
+  it('revokes every active server session on logout-all', async () => {
+    await expect(service.logoutAll('user-1')).resolves.toEqual({ success: true, revokedCount: 2 });
+    expect(sessionAuthority.revokeAllSessions).toHaveBeenCalledWith('user-1', 'LOGOUT_ALL');
+  });
+
+  it('fails closed if the signed token does not contain a finite expiry', async () => {
+    usersService.findByEmail.mockResolvedValue({
+      id: '123',
+      email: 'test@example.com',
+      passwordHash: await hash('password123', 4),
+      handle: 'testuser',
+    });
+    jwtService.decode.mockReturnValueOnce({});
+
+    await expect(
+      service.login({ email: 'test@example.com', password: 'password123' })
+    ).rejects.toThrow(new UnauthorizedException('Session is unavailable'));
+    expect(sessionAuthority.createSession).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -2,11 +2,20 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import type { User } from '@woof/database';
 import { compare, hash } from 'bcrypt';
+import { randomUUID } from 'node:crypto';
 import { UsersService } from '../users/users.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
+import { SessionAuthorityService } from './session-authority.service';
 
 type SafeUser = Omit<User, 'passwordHash'>;
+
+type AccessTokenClaims = {
+  sub: string;
+  email: string;
+  handle: string;
+  sid: string;
+};
 
 function withoutPassword(user: User): SafeUser {
   const { passwordHash, ...safeUser } = user;
@@ -17,8 +26,9 @@ function withoutPassword(user: User): SafeUser {
 @Injectable()
 export class AuthService {
   constructor(
-    private usersService: UsersService,
-    private jwtService: JwtService,
+    private readonly usersService: UsersService,
+    private readonly jwtService: JwtService,
+    private readonly sessionAuthority: SessionAuthorityService
   ) {}
 
   async validateUser(email: string, password: string): Promise<SafeUser> {
@@ -39,10 +49,10 @@ export class AuthService {
 
   async login(loginDto: LoginDto) {
     const user = await this.validateUser(loginDto.email, loginDto.password);
-    const payload = { sub: user.id, email: user.email, handle: user.handle };
+    const accessToken = await this.issueAccessToken(user);
 
     return {
-      access_token: this.jwtService.sign(payload),
+      access_token: accessToken,
       user: {
         id: user.id,
         email: user.email,
@@ -66,12 +76,22 @@ export class AuthService {
     });
 
     const userWithoutPassword = withoutPassword(user);
-    const payload = { sub: user.id, email: user.email, handle: user.handle };
+    const accessToken = await this.issueAccessToken(userWithoutPassword);
 
     return {
-      access_token: this.jwtService.sign(payload),
+      access_token: accessToken,
       user: userWithoutPassword,
     };
+  }
+
+  async logout(userId: string, sessionId: string) {
+    await this.sessionAuthority.revokeSession(userId, sessionId, 'LOGOUT');
+    return { success: true };
+  }
+
+  async logoutAll(userId: string) {
+    const result = await this.sessionAuthority.revokeAllSessions(userId, 'LOGOUT_ALL');
+    return { success: true, revokedCount: result.revokedCount };
   }
 
   async getProfile(userId: string) {
@@ -80,5 +100,35 @@ export class AuthService {
     } catch {
       throw new UnauthorizedException('User not found');
     }
+  }
+
+  private async issueAccessToken(user: SafeUser) {
+    const sessionId = randomUUID();
+    const payload: AccessTokenClaims = {
+      sub: user.id,
+      email: user.email,
+      handle: user.handle,
+      sid: sessionId,
+    };
+    const token = this.jwtService.sign(payload);
+    const decoded = this.jwtService.decode(token) as { exp?: unknown } | null;
+    const exp = decoded?.exp;
+
+    if (typeof exp !== 'number' || !Number.isSafeInteger(exp) || exp <= 0) {
+      throw new UnauthorizedException('Session is unavailable');
+    }
+
+    const expiresAt = new Date(exp * 1_000);
+    if (!Number.isFinite(expiresAt.getTime()) || expiresAt.getTime() <= Date.now()) {
+      throw new UnauthorizedException('Session is unavailable');
+    }
+
+    await this.sessionAuthority.createSession({
+      id: sessionId,
+      userId: user.id,
+      expiresAt,
+    });
+
+    return token;
   }
 }

--- a/apps/api/src/auth/authenticated-request.ts
+++ b/apps/api/src/auth/authenticated-request.ts
@@ -2,6 +2,7 @@ export interface AuthenticatedUser {
   sub: string;
   email: string;
   handle: string;
+  sid: string;
 }
 
 export interface AuthenticatedRequest {

--- a/apps/api/src/auth/session-authority.integration.spec.ts
+++ b/apps/api/src/auth/session-authority.integration.spec.ts
@@ -1,0 +1,335 @@
+import { randomUUID } from 'node:crypto';
+import { ChatSecurityService } from '../chat/chat-security.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { SessionAuthorityService } from './session-authority.service';
+
+describe('SessionAuthorityService integration', () => {
+  const prisma = new PrismaService();
+  const service = new SessionAuthorityService(prisma);
+  const usersToDelete: string[] = [];
+  const conversationsToDelete: string[] = [];
+
+  beforeAll(async () => {
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    if (conversationsToDelete.length > 0) {
+      await prisma.conversation.deleteMany({ where: { id: { in: conversationsToDelete } } });
+    }
+    if (usersToDelete.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: usersToDelete } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  async function userFixture(label: string) {
+    const suffix = randomUUID().slice(0, 8);
+    const user = await prisma.user.create({
+      data: {
+        handle: `session-${label}-${suffix}`,
+        email: `session-${label}-${suffix}@example.test`,
+      },
+      select: { id: true },
+    });
+    usersToDelete.push(user.id);
+    return user;
+  }
+
+  async function sessionFixture(userId: string, seconds = 300) {
+    const id = randomUUID();
+    await service.createSession({
+      id,
+      userId,
+      expiresAt: new Date(Date.now() + seconds * 1_000),
+    });
+    return id;
+  }
+
+  it('accepts an active session and rejects it after explicit revocation', async () => {
+    const user = await userFixture('revoke');
+    const sessionId = await sessionFixture(user.id);
+
+    await expect(service.assertActive(sessionId, user.id)).resolves.toMatchObject({
+      id: sessionId,
+      userId: user.id,
+      revokedAt: null,
+    });
+
+    await expect(service.revokeSession(user.id, sessionId)).resolves.toEqual({ revoked: true });
+    await expect(service.assertActive(sessionId, user.id)).rejects.toThrow(
+      'Session is unavailable'
+    );
+  });
+
+  it('revokes all active sessions for one user without touching another user', async () => {
+    const userA = await userFixture('all-a');
+    const userB = await userFixture('all-b');
+    const [sessionA1, sessionA2, sessionB] = await Promise.all([
+      sessionFixture(userA.id),
+      sessionFixture(userA.id),
+      sessionFixture(userB.id),
+    ]);
+
+    await expect(service.revokeAllSessions(userA.id)).resolves.toEqual({ revokedCount: 2 });
+    await expect(service.assertActive(sessionA1, userA.id)).rejects.toThrow(
+      'Session is unavailable'
+    );
+    await expect(service.assertActive(sessionA2, userA.id)).rejects.toThrow(
+      'Session is unavailable'
+    );
+    await expect(service.assertActive(sessionB, userB.id)).resolves.toMatchObject({ id: sessionB });
+  });
+
+  it('allows concurrent shared authority admissions for the same active session', async () => {
+    const user = await userFixture('shared-admission');
+    const sessionId = await sessionFixture(user.id);
+
+    let firstEnteredResolve!: () => void;
+    const firstEntered = new Promise<void>((resolve) => {
+      firstEnteredResolve = resolve;
+    });
+    let releaseFirstResolve!: () => void;
+    const releaseFirst = new Promise<void>((resolve) => {
+      releaseFirstResolve = resolve;
+    });
+
+    const first = service.withActiveSession(sessionId, user.id, async () => {
+      firstEnteredResolve();
+      await releaseFirst;
+      return 'first';
+    });
+    await firstEntered;
+
+    let secondEnteredResolve!: () => void;
+    const secondEntered = new Promise<void>((resolve) => {
+      secondEnteredResolve = resolve;
+    });
+    const second = service.withActiveSession(sessionId, user.id, async () => {
+      secondEnteredResolve();
+      return 'second';
+    });
+
+    await Promise.race([
+      secondEntered,
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('concurrent FOR SHARE admission was blocked')), 1_000);
+      }),
+    ]);
+
+    await expect(second).resolves.toEqual({ authorized: true, result: 'second' });
+    releaseFirstResolve();
+    await expect(first).resolves.toEqual({ authorized: true, result: 'first' });
+  });
+
+  it('reuses the authority transaction for canonical message work with a one-connection pool', async () => {
+    const originalDatabaseUrl = process.env.DATABASE_URL;
+    if (!originalDatabaseUrl) throw new Error('DATABASE_URL is required for integration tests');
+
+    const constrainedUrl = new URL(originalDatabaseUrl);
+    constrainedUrl.searchParams.set('connection_limit', '1');
+    constrainedUrl.searchParams.set('pool_timeout', '2');
+
+    process.env.DATABASE_URL = constrainedUrl.toString();
+    const constrainedPrisma = new PrismaService();
+    try {
+      await constrainedPrisma.$connect();
+    } finally {
+      process.env.DATABASE_URL = originalDatabaseUrl;
+    }
+
+    const constrainedAuthority = new SessionAuthorityService(constrainedPrisma);
+    const constrainedChat = new ChatSecurityService(constrainedPrisma);
+
+    try {
+      const suffix = randomUUID().slice(0, 8);
+      const [owner, peer] = await Promise.all([
+        constrainedPrisma.user.create({
+          data: {
+            handle: `session-pool-owner-${suffix}`,
+            email: `session-pool-owner-${suffix}@example.test`,
+          },
+          select: { id: true },
+        }),
+        constrainedPrisma.user.create({
+          data: {
+            handle: `session-pool-peer-${suffix}`,
+            email: `session-pool-peer-${suffix}@example.test`,
+          },
+          select: { id: true },
+        }),
+      ]);
+      usersToDelete.push(owner.id, peer.id);
+
+      const conversation = await constrainedPrisma.conversation.create({
+        data: {
+          participants: {
+            create: [{ userId: owner.id }, { userId: peer.id }],
+          },
+        },
+        select: { id: true },
+      });
+      conversationsToDelete.push(conversation.id);
+
+      const sessionId = randomUUID();
+      await constrainedAuthority.createSession({
+        id: sessionId,
+        userId: owner.id,
+        expiresAt: new Date(Date.now() + 300_000),
+      });
+
+      const actions = Array.from({ length: 3 }, (_, index) =>
+        constrainedAuthority.withActiveSession(sessionId, owner.id, (tx) =>
+          constrainedChat.persistMessageInTransaction(tx, {
+            userId: owner.id,
+            conversationId: conversation.id,
+            clientMessageId: `pool-message-${index}-${randomUUID()}`,
+            text: `pool-safe message ${index}`,
+          })
+        )
+      );
+
+      const results = await Promise.race([
+        Promise.all(actions),
+        new Promise<never>((_, reject) => {
+          setTimeout(
+            () =>
+              reject(new Error('transaction-bound message work exhausted the one-connection pool')),
+            4_000
+          );
+        }),
+      ]);
+
+      expect(results).toHaveLength(3);
+      expect(
+        results.every((result) => result.authorized && result.result.duplicate === false)
+      ).toBe(true);
+      await expect(
+        constrainedPrisma.message.count({ where: { conversationId: conversation.id } })
+      ).resolves.toBe(3);
+    } finally {
+      await constrainedPrisma.$disconnect();
+    }
+  });
+
+  it('orders an admitted realtime action against current-session revocation', async () => {
+    const user = await userFixture('action-ordering');
+    const sessionId = await sessionFixture(user.id);
+
+    let actionEnteredResolve!: () => void;
+    const actionEntered = new Promise<void>((resolve) => {
+      actionEnteredResolve = resolve;
+    });
+    let releaseActionResolve!: () => void;
+    const releaseAction = new Promise<void>((resolve) => {
+      releaseActionResolve = resolve;
+    });
+
+    const action = service.withActiveSession(sessionId, user.id, async () => {
+      actionEnteredResolve();
+      await releaseAction;
+      return 'persisted';
+    });
+    await actionEntered;
+
+    let revokeSettled = false;
+    const revoke = service.revokeSession(user.id, sessionId).finally(() => {
+      revokeSettled = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(revokeSettled).toBe(false);
+
+    releaseActionResolve();
+    await expect(action).resolves.toEqual({ authorized: true, result: 'persisted' });
+    await expect(revoke).resolves.toEqual({ revoked: true });
+
+    const work = jest.fn();
+    await expect(service.withActiveSession(sessionId, user.id, work)).resolves.toEqual({
+      authorized: false,
+    });
+    expect(work).not.toHaveBeenCalled();
+  });
+
+  it('serializes passive delivery against revocation of the same session row', async () => {
+    const user = await userFixture('ordering');
+    const sessionId = await sessionFixture(user.id);
+
+    let deliveryEnteredResolve!: () => void;
+    const deliveryEntered = new Promise<void>((resolve) => {
+      deliveryEnteredResolve = resolve;
+    });
+    let releaseDeliveryResolve!: () => void;
+    const releaseDelivery = new Promise<void>((resolve) => {
+      releaseDeliveryResolve = resolve;
+    });
+
+    const delivery = service.withActiveSessions([sessionId], async (activeSessionIds) => {
+      expect(activeSessionIds.has(sessionId)).toBe(true);
+      deliveryEnteredResolve();
+      await releaseDelivery;
+    });
+
+    await deliveryEntered;
+
+    let revokeSettled = false;
+    const revoke = service.revokeSession(user.id, sessionId).finally(() => {
+      revokeSettled = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(revokeSettled).toBe(false);
+
+    releaseDeliveryResolve();
+    await delivery;
+    await expect(revoke).resolves.toEqual({ revoked: true });
+
+    let deliveredAfterRevocation = false;
+    await service.withActiveSessions([sessionId], (activeSessionIds) => {
+      deliveredAfterRevocation = activeSessionIds.has(sessionId);
+    });
+    expect(deliveredAfterRevocation).toBe(false);
+  });
+
+  it('orders multi-session logout-all behind active delivery locks and revokes the whole user set', async () => {
+    const user = await userFixture('ordering-all');
+    const sessionIds = await Promise.all([sessionFixture(user.id), sessionFixture(user.id)]);
+
+    let deliveryEnteredResolve!: () => void;
+    const deliveryEntered = new Promise<void>((resolve) => {
+      deliveryEnteredResolve = resolve;
+    });
+    let releaseDeliveryResolve!: () => void;
+    const releaseDelivery = new Promise<void>((resolve) => {
+      releaseDeliveryResolve = resolve;
+    });
+
+    const delivery = service.withActiveSessions(
+      [...sessionIds].reverse(),
+      async (activeSessionIds) => {
+        expect([...activeSessionIds].sort()).toEqual([...sessionIds].sort());
+        deliveryEnteredResolve();
+        await releaseDelivery;
+      }
+    );
+    await deliveryEntered;
+
+    let revokeAllSettled = false;
+    const revokeAll = service.revokeAllSessions(user.id).finally(() => {
+      revokeAllSettled = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(revokeAllSettled).toBe(false);
+
+    releaseDeliveryResolve();
+    await delivery;
+    await expect(revokeAll).resolves.toEqual({ revokedCount: 2 });
+
+    for (const sessionId of sessionIds) {
+      await expect(service.assertActive(sessionId, user.id)).rejects.toThrow(
+        'Session is unavailable'
+      );
+    }
+  });
+});

--- a/apps/api/src/auth/session-authority.service.ts
+++ b/apps/api/src/auth/session-authority.service.ts
@@ -1,0 +1,157 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+
+type SessionRow = {
+  id: string;
+  userId: string;
+  expiresAt: Date;
+  revokedAt: Date | null;
+  revocationReason: string | null;
+  createdAt: Date;
+};
+
+type SessionIdRow = { id: string };
+type ActiveSessionDelivery = (activeSessionIds: ReadonlySet<string>) => void | Promise<void>;
+type ActiveSessionWork<T> = (tx: Prisma.TransactionClient) => T | Promise<T>;
+
+@Injectable()
+export class SessionAuthorityService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createSession(input: { id: string; userId: string; expiresAt: Date }) {
+    if (!input.id || !input.userId || input.expiresAt.getTime() <= Date.now()) {
+      throw new UnauthorizedException('Session is unavailable');
+    }
+
+    await this.prisma.$executeRaw(Prisma.sql`
+      INSERT INTO dogos_auth.sessions (id, user_id, expires_at)
+      VALUES (
+        CAST(${input.id} AS text),
+        CAST(${input.userId} AS text),
+        ${input.expiresAt}
+      )
+    `);
+
+    return { id: input.id, userId: input.userId, expiresAt: input.expiresAt };
+  }
+
+  async assertActive(sessionId: string, userId: string): Promise<SessionRow> {
+    if (!sessionId || !userId) throw new UnauthorizedException('Session is unavailable');
+
+    const rows = await this.prisma.$queryRaw<SessionRow[]>(Prisma.sql`
+      SELECT
+        id,
+        user_id AS "userId",
+        expires_at AS "expiresAt",
+        revoked_at AS "revokedAt",
+        revocation_reason AS "revocationReason",
+        created_at AS "createdAt"
+      FROM dogos_auth.sessions
+      WHERE id = CAST(${sessionId} AS text)
+        AND user_id = CAST(${userId} AS text)
+        AND revoked_at IS NULL
+        AND expires_at > NOW()
+      LIMIT 1
+    `);
+
+    const session = rows[0];
+    if (!session) throw new UnauthorizedException('Session is unavailable');
+    return session;
+  }
+
+  async withActiveSession<T>(sessionId: string, userId: string, work: ActiveSessionWork<T>) {
+    if (!sessionId || !userId) return { authorized: false as const };
+
+    return this.prisma.$transaction(async (tx) => {
+      const rows = await tx.$queryRaw<SessionIdRow[]>(Prisma.sql`
+        SELECT id
+        FROM dogos_auth.sessions
+        WHERE id = CAST(${sessionId} AS text)
+          AND user_id = CAST(${userId} AS text)
+          AND revoked_at IS NULL
+          AND expires_at > NOW()
+        LIMIT 1
+        FOR SHARE
+      `);
+      if (!rows[0]) return { authorized: false as const };
+
+      const result = await work(tx);
+      return { authorized: true as const, result };
+    });
+  }
+
+  async revokeSession(userId: string, sessionId: string, reason = 'LOGOUT') {
+    const rows = await this.prisma.$queryRaw<SessionIdRow[]>(Prisma.sql`
+      UPDATE dogos_auth.sessions
+      SET
+        revoked_at = COALESCE(revoked_at, NOW()),
+        revocation_reason = COALESCE(revocation_reason, ${reason})
+      WHERE id = CAST(${sessionId} AS text)
+        AND user_id = CAST(${userId} AS text)
+      RETURNING id
+    `);
+
+    return { revoked: rows.length > 0 };
+  }
+
+  async revokeAllSessions(userId: string, reason = 'LOGOUT_ALL') {
+    return this.prisma.$transaction(async (tx) => {
+      const activeRows = await tx.$queryRaw<SessionIdRow[]>(Prisma.sql`
+        SELECT id
+        FROM dogos_auth.sessions
+        WHERE user_id = CAST(${userId} AS text)
+          AND revoked_at IS NULL
+          AND expires_at > NOW()
+        ORDER BY id
+        FOR UPDATE
+      `);
+      const sessionIds = activeRows.map((row) => row.id);
+      if (sessionIds.length === 0) return { revokedCount: 0 };
+
+      const revokedRows = await tx.$queryRaw<SessionIdRow[]>(Prisma.sql`
+        UPDATE dogos_auth.sessions
+        SET
+          revoked_at = NOW(),
+          revocation_reason = ${reason}
+        WHERE id IN (${Prisma.join(sessionIds)})
+          AND user_id = CAST(${userId} AS text)
+        RETURNING id
+      `);
+
+      return { revokedCount: revokedRows.length };
+    });
+  }
+
+  async withActiveSessions(sessionIds: string[], deliver: ActiveSessionDelivery) {
+    return this.prisma.$transaction((tx) =>
+      this.withActiveSessionsInTransaction(tx, sessionIds, deliver)
+    );
+  }
+
+  async withActiveSessionsInTransaction(
+    tx: Prisma.TransactionClient,
+    sessionIds: string[],
+    deliver: ActiveSessionDelivery
+  ) {
+    const uniqueIds = [...new Set(sessionIds.filter(Boolean))];
+    if (uniqueIds.length === 0) {
+      const empty = new Set<string>();
+      await deliver(empty);
+      return { activeSessionIds: empty };
+    }
+
+    const rows = await tx.$queryRaw<SessionIdRow[]>(Prisma.sql`
+      SELECT id
+      FROM dogos_auth.sessions
+      WHERE id IN (${Prisma.join(uniqueIds)})
+        AND revoked_at IS NULL
+        AND expires_at > NOW()
+      ORDER BY id
+      FOR SHARE
+    `);
+    const activeSessionIds = new Set(rows.map((row) => row.id));
+    await deliver(activeSessionIds);
+    return { activeSessionIds };
+  }
+}

--- a/apps/api/src/auth/strategies/jwt.strategy.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.ts
@@ -1,11 +1,22 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { SessionAuthorityService } from '../session-authority.service';
+
+type JwtPayload = {
+  sub?: unknown;
+  email?: unknown;
+  handle?: unknown;
+  sid?: unknown;
+};
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(configService: ConfigService) {
+  constructor(
+    configService: ConfigService,
+    private readonly sessionAuthority: SessionAuthorityService
+  ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
@@ -13,11 +24,23 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: { sub: string; email: string; handle: string }) {
+  async validate(payload: JwtPayload) {
+    if (
+      typeof payload.sub !== 'string' ||
+      typeof payload.email !== 'string' ||
+      typeof payload.handle !== 'string' ||
+      typeof payload.sid !== 'string'
+    ) {
+      throw new UnauthorizedException('Session is unavailable');
+    }
+
+    await this.sessionAuthority.assertActive(payload.sid, payload.sub);
+
     return {
       sub: payload.sub,
       email: payload.email,
       handle: payload.handle,
+      sid: payload.sid,
     };
   }
 }

--- a/apps/api/src/chat/chat-security.service.ts
+++ b/apps/api/src/chat/chat-security.service.ts
@@ -24,7 +24,19 @@ type ConversationAccessClient = Pick<
   'conversationParticipant' | 'blockedUser' | '$queryRaw'
 >;
 
+type ChatTransactionClient = Pick<
+  Prisma.TransactionClient,
+  'conversationParticipant' | 'blockedUser' | 'message' | '$queryRaw'
+>;
+
 type RealtimeDelivery = (authorizedUserIds: string[]) => void | Promise<void>;
+
+type PersistMessageInput = {
+  userId: string;
+  conversationId: string;
+  clientMessageId: string;
+  text: string;
+};
 
 export type PersistedChatMessage = {
   id: string;
@@ -43,62 +55,174 @@ export class ChatSecurityService {
     return this.assertConversationAccessWithClient(this.prisma, userId, conversationId, false);
   }
 
+  async assertConversationAccessInTransaction(
+    tx: ConversationAccessClient,
+    userId: string,
+    conversationId: string
+  ) {
+    return this.assertConversationAccessWithClient(tx, userId, conversationId, true);
+  }
+
   async withAuthorizedRealtimeRecipients(
     conversationId: string,
     deliver: RealtimeDelivery,
     requiredUserId?: string
   ) {
-    return this.prisma.$transaction(async (tx) => {
-      const participants = await tx.conversationParticipant.findMany({
-        where: { conversationId },
-        select: { userId: true },
-        orderBy: { userId: 'asc' },
-      });
-      const participantUserIds = [...new Set(participants.map((entry) => entry.userId))];
-
-      if (participantUserIds.length < 2) {
-        throw new ForbiddenException('Conversation is unavailable');
-      }
-
-      await acquireParticipantRelationshipLocks(tx, participantUserIds);
-
-      const blocks = await tx.blockedUser.findMany({
-        where: {
-          userId: { in: participantUserIds },
-          blockedId: { in: participantUserIds },
-        },
-        select: { userId: true, blockedId: true },
-      });
-
-      const blockedEndpoints = new Set<string>();
-      for (const block of blocks) {
-        if (block.userId === block.blockedId) continue;
-        blockedEndpoints.add(block.userId);
-        blockedEndpoints.add(block.blockedId);
-      }
-
-      const authorizedUserIds = participantUserIds.filter(
-        (participantUserId) => !blockedEndpoints.has(participantUserId)
-      );
-
-      if (requiredUserId && !authorizedUserIds.includes(requiredUserId)) {
-        throw new ForbiddenException('Conversation is unavailable');
-      }
-
-      if (authorizedUserIds.length > 0) {
-        await deliver(authorizedUserIds);
-      }
-
-      return { authorizedUserIds };
-    });
+    return this.prisma.$transaction((tx) =>
+      this.withAuthorizedRealtimeRecipientsInTransaction(
+        tx,
+        conversationId,
+        deliver,
+        requiredUserId
+      )
+    );
   }
 
-  async persistMessage(input: {
-    userId: string;
-    conversationId: string;
-    clientMessageId: string;
-    text: string;
-  }): Promise<{ message: PersistedChatMessage; duplicate: boolean }> {
+  async withAuthorizedRealtimeRecipientsInTransaction(
+    tx: ConversationAccessClient,
+    conversationId: string,
+    deliver: RealtimeDelivery,
+    requiredUserId?: string
+  ) {
+    const participants = await tx.conversationParticipant.findMany({
+      where: { conversationId },
+      select: { userId: true },
+      orderBy: { userId: 'asc' },
+    });
+    const participantUserIds = [...new Set(participants.map((entry) => entry.userId))];
+
+    if (participantUserIds.length < 2) {
+      throw new ForbiddenException('Conversation is unavailable');
+    }
+
+    await acquireParticipantRelationshipLocks(tx, participantUserIds);
+
+    const blocks = await tx.blockedUser.findMany({
+      where: {
+        userId: { in: participantUserIds },
+        blockedId: { in: participantUserIds },
+      },
+      select: { userId: true, blockedId: true },
+    });
+
+    const blockedEndpoints = new Set<string>();
+    for (const block of blocks) {
+      if (block.userId === block.blockedId) continue;
+      blockedEndpoints.add(block.userId);
+      blockedEndpoints.add(block.blockedId);
+    }
+
+    const authorizedUserIds = participantUserIds.filter(
+      (participantUserId) => !blockedEndpoints.has(participantUserId)
+    );
+
+    if (requiredUserId && !authorizedUserIds.includes(requiredUserId)) {
+      throw new ForbiddenException('Conversation is unavailable');
+    }
+
+    if (authorizedUserIds.length > 0) {
+      await deliver(authorizedUserIds);
+    }
+
+    return { authorizedUserIds };
+  }
+
+  async persistMessage(input: PersistMessageInput): Promise<{
+    message: PersistedChatMessage;
+    duplicate: boolean;
+  }> {
+    const text = this.normalizePersistMessageInput(input);
+
+    await this.assertConversationAccess(input.userId, input.conversationId);
+
+    const existing = await this.getReceipt(input.userId, input.clientMessageId);
+    if (existing) {
+      this.assertReceiptConversation(existing, input.conversationId);
+      const message = await this.prisma.message.findUnique({ where: { id: existing.message_id } });
+      if (message) return { message, duplicate: true };
+    }
+
+    try {
+      const message = await this.prisma.$transaction(async (tx) => {
+        await this.assertConversationAccessWithClient(tx, input.userId, input.conversationId, true);
+
+        const receiptRows = await this.getReceiptWithClient(
+          tx,
+          input.userId,
+          input.clientMessageId
+        );
+        if (receiptRows) {
+          this.assertReceiptConversation(receiptRows, input.conversationId);
+          const persisted = await tx.message.findUnique({
+            where: { id: receiptRows.message_id },
+          });
+          if (!persisted) throw new DuplicateReceiptRaceError();
+          return { message: persisted, duplicate: true };
+        }
+
+        const persisted = await tx.message.create({
+          data: {
+            conversationId: input.conversationId,
+            senderId: input.userId,
+            text,
+          },
+        });
+
+        const inserted = await this.insertReceipt(tx, input, persisted.id);
+        if (!inserted) throw new DuplicateReceiptRaceError();
+        return { message: persisted, duplicate: false };
+      });
+
+      return message;
+    } catch (error) {
+      if (!(error instanceof DuplicateReceiptRaceError)) throw error;
+      const raced = await this.getReceipt(input.userId, input.clientMessageId);
+      if (!raced) throw error;
+      this.assertReceiptConversation(raced, input.conversationId);
+      const message = await this.prisma.message.findUnique({ where: { id: raced.message_id } });
+      if (!message) throw error;
+      return { message, duplicate: true };
+    }
+  }
+
+  async persistMessageInTransaction(
+    tx: ChatTransactionClient,
+    input: PersistMessageInput
+  ): Promise<{ message: PersistedChatMessage; duplicate: boolean }> {
+    const text = this.normalizePersistMessageInput(input);
+
+    await this.acquireReceiptIdentityLock(tx, input.userId, input.clientMessageId);
+    await this.assertConversationAccessWithClient(tx, input.userId, input.conversationId, true);
+
+    const existing = await this.getReceiptWithClient(tx, input.userId, input.clientMessageId);
+    if (existing) {
+      this.assertReceiptConversation(existing, input.conversationId);
+      const message = await tx.message.findUnique({ where: { id: existing.message_id } });
+      if (!message) throw new DuplicateReceiptRaceError();
+      return { message, duplicate: true };
+    }
+
+    const persisted = await tx.message.create({
+      data: {
+        conversationId: input.conversationId,
+        senderId: input.userId,
+        text,
+      },
+    });
+
+    const inserted = await this.insertReceipt(tx, input, persisted.id);
+    if (inserted) return { message: persisted, duplicate: false };
+
+    await tx.message.delete({ where: { id: persisted.id } });
+    const raced = await this.getReceiptWithClient(tx, input.userId, input.clientMessageId);
+    if (!raced) throw new DuplicateReceiptRaceError();
+    this.assertReceiptConversation(raced, input.conversationId);
+    const message = await tx.message.findUnique({ where: { id: raced.message_id } });
+    if (!message) throw new DuplicateReceiptRaceError();
+    return { message, duplicate: true };
+  }
+
+  private normalizePersistMessageInput(input: PersistMessageInput) {
     if (!isChatIdentifier(input.conversationId)) {
       throw new BadRequestException('conversationId is invalid');
     }
@@ -119,71 +243,7 @@ export class ChatSecurityService {
 
     const text = normalizeChatMessageText(input.text);
     if (!text) throw new BadRequestException('Message text is required');
-
-    await this.assertConversationAccess(input.userId, input.conversationId);
-
-    const existing = await this.getReceipt(input.userId, input.clientMessageId);
-    if (existing) {
-      this.assertReceiptConversation(existing, input.conversationId);
-      const message = await this.prisma.message.findUnique({ where: { id: existing.message_id } });
-      if (message) return { message, duplicate: true };
-    }
-
-    try {
-      const message = await this.prisma.$transaction(async (tx) => {
-        await this.assertConversationAccessWithClient(tx, input.userId, input.conversationId, true);
-
-        const receiptRows = await tx.$queryRaw<MessageReceiptRow[]>(Prisma.sql`
-          SELECT message_id, conversation_id
-          FROM dogos_chat.message_receipts
-          WHERE user_id = CAST(${input.userId} AS text)
-            AND client_message_id = ${input.clientMessageId}
-          LIMIT 1
-        `);
-        if (receiptRows[0]) {
-          this.assertReceiptConversation(receiptRows[0], input.conversationId);
-          const persisted = await tx.message.findUnique({
-            where: { id: receiptRows[0].message_id },
-          });
-          if (!persisted) throw new DuplicateReceiptRaceError();
-          return { message: persisted, duplicate: true };
-        }
-
-        const persisted = await tx.message.create({
-          data: {
-            conversationId: input.conversationId,
-            senderId: input.userId,
-            text,
-          },
-        });
-
-        const inserted = await tx.$queryRaw<Array<{ message_id: string }>>(Prisma.sql`
-          INSERT INTO dogos_chat.message_receipts (
-            user_id, client_message_id, conversation_id, message_id
-          ) VALUES (
-            CAST(${input.userId} AS text),
-            ${input.clientMessageId},
-            CAST(${input.conversationId} AS text),
-            CAST(${persisted.id} AS text)
-          )
-          ON CONFLICT (user_id, client_message_id) DO NOTHING
-          RETURNING message_id
-        `);
-
-        if (inserted.length === 0) throw new DuplicateReceiptRaceError();
-        return { message: persisted, duplicate: false };
-      });
-
-      return message;
-    } catch (error) {
-      if (!(error instanceof DuplicateReceiptRaceError)) throw error;
-      const raced = await this.getReceipt(input.userId, input.clientMessageId);
-      if (!raced) throw error;
-      this.assertReceiptConversation(raced, input.conversationId);
-      const message = await this.prisma.message.findUnique({ where: { id: raced.message_id } });
-      if (!message) throw error;
-      return { message, duplicate: true };
-    }
+    return text;
   }
 
   private async assertConversationAccessWithClient(
@@ -236,14 +296,56 @@ export class ChatSecurityService {
     return { otherUserIds };
   }
 
+  private async acquireReceiptIdentityLock(
+    tx: Pick<Prisma.TransactionClient, '$queryRaw'>,
+    userId: string,
+    clientMessageId: string
+  ) {
+    const key = `woof:chat-receipt:${userId}:${clientMessageId}`;
+    await tx.$queryRaw<Array<{ locked: number }>>(Prisma.sql`
+      SELECT 1 AS locked
+      FROM (
+        SELECT pg_advisory_xact_lock(hashtextextended(${key}, 0))
+      ) AS chat_receipt_lock
+    `);
+  }
+
   private assertReceiptConversation(receipt: MessageReceiptRow, conversationId: string) {
     if (receipt.conversation_id !== conversationId) {
       throw new BadRequestException('clientMessageId has already been used');
     }
   }
 
+  private async insertReceipt(
+    client: Pick<Prisma.TransactionClient, '$queryRaw'>,
+    input: Pick<PersistMessageInput, 'userId' | 'clientMessageId' | 'conversationId'>,
+    messageId: string
+  ) {
+    const inserted = await client.$queryRaw<Array<{ message_id: string }>>(Prisma.sql`
+      INSERT INTO dogos_chat.message_receipts (
+        user_id, client_message_id, conversation_id, message_id
+      ) VALUES (
+        CAST(${input.userId} AS text),
+        ${input.clientMessageId},
+        CAST(${input.conversationId} AS text),
+        CAST(${messageId} AS text)
+      )
+      ON CONFLICT (user_id, client_message_id) DO NOTHING
+      RETURNING message_id
+    `);
+    return inserted.length > 0;
+  }
+
   private async getReceipt(userId: string, clientMessageId: string) {
-    const rows = await this.prisma.$queryRaw<MessageReceiptRow[]>(Prisma.sql`
+    return this.getReceiptWithClient(this.prisma, userId, clientMessageId);
+  }
+
+  private async getReceiptWithClient(
+    client: Pick<Prisma.TransactionClient, '$queryRaw'>,
+    userId: string,
+    clientMessageId: string
+  ) {
+    const rows = await client.$queryRaw<MessageReceiptRow[]>(Prisma.sql`
       SELECT message_id, conversation_id
       FROM dogos_chat.message_receipts
       WHERE user_id = CAST(${userId} AS text)

--- a/apps/api/src/chat/chat-session-ready.spec.ts
+++ b/apps/api/src/chat/chat-session-ready.spec.ts
@@ -1,0 +1,144 @@
+import { ChatGateway } from './chat.gateway';
+
+describe('ChatGateway session readiness', () => {
+  function build() {
+    const jwtService = {
+      verifyAsync: jest.fn().mockResolvedValue({
+        sub: 'user-1',
+        sid: 'session-1',
+        exp: Math.floor(Date.now() / 1_000) + 300,
+      }),
+    };
+    const sessionAuthority = {
+      withActiveSession: jest.fn(),
+      withActiveSessions: jest.fn(),
+    };
+    const chatSecurity = {
+      persistMessage: jest.fn(),
+      assertConversationAccess: jest.fn(),
+      withAuthorizedRealtimeRecipients: jest.fn(),
+    };
+    const realtimeAdmission = {
+      consume: jest.fn().mockReturnValue({ allowed: true }),
+    };
+    const nudgesService = {
+      checkChatActivityNudges: jest.fn(),
+    };
+    const gateway = new ChatGateway(
+      jwtService as never,
+      sessionAuthority as never,
+      chatSecurity as never,
+      realtimeAdmission as never,
+      nudgesService as never
+    );
+    gateway.server = { to: jest.fn() } as never;
+
+    const client: {
+      id: string;
+      connected: boolean;
+      handshake: { auth: { token: string } };
+      join: jest.Mock;
+      leave: jest.Mock;
+      emit: jest.Mock;
+      disconnect: jest.Mock;
+    } = {
+      id: 'socket-1',
+      connected: true,
+      handshake: { auth: { token: 'token-1' } },
+      join: jest.fn().mockResolvedValue(undefined),
+      leave: jest.fn().mockResolvedValue(undefined),
+      emit: jest.fn(),
+      disconnect: jest.fn(),
+    };
+    client.disconnect.mockImplementation(() => {
+      client.connected = false;
+    });
+
+    return {
+      gateway,
+      client,
+      jwtService,
+      sessionAuthority,
+      chatSecurity,
+      realtimeAdmission,
+    };
+  }
+
+  it('emits session:ready only after persisted authority work and the private user-room join finish', async () => {
+    const { gateway, client, sessionAuthority } = build();
+    sessionAuthority.withActiveSession.mockImplementation(
+      async (_sessionId: string, _userId: string, work: () => Promise<unknown>) => {
+        const result = await work();
+        expect(client.join).toHaveBeenCalledWith('user:user-1');
+        expect(client.emit).not.toHaveBeenCalledWith('session:ready', expect.anything());
+        return { authorized: true, result };
+      }
+    );
+
+    await gateway.handleConnection(client as never);
+
+    expect(sessionAuthority.withActiveSession).toHaveBeenCalledWith(
+      'session-1',
+      'user-1',
+      expect.any(Function)
+    );
+    expect(client.emit).toHaveBeenCalledWith('session:ready', { socketId: 'socket-1' });
+    expect(client.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('never emits readiness for a revoked persisted session', async () => {
+    const { gateway, client, sessionAuthority } = build();
+    sessionAuthority.withActiveSession.mockResolvedValue({ authorized: false });
+
+    await gateway.handleConnection(client as never);
+
+    expect(client.emit).not.toHaveBeenCalledWith('session:ready', expect.anything());
+    expect(client.emit).toHaveBeenCalledWith('session:revoked', { reason: 'session_revoked' });
+    expect(client.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not create realtime authority when the transport disconnects before admission work starts', async () => {
+    const { gateway, client, sessionAuthority, realtimeAdmission, chatSecurity } = build();
+    sessionAuthority.withActiveSession.mockImplementation(
+      async (_sessionId: string, _userId: string, work: () => Promise<unknown>) => {
+        client.connected = false;
+        return { authorized: true, result: await work() };
+      }
+    );
+
+    await gateway.handleConnection(client as never);
+
+    expect(client.join).not.toHaveBeenCalled();
+    expect(client.emit).not.toHaveBeenCalledWith('session:ready', expect.anything());
+    await expect(
+      gateway.handleMessage(client as never, {
+        conversationId: 'conversation-1',
+        clientMessageId: 'client-message-after-disconnect',
+        text: 'hello',
+      })
+    ).resolves.toEqual({ success: false, error: 'unauthorized' });
+    expect(realtimeAdmission.consume).not.toHaveBeenCalled();
+    expect(chatSecurity.persistMessage).not.toHaveBeenCalled();
+  });
+
+  it('clears partial authority if the transport disconnects while the user room is joining', async () => {
+    const { gateway, client, sessionAuthority, realtimeAdmission } = build();
+    sessionAuthority.withActiveSession.mockImplementation(
+      async (_sessionId: string, _userId: string, work: () => Promise<unknown>) => ({
+        authorized: true,
+        result: await work(),
+      })
+    );
+    client.join.mockImplementationOnce(async () => {
+      client.connected = false;
+    });
+
+    await gateway.handleConnection(client as never);
+
+    expect(client.emit).not.toHaveBeenCalledWith('session:ready', expect.anything());
+    await expect(
+      gateway.handleTypingStart(client as never, { conversationId: 'conversation-1' })
+    ).resolves.toEqual({ success: false, error: 'unauthorized' });
+    expect(realtimeAdmission.consume).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/chat/chat.gateway.spec.ts
+++ b/apps/api/src/chat/chat.gateway.spec.ts
@@ -4,16 +4,61 @@ import { ChatGateway } from './chat.gateway';
 
 describe('ChatGateway realtime authorization', () => {
   function build() {
+    const authorityTx = { kind: 'authority-transaction' };
     const jwtService = {
       verifyAsync: jest.fn().mockResolvedValue({
         sub: 'user-1',
+        sid: 'session-1',
         exp: Math.floor(Date.now() / 1_000) + 300,
       }),
     };
+    const sessionAuthority = {
+      withActiveSession: jest
+        .fn()
+        .mockImplementation(
+          async (
+            _sessionId: string,
+            _userId: string,
+            work: (tx: unknown) => unknown | Promise<unknown>
+          ) => ({
+            authorized: true,
+            result: await work(authorityTx),
+          })
+        ),
+      withActiveSessions: jest
+        .fn()
+        .mockImplementation(
+          async (
+            sessionIds: string[],
+            deliver: (activeSessionIds: Set<string>) => void | Promise<void>
+          ) => {
+            const activeSessionIds = new Set(sessionIds);
+            await deliver(activeSessionIds);
+            return { activeSessionIds };
+          }
+        ),
+      withActiveSessionsInTransaction: jest
+        .fn()
+        .mockImplementation(
+          async (
+            tx: unknown,
+            sessionIds: string[],
+            deliver: (activeSessionIds: Set<string>) => void | Promise<void>
+          ) => {
+            expect(tx).toBe(authorityTx);
+            const activeSessionIds = new Set(sessionIds);
+            await deliver(activeSessionIds);
+            return { activeSessionIds };
+          }
+        ),
+    };
     const chatSecurity = {
       persistMessage: jest.fn(),
+      persistMessageInTransaction: jest.fn(),
       assertConversationAccess: jest.fn(),
+      assertConversationAccessInTransaction: jest.fn(),
       withAuthorizedRealtimeRecipients: jest.fn(),
+      withAuthorizedRealtimeRecipientsInTransaction: jest.fn(),
     };
     const realtimeAdmission = {
       consume: jest.fn().mockReturnValue({ allowed: true }),
@@ -22,46 +67,78 @@ describe('ChatGateway realtime authorization', () => {
       checkChatActivityNudges: jest.fn().mockResolvedValue({ created: false }),
     };
     const emit = jest.fn();
-    const except = jest.fn().mockReturnValue({ emit });
-    const to = jest.fn().mockReturnValue({ emit, except });
+    const operator = { emit, except: jest.fn() };
+    operator.except.mockReturnValue(operator);
+    const to = jest.fn().mockReturnValue(operator);
     const gateway = new ChatGateway(
       jwtService as never,
+      sessionAuthority as never,
       chatSecurity as never,
       realtimeAdmission as never,
       nudgesService as never
     );
     gateway.server = { to } as never;
 
-    const client = {
-      id: 'socket-1',
-      handshake: { auth: { token: 'token-1' } },
+    const makeClient = (id = 'socket-1') => ({
+      id,
+      handshake: { auth: { token: `token-${id}` } },
       join: jest.fn().mockResolvedValue(undefined),
       leave: jest.fn().mockResolvedValue(undefined),
       emit: jest.fn(),
       disconnect: jest.fn(),
-    };
+    });
+    const client = makeClient();
 
     return {
       gateway,
       client,
+      makeClient,
+      authorityTx,
       jwtService,
+      sessionAuthority,
       chatSecurity,
       realtimeAdmission,
       nudgesService,
       emit,
-      except,
+      except: operator.except,
       to,
     };
   }
 
   it('requires a finite JWT expiry before granting realtime membership', async () => {
-    const { gateway, client, jwtService } = build();
-    jwtService.verifyAsync.mockResolvedValueOnce({ sub: 'user-1' });
+    const { gateway, client, jwtService, sessionAuthority } = build();
+    jwtService.verifyAsync.mockResolvedValueOnce({ sub: 'user-1', sid: 'session-1' });
 
     await gateway.handleConnection(client as never);
 
+    expect(sessionAuthority.withActiveSession).not.toHaveBeenCalled();
     expect(client.join).not.toHaveBeenCalled();
     expect(client.emit).not.toHaveBeenCalled();
+    expect(client.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('requires a persisted session id before granting realtime membership', async () => {
+    const { gateway, client, jwtService, sessionAuthority } = build();
+    jwtService.verifyAsync.mockResolvedValueOnce({
+      sub: 'user-1',
+      exp: Math.floor(Date.now() / 1_000) + 300,
+    });
+
+    await gateway.handleConnection(client as never);
+
+    expect(sessionAuthority.withActiveSession).not.toHaveBeenCalled();
+    expect(client.join).not.toHaveBeenCalled();
+    expect(client.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a realtime connection whose persisted session is revoked', async () => {
+    const { gateway, client, sessionAuthority } = build();
+    sessionAuthority.withActiveSession.mockResolvedValueOnce({ authorized: false });
+
+    await gateway.handleConnection(client as never);
+
+    expect(client.emit).toHaveBeenCalledWith('session:revoked', { reason: 'session_revoked' });
+    expect(client.join).not.toHaveBeenCalled();
     expect(client.disconnect).toHaveBeenCalledTimes(1);
   });
 
@@ -73,6 +150,7 @@ describe('ChatGateway realtime authorization', () => {
       const { gateway, client, jwtService, chatSecurity, realtimeAdmission } = build();
       jwtService.verifyAsync.mockResolvedValueOnce({
         sub: 'user-1',
+        sid: 'session-1',
         exp: Math.floor(Date.now() / 1_000) + 2,
       });
 
@@ -96,7 +174,7 @@ describe('ChatGateway realtime authorization', () => {
       ).resolves.toEqual({ success: false, error: 'unauthorized' });
 
       expect(realtimeAdmission.consume).not.toHaveBeenCalled();
-      expect(chatSecurity.persistMessage).not.toHaveBeenCalled();
+      expect(chatSecurity.persistMessageInTransaction).not.toHaveBeenCalled();
     } finally {
       jest.useRealTimers();
     }
@@ -110,6 +188,7 @@ describe('ChatGateway realtime authorization', () => {
       const { gateway, client, jwtService, chatSecurity, realtimeAdmission } = build();
       jwtService.verifyAsync.mockResolvedValueOnce({
         sub: 'user-1',
+        sid: 'session-1',
         exp: Math.floor(Date.now() / 1_000) + 2,
       });
       await gateway.handleConnection(client as never);
@@ -123,7 +202,7 @@ describe('ChatGateway realtime authorization', () => {
       expect(client.emit).toHaveBeenCalledWith('session:expired', { reason: 'token_expired' });
       expect(client.disconnect).toHaveBeenCalledTimes(1);
       expect(realtimeAdmission.consume).not.toHaveBeenCalled();
-      expect(chatSecurity.withAuthorizedRealtimeRecipients).not.toHaveBeenCalled();
+      expect(chatSecurity.withAuthorizedRealtimeRecipientsInTransaction).not.toHaveBeenCalled();
     } finally {
       jest.useRealTimers();
     }
@@ -137,6 +216,7 @@ describe('ChatGateway realtime authorization', () => {
       const { gateway, client, jwtService } = build();
       jwtService.verifyAsync.mockResolvedValueOnce({
         sub: 'user-1',
+        sid: 'session-1',
         exp: Math.floor(Date.now() / 1_000) + 2,
       });
       await gateway.handleConnection(client as never);
@@ -151,12 +231,56 @@ describe('ChatGateway realtime authorization', () => {
     }
   });
 
-  it('delivers persisted messages only through authorized private user rooms', async () => {
-    const { gateway, client, chatSecurity, realtimeAdmission, to, emit } = build();
+  it('rejects a revoked persisted session after admission and before persistence', async () => {
+    const { gateway, client, sessionAuthority, chatSecurity, realtimeAdmission } = build();
+    await gateway.handleConnection(client as never);
+    sessionAuthority.withActiveSession.mockClear();
+    sessionAuthority.withActiveSession.mockResolvedValueOnce({ authorized: false });
+
+    await expect(
+      gateway.handleMessage(client as never, {
+        conversationId: 'conversation-1',
+        clientMessageId: 'client-message-123',
+        text: 'hello',
+      })
+    ).resolves.toEqual({ success: false, error: 'unauthorized' });
+
+    expect(realtimeAdmission.consume).toHaveBeenCalledWith('user-1', 'message');
+    expect(sessionAuthority.withActiveSession).toHaveBeenCalledWith(
+      'session-1',
+      'user-1',
+      expect.any(Function)
+    );
+    expect(client.emit).toHaveBeenCalledWith('session:revoked', { reason: 'session_revoked' });
+    expect(client.disconnect).toHaveBeenCalledTimes(1);
+    expect(chatSecurity.persistMessageInTransaction).not.toHaveBeenCalled();
+  });
+
+  it('threads the authority transaction through persistence and excludes revoked recipient sessions', async () => {
+    const {
+      gateway,
+      client,
+      makeClient,
+      authorityTx,
+      jwtService,
+      sessionAuthority,
+      chatSecurity,
+      to,
+      except,
+      emit,
+    } = build();
     await gateway.handleConnection(client as never);
 
+    const user3Client = makeClient('socket-3');
+    jwtService.verifyAsync.mockResolvedValueOnce({
+      sub: 'user-3',
+      sid: 'session-3',
+      exp: Math.floor(Date.now() / 1_000) + 300,
+    });
+    await gateway.handleConnection(user3Client as never);
+
     const createdAt = new Date('2026-08-24T04:00:00.000Z');
-    chatSecurity.persistMessage.mockResolvedValue({
+    chatSecurity.persistMessageInTransaction.mockResolvedValue({
       duplicate: false,
       message: {
         id: 'message-1',
@@ -168,9 +292,19 @@ describe('ChatGateway realtime authorization', () => {
       },
     });
     chatSecurity.withAuthorizedRealtimeRecipients.mockImplementation(
-      async (_conversationId: string, deliver: (userIds: string[]) => void) => {
-        deliver(['user-1', 'user-3']);
+      async (_conversationId: string, deliver: (userIds: string[]) => void | Promise<void>) => {
+        await deliver(['user-1', 'user-3']);
         return { authorizedUserIds: ['user-1', 'user-3'] };
+      }
+    );
+    sessionAuthority.withActiveSessions.mockImplementationOnce(
+      async (
+        _sessionIds: string[],
+        deliver: (activeSessionIds: Set<string>) => void | Promise<void>
+      ) => {
+        const activeSessionIds = new Set(['session-1']);
+        await deliver(activeSessionIds);
+        return { activeSessionIds };
       }
     );
 
@@ -182,18 +316,19 @@ describe('ChatGateway realtime authorization', () => {
       })
     ).resolves.toMatchObject({ success: true, duplicate: false });
 
-    expect(realtimeAdmission.consume).toHaveBeenCalledWith('user-1', 'message');
-    expect(chatSecurity.persistMessage).toHaveBeenCalledWith({
+    expect(chatSecurity.persistMessageInTransaction).toHaveBeenCalledWith(authorityTx, {
       userId: 'user-1',
       conversationId: 'conversation-1',
       clientMessageId: 'client-message-123',
       text: 'hello',
     });
-    expect(chatSecurity.withAuthorizedRealtimeRecipients).toHaveBeenCalledWith(
-      'conversation-1',
+    expect(chatSecurity.persistMessage).not.toHaveBeenCalled();
+    expect(sessionAuthority.withActiveSessions).toHaveBeenCalledWith(
+      expect.arrayContaining(['session-1', 'session-3']),
       expect.any(Function)
     );
     expect(to).toHaveBeenCalledWith(['user:user-1', 'user:user-3']);
+    expect(except).toHaveBeenCalledWith(['socket-3']);
     expect(emit).toHaveBeenCalledWith('message:received', {
       id: 'message-1',
       conversationId: 'conversation-1',
@@ -202,18 +337,12 @@ describe('ChatGateway realtime authorization', () => {
       mediaUrls: [],
       timestamp: createdAt,
     });
-    expect(
-      to.mock.calls.some(([rooms]) =>
-        Array.isArray(rooms)
-          ? rooms.some((room) => String(room).startsWith('conversation:'))
-          : String(rooms).startsWith('conversation:')
-      )
-    ).toBe(false);
   });
 
-  it('rejects malformed messages before admission or persistence work begins', async () => {
-    const { gateway, client, chatSecurity, realtimeAdmission } = build();
+  it('rejects malformed messages before admission or persisted session work begins', async () => {
+    const { gateway, client, chatSecurity, realtimeAdmission, sessionAuthority } = build();
     await gateway.handleConnection(client as never);
+    sessionAuthority.withActiveSession.mockClear();
 
     const invalidPayloads = [
       null,
@@ -235,13 +364,14 @@ describe('ChatGateway realtime authorization', () => {
     }
 
     expect(realtimeAdmission.consume).not.toHaveBeenCalled();
-    expect(chatSecurity.persistMessage).not.toHaveBeenCalled();
-    expect(chatSecurity.withAuthorizedRealtimeRecipients).not.toHaveBeenCalled();
+    expect(sessionAuthority.withActiveSession).not.toHaveBeenCalled();
+    expect(chatSecurity.persistMessageInTransaction).not.toHaveBeenCalled();
   });
 
-  it('rejects message floods before persistence work begins', async () => {
-    const { gateway, client, chatSecurity, realtimeAdmission } = build();
+  it('rejects message floods before persisted session and persistence work begins', async () => {
+    const { gateway, client, chatSecurity, realtimeAdmission, sessionAuthority } = build();
     await gateway.handleConnection(client as never);
+    sessionAuthority.withActiveSession.mockClear();
     realtimeAdmission.consume.mockReturnValueOnce({ allowed: false, retryAfterMs: 750 });
 
     await expect(
@@ -252,23 +382,45 @@ describe('ChatGateway realtime authorization', () => {
       })
     ).resolves.toEqual({ success: false, error: 'rate_limited', retryAfterMs: 750 });
 
-    expect(chatSecurity.persistMessage).not.toHaveBeenCalled();
-    expect(chatSecurity.withAuthorizedRealtimeRecipients).not.toHaveBeenCalled();
+    expect(sessionAuthority.withActiveSession).not.toHaveBeenCalled();
+    expect(chatSecurity.persistMessageInTransaction).not.toHaveBeenCalled();
   });
 
-  it('requires the typing actor to remain authorized and excludes only the current socket', async () => {
-    const { gateway, client, chatSecurity, realtimeAdmission, to, except, emit } = build();
+  it('keeps typing relationship and recipient-session checks on the authority transaction', async () => {
+    const {
+      gateway,
+      client,
+      makeClient,
+      authorityTx,
+      jwtService,
+      sessionAuthority,
+      chatSecurity,
+      realtimeAdmission,
+      to,
+      except,
+      emit,
+    } = build();
     await gateway.handleConnection(client as never);
 
-    chatSecurity.withAuthorizedRealtimeRecipients.mockImplementation(
+    const user2Client = makeClient('socket-2');
+    jwtService.verifyAsync.mockResolvedValueOnce({
+      sub: 'user-2',
+      sid: 'session-2',
+      exp: Math.floor(Date.now() / 1_000) + 300,
+    });
+    await gateway.handleConnection(user2Client as never);
+
+    chatSecurity.withAuthorizedRealtimeRecipientsInTransaction.mockImplementation(
       async (
+        tx: unknown,
         _conversationId: string,
-        deliver: (userIds: string[]) => void,
+        deliver: (userIds: string[]) => void | Promise<void>,
         requiredUserId?: string
       ) => {
+        expect(tx).toBe(authorityTx);
         expect(requiredUserId).toBe('user-1');
-        deliver(['user-1', 'user-2', 'user-3']);
-        return { authorizedUserIds: ['user-1', 'user-2', 'user-3'] };
+        await deliver(['user-1', 'user-2']);
+        return { authorizedUserIds: ['user-1', 'user-2'] };
       }
     );
 
@@ -277,14 +429,21 @@ describe('ChatGateway realtime authorization', () => {
     ).resolves.toEqual({ success: true });
 
     expect(realtimeAdmission.consume).toHaveBeenCalledWith('user-1', 'typing');
-    expect(to).toHaveBeenCalledWith(['user:user-1', 'user:user-2', 'user:user-3']);
+    expect(sessionAuthority.withActiveSessionsInTransaction).toHaveBeenCalledWith(
+      authorityTx,
+      expect.arrayContaining(['session-1', 'session-2']),
+      expect.any(Function)
+    );
+    expect(chatSecurity.withAuthorizedRealtimeRecipients).not.toHaveBeenCalled();
+    expect(to).toHaveBeenCalledWith(['user:user-1', 'user:user-2']);
     expect(except).toHaveBeenCalledWith('socket-1');
     expect(emit).toHaveBeenCalledWith('typing:start', { userId: 'user-1' });
   });
 
-  it('rejects malformed typing payloads before admission or relationship work', async () => {
-    const { gateway, client, chatSecurity, realtimeAdmission, to } = build();
+  it('rejects malformed typing payloads before admission or persisted session work', async () => {
+    const { gateway, client, chatSecurity, realtimeAdmission, sessionAuthority, to } = build();
     await gateway.handleConnection(client as never);
+    sessionAuthority.withActiveSession.mockClear();
 
     await expect(gateway.handleTypingStart(client as never, null)).resolves.toEqual({
       success: false,
@@ -292,55 +451,62 @@ describe('ChatGateway realtime authorization', () => {
     });
 
     expect(realtimeAdmission.consume).not.toHaveBeenCalled();
-    expect(chatSecurity.withAuthorizedRealtimeRecipients).not.toHaveBeenCalled();
+    expect(sessionAuthority.withActiveSession).not.toHaveBeenCalled();
+    expect(chatSecurity.withAuthorizedRealtimeRecipientsInTransaction).not.toHaveBeenCalled();
     expect(to).not.toHaveBeenCalled();
   });
 
-  it('rejects typing floods before relationship authorization work begins', async () => {
-    const { gateway, client, chatSecurity, realtimeAdmission, to } = build();
+  it('rejects typing floods before persisted session and relationship authorization work', async () => {
+    const { gateway, client, chatSecurity, realtimeAdmission, sessionAuthority, to } = build();
     await gateway.handleConnection(client as never);
+    sessionAuthority.withActiveSession.mockClear();
     realtimeAdmission.consume.mockReturnValueOnce({ allowed: false, retryAfterMs: 500 });
 
     await expect(
       gateway.handleTypingStart(client as never, { conversationId: 'conversation-1' })
     ).resolves.toEqual({ success: false, error: 'rate_limited', retryAfterMs: 500 });
 
-    expect(chatSecurity.withAuthorizedRealtimeRecipients).not.toHaveBeenCalled();
+    expect(sessionAuthority.withActiveSession).not.toHaveBeenCalled();
+    expect(chatSecurity.withAuthorizedRealtimeRecipientsInTransaction).not.toHaveBeenCalled();
     expect(to).not.toHaveBeenCalled();
   });
 
-  it('rejects malformed membership payloads before admission or access checks', async () => {
-    const { gateway, client, chatSecurity, realtimeAdmission } = build();
+  it('rejects malformed membership payloads before admission or persisted session checks', async () => {
+    const { gateway, client, chatSecurity, realtimeAdmission, sessionAuthority } = build();
     await gateway.handleConnection(client as never);
     client.join.mockClear();
+    sessionAuthority.withActiveSession.mockClear();
 
     await expect(
       gateway.handleJoinConversation(client as never, { conversationId: 'bad id' })
     ).resolves.toEqual({ success: false, error: 'invalid_payload' });
 
     expect(realtimeAdmission.consume).not.toHaveBeenCalled();
-    expect(chatSecurity.assertConversationAccess).not.toHaveBeenCalled();
+    expect(sessionAuthority.withActiveSession).not.toHaveBeenCalled();
+    expect(chatSecurity.assertConversationAccessInTransaction).not.toHaveBeenCalled();
     expect(client.join).not.toHaveBeenCalled();
   });
 
-  it('rate-limits room membership churn before access checks', async () => {
-    const { gateway, client, chatSecurity, realtimeAdmission } = build();
+  it('rate-limits room membership churn before persisted session access checks', async () => {
+    const { gateway, client, chatSecurity, realtimeAdmission, sessionAuthority } = build();
     await gateway.handleConnection(client as never);
     client.join.mockClear();
+    sessionAuthority.withActiveSession.mockClear();
     realtimeAdmission.consume.mockReturnValueOnce({ allowed: false, retryAfterMs: 400 });
 
     await expect(
       gateway.handleJoinConversation(client as never, { conversationId: 'conversation-1' })
     ).resolves.toEqual({ success: false, error: 'rate_limited', retryAfterMs: 400 });
 
-    expect(chatSecurity.assertConversationAccess).not.toHaveBeenCalled();
+    expect(sessionAuthority.withActiveSession).not.toHaveBeenCalled();
+    expect(chatSecurity.assertConversationAccessInTransaction).not.toHaveBeenCalled();
     expect(client.join).not.toHaveBeenCalled();
   });
 
   it('does not emit typing after relationship authorization is revoked', async () => {
     const { gateway, client, chatSecurity, to } = build();
     await gateway.handleConnection(client as never);
-    chatSecurity.withAuthorizedRealtimeRecipients.mockRejectedValue(
+    chatSecurity.withAuthorizedRealtimeRecipientsInTransaction.mockRejectedValue(
       new ForbiddenException('Conversation is unavailable')
     );
 

--- a/apps/api/src/chat/chat.gateway.ts
+++ b/apps/api/src/chat/chat.gateway.ts
@@ -9,7 +9,9 @@ import {
   WebSocketGateway,
   WebSocketServer,
 } from '@nestjs/websockets';
+import type { Prisma } from '@woof/database';
 import { Server, Socket } from 'socket.io';
+import { SessionAuthorityService } from '../auth/session-authority.service';
 import { NudgesService } from '../nudges/nudges.service';
 import {
   MAX_REALTIME_PACKET_BYTES,
@@ -24,6 +26,7 @@ const MAX_SESSION_TIMER_DELAY_MS = 2_147_483_647;
 type RealtimeJwtPayload = {
   sub?: unknown;
   exp?: unknown;
+  sid?: unknown;
 };
 
 @WebSocketGateway({
@@ -39,11 +42,13 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   private readonly logger = new Logger(ChatGateway.name);
   private readonly connectedUsers = new Map<string, string>();
+  private readonly connectedSessions = new Map<string, string>();
   private readonly sessionExpiries = new Map<string, number>();
   private readonly sessionExpiryTimers = new Map<string, NodeJS.Timeout>();
 
   constructor(
     private readonly jwtService: JwtService,
+    private readonly sessionAuthority: SessionAuthorityService,
     private readonly chatSecurity: ChatSecurityService,
     private readonly realtimeAdmission: RealtimeAdmissionService,
     private readonly nudgesService: NudgesService
@@ -58,18 +63,47 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       }
 
       const payload = await this.jwtService.verifyAsync<RealtimeJwtPayload>(token);
-      const userId = this.userIdFromPayload(payload.sub);
+      const userId = this.stringClaim(payload.sub);
+      const sessionId = this.stringClaim(payload.sid);
       const expiresAtMs = this.expiryFromPayload(payload.exp);
-      if (!userId || !expiresAtMs) {
+      if (!userId || !sessionId || !expiresAtMs) {
         client.disconnect();
         return;
       }
 
-      this.connectedUsers.set(client.id, userId);
-      this.sessionExpiries.set(client.id, expiresAtMs);
-      this.scheduleSessionExpiry(client, expiresAtMs);
-      if (!this.hasActiveSession(client, userId)) return;
-      await client.join(`user:${userId}`);
+      const admission = await this.sessionAuthority.withActiveSession(
+        sessionId,
+        userId,
+        async () => {
+          if (this.isSocketDisconnected(client)) return false;
+
+          this.connectedUsers.set(client.id, userId);
+          this.connectedSessions.set(client.id, sessionId);
+          this.sessionExpiries.set(client.id, expiresAtMs);
+          this.scheduleSessionExpiry(client, expiresAtMs);
+          if (!this.hasActiveSession(client, userId)) return false;
+
+          await client.join(`user:${userId}`);
+          if (this.isSocketDisconnected(client)) {
+            this.clearSession(client.id);
+            return false;
+          }
+
+          return true;
+        }
+      );
+
+      if (!admission.authorized) {
+        this.revokeSocket(client);
+        return;
+      }
+
+      if (!admission.result || this.isSocketDisconnected(client)) {
+        this.clearSession(client.id);
+        return;
+      }
+
+      client.emit('session:ready', { socketId: client.id });
     } catch (error) {
       this.clearSession(client.id);
       this.logger.warn(`Rejected socket connection: ${this.errorName(error)}`);
@@ -96,37 +130,53 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       return { success: false, error: 'rate_limited', retryAfterMs: admission.retryAfterMs };
     }
 
-    try {
-      const result = await this.chatSecurity.persistMessage({ userId, ...payload });
+    const response = await this.withAuthoritativeSession(client, userId, async (tx) => {
+      try {
+        const result = await this.chatSecurity.persistMessageInTransaction(tx, {
+          userId,
+          ...payload,
+        });
 
-      const message = {
-        id: result.message.id,
-        conversationId: result.message.conversationId,
-        senderId: result.message.senderId,
-        text: result.message.text,
-        mediaUrls: result.message.mediaUrls,
-        timestamp: result.message.createdAt,
-      };
+        const message = {
+          id: result.message.id,
+          conversationId: result.message.conversationId,
+          senderId: result.message.senderId,
+          text: result.message.text,
+          mediaUrls: result.message.mediaUrls,
+          timestamp: result.message.createdAt,
+        };
 
-      if (!result.duplicate) {
+        return { success: true, duplicate: result.duplicate, message };
+      } catch (error) {
+        this.logger.warn(`Rejected chat message: ${this.errorName(error)}`);
+        return { success: false, error: 'message_rejected' };
+      }
+    });
+
+    if (response?.success && !response.duplicate) {
+      try {
         await this.chatSecurity.withAuthorizedRealtimeRecipients(
           payload.conversationId,
-          (authorizedUserIds) => {
-            this.server.to(this.userRooms(authorizedUserIds)).emit('message:received', message);
+          async (authorizedUserIds) => {
+            await this.emitToActiveSessions(
+              authorizedUserIds,
+              'message:received',
+              response.message
+            );
           }
         );
-        void this.nudgesService
-          .checkChatActivityNudges(payload.conversationId, userId)
-          .catch((error) => {
-            this.logger.warn(`Chat nudge check failed: ${this.errorName(error)}`);
-          });
+      } catch (error) {
+        this.logger.warn(`Chat realtime delivery failed: ${this.errorName(error)}`);
       }
 
-      return { success: true, duplicate: result.duplicate, message };
-    } catch (error) {
-      this.logger.warn(`Rejected chat message: ${this.errorName(error)}`);
-      return { success: false, error: 'message_rejected' };
+      void this.nudgesService
+        .checkChatActivityNudges(payload.conversationId, userId)
+        .catch((error) => {
+          this.logger.warn(`Chat nudge check failed: ${this.errorName(error)}`);
+        });
     }
+
+    return response ?? { success: false, error: 'unauthorized' };
   }
 
   @SubscribeMessage('conversation:join')
@@ -144,13 +194,21 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       return { success: false, error: 'rate_limited', retryAfterMs: admission.retryAfterMs };
     }
 
-    try {
-      await this.chatSecurity.assertConversationAccess(userId, payload.conversationId);
-      await client.join(`conversation:${payload.conversationId}`);
-      return { success: true };
-    } catch {
-      return { success: false, error: 'conversation_unavailable' };
-    }
+    const response = await this.withAuthoritativeSession(client, userId, async (tx) => {
+      try {
+        await this.chatSecurity.assertConversationAccessInTransaction(
+          tx,
+          userId,
+          payload.conversationId
+        );
+        await client.join(`conversation:${payload.conversationId}`);
+        return { success: true };
+      } catch {
+        return { success: false, error: 'conversation_unavailable' };
+      }
+    });
+
+    return response ?? { success: false, error: 'unauthorized' };
   }
 
   @SubscribeMessage('conversation:leave')
@@ -168,13 +226,21 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       return { success: false, error: 'rate_limited', retryAfterMs: admission.retryAfterMs };
     }
 
-    try {
-      await this.chatSecurity.assertConversationAccess(userId, payload.conversationId);
-      await client.leave(`conversation:${payload.conversationId}`);
-      return { success: true };
-    } catch {
-      return { success: false, error: 'conversation_unavailable' };
-    }
+    const response = await this.withAuthoritativeSession(client, userId, async (tx) => {
+      try {
+        await this.chatSecurity.assertConversationAccessInTransaction(
+          tx,
+          userId,
+          payload.conversationId
+        );
+        await client.leave(`conversation:${payload.conversationId}`);
+        return { success: true };
+      } catch {
+        return { success: false, error: 'conversation_unavailable' };
+      }
+    });
+
+    return response ?? { success: false, error: 'unauthorized' };
   }
 
   @SubscribeMessage('typing:start')
@@ -201,21 +267,87 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       return { success: false, error: 'rate_limited', retryAfterMs: admission.retryAfterMs };
     }
 
-    try {
-      await this.chatSecurity.withAuthorizedRealtimeRecipients(
-        payload.conversationId,
-        (authorizedUserIds) => {
-          this.server
-            .to(this.userRooms(authorizedUserIds))
-            .except(client.id)
-            .emit(event, { userId });
-        },
-        userId
-      );
-      return { success: true };
-    } catch {
-      return { success: false, error: 'conversation_unavailable' };
+    const response = await this.withAuthoritativeSession(client, userId, async (tx) => {
+      try {
+        await this.chatSecurity.withAuthorizedRealtimeRecipientsInTransaction(
+          tx,
+          payload.conversationId,
+          async (authorizedUserIds) => {
+            const candidates = this.sessionCandidates(authorizedUserIds);
+            await this.sessionAuthority.withActiveSessionsInTransaction(
+              tx,
+              candidates.map((candidate) => candidate.sessionId),
+              (activeSessionIds) => {
+                const inactiveSocketIds = candidates
+                  .filter((candidate) => !activeSessionIds.has(candidate.sessionId))
+                  .map((candidate) => candidate.socketId);
+                const authorizedRooms = this.server
+                  .to(this.userRooms(authorizedUserIds))
+                  .except(client.id);
+                if (inactiveSocketIds.length > 0) {
+                  authorizedRooms.except(inactiveSocketIds).emit(event, { userId });
+                } else {
+                  authorizedRooms.emit(event, { userId });
+                }
+              }
+            );
+          },
+          userId
+        );
+        return { success: true };
+      } catch {
+        return { success: false, error: 'conversation_unavailable' };
+      }
+    });
+
+    return response ?? { success: false, error: 'unauthorized' };
+  }
+
+  private async withAuthoritativeSession<T>(
+    client: Socket,
+    userId: string,
+    work: (tx: Prisma.TransactionClient) => Promise<T>
+  ) {
+    const sessionId = this.connectedSessions.get(client.id);
+    if (!sessionId) return null;
+
+    const authority = await this.sessionAuthority.withActiveSession(sessionId, userId, work);
+    if (!authority.authorized) {
+      this.revokeSocket(client);
+      return null;
     }
+    return authority.result;
+  }
+
+  private async emitToActiveSessions(authorizedUserIds: string[], event: string, payload: unknown) {
+    const candidates = this.sessionCandidates(authorizedUserIds);
+    await this.sessionAuthority.withActiveSessions(
+      candidates.map((candidate) => candidate.sessionId),
+      (activeSessionIds) => {
+        const inactiveSocketIds = candidates
+          .filter((candidate) => !activeSessionIds.has(candidate.sessionId))
+          .map((candidate) => candidate.socketId);
+        const authorizedRooms = this.server.to(this.userRooms(authorizedUserIds));
+        if (inactiveSocketIds.length > 0) {
+          authorizedRooms.except(inactiveSocketIds).emit(event, payload);
+        } else {
+          authorizedRooms.emit(event, payload);
+        }
+      }
+    );
+  }
+
+  private sessionCandidates(userIds: string[]) {
+    const authorizedUsers = new Set(userIds);
+    const candidates: Array<{ socketId: string; sessionId: string }> = [];
+
+    for (const [socketId, userId] of this.connectedUsers.entries()) {
+      if (!authorizedUsers.has(userId)) continue;
+      const sessionId = this.connectedSessions.get(socketId);
+      if (sessionId) candidates.push({ socketId, sessionId });
+    }
+
+    return candidates;
   }
 
   private hasActiveSession(client: Socket, userId: string) {
@@ -264,8 +396,15 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     client.disconnect();
   }
 
+  private revokeSocket(client: Socket) {
+    this.clearSession(client.id);
+    client.emit('session:revoked', { reason: 'session_revoked' });
+    client.disconnect();
+  }
+
   private clearSession(socketId: string) {
     this.connectedUsers.delete(socketId);
+    this.connectedSessions.delete(socketId);
     this.sessionExpiries.delete(socketId);
     this.clearSessionTimer(socketId);
   }
@@ -278,7 +417,11 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     this.sessionExpiryTimers.delete(socketId);
   }
 
-  private userIdFromPayload(value: unknown) {
+  private isSocketDisconnected(client: Socket) {
+    return client.connected === false;
+  }
+
+  private stringClaim(value: unknown) {
     return typeof value === 'string' && value.length > 0 ? value : null;
   }
 

--- a/apps/api/src/chat/chat.module.ts
+++ b/apps/api/src/chat/chat.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
+import { AuthModule } from '../auth/auth.module';
 import { NudgesModule } from '../nudges/nudges.module';
 import { PrismaModule } from '../prisma/prisma.module';
 import { ChatController } from './chat.controller';
@@ -18,6 +19,7 @@ import { RealtimeAdmissionService } from './realtime-admission.service';
         signOptions: { expiresIn: config.get('JWT_EXPIRES_IN') || '7d' },
       }),
     }),
+    AuthModule,
     NudgesModule,
     PrismaModule,
   ],

--- a/apps/mobile/src/api/auth.ts
+++ b/apps/mobile/src/api/auth.ts
@@ -31,6 +31,10 @@ async function persist(response: AuthResponse) {
   return response;
 }
 
+function authHeader(token: string) {
+  return { headers: { Authorization: `Bearer ${token}` } };
+}
+
 export const authApi = {
   async register(data: RegisterDto): Promise<AuthResponse> {
     const response = await apiClient.post<AuthResponse>('/auth/register', data);
@@ -43,7 +47,23 @@ export const authApi = {
   },
 
   async logout(): Promise<void> {
+    const token = await SecureStore.getItemAsync(ACCESS_TOKEN_KEY);
     await SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY);
+    if (!token) return;
+
+    try {
+      await apiClient.post('/auth/logout', {}, authHeader(token));
+    } catch {
+      // Local logout remains available when the server is unreachable or already
+      // considers the captured session invalid.
+    }
+  },
+
+  async logoutAll(): Promise<void> {
+    const token = await SecureStore.getItemAsync(ACCESS_TOKEN_KEY);
+    await SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY);
+    if (!token) return;
+    await apiClient.post('/auth/logout-all', {}, authHeader(token));
   },
 
   async getProfile() {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { apiClient } from './api/client';
+import { disconnectSocket } from './socket';
 import { useAuthStore, type AuthPet, type AuthUser } from './stores/auth-store';
 import type { Event, Match, ServiceProvider } from './types';
 
@@ -27,6 +28,15 @@ export type Nudge = {
   dismissed: boolean;
 };
 
+function clearLocalAuth() {
+  disconnectSocket();
+  useAuthStore.getState().logout();
+}
+
+function authHeader(token: string) {
+  return { headers: { Authorization: `Bearer ${token}` } };
+}
+
 export const authApi = {
   register: async (data: { handle: string; email: string; password: string; bio?: string }) => {
     const response = await apiClient.post<AuthResponse>('/auth/register', data);
@@ -44,8 +54,24 @@ export const authApi = {
     return response;
   },
 
-  logout: () => {
-    useAuthStore.getState().logout();
+  logout: async () => {
+    const token = useAuthStore.getState().token;
+    clearLocalAuth();
+    if (!token) return;
+
+    try {
+      await apiClient.post('/auth/logout', {}, authHeader(token));
+    } catch {
+      // Local logout is authoritative for this device when the server is unreachable
+      // or already considers the captured session invalid.
+    }
+  },
+
+  logoutAll: async () => {
+    const token = useAuthStore.getState().token;
+    clearLocalAuth();
+    if (!token) return;
+    await apiClient.post('/auth/logout-all', {}, authHeader(token));
   },
 
   me: () => apiClient.get<AuthUser>('/auth/me'),

--- a/apps/web/src/lib/socket.spec.ts
+++ b/apps/web/src/lib/socket.spec.ts
@@ -1,0 +1,342 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const harness = vi.hoisted(() => ({
+  io: vi.fn(),
+  logout: vi.fn(),
+  token: 'token-1',
+}));
+
+vi.mock('socket.io-client', () => ({ io: harness.io }));
+vi.mock('./stores/auth-store', () => ({
+  useAuthStore: {
+    getState: () => ({ token: harness.token, logout: harness.logout }),
+  },
+}));
+
+type Listener = (...args: unknown[]) => void;
+
+function createSocketHarness() {
+  const persistent = new Map<string, Set<Listener>>();
+  const once = new Map<string, Set<Listener>>();
+  const outgoing = vi.fn();
+  let connectionNumber = 0;
+
+  const add = (collection: Map<string, Set<Listener>>, event: string, listener: Listener) => {
+    const listeners = collection.get(event) ?? new Set<Listener>();
+    listeners.add(listener);
+    collection.set(event, listeners);
+  };
+  const remove = (collection: Map<string, Set<Listener>>, event: string, listener: Listener) => {
+    collection.get(event)?.delete(listener);
+  };
+  const serverEmit = (event: string, ...args: unknown[]) => {
+    const eventArgs =
+      event === 'session:ready' && args.length === 0 ? [{ socketId: socket.id }] : args;
+    for (const listener of persistent.get(event) ?? []) listener(...eventArgs);
+    const oneTimeListeners = [...(once.get(event) ?? [])];
+    once.delete(event);
+    for (const listener of oneTimeListeners) listener(...eventArgs);
+  };
+
+  const socket = {
+    id: 'socket-0',
+    connected: false,
+    auth: {} as Record<string, unknown>,
+    on: vi.fn((event: string, listener: Listener) => {
+      add(persistent, event, listener);
+      return socket;
+    }),
+    once: vi.fn((event: string, listener: Listener) => {
+      add(once, event, listener);
+      return socket;
+    }),
+    off: vi.fn((event: string, listener: Listener) => {
+      remove(persistent, event, listener);
+      remove(once, event, listener);
+      return socket;
+    }),
+    connect: vi.fn(() => {
+      connectionNumber += 1;
+      socket.id = `socket-${connectionNumber}`;
+      socket.connected = true;
+      serverEmit('connect');
+      return socket;
+    }),
+    disconnect: vi.fn(() => {
+      socket.connected = false;
+      serverEmit('disconnect', 'io client disconnect');
+      return socket;
+    }),
+    emit: outgoing,
+    timeout: vi.fn(() => ({ emit: outgoing })),
+  };
+
+  return { socket, outgoing, serverEmit };
+}
+
+function installSuccessfulMessageAck(
+  transport: ReturnType<typeof createSocketHarness>,
+  id = 'message-1'
+) {
+  transport.outgoing.mockImplementation(
+    (event: string, _payload: unknown, ack?: (error: Error | null, response?: unknown) => void) => {
+      if (event === 'message:send') {
+        ack?.(null, {
+          success: true,
+          duplicate: false,
+          message: {
+            id,
+            conversationId: 'conversation-1',
+            senderId: 'user-1',
+            text: 'hello',
+            mediaUrls: [],
+            timestamp: '2026-08-25T03:00:00.000Z',
+          },
+        });
+      }
+      return transport.socket;
+    }
+  );
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function expectNoJoin(transport: ReturnType<typeof createSocketHarness>) {
+  expect(transport.outgoing).not.toHaveBeenCalledWith('conversation:join', expect.anything());
+}
+
+function expectNoTyping(transport: ReturnType<typeof createSocketHarness>) {
+  expect(transport.outgoing).not.toHaveBeenCalledWith('typing:start', expect.anything());
+  expect(transport.outgoing).not.toHaveBeenCalledWith('typing:stop', expect.anything());
+}
+
+describe('realtime session readiness', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    harness.io.mockReset();
+    harness.logout.mockReset();
+    harness.token = 'token-1';
+  });
+
+  it('releases desired membership exactly once after persisted session authority becomes ready', async () => {
+    const transport = createSocketHarness();
+    harness.io.mockReturnValue(transport.socket);
+    const { chatSocket } = await import('./socket');
+
+    chatSocket.joinConversation('conversation-1');
+    await flushPromises();
+
+    expect(transport.socket.connect).toHaveBeenCalledTimes(1);
+    expectNoJoin(transport);
+
+    transport.serverEmit('session:ready');
+    await flushPromises();
+
+    expect(transport.outgoing).toHaveBeenCalledTimes(1);
+    expect(transport.outgoing).toHaveBeenCalledWith('conversation:join', {
+      conversationId: 'conversation-1',
+    });
+  });
+
+  it('does not replay desired membership when session ready is emitted twice', async () => {
+    const transport = createSocketHarness();
+    harness.io.mockReturnValue(transport.socket);
+    const { chatSocket } = await import('./socket');
+
+    chatSocket.joinConversation('conversation-1');
+    transport.serverEmit('session:ready');
+    transport.serverEmit('session:ready');
+    await flushPromises();
+
+    expect(transport.outgoing).toHaveBeenCalledTimes(1);
+    expect(transport.outgoing).toHaveBeenCalledWith('conversation:join', {
+      conversationId: 'conversation-1',
+    });
+  });
+
+  it('ignores stale readiness from a previous transport epoch', async () => {
+    const transport = createSocketHarness();
+    harness.io.mockReturnValue(transport.socket);
+    const { chatSocket, connectSocket } = await import('./socket');
+
+    chatSocket.joinConversation('conversation-1');
+    const firstSocketId = transport.socket.id;
+    transport.serverEmit('session:ready');
+    transport.outgoing.mockClear();
+
+    transport.socket.disconnect();
+    connectSocket();
+    expect(transport.socket.id).not.toBe(firstSocketId);
+
+    transport.serverEmit('session:ready', { socketId: firstSocketId });
+    await flushPromises();
+    expectNoJoin(transport);
+    chatSocket.startTyping('conversation-1');
+    expectNoTyping(transport);
+
+    transport.serverEmit('session:ready');
+    await flushPromises();
+    expect(transport.outgoing).toHaveBeenCalledWith('conversation:join', {
+      conversationId: 'conversation-1',
+    });
+  });
+
+  it('cancels desired membership when leave occurs before authorization readiness', async () => {
+    const transport = createSocketHarness();
+    harness.io.mockReturnValue(transport.socket);
+    const { chatSocket } = await import('./socket');
+
+    chatSocket.joinConversation('conversation-1');
+    chatSocket.leaveConversation('conversation-1');
+    transport.serverEmit('session:ready');
+    await flushPromises();
+
+    expectNoJoin(transport);
+    expect(transport.outgoing).not.toHaveBeenCalledWith('conversation:leave', expect.anything());
+  });
+
+  it('does not send a message until the realtime session is authorized', async () => {
+    const transport = createSocketHarness();
+    installSuccessfulMessageAck(transport);
+    harness.io.mockReturnValue(transport.socket);
+    const { chatSocket } = await import('./socket');
+
+    const pending = chatSocket.sendMessage('conversation-1', 'hello', 'client-message-readiness-1');
+    await flushPromises();
+    expect(transport.outgoing).not.toHaveBeenCalledWith(
+      'message:send',
+      expect.anything(),
+      expect.anything()
+    );
+
+    transport.serverEmit('session:ready');
+    await expect(pending).resolves.toMatchObject({ id: 'message-1', content: 'hello' });
+  });
+
+  it('rejoins desired conversations once after each authorized reconnect', async () => {
+    const transport = createSocketHarness();
+    harness.io.mockReturnValue(transport.socket);
+    const { chatSocket, connectSocket } = await import('./socket');
+
+    chatSocket.joinConversation('conversation-1');
+    transport.serverEmit('session:ready');
+    await flushPromises();
+    expect(transport.outgoing).toHaveBeenCalledWith('conversation:join', {
+      conversationId: 'conversation-1',
+    });
+
+    transport.outgoing.mockClear();
+    transport.socket.disconnect();
+    connectSocket();
+    await flushPromises();
+    expectNoJoin(transport);
+
+    transport.serverEmit('session:ready');
+    await flushPromises();
+    expect(transport.outgoing).toHaveBeenCalledTimes(1);
+    expect(transport.outgoing).toHaveBeenCalledWith('conversation:join', {
+      conversationId: 'conversation-1',
+    });
+  });
+
+  it('drops ephemeral typing while not ready instead of replaying stale presence', async () => {
+    const transport = createSocketHarness();
+    harness.io.mockReturnValue(transport.socket);
+    const { chatSocket } = await import('./socket');
+
+    chatSocket.startTyping('conversation-1');
+    chatSocket.stopTyping('conversation-1');
+    await flushPromises();
+    expectNoTyping(transport);
+
+    transport.serverEmit('session:ready');
+    await flushPromises();
+    expectNoTyping(transport);
+
+    chatSocket.startTyping('conversation-1');
+    expect(transport.outgoing).toHaveBeenCalledWith('typing:start', {
+      conversationId: 'conversation-1',
+    });
+  });
+
+  it('forces a fresh identity boundary and drops desired rooms when the token changes', async () => {
+    const transport = createSocketHarness();
+    harness.io.mockReturnValue(transport.socket);
+    const { chatSocket, connectSocket } = await import('./socket');
+
+    chatSocket.joinConversation('conversation-1');
+    transport.serverEmit('session:ready');
+    transport.outgoing.mockClear();
+
+    harness.token = 'token-2';
+    connectSocket();
+
+    expect(transport.socket.disconnect).toHaveBeenCalledTimes(1);
+    expect(transport.socket.connect).toHaveBeenCalledTimes(2);
+    expect(transport.socket.auth).toEqual({ token: 'token-2' });
+
+    chatSocket.startTyping('conversation-1');
+    expectNoTyping(transport);
+    transport.serverEmit('session:ready');
+    await flushPromises();
+    expectNoJoin(transport);
+
+    chatSocket.startTyping('conversation-1');
+    expect(transport.outgoing).toHaveBeenCalledWith('typing:start', {
+      conversationId: 'conversation-1',
+    });
+  });
+
+  it('rejects all concurrent message waiters when authorization never becomes ready', async () => {
+    vi.useFakeTimers();
+    try {
+      const transport = createSocketHarness();
+      harness.io.mockReturnValue(transport.socket);
+      const { chatSocket } = await import('./socket');
+
+      const first = chatSocket.sendMessage('conversation-1', 'hello', 'client-message-timeout-1');
+      const second = chatSocket.sendMessage('conversation-1', 'hello', 'client-message-timeout-2');
+      const firstRejected = expect(first).rejects.toThrow(
+        'Realtime session authorization timed out'
+      );
+      const secondRejected = expect(second).rejects.toThrow(
+        'Realtime session authorization timed out'
+      );
+
+      await vi.advanceTimersByTimeAsync(8_000);
+      await firstRejected;
+      await secondRejected;
+      expect(transport.outgoing).not.toHaveBeenCalledWith(
+        'message:send',
+        expect.anything(),
+        expect.anything()
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears desired membership and local auth when an admitted session is revoked', async () => {
+    const transport = createSocketHarness();
+    harness.io.mockReturnValue(transport.socket);
+    const { chatSocket, connectSocket } = await import('./socket');
+
+    chatSocket.joinConversation('conversation-1');
+    transport.serverEmit('session:ready');
+    transport.outgoing.mockClear();
+
+    transport.serverEmit('session:revoked', { reason: 'session_revoked' });
+    expect(harness.logout).toHaveBeenCalledTimes(1);
+
+    transport.socket.disconnect();
+    harness.token = 'token-2';
+    connectSocket();
+    transport.serverEmit('session:ready');
+    await flushPromises();
+
+    expectNoJoin(transport);
+  });
+});

--- a/apps/web/src/lib/socket.ts
+++ b/apps/web/src/lib/socket.ts
@@ -2,7 +2,49 @@ import { io, Socket } from 'socket.io-client';
 import type { ChatMessage } from './api/chat';
 import { useAuthStore } from './stores/auth-store';
 
+const SESSION_READY_TIMEOUT_MS = 8_000;
+
 let socket: Socket | null = null;
+let sessionReady = false;
+let activeToken: string | null = null;
+const desiredConversations = new Set<string>();
+
+type PendingReadiness = {
+  promise: Promise<Socket>;
+  resolve: (socket: Socket) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+type SessionReadyPayload = {
+  socketId?: unknown;
+};
+
+let pendingReadiness: PendingReadiness | null = null;
+
+function settleReadiness(error?: Error) {
+  const pending = pendingReadiness;
+  if (!pending) return;
+
+  pendingReadiness = null;
+  clearTimeout(pending.timer);
+  if (error) pending.reject(error);
+  else if (socket) pending.resolve(socket);
+}
+
+function replayDesiredConversations(activeSocket: Socket) {
+  for (const conversationId of desiredConversations) {
+    activeSocket.emit('conversation:join', { conversationId });
+  }
+}
+
+function clearRevokedAuth() {
+  sessionReady = false;
+  activeToken = null;
+  desiredConversations.clear();
+  settleReadiness(new Error('Realtime session is no longer authorized'));
+  useAuthStore.getState().logout();
+}
 
 export function getSocket(): Socket {
   if (!socket) {
@@ -10,13 +52,32 @@ export function getSocket(): Socket {
     const apiUrl =
       process.env.NEXT_PUBLIC_API_URL?.replace('/api/v1', '') || 'http://localhost:4000';
 
-    socket = io(apiUrl, {
+    activeToken = token;
+    const activeSocket = io(apiUrl, {
       auth: { token },
       autoConnect: false,
     });
-    socket.on('session:expired', () => {
-      useAuthStore.getState().logout();
+    socket = activeSocket;
+
+    activeSocket.on('connect', () => {
+      sessionReady = false;
     });
+    activeSocket.on('session:ready', (payload: SessionReadyPayload) => {
+      if (sessionReady || payload?.socketId !== activeSocket.id) return;
+      sessionReady = true;
+      replayDesiredConversations(activeSocket);
+      settleReadiness();
+    });
+    activeSocket.on('disconnect', () => {
+      sessionReady = false;
+      settleReadiness(new Error('Realtime session disconnected before authorization'));
+    });
+    activeSocket.on('connect_error', (error: Error) => {
+      sessionReady = false;
+      settleReadiness(error);
+    });
+    activeSocket.on('session:expired', clearRevokedAuth);
+    activeSocket.on('session:revoked', clearRevokedAuth);
   }
 
   return socket;
@@ -24,13 +85,58 @@ export function getSocket(): Socket {
 
 export function connectSocket() {
   const activeSocket = getSocket();
-  activeSocket.auth = { token: useAuthStore.getState().token };
-  if (!activeSocket.connected) activeSocket.connect();
+  const token = useAuthStore.getState().token;
+  const tokenChanged = activeToken !== token;
+
+  if (tokenChanged) {
+    sessionReady = false;
+    desiredConversations.clear();
+    settleReadiness(new Error('Realtime credentials changed before authorization'));
+    activeSocket.disconnect();
+  }
+
+  activeToken = token;
+  activeSocket.auth = { token };
+  if (!activeSocket.connected) {
+    sessionReady = false;
+    activeSocket.connect();
+  }
   return activeSocket;
 }
 
 export function disconnectSocket() {
-  if (socket?.connected) socket.disconnect();
+  sessionReady = false;
+  activeToken = null;
+  desiredConversations.clear();
+  settleReadiness(new Error('Realtime session disconnected'));
+  socket?.disconnect();
+}
+
+function waitForSessionReady(): Promise<Socket> {
+  const activeSocket = connectSocket();
+  if (activeSocket.connected && sessionReady) return Promise.resolve(activeSocket);
+  if (pendingReadiness) return pendingReadiness.promise;
+
+  let resolveReadiness!: (socket: Socket) => void;
+  let rejectReadiness!: (error: Error) => void;
+  const promise = new Promise<Socket>((resolve, reject) => {
+    resolveReadiness = resolve;
+    rejectReadiness = reject;
+  });
+  const timer = setTimeout(() => {
+    if (pendingReadiness?.promise !== promise) return;
+    settleReadiness(new Error('Realtime session authorization timed out'));
+  }, SESSION_READY_TIMEOUT_MS);
+
+  pendingReadiness = {
+    promise,
+    resolve: resolveReadiness,
+    reject: rejectReadiness,
+    timer,
+  };
+
+  if (activeSocket.connected && sessionReady) settleReadiness();
+  return promise;
 }
 
 type SendAck = {
@@ -49,35 +155,46 @@ type SendAck = {
 
 export const chatSocket = {
   joinConversation: (conversationId: string) => {
-    getSocket().emit('conversation:join', { conversationId });
+    desiredConversations.add(conversationId);
+    const activeSocket = connectSocket();
+    if (activeSocket.connected && sessionReady) {
+      activeSocket.emit('conversation:join', { conversationId });
+    }
   },
   leaveConversation: (conversationId: string) => {
-    getSocket().emit('conversation:leave', { conversationId });
+    desiredConversations.delete(conversationId);
+    const activeSocket = getSocket();
+    if (activeSocket.connected && sessionReady) {
+      activeSocket.emit('conversation:leave', { conversationId });
+    }
   },
   sendMessage: (conversationId: string, text: string, clientMessageId: string) =>
-    new Promise<ChatMessage>((resolve, reject) => {
-      getSocket()
-        .timeout(8_000)
-        .emit(
-          'message:send',
-          { conversationId, clientMessageId, text },
-          (timeoutError: Error | null, ack?: SendAck) => {
-            if (timeoutError || !ack?.success || !ack.message) {
-              reject(timeoutError ?? new Error(ack?.error ?? 'Message was not accepted'));
-              return;
-            }
-            resolve({
-              id: ack.message.id,
-              conversationId: ack.message.conversationId,
-              senderId: ack.message.senderId,
-              content: ack.message.text,
-              type: ack.message.mediaUrls.length > 0 ? 'image' : 'text',
-              mediaUrl: ack.message.mediaUrls[0] ?? null,
-              createdAt: ack.message.timestamp,
-            });
-          }
-        );
-    }),
+    waitForSessionReady().then(
+      (activeSocket) =>
+        new Promise<ChatMessage>((resolve, reject) => {
+          activeSocket
+            .timeout(8_000)
+            .emit(
+              'message:send',
+              { conversationId, clientMessageId, text },
+              (timeoutError: Error | null, ack?: SendAck) => {
+                if (timeoutError || !ack?.success || !ack.message) {
+                  reject(timeoutError ?? new Error(ack?.error ?? 'Message was not accepted'));
+                  return;
+                }
+                resolve({
+                  id: ack.message.id,
+                  conversationId: ack.message.conversationId,
+                  senderId: ack.message.senderId,
+                  content: ack.message.text,
+                  type: ack.message.mediaUrls.length > 0 ? 'image' : 'text',
+                  mediaUrl: ack.message.mediaUrls[0] ?? null,
+                  createdAt: ack.message.timestamp,
+                });
+              }
+            );
+        })
+    ),
   onMessage: (callback: (message: ChatMessage) => void) => {
     const handler = (message: {
       id: string;
@@ -100,10 +217,16 @@ export const chatSocket = {
     return () => getSocket().off('message:received', handler);
   },
   startTyping: (conversationId: string) => {
-    getSocket().emit('typing:start', { conversationId });
+    const activeSocket = connectSocket();
+    if (activeSocket.connected && sessionReady) {
+      activeSocket.emit('typing:start', { conversationId });
+    }
   },
   stopTyping: (conversationId: string) => {
-    getSocket().emit('typing:stop', { conversationId });
+    const activeSocket = getSocket();
+    if (activeSocket.connected && sessionReady) {
+      activeSocket.emit('typing:stop', { conversationId });
+    }
   },
   onTyping: (callback: (data: { userId: string }) => void) => {
     getSocket().on('typing:start', callback);

--- a/docs/DOGOS_SESSION_AUTHORITY.md
+++ b/docs/DOGOS_SESSION_AUTHORITY.md
@@ -1,0 +1,186 @@
+# dogOS Session Authority v1
+
+Session Authority v1 turns Woof access tokens from self-contained bearer credentials into finite leases backed by server-owned session state. It builds directly on Realtime Session Lifetime v1 and does not replace JWT signature or expiry validation.
+
+## Problem closed
+
+Before this release, a valid signed access token remained authoritative until its JWT expiry. Browser and mobile logout only deleted the local token. The server had no persisted login-session identity, so it could not distinguish two devices, revoke one stolen token, revoke all sessions after a credential event, or reject an otherwise valid JWT after logout.
+
+Realtime Session Lifetime v1 correctly enforced `exp`, but expiry alone is not revocation.
+
+## Canonical authority model
+
+Every successful register or login now creates a random server-owned session ID and places it in the access-token `sid` claim.
+
+The server persists only the minimum session authority required for enforcement:
+
+- session ID;
+- user ID;
+- expiry time;
+- optional revocation time and bounded reason;
+- creation time.
+
+The session table deliberately stores no raw JWT, IP address, device fingerprint, browser user agent, location, refresh token, or other behavioral metadata.
+
+An authenticated request is valid only when both layers pass:
+
+1. JWT signature and finite expiry validation; and
+2. `dogos_auth.sessions` contains the matching `sid` + `user_id` with no revocation and an expiry still in the future.
+
+A token signed correctly but lacking `sid` fails closed.
+
+## Login and registration
+
+`AuthService` signs a token with `sub`, `email`, `handle`, and a fresh random `sid`, decodes the signed token only to obtain its canonical `exp`, and persists the session with that exact expiry before returning the token to the client.
+
+If the token has no finite future expiry or session persistence fails, the login does not return an access token.
+
+## HTTP revocation
+
+Two authenticated endpoints become authoritative:
+
+- `POST /api/v1/auth/logout` revokes the current `sid` for the current user.
+- `POST /api/v1/auth/logout-all` revokes every still-active session for the current user.
+
+`JwtStrategy` checks persisted session authority on every protected HTTP request. A revoked token therefore receives `401` even when its signature and `exp` remain valid.
+
+`logout-all` first locks the user's active session rows in deterministic session-ID order, then revokes that exact set. Revocation is user-scoped, so one user's operation cannot alter another user's sessions.
+
+## Realtime ingress
+
+Socket.IO authentication now requires `sub`, finite `exp`, and `sid`. The persisted session must be active before the socket may enter its private `user:<userId>` room.
+
+Inbound realtime actions preserve the established anti-abuse ordering:
+
+1. resolve authenticated socket identity;
+2. require the in-memory finite JWT lease;
+3. validate and normalize the payload;
+4. consume the authenticated-user admission budget;
+5. acquire lock-bound persisted session authority;
+6. perform canonical relationship authorization, persistence, or room work while that authority remains held.
+
+The database-backed session boundary intentionally remains after rate admission. A client cannot create an unlimited session-table read workload by flooding malformed or already-rate-limited events.
+
+`withActiveSession()` selects the actor's still-active session row with `FOR SHARE` and executes the admitted realtime action before releasing that lock. Multiple active operations for the same still-valid session may hold compatible `FOR SHARE` authority concurrently. Revocation updates conflict with those locks. Therefore, if revocation commits first the action never starts; if one or more actions acquire authority first, those already-admitted actions complete before revocation can commit. A stale pre-revocation read cannot authorize post-revocation persistence.
+
+If persisted session authority is unavailable, the gateway emits `session:revoked { reason: 'session_revoked' }`, removes local socket authority, and server-disconnects that socket.
+
+### Transaction ownership and pool safety
+
+Lock-bound authority and canonical realtime database work share **one Prisma transaction client**. `withActiveSession()` passes its `Prisma.TransactionClient` into the admitted callback, and message persistence, conversation membership authorization, typing relationship authorization, and typing recipient-session filtering reuse that exact client.
+
+This is a correctness and availability requirement, not merely an optimization. A lock-bound callback must never call a standalone service path that opens another Prisma transaction or uses the global Prisma client for canonical work. Otherwise several concurrent actions can occupy every pool connection with session-authority transactions and then deadlock while each waits for a second connection.
+
+The transaction-bound message path therefore:
+
+1. validates and normalizes the message before database work;
+2. takes a transaction-scoped advisory lock on the caller-owned receipt identity;
+3. rechecks relationship authorization under the same transaction;
+4. resolves or creates the canonical message and receipt under that same transaction; and
+5. returns the committed message result to the gateway.
+
+Socket.IO message fanout intentionally happens **after** canonical persistence commits. Delivery then performs a fresh, short relationship/session-recipient authorization transaction. A transient fanout failure cannot roll back a valid persisted message, and the actor's session lock is not held across network emission.
+
+Typing is different because it is ephemeral. Its relationship authorization and recipient-session filtering remain inside the actor's authority transaction, and only an already-authorized recipient set is emitted.
+
+CI includes both a production concurrent flood/reconnect probe and a real PostgreSQL one-connection-pool regression. The latter sets `connection_limit=1`; valid lock-bound message work must still complete because it never asks Prisma for a second connection while the authority transaction is open.
+
+## Transport connectivity is not authorization readiness
+
+Socket.IO's client-side `connect` event proves that the transport handshake completed. It does **not** prove that Nest's asynchronous persisted-session admission has finished. Treating those two moments as equivalent creates a race where a valid user can emit immediately after transport connection while the gateway has not yet populated its authoritative socket/session maps.
+
+Session Authority therefore defines an explicit application-level readiness boundary:
+
+1. Socket.IO transport connects;
+2. the server verifies JWT signature, finite `exp`, `sub`, and `sid`;
+3. `SessionAuthorityService.withActiveSession()` proves the persisted session is active;
+4. the gateway installs the socket's in-memory user, session, and finite-expiry authority;
+5. the socket joins its private `user:<userId>` room;
+6. the server rechecks that the transport did not disappear during asynchronous admission; and
+7. only then does the server emit `session:ready { socketId: client.id }`.
+
+The `socketId` is an authorization-epoch binding, not a user identifier. The web client accepts readiness only when the payload matches the current Socket.IO `socket.id`. A delayed `session:ready` from a previous transport epoch therefore cannot release queued work or restore room membership on a replacement connection.
+
+No application realtime action may rely on raw Socket.IO `connect` as an authorization signal. A production probe must be able to perform its very first action immediately after a matching socket-bound `session:ready` and reach canonical chat authorization without receiving the handshake-race sentinel `unauthorized`.
+
+Disconnect is checked both before local authority is installed and again after the asynchronous private-room join. A transport that disappears during admission cannot leave stale in-memory session maps behind or receive authoritative readiness after it is gone.
+
+The web transport treats readiness according to the semantics of each operation:
+
+- messages are durable user intent and wait, with a bounded eight-second authorization timeout, for socket-bound `session:ready`;
+- conversation membership is desired state, so active conversations are rejoined exactly once after an authorized reconnect;
+- leaving a conversation before readiness cancels that desired membership rather than replaying a stale join;
+- typing indicators are ephemeral presence and are dropped while the session is not ready rather than replayed later;
+- a token change clears desired room state and forces a fresh transport authorization boundary before new actions are released; and
+- expiry, revocation, or explicit logout clears readiness and desired conversation membership.
+
+Concurrent message callers share the same pending readiness boundary. This avoids listener growth and ensures one failed authorization attempt rejects every waiter consistently rather than leaving partially authorized callers behind.
+
+## Passive realtime delivery
+
+Revocation must also prevent an idle socket from continuing to receive private payloads.
+
+Relationship authorization remains the first delivery authority and still produces private `user:<userId>` rooms. Session Authority then evaluates the connected session IDs for those authorized users. Active session rows are selected inside a PostgreSQL transaction with `FOR SHARE`, and delivery executes while those row locks are held. Revoked or expired socket IDs are excluded from the authorized user-room broadcast.
+
+Revocation updates conflict with those share locks, creating deterministic ordering:
+
+- if revocation commits first, the session is absent from later delivery;
+- if delivery acquires the session authority first, that already-authorized delivery completes before revocation can commit.
+
+For persisted messages, this recipient filtering transaction begins only after canonical message commit. For typing, it is nested inside the already-open actor authority transaction by reusing the same transaction client rather than opening another transaction.
+
+This preserves the existing block-dominance and relationship-lock ordering while adding session dominance beneath the private-room layer.
+
+## Client logout behavior
+
+Web logout captures the current token, immediately disconnects realtime and clears local auth state, then sends the revocation request with the captured token explicitly. Existing UI call sites therefore keep instant sign-out behavior even when they do not await the returned promise.
+
+Mobile follows the same authority model around SecureStore: it captures the token, clears the device credential, then uses the captured credential for server revocation.
+
+Current-session logout remains locally fail-safe if the network is unavailable or the server already considers the captured token invalid. `logout-all` intentionally reports server failure because a client cannot truthfully claim that other sessions were revoked when the server was unreachable, even though the initiating device has already cleared its local credential.
+
+The web Socket.IO transport clears persisted auth on both `session:expired` and `session:revoked`.
+
+## Deployment compatibility
+
+Tokens issued before Session Authority v1 do not contain `sid`. They intentionally fail closed after this release is deployed. Existing signed-in users therefore need to log in again once after rollout. This avoids inventing unverifiable legacy session state.
+
+No refresh-token protocol is introduced in this release. Access tokens remain finite and use the existing configured JWT lifetime.
+
+## Multi-process semantics
+
+The security authority is database-backed and therefore shared across API processes. A revoked session cannot make a protected HTTP request, perform a new realtime action, reconnect, or remain eligible for private realtime delivery once revocation commits.
+
+Without a shared Socket.IO adapter or revocation pub/sub bus, an idle revoked socket on another process may remain physically connected until it acts, expires, or disconnects normally. Physical connection state is not treated as authorization. Immediate cross-process socket teardown is an optional future operational optimization, not a security dependency of this release.
+
+## Qualification contract
+
+The Session Authority CI lane must prove one exact candidate head and must:
+
+1. permit exactly one owned migration, `20260824233000_add_dogos_auth_sessions`, only as a newly added immutable migration, and reject Prisma schema edits or unrelated migrations;
+2. apply the complete migration chain to PostgreSQL;
+3. pass read-only Prettier and zero-warning lint across touched API, web, mobile, workflow, and documentation surfaces;
+4. enforce privacy-thin `dogos_auth.sessions` storage with canonical TEXT foreign keys;
+5. prove login/register mint `sid` and persist the session before returning the token;
+6. prove `JwtStrategy` requires persisted session authority;
+7. prove `session:ready { socketId }` occurs only after persisted authority, local socket authority, and the private user-room join, and that clients reject readiness from stale transport epochs;
+8. prove disconnect-before-admission and disconnect-during-room-join leave no realtime authority behind;
+9. prove the web client waits for readiness for durable sends, restores desired room membership after reconnect, drops stale typing, and requires fresh readiness after token replacement;
+10. prove concurrent readiness waiters fail together on bounded timeout without releasing message traffic;
+11. prove malformed and rate-limited realtime traffic is rejected before persisted-session database work;
+12. prove compatible `FOR SHARE` admissions may coexist for one active session while admitted realtime work and current-session revocation serialize on that session row;
+13. prove lock-bound canonical realtime work receives and reuses the authority transaction client rather than reacquiring Prisma;
+14. prove real message persistence completes with a deliberately constrained one-connection Prisma pool;
+15. prove passive delivery and revocation serialize on session rows;
+16. prove multi-session `logout-all` uses deterministic row-lock ordering and remains user-scoped;
+17. pass API, web, and mobile TypeScript;
+18. pass auth, gateway, readiness, chat, admission, relationship, and real PostgreSQL session regressions;
+19. build API and web production bundles and the real API Docker image;
+20. prove against the production image that the first action immediately after matching socket-bound `session:ready` reaches canonical authorization and never receives the pre-readiness `unauthorized` race;
+21. prove concurrent authenticated Socket.IO flood traffic completes canonical work without connection-pool starvation, remains rate-limited by authenticated user across reconnect, and leaves unrelated users in independent buckets;
+22. prove current-session logout turns a previously valid token into HTTP `401`;
+23. prove an already-ready Socket.IO session emits `session:revoked` and is server-disconnected on its next action after logout;
+24. prove a server-issued finite JWT reaches matching socket-bound `session:ready`, then emits `session:expired` and is server-disconnected at expiry; and
+25. prove `logout-all` invalidates multiple independently issued sessions while leaving another user's session valid.
+
+Diagnostic heads do not qualify the release.

--- a/packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/migration.sql
+++ b/packages/database/prisma/migrations/20260824233000_add_dogos_auth_sessions/migration.sql
@@ -1,0 +1,18 @@
+CREATE SCHEMA IF NOT EXISTS dogos_auth;
+
+CREATE TABLE IF NOT EXISTS dogos_auth.sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  expires_at TIMESTAMPTZ NOT NULL,
+  revoked_at TIMESTAMPTZ,
+  revocation_reason TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT auth_sessions_id_length CHECK (char_length(id) BETWEEN 8 AND 128),
+  CONSTRAINT auth_sessions_expiry_after_creation CHECK (expires_at > created_at)
+);
+
+CREATE INDEX IF NOT EXISTS auth_sessions_user_active_idx
+  ON dogos_auth.sessions (user_id, revoked_at, expires_at DESC);
+
+CREATE INDEX IF NOT EXISTS auth_sessions_expiry_idx
+  ON dogos_auth.sessions (expires_at);


### PR DESCRIPTION
## dogOS Session Authority v1

**Exact qualified head:** `ab92e01fed06aa5fe90bb882793663a6b023a2c3`

This release is one clean commit directly on current `main` (`9e7144b3aa478478762d912426921f6dd45b46fa`). Its Git tree is byte-identical to the fully qualified diagnostic tree and contains exactly 31 release files.

### Authority gap closed

Woof access tokens were previously finite signed bearer credentials, but the server had no durable login-session identity that could be revoked before JWT expiry.

Session Authority v1 gives every successful register/login a fresh random server-owned `sid`, persists that finite session in PostgreSQL, and requires both JWT validity and active persisted session authority.

The privacy-thin `dogos_auth.sessions` table stores only:

- session ID
- user ID
- expiry
- optional revocation timestamp/reason
- creation time

It stores no raw JWT, IP address, user agent, device fingerprint, location, refresh token, or behavioral exhaust.

Login/register now mint `sid`, sign it into the finite JWT, recover the canonical signed `exp`, persist the session with that exact expiry, and only then return the token. Tokens without `sid` fail closed, so credentials issued before this release require one re-login after rollout.

### HTTP revocation

- `POST /api/v1/auth/logout` revokes the current persisted session.
- `POST /api/v1/auth/logout-all` revokes every still-active session for the current user.
- `JwtStrategy` checks persisted session authority for every protected HTTP request.
- `logout-all` locks active rows in deterministic session-ID order and remains strictly user-scoped.

A correctly signed and otherwise unexpired JWT therefore becomes unusable immediately after its persisted session is revoked.

### Realtime authority + socket readiness

Realtime preserves the security ordering:

`identity -> finite JWT lease -> payload validation -> authenticated-user admission -> persisted session authority -> canonical work`

`withActiveSession()` holds the actor's active session row with PostgreSQL `FOR SHARE`. Revocation conflicts with that lock, producing deterministic ordering between already-admitted work and revocation.

Socket.IO transport connection is not considered application authorization. The server emits `session:ready { socketId }` only after JWT validation, persisted-session admission, local authority installation, and private `user:<id>` room admission. The web client accepts readiness only for its current Socket.IO `socket.id`, so a delayed event from an old transport epoch cannot release new work.

Passive private delivery remains relationship-authorized first, then filters connected socket sessions through persisted session authority. Revoked or expired sessions cannot continue receiving private fanout merely because another session for the same user remains active.

### Transaction ownership and pool safety

Qualification uncovered a real concurrency failure in the earlier implementation: `withActiveSession()` could hold one Prisma transaction connection and then invoke canonical chat work through the global Prisma client, requiring a second connection. Under concurrent traffic, the pool could fill with authority transactions all waiting for another connection.

This PR fixes the architecture rather than weakening the flood test:

- `withActiveSession()` passes its existing `Prisma.TransactionClient` into admitted work.
- Message persistence, conversation membership authorization, typing relationship authorization, and typing recipient-session filtering reuse that exact transaction client while authority is held.
- Transaction-bound message persistence never opens another Prisma transaction or uses the global Prisma client.
- Caller-owned message receipt identity is serialized with a transaction-scoped PostgreSQL advisory lock, preserving idempotent retries without nested acquisition.
- Canonical message persistence commits before Socket.IO message fanout. Fanout then performs a fresh short relationship/session-recipient authorization transaction, so network delivery cannot roll back a valid message and the actor session lock is not held across network emission.
- Typing remains ephemeral and fully authority-transaction-bound.

CI now explicitly rejects regressions back to nested Prisma acquisition.

A real PostgreSQL regression constrains a dedicated Prisma client to `connection_limit=1` and launches three canonical message actions. They complete safely because lock-bound work never asks for a second connection. Separately, the production Docker lane runs the concurrent authenticated Socket.IO flood/reconnect workload that originally exposed the deadlock.

### Client behavior

Web and mobile logout capture the current token, clear local credentials immediately, then use that captured credential for server revocation. The web realtime client clears auth on both `session:expired` and `session:revoked`.

Current-session logout remains locally fail-safe if the network is unavailable. `logout-all` surfaces server failure because a client cannot truthfully claim that remote sessions were revoked when the server could not be reached.

### Multi-process semantics

PostgreSQL is the authorization source, not process memory. Once revocation commits, that session cannot make protected HTTP requests, perform a new realtime action, reconnect, or remain eligible for private realtime delivery on any API process.

Without a shared Socket.IO adapter/pub-sub bus, an idle revoked socket on another process may remain physically connected until it acts, expires, or disconnects. Physical connection is not authorization. Immediate cross-process socket teardown can be added later as an operational latency improvement without changing this security boundary.

No refresh-token protocol is introduced in this release.

## Exact-head qualification receipt

All 15 registered PR workflows are green on exact head `ab92e01fed06aa5fe90bb882793663a6b023a2c3`:

- **dogOS Session Authority CI** — run `32887028912` — success
- **dogOS Session Migration Immutability CI** — run `32887028944` — success
- **dogOS Realtime Session Readiness CI** — run `32887028913` — success
- **dogOS Realtime Session Lifetime CI** — run `32887028948` — success
- **dogOS Realtime Abuse Control CI** — run `32887028941` — success
- **dogOS Realtime Payload Integrity CI** — run `32887028906` — success
- **dogOS Chat Delivery Integrity CI** — run `32887028976` — success
- **dogOS Live Authorization CI** — run `32887028945` — success
- **dogOS Network Integrity + Scale CI** — run `32887028908` — success
- **dogOS Trust Enforcement Atomicity CI** — run `32887028950` — success
- **dogOS Trust + Discovery CI** — run `32887028978` — success
- **dogOS Foundation CI** — run `32887028919` — success
- **Adventure System CI** — run `32887028940` — success
- **CI Action Runtime Qualification** — run `32887028938` — success
- **root CI** — run `32887028947` — success

The qualification matrix includes:

- frozen-lockfile install and Prisma generation;
- exact add-only database ownership and migration immutability;
- the complete 17-migration PostgreSQL chain;
- read-only Prettier, whitespace checks, and zero-warning lint;
- API, web, and mobile type-check;
- auth, gateway, payload, readiness, retry, admission, relationship, and revocation unit contracts;
- real PostgreSQL action-vs-revoke, passive-delivery-vs-revoke, logout-all ordering, block dominance, relationship authorization, receipt persistence, and the one-connection pool regression;
- backend API tests, frontend tests, Playwright smoke/accessibility/visual contracts, and production API/web builds;
- production Docker proof of socket-bound first-action readiness;
- production Docker proof of finite JWT expiry and server ejection;
- production Docker proof of concurrent authenticated flood admission and rate-limit retention across reconnect;
- production HTTP/Socket.IO proof that current logout turns an active token into `401`, the connected socket emits `session:revoked` and is server-disconnected, `logout-all` invalidates multiple independently issued sessions, and an unrelated user's session remains valid.

Production HTTP throttling remains enabled throughout the live qualification. Tests are paced where necessary rather than bypassing or weakening the real limiter.

`docs/DOGOS_SESSION_AUTHORITY.md` is the detailed executable release contract.

No merge is performed by this PR.