### PR TITLE
dogOS Intelligence 1B: add replayable evidence projection foundation

### DIFF
--- a/.github/workflows/dogos-intelligence-evidence-projection-ci.yml
+++ b/.github/workflows/dogos-intelligence-evidence-projection-ci.yml
@@ -1,0 +1,255 @@
+name: dogOS Intelligence Evidence Projection CI
+
+on:
+  pull_request:
+    branches: [main, agent/dogos-intelligence-baseline-policy-v1]
+    paths:
+      - 'apps/api/src/intelligence/**'
+      - 'apps/api/src/care-events/care-events.service.ts'
+      - 'apps/api/src/care-events/care-events.module.ts'
+      - 'apps/api/src/care-events/care-events.integration.spec.ts'
+      - 'packages/database/prisma/migrations/20260826013000_add_dogos_intelligence_observations/**'
+      - '.github/workflows/dogos-intelligence-evidence-projection-ci.yml'
+      - 'docs/DOGOS_INTELLIGENCE_EVIDENCE_PROJECTION_V1.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-intelligence-evidence-projection-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  NODE_ENV: test
+  ML_SERVICE_ENABLED: 'false'
+
+jobs:
+  qualify:
+    name: Replayable evidence projection + household authority qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Enforce exact add-only database ownership
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: >-
+          python .github/scripts/assert-database-ownership.py "$BASE_SHA"
+          packages/database/prisma/migrations/20260826013000_add_dogos_intelligence_observations/migration.sql
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check touched-file formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/intelligence/baseline-policy-v1.ts
+          apps/api/src/intelligence/baseline-policy-v1.types.ts
+          apps/api/src/intelligence/baseline-policy-v1.receipt.ts
+          apps/api/src/intelligence/baseline-policy-v1.fixtures.ts
+          apps/api/src/intelligence/baseline-policy-v1.spec.ts
+          apps/api/src/intelligence/evidence-projection-v1.types.ts
+          apps/api/src/intelligence/evidence-normalization-v1.receipt.ts
+          apps/api/src/intelligence/evidence-normalization-v1.ts
+          apps/api/src/intelligence/evidence-normalization-v1.spec.ts
+          apps/api/src/intelligence/intelligence-projection.service.ts
+          apps/api/src/intelligence/intelligence-projection.integration.spec.ts
+          apps/api/src/intelligence/intelligence.module.ts
+          apps/api/src/care-events/care-events.service.ts
+          apps/api/src/care-events/care-events.module.ts
+          apps/api/src/care-events/care-events.integration.spec.ts
+          docs/DOGOS_INTELLIGENCE_BASELINE_POLICY_V1.md
+          docs/DOGOS_INTELLIGENCE_EVIDENCE_PROJECTION_V1.md
+          .github/workflows/dogos-intelligence-evidence-projection-ci.yml
+
+      - name: Reject whitespace errors
+        run: git diff --check ${{ github.event.pull_request.base.sha }}...HEAD
+
+      - name: Lint intelligence and CareEvent surfaces with zero warnings
+        run: |
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish \
+            src/intelligence/baseline-policy-v1.ts \
+            src/intelligence/baseline-policy-v1.types.ts \
+            src/intelligence/baseline-policy-v1.receipt.ts \
+            src/intelligence/baseline-policy-v1.fixtures.ts \
+            src/intelligence/baseline-policy-v1.spec.ts \
+            src/intelligence/evidence-projection-v1.types.ts \
+            src/intelligence/evidence-normalization-v1.receipt.ts \
+            src/intelligence/evidence-normalization-v1.ts \
+            src/intelligence/evidence-normalization-v1.spec.ts \
+            src/intelligence/intelligence-projection.service.ts \
+            src/intelligence/intelligence-projection.integration.spec.ts \
+            src/intelligence/intelligence.module.ts \
+            src/care-events/care-events.service.ts \
+            src/care-events/care-events.module.ts \
+            src/care-events/care-events.integration.spec.ts
+
+      - name: Enforce projection, privacy and authority invariants
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          migration = Path(
+              'packages/database/prisma/migrations/20260826013000_add_dogos_intelligence_observations/migration.sql'
+          ).read_text()
+          service = Path('apps/api/src/intelligence/intelligence-projection.service.ts').read_text()
+          normalization = Path('apps/api/src/intelligence/evidence-normalization-v1.ts').read_text()
+          receipt = Path('apps/api/src/intelligence/evidence-normalization-v1.receipt.ts').read_text()
+          spec = Path('apps/api/src/intelligence/evidence-normalization-v1.spec.ts').read_text()
+          integration_spec = Path(
+              'apps/api/src/intelligence/intelligence-projection.integration.spec.ts'
+          ).read_text()
+          care_events = Path('apps/api/src/care-events/care-events.service.ts').read_text()
+
+          migration_required = [
+              'CREATE SCHEMA IF NOT EXISTS dogos_intelligence',
+              'CREATE TABLE IF NOT EXISTS dogos_intelligence.observations',
+              'user_id TEXT NOT NULL REFERENCES public.users(id) ON DELETE CASCADE',
+              'pet_id TEXT NOT NULL REFERENCES public.pets(id) ON DELETE CASCADE',
+              "CHECK (source_type IN ('OWNER_CHECKIN', 'ACTIVITY', 'COACHING'))",
+              "CHECK (authority IN ('BASELINE_ELIGIBLE', 'CONTEXT_ONLY'))",
+              'CHECK (delta_bucket IS NULL OR delta_bucket BETWEEN -2 AND 2)',
+              "'NaN'::float8",
+              'payload_hash',
+              'octet_length(context::text) <= 4096',
+              'supersedes_observation_id',
+              'retracted_at',
+              'retraction_reason',
+              'UNIQUE (pet_id, dimension, source_type, source_identity, normalization_version)',
+              'CREATE UNIQUE INDEX IF NOT EXISTS intelligence_observations_one_active_superseder_idx',
+              'WHERE supersedes_observation_id IS NOT NULL AND retracted_at IS NULL',
+          ]
+          missing = [token for token in migration_required if token not in migration]
+          if missing:
+              raise SystemExit(f'missing intelligence projection schema invariant: {missing}')
+
+          privacy_forbidden = [
+              'raw_token',
+              'access_token',
+              'refresh_token',
+              'ip_address',
+              'user_agent',
+              'device_fingerprint',
+              'latitude',
+              'longitude',
+              'raw_image',
+              'raw_video',
+              'model_trace',
+          ]
+          present = [token for token in privacy_forbidden if token in migration.lower()]
+          if present:
+              raise SystemExit(f'intelligence projection must remain privacy-thin: {present}')
+
+          service_required = [
+              'await this.households.assertPetAccessible(candidate.userId, candidate.petId)',
+              'payloadHash(candidate)',
+              'Projection source identity was replayed with different semantics',
+              'FOR UPDATE',
+              'ON CONFLICT (',
+              'supersedes_observation_id',
+              'WHERE successor.supersedes_observation_id = o.id',
+              'LIMIT 512',
+              "candidate.sourceType === 'OWNER_CHECKIN'",
+              "candidate.authority !== 'BASELINE_ELIGIBLE'",
+              "candidate.sourceType === 'ACTIVITY'",
+              "candidate.sourceType === 'COACHING'",
+          ]
+          missing = [token for token in service_required if token not in service]
+          if missing:
+              raise SystemExit(f'missing replay/authority service invariant: {missing}')
+          if 'AND successor.retracted_at IS NULL' in service:
+              raise SystemExit(
+                  'effective evidence must not resurrect a superseded predecessor when a successor is retracted'
+              )
+          lifecycle_required = [
+              'retraction never resurrects superseded evidence without an explicit replacement',
+              'expect(afterRetraction).toEqual([])',
+              'explicitReplacement',
+          ]
+          missing = [token for token in lifecycle_required if token not in integration_spec]
+          if missing:
+              raise SystemExit(f'missing explicit reversion lifecycle regression: {missing}')
+
+          if 'assertOwnedPet' in care_events:
+              raise SystemExit('CareEvents must not reintroduce an owner-only pet authority helper')
+          if care_events.count('households.assertPetAccessible') < 4:
+              raise SystemExit('CareEvents pet-scoped write/read paths must use household authority')
+
+          normalization_required = [
+              "choice === 'UNSURE'",
+              "authority: 'BASELINE_ELIGIBLE'",
+              "sourceType: 'OWNER_CHECKIN'",
+              "sourceType: 'ACTIVITY'",
+              "authority: 'CONTEXT_ONLY'",
+              "sourceType: 'COACHING'",
+              'no health-like relative bucket is inferred',
+          ]
+          missing = [token for token in normalization_required if token not in normalization]
+          if missing:
+              raise SystemExit(f'missing conservative normalization invariant: {missing}')
+
+          receipt_required = [
+              "version: 'evidence-normalization-v1'",
+              "SELF_REPORT: { sourceType: 'OWNER_CHECKIN', authority: 'BASELINE_ELIGIBLE' }",
+              "ACTIVITY: { sourceType: 'ACTIVITY', authority: 'CONTEXT_ONLY' }",
+              "COACH: { sourceType: 'COACHING', authority: 'CONTEXT_ONLY' }",
+              'maxContextBytes: 4096',
+          ]
+          missing = [token for token in receipt_required if token not in receipt]
+          if missing:
+              raise SystemExit(f'evidence-normalization-v1 receipt drifted: {missing}')
+
+          fingerprint = '5c4262303923f9499bd08e6f34d5b2a7890c1d1839aa1933da5a6e8f4a8825f0'
+          if fingerprint not in spec:
+              raise SystemExit('evidence-normalization-v1 SHA-256 receipt pin is missing')
+          PY
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Run baseline, normalization, replay and CareEvent contracts
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/intelligence/baseline-policy-v1.spec.ts
+          src/intelligence/evidence-normalization-v1.spec.ts
+          src/intelligence/intelligence-projection.integration.spec.ts
+          src/care-events/care-events.integration.spec.ts
+
+      - name: Build API
+        run: pnpm --filter @woof/api build

--- a/apps/api/src/care-events/care-events.integration.spec.ts
+++ b/apps/api/src/care-events/care-events.integration.spec.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { Prisma } from '@woof/database';
+import { HouseholdsService } from '../households/households.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { CareEventsService } from './care-events.service';
 import { rewardCareEvent } from './reward-policy';
@@ -18,7 +19,8 @@ type Fixture = {
 
 describe('CareEventsService integration', () => {
   const prisma = new PrismaService();
-  const service = new CareEventsService(prisma);
+  const households = new HouseholdsService(prisma);
+  const service = new CareEventsService(prisma, households);
   const usersToDelete: string[] = [];
 
   beforeAll(async () => {
@@ -32,7 +34,7 @@ describe('CareEventsService integration', () => {
     await prisma.$disconnect();
   });
 
-  async function fixture(label: string): Promise<Fixture> {
+  async function createUser(label: string) {
     const suffix = randomUUID().slice(0, 8);
     const user = await prisma.user.create({
       data: {
@@ -42,7 +44,11 @@ describe('CareEventsService integration', () => {
       select: { id: true },
     });
     usersToDelete.push(user.id);
+    return user;
+  }
 
+  async function fixture(label: string): Promise<Fixture> {
+    const user = await createUser(label);
     const pet = await prisma.pet.create({
       data: {
         ownerId: user.id,
@@ -216,5 +222,75 @@ describe('CareEventsService integration', () => {
     );
 
     expect(legitimate.bondXp).toBe(baseline.bondXp);
+  });
+
+  it('uses household pet authority for canonical zero-reward Daily Signals evidence', async () => {
+    const { userId: ownerId, petId } = await fixture('household-owner');
+    const member = await createUser('household-member');
+    const outsider = await createUser('household-outsider');
+    const householdId = await households.ensurePersonalHousehold(ownerId);
+
+    await prisma.householdMember.upsert({
+      where: {
+        householdId_userId: {
+          householdId,
+          userId: member.id,
+        },
+      },
+      update: { status: 'ACTIVE', role: 'MEMBER' },
+      create: {
+        householdId,
+        userId: member.id,
+        status: 'ACTIVE',
+        role: 'MEMBER',
+      },
+    });
+
+    const dedupeKey = `daily-signals:${petId}:2026-08-25:${randomUUID()}`;
+    const receipt = await service.record({
+      userId: member.id,
+      petId,
+      eventType: 'DAILY_SIGNALS_CHECKIN',
+      pathway: 'CARE',
+      occurredAt: new Date('2026-08-25T18:00:00.000Z'),
+      source: 'INTELLIGENCE',
+      evidenceType: 'SELF_REPORT',
+      evidenceConfidence: 0.8,
+      dedupeKey,
+      visibility: 'PRIVATE',
+      safetyEligible: false,
+      context: { localDate: '2026-08-25', timezone: 'America/Los_Angeles' },
+      outcome: { APPETITE: 'USUAL' },
+    });
+
+    expect(receipt.bondXp).toBe(0);
+    expect(receipt.duplicate).toBe(false);
+
+    const stored = await prisma.$queryRaw<
+      Array<{ user_id: string; pet_id: string; visibility: string; evidence_type: string }>
+    >(Prisma.sql`
+      SELECT user_id, pet_id, visibility, evidence_type
+      FROM care_events
+      WHERE id = ${receipt.careEventId}
+    `);
+    expect(stored[0]).toEqual({
+      user_id: member.id,
+      pet_id: petId,
+      visibility: 'PRIVATE',
+      evidence_type: 'SELF_REPORT',
+    });
+
+    await expect(
+      service.record({
+        userId: outsider.id,
+        petId,
+        eventType: 'DAILY_SIGNALS_CHECKIN',
+        pathway: 'CARE',
+        source: 'INTELLIGENCE',
+        evidenceType: 'SELF_REPORT',
+        dedupeKey: `outsider:${randomUUID()}`,
+        safetyEligible: false,
+      })
+    ).rejects.toThrow('Pet not found');
   });
 });

--- a/apps/api/src/care-events/care-events.module.ts
+++ b/apps/api/src/care-events/care-events.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { HouseholdsModule } from '../households/households.module';
 import { CareEventsService } from './care-events.service';
 
 @Module({
+  imports: [HouseholdsModule],
   providers: [CareEventsService],
   exports: [CareEventsService],
 })

--- a/apps/api/src/care-events/care-events.service.ts
+++ b/apps/api/src/care-events/care-events.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Prisma } from '@woof/database';
 import { randomUUID } from 'node:crypto';
+import { HouseholdsService } from '../households/households.service';
 import { PrismaService } from '../prisma/prisma.service';
 import {
   WELLBEING_PATHWAYS,
@@ -60,10 +61,13 @@ const PATHWAY_LABELS: Record<WellbeingPathway, string> = {
 export class CareEventsService {
   private readonly logger = new Logger(CareEventsService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly households: HouseholdsService
+  ) {}
 
   async record(input: CareEventInput): Promise<RewardReceipt> {
-    if (input.petId) await this.assertOwnedPet(input.userId, input.petId);
+    if (input.petId) await this.households.assertPetAccessible(input.userId, input.petId);
 
     const now = new Date();
     const requestedOccurrenceMs = input.occurredAt?.getTime();
@@ -220,7 +224,7 @@ export class CareEventsService {
     pathway: WellbeingPathway;
     context?: Record<string, unknown>;
   }) {
-    await this.assertOwnedPet(input.userId, input.petId);
+    await this.households.assertPetAccessible(input.userId, input.petId);
     const id = randomUUID();
     const rows = await this.prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
       INSERT INTO quest_interactions (
@@ -240,7 +244,7 @@ export class CareEventsService {
   }
 
   async getRecentSelectedQuestContext(userId: string, petId: string, questId: string) {
-    await this.assertOwnedPet(userId, petId);
+    await this.households.assertPetAccessible(userId, petId);
     const rows = await this.prisma.$queryRaw<SelectedQuestContextRow[]>(Prisma.sql`
       SELECT context, created_at
       FROM quest_interactions
@@ -256,7 +260,7 @@ export class CareEventsService {
   }
 
   async getSummary(userId: string, petId?: string): Promise<CareSummary> {
-    if (petId) await this.assertOwnedPet(userId, petId);
+    if (petId) await this.households.assertPetAccessible(userId, petId);
 
     const petFilter = petId ? Prisma.sql`AND ce.pet_id = ${petId}` : Prisma.empty;
     const [totalRows, pathwayRows, recentRows, rhythmRows] = await Promise.all([
@@ -333,14 +337,5 @@ export class CareEventsService {
         bondXp: row.bond_xp,
       })),
     };
-  }
-
-  private async assertOwnedPet(userId: string, petId: string) {
-    const pet = await this.prisma.pet.findFirst({
-      where: { id: petId, ownerId: userId },
-      select: { id: true },
-    });
-    if (!pet) throw new NotFoundException('Pet not found');
-    return pet;
   }
 }

--- a/apps/api/src/intelligence/evidence-normalization-v1.receipt.ts
+++ b/apps/api/src/intelligence/evidence-normalization-v1.receipt.ts
@@ -1,0 +1,50 @@
+import type { EvidenceType } from '../care-events/care-event.types';
+import type {
+  ProjectionAuthority,
+  QualifiedProjectionSourceType,
+} from './evidence-projection-v1.types';
+
+export type QualifiedEvidenceMapping = {
+  sourceType: QualifiedProjectionSourceType;
+  authority: ProjectionAuthority;
+};
+
+export const EVIDENCE_NORMALIZATION_V1 = Object.freeze({
+  version: 'evidence-normalization-v1' as const,
+  ownerChoiceBuckets: {
+    LESS: -1,
+    USUAL: 0,
+    MORE: 1,
+  } as const,
+  evidenceMappings: {
+    SELF_REPORT: { sourceType: 'OWNER_CHECKIN', authority: 'BASELINE_ELIGIBLE' },
+    ACTIVITY: { sourceType: 'ACTIVITY', authority: 'CONTEXT_ONLY' },
+    COACH: { sourceType: 'COACHING', authority: 'CONTEXT_ONLY' },
+  } as const satisfies Partial<Record<EvidenceType, QualifiedEvidenceMapping>>,
+  maxContextBytes: 4096,
+  maxNormalizationReasonLength: 512,
+  maxSourceIdentityLength: 256,
+  baselineDimensions: [
+    'APPETITE',
+    'ENERGY',
+    'BATHROOM_ROUTINE',
+    'MOBILITY_COMFORT',
+    'ENGAGEMENT_SOCIAL_COMFORT',
+    'SLEEP_REST',
+  ] as const,
+  contextOnlyDimensions: [
+    'ACTIVITY_LOAD',
+    'RECOVERY_REST_PROXY',
+    'TRAINING_COMFORT_SUCCESS',
+  ] as const,
+});
+
+export function qualifiedEvidenceMapping(
+  evidenceType: EvidenceType
+): QualifiedEvidenceMapping | null {
+  const mapping =
+    EVIDENCE_NORMALIZATION_V1.evidenceMappings[
+      evidenceType as keyof typeof EVIDENCE_NORMALIZATION_V1.evidenceMappings
+    ];
+  return mapping ?? null;
+}

--- a/apps/api/src/intelligence/evidence-normalization-v1.spec.ts
+++ b/apps/api/src/intelligence/evidence-normalization-v1.spec.ts
@@ -1,0 +1,181 @@
+import { createHash } from 'node:crypto';
+import type { EvidenceType } from '../care-events/care-event.types';
+import {
+  isQualifiedProjectionSourceType,
+  normalizeActivityMeasurement,
+  normalizeCoachingObservation,
+  normalizeOwnerCheckinObservation,
+} from './evidence-normalization-v1';
+import {
+  EVIDENCE_NORMALIZATION_V1,
+  qualifiedEvidenceMapping,
+} from './evidence-normalization-v1.receipt';
+
+const common = {
+  userId: 'user-1',
+  petId: 'pet-1',
+  observedAt: '2026-08-25T18:00:00.000Z',
+  localDate: '2026-08-25',
+};
+
+describe('evidence-normalization-v1 receipt', () => {
+  it('pins the complete normalization authority contract', () => {
+    expect(EVIDENCE_NORMALIZATION_V1).toEqual({
+      version: 'evidence-normalization-v1',
+      ownerChoiceBuckets: { LESS: -1, USUAL: 0, MORE: 1 },
+      evidenceMappings: {
+        SELF_REPORT: { sourceType: 'OWNER_CHECKIN', authority: 'BASELINE_ELIGIBLE' },
+        ACTIVITY: { sourceType: 'ACTIVITY', authority: 'CONTEXT_ONLY' },
+        COACH: { sourceType: 'COACHING', authority: 'CONTEXT_ONLY' },
+      },
+      maxContextBytes: 4096,
+      maxNormalizationReasonLength: 512,
+      maxSourceIdentityLength: 256,
+      baselineDimensions: [
+        'APPETITE',
+        'ENERGY',
+        'BATHROOM_ROUTINE',
+        'MOBILITY_COMFORT',
+        'ENGAGEMENT_SOCIAL_COMFORT',
+        'SLEEP_REST',
+      ],
+      contextOnlyDimensions: ['ACTIVITY_LOAD', 'RECOVERY_REST_PROXY', 'TRAINING_COMFORT_SUCCESS'],
+    });
+
+    const fingerprint = createHash('sha256')
+      .update(JSON.stringify(EVIDENCE_NORMALIZATION_V1))
+      .digest('hex');
+    expect(fingerprint).toBe('5c4262303923f9499bd08e6f34d5b2a7890c1d1839aa1933da5a6e8f4a8825f0');
+  });
+
+  it('fails closed for evidence classes that are not qualified in Release 1', () => {
+    const unqualified: EvidenceType[] = [
+      'BEHAVIOR_VISION',
+      'LOCATION',
+      'MEDIA',
+      'CLINIC',
+      'WEARABLE',
+    ];
+    for (const evidenceType of unqualified) {
+      expect(qualifiedEvidenceMapping(evidenceType)).toBeNull();
+    }
+  });
+});
+
+describe('evidence-normalization-v1 adapters', () => {
+  it('maps owner semantic choices directly to bounded baseline-eligible buckets', () => {
+    const less = normalizeOwnerCheckinObservation({
+      ...common,
+      careEventId: 'event-1',
+      dimension: 'APPETITE',
+      choice: 'LESS',
+    });
+    const usual = normalizeOwnerCheckinObservation({
+      ...common,
+      careEventId: 'event-2',
+      dimension: 'ENERGY',
+      choice: 'USUAL',
+    });
+    const more = normalizeOwnerCheckinObservation({
+      ...common,
+      careEventId: 'event-3',
+      dimension: 'SLEEP_REST',
+      choice: 'MORE',
+    });
+
+    expect(less).toMatchObject({
+      sourceType: 'OWNER_CHECKIN',
+      authority: 'BASELINE_ELIGIBLE',
+      deltaBucket: -1,
+      sourceEventId: 'event-1',
+    });
+    expect(usual?.deltaBucket).toBe(0);
+    expect(more?.deltaBucket).toBe(1);
+  });
+
+  it('treats unsure as missing evidence rather than normal evidence', () => {
+    expect(
+      normalizeOwnerCheckinObservation({
+        ...common,
+        careEventId: 'event-unsure',
+        dimension: 'APPETITE',
+        choice: 'UNSURE',
+      })
+    ).toBeNull();
+  });
+
+  it('keeps activity measurements context-only without inventing a relative bucket', () => {
+    const result = normalizeActivityMeasurement({
+      ...common,
+      activityId: 'activity-1',
+      dimension: 'ACTIVITY_LOAD',
+      numericValue: 42,
+      unit: 'minutes',
+    });
+
+    expect(result).toMatchObject({
+      sourceType: 'ACTIVITY',
+      authority: 'CONTEXT_ONLY',
+      numericValue: 42,
+      unit: 'minutes',
+    });
+    expect(result.deltaBucket).toBeUndefined();
+  });
+
+  it('keeps coaching comfort/success context-only', () => {
+    const result = normalizeCoachingObservation({
+      ...common,
+      coachingRecordId: 'coach-1',
+      comfortSuccess: 0.75,
+    });
+
+    expect(result).toMatchObject({
+      dimension: 'TRAINING_COMFORT_SUCCESS',
+      sourceType: 'COACHING',
+      authority: 'CONTEXT_ONLY',
+      numericValue: 0.75,
+      unit: 'ratio',
+    });
+    expect(result.deltaBucket).toBeUndefined();
+  });
+
+  it('rejects malformed time, local-day and confidence inputs', () => {
+    expect(() =>
+      normalizeOwnerCheckinObservation({
+        ...common,
+        observedAt: 'nope',
+        careEventId: 'event-bad-time',
+        dimension: 'APPETITE',
+        choice: 'USUAL',
+      })
+    ).toThrow('valid observedAt');
+
+    expect(() =>
+      normalizeActivityMeasurement({
+        ...common,
+        localDate: '08/25/2026',
+        activityId: 'activity-bad-date',
+        dimension: 'ACTIVITY_LOAD',
+        numericValue: 10,
+        unit: 'minutes',
+      })
+    ).toThrow('upstream-normalized localDate');
+
+    expect(() =>
+      normalizeCoachingObservation({
+        ...common,
+        coachingRecordId: 'coach-bad-confidence',
+        comfortSuccess: 0.5,
+        confidence: 2,
+      })
+    ).toThrow('confidence must be in (0, 1]');
+  });
+
+  it('recognizes only the three qualified projection source classes', () => {
+    expect(isQualifiedProjectionSourceType('OWNER_CHECKIN')).toBe(true);
+    expect(isQualifiedProjectionSourceType('ACTIVITY')).toBe(true);
+    expect(isQualifiedProjectionSourceType('COACHING')).toBe(true);
+    expect(isQualifiedProjectionSourceType('HEALTH_LENS')).toBe(false);
+    expect(isQualifiedProjectionSourceType('BEHAVIOR_VISION')).toBe(false);
+  });
+});

--- a/apps/api/src/intelligence/evidence-normalization-v1.ts
+++ b/apps/api/src/intelligence/evidence-normalization-v1.ts
@@ -1,0 +1,169 @@
+import type { SignalDimension } from './baseline-policy-v1.types';
+import { EVIDENCE_NORMALIZATION_V1 } from './evidence-normalization-v1.receipt';
+import type {
+  ProjectionObservationCandidate,
+  QualifiedProjectionSourceType,
+} from './evidence-projection-v1.types';
+
+export type OwnerCheckinChoice = 'LESS' | 'USUAL' | 'MORE' | 'UNSURE';
+
+const LOCAL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function assertCommon(input: {
+  userId: string;
+  petId: string;
+  observedAt: string;
+  localDate: string;
+  confidence: number;
+}) {
+  if (!input.userId || !input.petId)
+    throw new Error('Evidence normalization requires user and pet IDs');
+  if (!Number.isFinite(Date.parse(input.observedAt))) {
+    throw new Error('Evidence normalization requires a valid observedAt timestamp');
+  }
+  if (!LOCAL_DATE_PATTERN.test(input.localDate)) {
+    throw new Error('Evidence normalization requires an upstream-normalized localDate');
+  }
+  if (!Number.isFinite(input.confidence) || input.confidence <= 0 || input.confidence > 1) {
+    throw new Error('Evidence normalization confidence must be in (0, 1]');
+  }
+}
+
+function sourceIdentity(parts: readonly string[]) {
+  const identity = parts.join(':');
+  if (identity.length > EVIDENCE_NORMALIZATION_V1.maxSourceIdentityLength) {
+    throw new Error('Evidence normalization source identity is too long');
+  }
+  return identity;
+}
+
+export function normalizeOwnerCheckinObservation(input: {
+  userId: string;
+  petId: string;
+  careEventId: string;
+  dimension: SignalDimension;
+  choice: OwnerCheckinChoice;
+  observedAt: string;
+  localDate: string;
+  confidence?: number;
+  supersedesObservationId?: string;
+}): ProjectionObservationCandidate | null {
+  const confidence = input.confidence ?? 0.8;
+  assertCommon({ ...input, confidence });
+
+  if (input.choice === 'UNSURE') return null;
+
+  return {
+    userId: input.userId,
+    petId: input.petId,
+    dimension: input.dimension,
+    sourceType: 'OWNER_CHECKIN',
+    sourceIdentity: sourceIdentity(['care-event', input.careEventId, input.dimension]),
+    sourceEventId: input.careEventId,
+    observedAt: input.observedAt,
+    localDate: input.localDate,
+    deltaBucket: EVIDENCE_NORMALIZATION_V1.ownerChoiceBuckets[input.choice],
+    confidence,
+    reliability: 'STANDARD',
+    authority: 'BASELINE_ELIGIBLE',
+    normalizationVersion: EVIDENCE_NORMALIZATION_V1.version,
+    normalizationReason:
+      'Owner Daily Signals semantic choice normalized directly to a bounded relative bucket.',
+    context: { choice: input.choice },
+    ...(input.supersedesObservationId
+      ? { supersedesObservationId: input.supersedesObservationId }
+      : {}),
+  };
+}
+
+export function normalizeActivityMeasurement(input: {
+  userId: string;
+  petId: string;
+  activityId: string;
+  dimension: 'ACTIVITY_LOAD' | 'RECOVERY_REST_PROXY';
+  numericValue: number;
+  unit: 'minutes' | 'load_units';
+  observedAt: string;
+  localDate: string;
+  confidence?: number;
+}): ProjectionObservationCandidate {
+  const confidence = input.confidence ?? 0.78;
+  assertCommon({ ...input, confidence });
+  if (!Number.isFinite(input.numericValue) || input.numericValue < 0) {
+    throw new Error('Activity measurement must be a finite non-negative value');
+  }
+
+  return {
+    userId: input.userId,
+    petId: input.petId,
+    dimension: input.dimension,
+    sourceType: 'ACTIVITY',
+    sourceIdentity: sourceIdentity(['activity', input.activityId, input.dimension]),
+    sourceRecordId: input.activityId,
+    observedAt: input.observedAt,
+    localDate: input.localDate,
+    numericValue: input.numericValue,
+    unit: input.unit,
+    confidence,
+    reliability: 'STANDARD',
+    authority: 'CONTEXT_ONLY',
+    normalizationVersion: EVIDENCE_NORMALIZATION_V1.version,
+    normalizationReason:
+      'Activity measurement preserved as context-only numeric evidence; no health-like relative bucket is inferred.',
+    context: {},
+  };
+}
+
+export function normalizeCoachingObservation(input: {
+  userId: string;
+  petId: string;
+  coachingRecordId: string;
+  comfortSuccess: number;
+  observedAt: string;
+  localDate: string;
+  confidence?: number;
+}): ProjectionObservationCandidate {
+  const confidence = input.confidence ?? 0.72;
+  assertCommon({ ...input, confidence });
+  if (
+    !Number.isFinite(input.comfortSuccess) ||
+    input.comfortSuccess < 0 ||
+    input.comfortSuccess > 1
+  ) {
+    throw new Error('Coaching comfort/success measurement must be in [0, 1]');
+  }
+
+  return {
+    userId: input.userId,
+    petId: input.petId,
+    dimension: 'TRAINING_COMFORT_SUCCESS',
+    sourceType: 'COACHING',
+    sourceIdentity: sourceIdentity([
+      'coaching',
+      input.coachingRecordId,
+      'TRAINING_COMFORT_SUCCESS',
+    ]),
+    sourceRecordId: input.coachingRecordId,
+    observedAt: input.observedAt,
+    localDate: input.localDate,
+    numericValue: input.comfortSuccess,
+    unit: 'ratio',
+    confidence,
+    reliability: 'STANDARD',
+    authority: 'CONTEXT_ONLY',
+    normalizationVersion: EVIDENCE_NORMALIZATION_V1.version,
+    normalizationReason:
+      'Coaching comfort/success is preserved as context-only evidence and cannot directly alter baseline health-like dimensions.',
+    context: {},
+  };
+}
+
+export function isQualifiedProjectionSourceType(
+  value: string
+): value is QualifiedProjectionSourceType {
+  return (
+    EVIDENCE_NORMALIZATION_V1.evidenceMappings.SELF_REPORT.sourceType === value ||
+    EVIDENCE_NORMALIZATION_V1.evidenceMappings.ACTIVITY.sourceType === value ||
+    EVIDENCE_NORMALIZATION_V1.evidenceMappings.COACH.sourceType === value
+  );
+}

--- a/apps/api/src/intelligence/evidence-projection-v1.types.ts
+++ b/apps/api/src/intelligence/evidence-projection-v1.types.ts
@@ -1,0 +1,93 @@
+import type {
+  DeltaBucket,
+  EvidenceReliability,
+  NormalizedObservation,
+  SignalDimension,
+} from './baseline-policy-v1.types';
+
+export const MEASURED_INTELLIGENCE_DIMENSIONS = [
+  'ACTIVITY_LOAD',
+  'RECOVERY_REST_PROXY',
+  'TRAINING_COMFORT_SUCCESS',
+] as const;
+
+export type MeasuredIntelligenceDimension = (typeof MEASURED_INTELLIGENCE_DIMENSIONS)[number];
+export type IntelligenceDimension = SignalDimension | MeasuredIntelligenceDimension;
+
+export const QUALIFIED_PROJECTION_SOURCE_TYPES = ['OWNER_CHECKIN', 'ACTIVITY', 'COACHING'] as const;
+export type QualifiedProjectionSourceType = (typeof QUALIFIED_PROJECTION_SOURCE_TYPES)[number];
+
+export type ProjectionAuthority = 'BASELINE_ELIGIBLE' | 'CONTEXT_ONLY';
+
+export type ProjectionObservationCandidate = {
+  userId: string;
+  petId: string;
+  dimension: IntelligenceDimension;
+  sourceType: QualifiedProjectionSourceType;
+  sourceIdentity: string;
+  sourceEventId?: string;
+  sourceRecordId?: string;
+  observedAt: string;
+  localDate: string;
+  deltaBucket?: DeltaBucket;
+  numericValue?: number;
+  unit?: string;
+  confidence: number;
+  reliability: EvidenceReliability;
+  authority: ProjectionAuthority;
+  normalizationVersion: 'evidence-normalization-v1';
+  normalizationReason: string;
+  context?: Record<string, unknown>;
+  supersedesObservationId?: string;
+};
+
+export type PersistedProjectionObservation = ProjectionObservationCandidate & {
+  id: string;
+  ingestedAt: string;
+  payloadHash: string;
+  retractedAt: string | null;
+  retractionReason: string | null;
+};
+
+export type ProjectionWriteReceipt = {
+  observationId: string;
+  payloadHash: string;
+  duplicate: boolean;
+};
+
+export type ProjectionRetractionReceipt = {
+  observationId: string;
+  retracted: boolean;
+  duplicate: boolean;
+};
+
+export type BaselineEvidenceRow = Pick<
+  PersistedProjectionObservation,
+  | 'id'
+  | 'sourceIdentity'
+  | 'dimension'
+  | 'sourceType'
+  | 'observedAt'
+  | 'localDate'
+  | 'deltaBucket'
+  | 'confidence'
+  | 'reliability'
+>;
+
+export function toBaselineObservation(row: BaselineEvidenceRow): NormalizedObservation {
+  if (row.deltaBucket === undefined) {
+    throw new Error('Baseline-eligible projection evidence requires a delta bucket');
+  }
+
+  return {
+    id: row.id,
+    dedupeKey: row.sourceIdentity,
+    dimension: row.dimension as SignalDimension,
+    observedAt: row.observedAt,
+    localDate: row.localDate,
+    deltaBucket: row.deltaBucket,
+    sourceType: row.sourceType,
+    reliability: row.reliability,
+    confidence: row.confidence,
+  };
+}

--- a/apps/api/src/intelligence/intelligence-projection.integration.spec.ts
+++ b/apps/api/src/intelligence/intelligence-projection.integration.spec.ts
@@ -1,0 +1,382 @@
+import { randomUUID } from 'node:crypto';
+import { Prisma } from '@woof/database';
+import { HouseholdsService } from '../households/households.service';
+import { PrismaService } from '../prisma/prisma.service';
+import {
+  normalizeActivityMeasurement,
+  normalizeOwnerCheckinObservation,
+} from './evidence-normalization-v1';
+import { IntelligenceProjectionService } from './intelligence-projection.service';
+import type { ProjectionObservationCandidate } from './evidence-projection-v1.types';
+
+type Fixture = {
+  ownerId: string;
+  petId: string;
+};
+
+const NOW = '2026-08-25T23:00:00.000Z';
+const OBSERVED_AT = '2026-08-25T18:00:00.000Z';
+const LOCAL_DATE = '2026-08-25';
+
+describe('IntelligenceProjectionService integration', () => {
+  const prisma = new PrismaService();
+  const households = new HouseholdsService(prisma);
+  const service = new IntelligenceProjectionService(prisma, households);
+  const usersToDelete: string[] = [];
+
+  beforeAll(async () => {
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    if (usersToDelete.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: usersToDelete } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  async function createUser(label: string) {
+    const suffix = randomUUID().slice(0, 8);
+    const user = await prisma.user.create({
+      data: {
+        handle: `intel-${label}-${suffix}`,
+        email: `intel-${label}-${suffix}@example.test`,
+      },
+      select: { id: true },
+    });
+    usersToDelete.push(user.id);
+    return user;
+  }
+
+  async function fixture(label: string): Promise<Fixture> {
+    const owner = await createUser(`${label}-owner`);
+    const pet = await prisma.pet.create({
+      data: {
+        ownerId: owner.id,
+        name: `Intel ${label}`,
+        species: 'DOG',
+      },
+      select: { id: true },
+    });
+    return { ownerId: owner.id, petId: pet.id };
+  }
+
+  function ownerCandidate(input: {
+    ownerId: string;
+    petId: string;
+    careEventId?: string;
+    choice?: 'LESS' | 'USUAL' | 'MORE';
+    dimension?: 'APPETITE' | 'ENERGY';
+    supersedesObservationId?: string;
+    observedAt?: string;
+  }): ProjectionObservationCandidate {
+    const candidate = normalizeOwnerCheckinObservation({
+      userId: input.ownerId,
+      petId: input.petId,
+      careEventId: input.careEventId ?? randomUUID(),
+      dimension: input.dimension ?? 'APPETITE',
+      choice: input.choice ?? 'USUAL',
+      observedAt: input.observedAt ?? OBSERVED_AT,
+      localDate: LOCAL_DATE,
+      ...(input.supersedesObservationId
+        ? { supersedesObservationId: input.supersedesObservationId }
+        : {}),
+    });
+    if (!candidate) throw new Error('fixture owner candidate unexpectedly normalized to null');
+    return candidate;
+  }
+
+  it('makes 20 simultaneous identical projection writes one logical observation', async () => {
+    const { ownerId, petId } = await fixture('replay-race');
+    const candidate = ownerCandidate({ ownerId, petId, careEventId: randomUUID() });
+
+    const receipts = await Promise.all(
+      Array.from({ length: 20 }, () => service.projectObservation(candidate))
+    );
+
+    expect(receipts.filter((receipt) => !receipt.duplicate)).toHaveLength(1);
+    expect(receipts.filter((receipt) => receipt.duplicate)).toHaveLength(19);
+    expect(new Set(receipts.map((receipt) => receipt.observationId)).size).toBe(1);
+    expect(new Set(receipts.map((receipt) => receipt.payloadHash)).size).toBe(1);
+
+    const rows = await prisma.$queryRaw<Array<{ count: number }>>(Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM dogos_intelligence.observations
+      WHERE pet_id = ${petId}
+        AND source_identity = ${candidate.sourceIdentity}
+    `);
+    expect(rows[0]?.count).toBe(1);
+  });
+
+  it('rejects the same source identity replayed with different semantics', async () => {
+    const { ownerId, petId } = await fixture('divergent-replay');
+    const candidate = ownerCandidate({ ownerId, petId, careEventId: randomUUID() });
+    await service.projectObservation(candidate);
+
+    await expect(
+      service.projectObservation({
+        ...candidate,
+        deltaBucket: candidate.deltaBucket === 0 ? 1 : 0,
+      })
+    ).rejects.toThrow('different semantics');
+  });
+
+  it('serializes competing corrections so exactly one active successor wins', async () => {
+    const { ownerId, petId } = await fixture('correction-race');
+    const original = await service.projectObservation(
+      ownerCandidate({ ownerId, petId, careEventId: randomUUID(), choice: 'LESS' })
+    );
+
+    const correctionA = ownerCandidate({
+      ownerId,
+      petId,
+      careEventId: randomUUID(),
+      choice: 'USUAL',
+      supersedesObservationId: original.observationId,
+    });
+    const correctionB = ownerCandidate({
+      ownerId,
+      petId,
+      careEventId: randomUUID(),
+      choice: 'MORE',
+      supersedesObservationId: original.observationId,
+    });
+
+    const settled = await Promise.allSettled([
+      service.projectObservation(correctionA),
+      service.projectObservation(correctionB),
+    ]);
+    const fulfilled = settled.filter(
+      (
+        result
+      ): result is PromiseFulfilledResult<Awaited<ReturnType<typeof service.projectObservation>>> =>
+        result.status === 'fulfilled'
+    );
+    const rejected = settled.filter((result) => result.status === 'rejected');
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+
+    const effective = await service.getBaselineEvidence({
+      userId: ownerId,
+      petId,
+      dimension: 'APPETITE',
+      now: NOW,
+    });
+    expect(effective).toHaveLength(1);
+    expect(effective[0]?.id).toBe(fulfilled[0]?.value.observationId);
+    expect(effective[0]?.id).not.toBe(original.observationId);
+
+    const activeSuccessors = await prisma.$queryRaw<Array<{ count: number }>>(Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM dogos_intelligence.observations
+      WHERE supersedes_observation_id = ${original.observationId}
+        AND retracted_at IS NULL
+    `);
+    expect(activeSuccessors[0]?.count).toBe(1);
+  });
+
+  it('retraction never resurrects superseded evidence without an explicit replacement', async () => {
+    const { ownerId, petId } = await fixture('correction-retraction');
+    const original = await service.projectObservation(
+      ownerCandidate({ ownerId, petId, careEventId: randomUUID(), choice: 'LESS' })
+    );
+    const correction = await service.projectObservation(
+      ownerCandidate({
+        ownerId,
+        petId,
+        careEventId: randomUUID(),
+        choice: 'USUAL',
+        supersedesObservationId: original.observationId,
+      })
+    );
+
+    const before = await service.getBaselineEvidence({
+      userId: ownerId,
+      petId,
+      dimension: 'APPETITE',
+      now: NOW,
+    });
+    expect(before.map((row) => row.id)).toEqual([correction.observationId]);
+
+    const retraction = await service.retractObservation({
+      userId: ownerId,
+      petId,
+      observationId: correction.observationId,
+      reason: 'Correction withdrawn by authorized household member',
+    });
+    expect(retraction).toEqual({
+      observationId: correction.observationId,
+      retracted: true,
+      duplicate: false,
+    });
+    expect(
+      await service.retractObservation({
+        userId: ownerId,
+        petId,
+        observationId: correction.observationId,
+        reason: 'Correction withdrawn by authorized household member',
+      })
+    ).toEqual({
+      observationId: correction.observationId,
+      retracted: true,
+      duplicate: true,
+    });
+
+    const afterRetraction = await service.getBaselineEvidence({
+      userId: ownerId,
+      petId,
+      dimension: 'APPETITE',
+      now: NOW,
+    });
+    expect(afterRetraction).toEqual([]);
+
+    const explicitReplacement = await service.projectObservation(
+      ownerCandidate({
+        ownerId,
+        petId,
+        careEventId: randomUUID(),
+        choice: 'LESS',
+        supersedesObservationId: original.observationId,
+      })
+    );
+    const afterReplacement = await service.getBaselineEvidence({
+      userId: ownerId,
+      petId,
+      dimension: 'APPETITE',
+      now: NOW,
+    });
+    expect(afterReplacement.map((row) => row.id)).toEqual([explicitReplacement.observationId]);
+    expect(afterReplacement.map((row) => row.id)).not.toContain(original.observationId);
+
+    const historicalRows = await prisma.$queryRaw<Array<{ count: number }>>(Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM dogos_intelligence.observations
+      WHERE id IN (
+        ${original.observationId},
+        ${correction.observationId},
+        ${explicitReplacement.observationId}
+      )
+    `);
+    expect(historicalRows[0]?.count).toBe(3);
+  });
+
+  it('keeps Activity measurements context-only and outside baseline evidence', async () => {
+    const { ownerId, petId } = await fixture('activity-context');
+    const owner = await service.projectObservation(
+      ownerCandidate({ ownerId, petId, careEventId: randomUUID(), choice: 'USUAL' })
+    );
+    const activity = await service.projectObservation(
+      normalizeActivityMeasurement({
+        userId: ownerId,
+        petId,
+        activityId: randomUUID(),
+        dimension: 'ACTIVITY_LOAD',
+        numericValue: 45,
+        unit: 'minutes',
+        observedAt: OBSERVED_AT,
+        localDate: LOCAL_DATE,
+      })
+    );
+
+    const baseline = await service.getBaselineEvidence({
+      userId: ownerId,
+      petId,
+      dimension: 'APPETITE',
+      now: NOW,
+    });
+    expect(baseline.map((row) => row.id)).toEqual([owner.observationId]);
+    expect(baseline.map((row) => row.id)).not.toContain(activity.observationId);
+
+    const activityHistory = await service.getEffectiveProjectionHistory({
+      userId: ownerId,
+      petId,
+      dimension: 'ACTIVITY_LOAD',
+      from: '2026-08-25T00:00:00.000Z',
+      to: NOW,
+    });
+    expect(activityHistory).toHaveLength(1);
+    expect(activityHistory[0]).toMatchObject({
+      id: activity.observationId,
+      authority: 'CONTEXT_ONLY',
+      numericValue: 45,
+      unit: 'minutes',
+    });
+  });
+
+  it('enforces the same household pet authority on projection writes and reads', async () => {
+    const { ownerId, petId } = await fixture('household-authority');
+    const member = await createUser('projection-member');
+    const outsider = await createUser('projection-outsider');
+    const householdId = await households.ensurePersonalHousehold(ownerId);
+
+    await prisma.householdMember.upsert({
+      where: { householdId_userId: { householdId, userId: member.id } },
+      update: { status: 'ACTIVE', role: 'MEMBER' },
+      create: { householdId, userId: member.id, status: 'ACTIVE', role: 'MEMBER' },
+    });
+
+    const memberCandidate = ownerCandidate({
+      ownerId: member.id,
+      petId,
+      careEventId: randomUUID(),
+      choice: 'USUAL',
+    });
+    const memberReceipt = await service.projectObservation(memberCandidate);
+    expect(memberReceipt.duplicate).toBe(false);
+
+    const memberRead = await service.getBaselineEvidence({
+      userId: member.id,
+      petId,
+      dimension: 'APPETITE',
+      now: NOW,
+    });
+    expect(memberRead.map((row) => row.id)).toEqual([memberReceipt.observationId]);
+
+    const outsiderCandidate = ownerCandidate({
+      ownerId: outsider.id,
+      petId,
+      careEventId: randomUUID(),
+      choice: 'MORE',
+    });
+    await expect(service.projectObservation(outsiderCandidate)).rejects.toThrow('Pet not found');
+    await expect(
+      service.getBaselineEvidence({
+        userId: outsider.id,
+        petId,
+        dimension: 'APPETITE',
+        now: NOW,
+      })
+    ).rejects.toThrow('Pet not found');
+  });
+
+  it('returns effective evidence in deterministic observed-time then canonical-id order', async () => {
+    const { ownerId, petId } = await fixture('ordering');
+    const later = await service.projectObservation(
+      ownerCandidate({
+        ownerId,
+        petId,
+        careEventId: randomUUID(),
+        dimension: 'ENERGY',
+        observedAt: '2026-08-25T20:00:00.000Z',
+      })
+    );
+    const earlier = await service.projectObservation(
+      ownerCandidate({
+        ownerId,
+        petId,
+        careEventId: randomUUID(),
+        dimension: 'ENERGY',
+        observedAt: '2026-08-25T16:00:00.000Z',
+      })
+    );
+
+    const evidence = await service.getBaselineEvidence({
+      userId: ownerId,
+      petId,
+      dimension: 'ENERGY',
+      now: NOW,
+    });
+    expect(evidence.map((row) => row.id)).toEqual([earlier.observationId, later.observationId]);
+  });
+});

--- a/apps/api/src/intelligence/intelligence-projection.service.ts
+++ b/apps/api/src/intelligence/intelligence-projection.service.ts
@@ -1,0 +1,571 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { createHash, randomUUID } from 'node:crypto';
+import { HouseholdsService } from '../households/households.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { BASELINE_POLICY_V1 } from './baseline-policy-v1.receipt';
+import type { NormalizedObservation, SignalDimension } from './baseline-policy-v1.types';
+import { EVIDENCE_NORMALIZATION_V1 } from './evidence-normalization-v1.receipt';
+import type {
+  IntelligenceDimension,
+  PersistedProjectionObservation,
+  ProjectionObservationCandidate,
+  ProjectionRetractionReceipt,
+  ProjectionWriteReceipt,
+  QualifiedProjectionSourceType,
+} from './evidence-projection-v1.types';
+import { toBaselineObservation } from './evidence-projection-v1.types';
+
+const DAY_MS = 86_400_000;
+const LOCAL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+type ObservationRow = {
+  id: string;
+  user_id: string;
+  pet_id: string;
+  dimension: IntelligenceDimension;
+  source_type: QualifiedProjectionSourceType;
+  source_event_id: string | null;
+  source_record_id: string | null;
+  source_identity: string;
+  observed_at: Date;
+  ingested_at: Date;
+  local_date: Date | string;
+  delta_bucket: number | null;
+  numeric_value: number | null;
+  unit: string | null;
+  confidence: number;
+  reliability: 'WEAK' | 'STANDARD' | 'STRONG';
+  authority: 'BASELINE_ELIGIBLE' | 'CONTEXT_ONLY';
+  normalization_version: 'evidence-normalization-v1';
+  normalization_reason: string;
+  payload_hash: string;
+  context: Record<string, unknown> | null;
+  supersedes_observation_id: string | null;
+  retracted_at: Date | null;
+  retraction_reason: string | null;
+};
+
+type ExistingIdentityRow = {
+  id: string;
+  payload_hash: string;
+};
+
+type SupersessionRow = {
+  id: string;
+  pet_id: string;
+  dimension: IntelligenceDimension;
+  retracted_at: Date | null;
+};
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, stableValue(entry)])
+    );
+  }
+  return value;
+}
+
+function canonicalPayload(candidate: ProjectionObservationCandidate) {
+  return {
+    userId: candidate.userId,
+    petId: candidate.petId,
+    dimension: candidate.dimension,
+    sourceType: candidate.sourceType,
+    sourceIdentity: candidate.sourceIdentity,
+    sourceEventId: candidate.sourceEventId ?? null,
+    sourceRecordId: candidate.sourceRecordId ?? null,
+    observedAt: candidate.observedAt,
+    localDate: candidate.localDate,
+    deltaBucket: candidate.deltaBucket ?? null,
+    numericValue: candidate.numericValue ?? null,
+    unit: candidate.unit ?? null,
+    confidence: candidate.confidence,
+    reliability: candidate.reliability,
+    authority: candidate.authority,
+    normalizationVersion: candidate.normalizationVersion,
+    normalizationReason: candidate.normalizationReason,
+    context: stableValue(candidate.context ?? {}),
+    supersedesObservationId: candidate.supersedesObservationId ?? null,
+  };
+}
+
+function payloadHash(candidate: ProjectionObservationCandidate) {
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalPayload(candidate)))
+    .digest('hex');
+}
+
+function localDateString(value: Date | string) {
+  return typeof value === 'string' ? value.slice(0, 10) : value.toISOString().slice(0, 10);
+}
+
+@Injectable()
+export class IntelligenceProjectionService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly households: HouseholdsService
+  ) {}
+
+  async projectObservation(
+    candidate: ProjectionObservationCandidate
+  ): Promise<ProjectionWriteReceipt> {
+    this.validateCandidate(candidate);
+    await this.households.assertPetAccessible(candidate.userId, candidate.petId);
+    const hash = payloadHash(candidate);
+    const contextJson = JSON.stringify(stableValue(candidate.context ?? {}));
+
+    return this.prisma.$transaction(async (tx) => {
+      const existing = await this.findByIdentity(tx, candidate);
+      if (existing) return this.duplicateReceipt(existing, hash);
+
+      if (candidate.supersedesObservationId) {
+        const predecessor = await tx.$queryRaw<SupersessionRow[]>(Prisma.sql`
+          SELECT id, pet_id, dimension, retracted_at
+          FROM dogos_intelligence.observations
+          WHERE id = ${candidate.supersedesObservationId}
+          FOR UPDATE
+        `);
+        const prior = predecessor[0];
+        if (!prior) throw new NotFoundException('Superseded observation not found');
+        if (prior.retracted_at) {
+          throw new ConflictException('Retracted evidence cannot receive a new correction');
+        }
+        if (prior.pet_id !== candidate.petId || prior.dimension !== candidate.dimension) {
+          throw new BadRequestException('Correction must preserve pet and dimension identity');
+        }
+
+        const activeSuccessor = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+          SELECT id
+          FROM dogos_intelligence.observations
+          WHERE supersedes_observation_id = ${candidate.supersedesObservationId}
+            AND retracted_at IS NULL
+          LIMIT 1
+        `);
+        if (activeSuccessor[0]) {
+          throw new ConflictException('Observation already has an active correction');
+        }
+      }
+
+      const observationId = randomUUID();
+      const inserted = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+        INSERT INTO dogos_intelligence.observations (
+          id,
+          user_id,
+          pet_id,
+          dimension,
+          source_type,
+          source_event_id,
+          source_record_id,
+          source_identity,
+          observed_at,
+          local_date,
+          delta_bucket,
+          numeric_value,
+          unit,
+          confidence,
+          reliability,
+          authority,
+          normalization_version,
+          normalization_reason,
+          payload_hash,
+          context,
+          supersedes_observation_id
+        ) VALUES (
+          ${observationId},
+          ${candidate.userId},
+          ${candidate.petId},
+          ${candidate.dimension},
+          ${candidate.sourceType},
+          ${candidate.sourceEventId ?? null},
+          ${candidate.sourceRecordId ?? null},
+          ${candidate.sourceIdentity},
+          ${new Date(candidate.observedAt)},
+          CAST(${candidate.localDate} AS DATE),
+          ${candidate.deltaBucket ?? null},
+          ${candidate.numericValue ?? null},
+          ${candidate.unit ?? null},
+          ${candidate.confidence},
+          ${candidate.reliability},
+          ${candidate.authority},
+          ${candidate.normalizationVersion},
+          ${candidate.normalizationReason},
+          ${hash},
+          CAST(${contextJson} AS JSONB),
+          ${candidate.supersedesObservationId ?? null}
+        )
+        ON CONFLICT (
+          pet_id,
+          dimension,
+          source_type,
+          source_identity,
+          normalization_version
+        ) DO NOTHING
+        RETURNING id
+      `);
+
+      if (inserted[0]) {
+        return { observationId: inserted[0].id, payloadHash: hash, duplicate: false };
+      }
+
+      const raced = await this.findByIdentity(tx, candidate);
+      if (!raced) {
+        throw new ConflictException('Projection write conflicted with another active correction');
+      }
+      return this.duplicateReceipt(raced, hash);
+    });
+  }
+
+  async getBaselineEvidence(input: {
+    userId: string;
+    petId: string;
+    dimension: SignalDimension;
+    now: string;
+  }): Promise<NormalizedObservation[]> {
+    await this.households.assertPetAccessible(input.userId, input.petId);
+    const nowMs = Date.parse(input.now);
+    if (!Number.isFinite(nowMs)) throw new BadRequestException('A valid explicit now is required');
+
+    const from = new Date(nowMs - BASELINE_POLICY_V1.retentionWindowDays * DAY_MS);
+    const to = new Date(nowMs);
+    const rows = await this.prisma.$queryRaw<ObservationRow[]>(Prisma.sql`
+      SELECT
+        o.id,
+        o.user_id,
+        o.pet_id,
+        o.dimension,
+        o.source_type,
+        o.source_event_id,
+        o.source_record_id,
+        o.source_identity,
+        o.observed_at,
+        o.ingested_at,
+        o.local_date,
+        o.delta_bucket,
+        o.numeric_value,
+        o.unit,
+        o.confidence,
+        o.reliability,
+        o.authority,
+        o.normalization_version,
+        o.normalization_reason,
+        o.payload_hash,
+        o.context,
+        o.supersedes_observation_id,
+        o.retracted_at,
+        o.retraction_reason
+      FROM dogos_intelligence.observations o
+      WHERE o.pet_id = ${input.petId}
+        AND o.dimension = ${input.dimension}
+        AND o.authority = 'BASELINE_ELIGIBLE'
+        AND o.delta_bucket IS NOT NULL
+        AND o.observed_at >= ${from}
+        AND o.observed_at <= ${to}
+        AND o.retracted_at IS NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM dogos_intelligence.observations successor
+          WHERE successor.supersedes_observation_id = o.id
+        )
+      ORDER BY o.observed_at ASC, o.id ASC
+      LIMIT 512
+    `);
+
+    return rows.map((row) =>
+      toBaselineObservation({
+        id: row.id,
+        sourceIdentity: row.source_identity,
+        dimension: row.dimension,
+        sourceType: row.source_type,
+        observedAt: row.observed_at.toISOString(),
+        localDate: localDateString(row.local_date),
+        deltaBucket: row.delta_bucket as -2 | -1 | 0 | 1 | 2,
+        confidence: row.confidence,
+        reliability: row.reliability,
+      })
+    );
+  }
+
+  async retractObservation(input: {
+    userId: string;
+    petId: string;
+    observationId: string;
+    reason: string;
+  }): Promise<ProjectionRetractionReceipt> {
+    await this.households.assertPetAccessible(input.userId, input.petId);
+    const reason = input.reason.trim();
+    if (!reason || reason.length > 256) {
+      throw new BadRequestException('Retraction reason must be between 1 and 256 characters');
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const rows = await tx.$queryRaw<Array<{ id: string; retracted_at: Date | null }>>(Prisma.sql`
+        SELECT id, retracted_at
+        FROM dogos_intelligence.observations
+        WHERE id = ${input.observationId}
+          AND pet_id = ${input.petId}
+        FOR UPDATE
+      `);
+      const row = rows[0];
+      if (!row) throw new NotFoundException('Observation not found');
+      if (row.retracted_at) {
+        return { observationId: row.id, retracted: true, duplicate: true };
+      }
+
+      await tx.$executeRaw(Prisma.sql`
+        UPDATE dogos_intelligence.observations
+        SET retracted_at = NOW(), retraction_reason = ${reason}
+        WHERE id = ${row.id}
+      `);
+      return { observationId: row.id, retracted: true, duplicate: false };
+    });
+  }
+
+  async getEffectiveProjectionHistory(input: {
+    userId: string;
+    petId: string;
+    dimension: IntelligenceDimension;
+    from: string;
+    to: string;
+    limit?: number;
+  }): Promise<PersistedProjectionObservation[]> {
+    await this.households.assertPetAccessible(input.userId, input.petId);
+    const fromMs = Date.parse(input.from);
+    const toMs = Date.parse(input.to);
+    if (!Number.isFinite(fromMs) || !Number.isFinite(toMs) || fromMs > toMs) {
+      throw new BadRequestException('A valid bounded projection history window is required');
+    }
+    if (toMs - fromMs > BASELINE_POLICY_V1.retentionWindowDays * DAY_MS) {
+      throw new BadRequestException(
+        'Projection history window exceeds the retained intelligence horizon'
+      );
+    }
+    const limit = Math.max(1, Math.min(input.limit ?? 200, 512));
+
+    const rows = await this.prisma.$queryRaw<ObservationRow[]>(Prisma.sql`
+      SELECT
+        o.id,
+        o.user_id,
+        o.pet_id,
+        o.dimension,
+        o.source_type,
+        o.source_event_id,
+        o.source_record_id,
+        o.source_identity,
+        o.observed_at,
+        o.ingested_at,
+        o.local_date,
+        o.delta_bucket,
+        o.numeric_value,
+        o.unit,
+        o.confidence,
+        o.reliability,
+        o.authority,
+        o.normalization_version,
+        o.normalization_reason,
+        o.payload_hash,
+        o.context,
+        o.supersedes_observation_id,
+        o.retracted_at,
+        o.retraction_reason
+      FROM dogos_intelligence.observations o
+      WHERE o.pet_id = ${input.petId}
+        AND o.dimension = ${input.dimension}
+        AND o.observed_at >= ${new Date(fromMs)}
+        AND o.observed_at <= ${new Date(toMs)}
+        AND o.retracted_at IS NULL
+        AND NOT EXISTS (
+          SELECT 1
+          FROM dogos_intelligence.observations successor
+          WHERE successor.supersedes_observation_id = o.id
+        )
+      ORDER BY o.observed_at ASC, o.id ASC
+      LIMIT ${limit}
+    `);
+
+    return rows.map((row) => this.toPersisted(row));
+  }
+
+  private async findByIdentity(
+    tx: Prisma.TransactionClient,
+    candidate: ProjectionObservationCandidate
+  ): Promise<ExistingIdentityRow | null> {
+    const rows = await tx.$queryRaw<ExistingIdentityRow[]>(Prisma.sql`
+      SELECT id, payload_hash
+      FROM dogos_intelligence.observations
+      WHERE pet_id = ${candidate.petId}
+        AND dimension = ${candidate.dimension}
+        AND source_type = ${candidate.sourceType}
+        AND source_identity = ${candidate.sourceIdentity}
+        AND normalization_version = ${candidate.normalizationVersion}
+      LIMIT 1
+    `);
+    return rows[0] ?? null;
+  }
+
+  private duplicateReceipt(
+    existing: ExistingIdentityRow,
+    expectedHash: string
+  ): ProjectionWriteReceipt {
+    if (existing.payload_hash !== expectedHash) {
+      throw new ConflictException(
+        'Projection source identity was replayed with different semantics'
+      );
+    }
+    return { observationId: existing.id, payloadHash: expectedHash, duplicate: true };
+  }
+
+  private validateCandidate(candidate: ProjectionObservationCandidate) {
+    if (!candidate.userId || !candidate.petId) {
+      throw new BadRequestException('Projection evidence requires user and pet IDs');
+    }
+    if (
+      !candidate.sourceIdentity.trim() ||
+      candidate.sourceIdentity.length > EVIDENCE_NORMALIZATION_V1.maxSourceIdentityLength
+    ) {
+      throw new BadRequestException('Projection source identity is invalid');
+    }
+    if (!Number.isFinite(Date.parse(candidate.observedAt))) {
+      throw new BadRequestException('Projection observedAt is invalid');
+    }
+    if (!LOCAL_DATE_PATTERN.test(candidate.localDate)) {
+      throw new BadRequestException('Projection localDate must already be normalized upstream');
+    }
+    if (
+      !Number.isFinite(candidate.confidence) ||
+      candidate.confidence <= 0 ||
+      candidate.confidence > 1
+    ) {
+      throw new BadRequestException('Projection confidence must be in (0, 1]');
+    }
+    if (candidate.normalizationVersion !== EVIDENCE_NORMALIZATION_V1.version) {
+      throw new BadRequestException('Unsupported evidence normalization version');
+    }
+    if (
+      !candidate.normalizationReason ||
+      candidate.normalizationReason.length > EVIDENCE_NORMALIZATION_V1.maxNormalizationReasonLength
+    ) {
+      throw new BadRequestException('Projection normalization reason is invalid');
+    }
+    const contextJson = JSON.stringify(stableValue(candidate.context ?? {}));
+    if (Buffer.byteLength(contextJson, 'utf8') > EVIDENCE_NORMALIZATION_V1.maxContextBytes) {
+      throw new BadRequestException('Projection context exceeds the privacy-thin size limit');
+    }
+    if (
+      candidate.deltaBucket !== undefined &&
+      (!Number.isInteger(candidate.deltaBucket) ||
+        candidate.deltaBucket < -2 ||
+        candidate.deltaBucket > 2)
+    ) {
+      throw new BadRequestException('Projection delta bucket must be an integer from -2 through 2');
+    }
+    if (
+      candidate.numericValue !== undefined &&
+      (!Number.isFinite(candidate.numericValue) || Number.isNaN(candidate.numericValue))
+    ) {
+      throw new BadRequestException('Projection numeric value must be finite');
+    }
+    if (candidate.deltaBucket === undefined && candidate.numericValue === undefined) {
+      throw new BadRequestException(
+        'Projection evidence requires a bounded bucket or numeric measurement'
+      );
+    }
+    if (candidate.numericValue !== undefined && !candidate.unit) {
+      throw new BadRequestException('Projection numeric measurements require an explicit unit');
+    }
+    if (candidate.unit && candidate.numericValue === undefined) {
+      throw new BadRequestException('Projection units are only valid for numeric measurements');
+    }
+
+    const baselineDimension = EVIDENCE_NORMALIZATION_V1.baselineDimensions.includes(
+      candidate.dimension as (typeof EVIDENCE_NORMALIZATION_V1.baselineDimensions)[number]
+    );
+    if (candidate.sourceType === 'OWNER_CHECKIN') {
+      if (
+        candidate.authority !== 'BASELINE_ELIGIBLE' ||
+        !baselineDimension ||
+        candidate.deltaBucket === undefined ||
+        candidate.numericValue !== undefined
+      ) {
+        throw new BadRequestException(
+          'Owner check-ins are restricted to baseline-eligible semantic evidence in evidence-normalization-v1'
+        );
+      }
+    }
+    if (candidate.authority === 'BASELINE_ELIGIBLE') {
+      if (
+        !baselineDimension ||
+        candidate.deltaBucket === undefined ||
+        candidate.sourceType !== 'OWNER_CHECKIN'
+      ) {
+        throw new BadRequestException(
+          'Release 1 baseline authority is restricted to owner check-ins on qualified baseline dimensions'
+        );
+      }
+    }
+    if (candidate.sourceType === 'ACTIVITY') {
+      if (
+        candidate.authority !== 'CONTEXT_ONLY' ||
+        !['ACTIVITY_LOAD', 'RECOVERY_REST_PROXY'].includes(candidate.dimension) ||
+        candidate.numericValue === undefined
+      ) {
+        throw new BadRequestException(
+          'Activity evidence is context-only in evidence-normalization-v1'
+        );
+      }
+    }
+    if (candidate.sourceType === 'COACHING') {
+      if (
+        candidate.authority !== 'CONTEXT_ONLY' ||
+        candidate.dimension !== 'TRAINING_COMFORT_SUCCESS' ||
+        candidate.numericValue === undefined
+      ) {
+        throw new BadRequestException(
+          'Coaching evidence is context-only in evidence-normalization-v1'
+        );
+      }
+    }
+  }
+
+  private toPersisted(row: ObservationRow): PersistedProjectionObservation {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      petId: row.pet_id,
+      dimension: row.dimension,
+      sourceType: row.source_type,
+      sourceIdentity: row.source_identity,
+      ...(row.source_event_id ? { sourceEventId: row.source_event_id } : {}),
+      ...(row.source_record_id ? { sourceRecordId: row.source_record_id } : {}),
+      observedAt: row.observed_at.toISOString(),
+      localDate: localDateString(row.local_date),
+      ...(row.delta_bucket === null
+        ? {}
+        : { deltaBucket: row.delta_bucket as -2 | -1 | 0 | 1 | 2 }),
+      ...(row.numeric_value === null ? {} : { numericValue: row.numeric_value }),
+      ...(row.unit ? { unit: row.unit } : {}),
+      confidence: row.confidence,
+      reliability: row.reliability,
+      authority: row.authority,
+      normalizationVersion: row.normalization_version,
+      normalizationReason: row.normalization_reason,
+      context: row.context ?? {},
+      ...(row.supersedes_observation_id
+        ? { supersedesObservationId: row.supersedes_observation_id }
+        : {}),
+      ingestedAt: row.ingested_at.toISOString(),
+      payloadHash: row.payload_hash,
+      retractedAt: row.retracted_at?.toISOString() ?? null,
+      retractionReason: row.retraction_reason,
+    };
+  }
+}

--- a/apps/api/src/intelligence/intelligence.module.ts
+++ b/apps/api/src/intelligence/intelligence.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { HouseholdsModule } from '../households/households.module';
+import { IntelligenceProjectionService } from './intelligence-projection.service';
+
+@Module({
+  imports: [HouseholdsModule],
+  providers: [IntelligenceProjectionService],
+  exports: [IntelligenceProjectionService],
+})
+export class IntelligenceModule {}

--- a/docs/DOGOS_INTELLIGENCE_EVIDENCE_PROJECTION_V1.md
+++ b/docs/DOGOS_INTELLIGENCE_EVIDENCE_PROJECTION_V1.md
@@ -1,0 +1,182 @@
+# dogOS Intelligence: Evidence Projection v1
+
+`evidence-normalization-v1` and the `dogos_intelligence.observations` projection form the persistence boundary between canonical dogOS product events and the pure `baseline-policy-v1` oracle.
+
+This release foundation is intentionally **derived and replayable**. It is not a second source-of-truth event ledger.
+
+## Authority boundaries
+
+Canonical product records remain authoritative:
+
+- owner Daily Signals become canonical private `CareEvent` records before projection;
+- Activities remain canonical Activity records;
+- Coach remains authoritative for its own session/outcome records.
+
+The intelligence projection stores only bounded normalized evidence derived from those sources. Projection rows may be rebuilt, corrected, retracted, or repaired without rewriting canonical source history.
+
+## Release 1 source authority
+
+Only three source classes are qualified:
+
+| Canonical evidence | Projection source | Release 1 authority                                               |
+| ------------------ | ----------------- | ----------------------------------------------------------------- |
+| `SELF_REPORT`      | `OWNER_CHECKIN`   | `BASELINE_ELIGIBLE` on the six qualified Daily Signals dimensions |
+| `ACTIVITY`         | `ACTIVITY`        | `CONTEXT_ONLY`                                                    |
+| `COACH`            | `COACHING`        | `CONTEXT_ONLY`                                                    |
+
+`BEHAVIOR_VISION`, `LOCATION`, `MEDIA`, `CLINIC`, and `WEARABLE` fail closed in `evidence-normalization-v1`. They do not receive projection authority merely because an EvidenceType exists elsewhere in dogOS.
+
+### Why Activity and Coach are context-only
+
+Release 1 does not infer that 45 minutes of activity means a dog's energy is `HIGHER`, or that a coaching result directly means mobility is `LOWER`.
+
+That would manufacture health-like relative evidence from heterogeneous raw measurements without a qualified normalization model.
+
+Instead:
+
+- Activity may preserve `ACTIVITY_LOAD` or `RECOVERY_REST_PROXY` numeric measurements;
+- Coach may preserve `TRAINING_COMFORT_SUCCESS`;
+- those rows keep provenance and can support later context or separately qualified normalization policies;
+- they cannot directly enter the six user-facing baseline dimensions in v1.
+
+## Owner Daily Signals normalization
+
+Owner semantic choices are deliberately simple:
+
+- `LESS` → `-1`
+- `USUAL` → `0`
+- `MORE` → `1`
+- `UNSURE` → **no observation**
+
+`UNSURE` is missing evidence, never normal evidence.
+
+The six baseline-eligible dimensions are:
+
+- appetite
+- energy
+- bathroom/routine
+- mobility/comfort
+- engagement/social comfort
+- sleep/rest
+
+## Projection row contract
+
+`dogos_intelligence.observations` stores bounded operational evidence:
+
+- canonical text ID;
+- actor user ID and pet ID;
+- dimension and qualified source class;
+- canonical source event/record identity when available;
+- stable logical source identity;
+- `observed_at` separate from `ingested_at`;
+- upstream-normalized local date;
+- bounded `delta_bucket` only where semantically valid;
+- numeric value and explicit unit for measurements;
+- confidence and reliability;
+- `BASELINE_ELIGIBLE` versus `CONTEXT_ONLY` authority;
+- normalization version and bounded reason;
+- SHA-256 canonical payload hash;
+- bounded structured context;
+- supersession and explicit retraction lineage.
+
+It stores no raw camera/video, access or refresh token, IP address, device fingerprint, precise location trail, unbounded note, or model trace.
+
+## Replay identity
+
+A projection identity is unique over:
+
+`pet + dimension + source type + source identity + normalization version`
+
+Replay behavior is strict:
+
+1. same identity + same canonical payload hash → idempotent duplicate receipt;
+2. same identity + different canonical payload → hard conflict;
+3. concurrent identical inserts converge through the database uniqueness boundary;
+4. projection replay may not silently reinterpret history under an existing identity.
+
+This gives replay jobs a deterministic repair contract rather than `ON CONFLICT DO UPDATE` last-write-wins behavior.
+
+## Correction, retraction, and explicit reversion semantics
+
+Corrections are append-only successors.
+
+An observation may have at most one active successor. Once an observation has been superseded, the predecessor remains historical truth but never silently regains effective authority merely because its successor is later retracted.
+
+A correction is allowed only when it preserves pet and dimension identity.
+
+Retraction is explicit and reasoned. Retracting an active correction removes that correction from effective evidence, but **does not resurrect the predecessor**. If an authorized user intentionally wants to return to an earlier semantic value, that decision must be represented by a new explicit successor with its own source identity and provenance.
+
+The effective evidence query excludes:
+
+- retracted rows; and
+- every row that has a successor in the append-only lineage, regardless of whether that successor was later retracted.
+
+This makes authority changes auditable. A disappearing correction cannot accidentally reactivate stale evidence.
+
+Canonical source deletion/redaction will later invoke an explicit repair/retraction path rather than relying on physical projection deletion.
+
+## Household authorization
+
+Pet access is resolved through `HouseholdsService.assertPetAccessible` for projection writes, baseline reads, history reads, and retractions.
+
+The same authority is now used by `CareEventsService`, replacing its older owner-only pet assertion. This closes an existing coherence bug where an active household member could legitimately record a shared-pet Activity but the resulting canonical CareEvent emission could fail because a deeper layer required ownership.
+
+Authorization failures retain the canonical `Pet not found` behavior so unrelated users cannot infer pet existence through this surface.
+
+## Bounded reads
+
+Baseline evidence reads are bounded to the `baseline-policy-v1` retained horizon and capped at 512 rows per pet/dimension query.
+
+Effective projection history requests may span at most the same retained horizon and are capped at 512 rows.
+
+Rows are ordered deterministically by `observed_at`, then canonical observation ID.
+
+## Privacy and operational limits
+
+The database and service both enforce bounded structure where practical:
+
+- context ≤ 4096 serialized bytes;
+- normalization reason ≤ 512 characters;
+- source identity ≤ 256 characters;
+- confidence in `(0, 1]`;
+- delta bucket from `-2..2`;
+- numeric measurements must be finite and carry a unit;
+- payload hash is a lowercase SHA-256 hex digest.
+
+## Qualification
+
+The dedicated Evidence Projection CI lane must prove on real PostgreSQL:
+
+- exactly one additive intelligence migration is owned by this release;
+- the full historical migration chain still deploys;
+- privacy-thin schema constraints remain present;
+- only Owner Check-in has Release 1 baseline authority;
+- `baseline-policy-v1` remains green;
+- normalization receipt and fail-closed source mapping remain green;
+- 20 concurrent identical writes create one logical projection observation;
+- same identity with changed semantics is rejected;
+- competing corrections serialize to one active successor;
+- retracting a correction cannot implicitly resurrect its predecessor;
+- an intentional return to an earlier semantic value requires a new explicit successor;
+- Activity remains context-only;
+- household members may operate on shared pets while unrelated users fail closed;
+- canonical CareEvent household authority remains race-safe and zero-reward Daily Signals evidence stays private;
+- API type-check and production build remain green.
+
+## Not yet included
+
+This foundation does **not** yet complete issue #33.
+
+Still required in later commits/releases before 1B is complete:
+
+- canonical Daily Signals capture service and DTO validation;
+- household-local-day idempotency across multiple household members;
+- timezone/DST fixtures and one documented local-day policy;
+- projection replay from canonical CareEvents after partial failure;
+- source repair/redaction orchestration;
+- Activity and Coach canonical-record adapters wired into replay;
+- public `/api/v1/intelligence/*` endpoints;
+- production HTTP retry/isolation proof;
+- Docker production qualification.
+
+Those layers should depend on this replay and authority contract rather than redefining it.

--- a/packages/database/prisma/migrations/20260826013000_add_dogos_intelligence_observations/migration.sql
+++ b/packages/database/prisma/migrations/20260826013000_add_dogos_intelligence_observations/migration.sql
@@ -1,0 +1,123 @@
+CREATE SCHEMA IF NOT EXISTS dogos_intelligence;
+
+CREATE TABLE IF NOT EXISTS dogos_intelligence.observations (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  pet_id TEXT NOT NULL REFERENCES public.pets(id) ON DELETE CASCADE,
+  dimension TEXT NOT NULL,
+  source_type TEXT NOT NULL,
+  source_event_id TEXT,
+  source_record_id TEXT,
+  source_identity TEXT NOT NULL,
+  observed_at TIMESTAMPTZ NOT NULL,
+  ingested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  local_date DATE NOT NULL,
+  delta_bucket SMALLINT,
+  numeric_value DOUBLE PRECISION,
+  unit TEXT,
+  confidence DOUBLE PRECISION NOT NULL,
+  reliability TEXT NOT NULL,
+  authority TEXT NOT NULL,
+  normalization_version TEXT NOT NULL,
+  normalization_reason TEXT NOT NULL,
+  payload_hash TEXT NOT NULL,
+  context JSONB NOT NULL DEFAULT '{}'::jsonb,
+  supersedes_observation_id TEXT REFERENCES dogos_intelligence.observations(id) ON DELETE RESTRICT,
+  retracted_at TIMESTAMPTZ,
+  retraction_reason TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT intelligence_observation_id_length
+    CHECK (char_length(id) BETWEEN 8 AND 128),
+  CONSTRAINT intelligence_observation_source_identity_length
+    CHECK (char_length(source_identity) BETWEEN 1 AND 256),
+  CONSTRAINT intelligence_observation_source_event_id_length
+    CHECK (source_event_id IS NULL OR char_length(source_event_id) BETWEEN 1 AND 128),
+  CONSTRAINT intelligence_observation_source_record_id_length
+    CHECK (source_record_id IS NULL OR char_length(source_record_id) BETWEEN 1 AND 128),
+  CONSTRAINT intelligence_observation_dimension
+    CHECK (dimension IN (
+      'APPETITE',
+      'ENERGY',
+      'BATHROOM_ROUTINE',
+      'MOBILITY_COMFORT',
+      'ENGAGEMENT_SOCIAL_COMFORT',
+      'SLEEP_REST',
+      'ACTIVITY_LOAD',
+      'RECOVERY_REST_PROXY',
+      'TRAINING_COMFORT_SUCCESS'
+    )),
+  CONSTRAINT intelligence_observation_source_type
+    CHECK (source_type IN ('OWNER_CHECKIN', 'ACTIVITY', 'COACHING')),
+  CONSTRAINT intelligence_observation_delta_bucket
+    CHECK (delta_bucket IS NULL OR delta_bucket BETWEEN -2 AND 2),
+  CONSTRAINT intelligence_observation_value_present
+    CHECK (delta_bucket IS NOT NULL OR numeric_value IS NOT NULL),
+  CONSTRAINT intelligence_observation_numeric_finite
+    CHECK (
+      numeric_value IS NULL
+      OR numeric_value NOT IN ('Infinity'::float8, '-Infinity'::float8, 'NaN'::float8)
+    ),
+  CONSTRAINT intelligence_observation_unit_length
+    CHECK (unit IS NULL OR char_length(unit) BETWEEN 1 AND 32),
+  CONSTRAINT intelligence_observation_confidence
+    CHECK (confidence > 0 AND confidence <= 1),
+  CONSTRAINT intelligence_observation_reliability
+    CHECK (reliability IN ('WEAK', 'STANDARD', 'STRONG')),
+  CONSTRAINT intelligence_observation_authority
+    CHECK (authority IN ('BASELINE_ELIGIBLE', 'CONTEXT_ONLY')),
+  CONSTRAINT intelligence_observation_baseline_authority_shape
+    CHECK (
+      authority <> 'BASELINE_ELIGIBLE'
+      OR (
+        dimension IN (
+          'APPETITE',
+          'ENERGY',
+          'BATHROOM_ROUTINE',
+          'MOBILITY_COMFORT',
+          'ENGAGEMENT_SOCIAL_COMFORT',
+          'SLEEP_REST'
+        )
+        AND delta_bucket IS NOT NULL
+      )
+    ),
+  CONSTRAINT intelligence_observation_normalization_version_length
+    CHECK (char_length(normalization_version) BETWEEN 1 AND 64),
+  CONSTRAINT intelligence_observation_reason_length
+    CHECK (char_length(normalization_reason) BETWEEN 1 AND 512),
+  CONSTRAINT intelligence_observation_payload_hash
+    CHECK (payload_hash ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT intelligence_observation_context_size
+    CHECK (octet_length(context::text) <= 4096),
+  CONSTRAINT intelligence_observation_retraction_reason_length
+    CHECK (retraction_reason IS NULL OR char_length(retraction_reason) BETWEEN 1 AND 256),
+  CONSTRAINT intelligence_observation_retraction_pair
+    CHECK (
+      (retracted_at IS NULL AND retraction_reason IS NULL)
+      OR (retracted_at IS NOT NULL AND retraction_reason IS NOT NULL)
+    ),
+  CONSTRAINT intelligence_observation_not_self_superseding
+    CHECK (supersedes_observation_id IS NULL OR supersedes_observation_id <> id),
+
+  CONSTRAINT intelligence_observation_source_identity_unique
+    UNIQUE (pet_id, dimension, source_type, source_identity, normalization_version)
+);
+
+CREATE INDEX IF NOT EXISTS intelligence_observations_pet_dimension_time_idx
+  ON dogos_intelligence.observations (pet_id, dimension, observed_at DESC, id);
+
+CREATE INDEX IF NOT EXISTS intelligence_observations_source_event_idx
+  ON dogos_intelligence.observations (source_event_id, dimension)
+  WHERE source_event_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS intelligence_observations_source_record_idx
+  ON dogos_intelligence.observations (source_record_id, dimension)
+  WHERE source_record_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS intelligence_observations_supersedes_idx
+  ON dogos_intelligence.observations (supersedes_observation_id)
+  WHERE supersedes_observation_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS intelligence_observations_one_active_superseder_idx
+  ON dogos_intelligence.observations (supersedes_observation_id)
+  WHERE supersedes_observation_id IS NOT NULL AND retracted_at IS NULL;


### PR DESCRIPTION
## dogOS Intelligence 1B foundation

Part of #33. Stacked on qualified PR #36 / `baseline-policy-v1`.

This PR does **not** close #33 yet. It establishes the persistence, normalization, repair, and household-authority substrate that the Daily Signals APIs will depend on.

### What this slice adds

- additive `dogos_intelligence.observations` projection schema
- explicit `BASELINE_ELIGIBLE` vs `CONTEXT_ONLY` authority
- `evidence-normalization-v1` receipt with SHA-256 pinning
- owner Daily Signals semantic normalization (`LESS / USUAL / MORE / UNSURE`)
- Activity + Coach context-only measurement adapters
- replay-safe canonical payload hashing
- same-identity/same-payload idempotency
- same-identity/different-payload hard conflicts
- append-only supersession and explicit retraction lineage
- non-resurrecting effective-evidence semantics
- bounded baseline/history queries
- household authorization on projection writes, reads, and repair
- canonical `CareEventsService` migration from owner-only pet checks to `HouseholdsService.assertPetAccessible`
- real PostgreSQL race/repair/authorization tests
- dedicated stacked/main-target qualification workflow

### Conservative source authority

Release 1 intentionally gives direct baseline authority only to owner semantic check-ins on the six qualified baseline dimensions.

`ACTIVITY` and `COACH` are persisted with provenance but remain `CONTEXT_ONLY`; this release refuses to pretend that raw activity duration or coaching outcome is automatically a health-like relative change.

Unqualified EvidenceTypes such as Behavior Vision, Media, Location, Clinic, and Wearable fail closed in `evidence-normalization-v1`.

### Replay, correction, and reversion model

Projection identity is unique over:

`pet + dimension + source type + source identity + normalization version`

- identical replay → duplicate receipt
- divergent replay under the same identity → conflict
- one active correction may supersede an observation at a time
- predecessor history remains stored but loses effective authority once superseded
- retracting a successor removes that successor from effective evidence but **does not resurrect the predecessor**
- intentionally returning to an earlier semantic value requires a new explicit successor with its own provenance
- physical deletion is not used as a correction protocol

This closes a subtle authority bug found during the 1B audit: issue #33 explicitly requires correction removal not to reactivate stale evidence unless reversion is separately represented.

### Existing coherence fix

The audit found that household-aware callers such as Activities could legally operate on a shared pet, then fail deeper CareEvent emission because `CareEventsService` still enforced owner-only pet access. This branch centralizes those pet-scoped CareEvent checks on `HouseholdsService.assertPetAccessible` and adds a PostgreSQL regression proof for a household member recording private zero-reward `DAILY_SIGNALS_CHECKIN` evidence while an unrelated user fails closed.

### Release shape

The final candidate is reconstructed as **one commit / 13 files** directly on qualified #36 head `5d363918d85eb31065acaabcb9822cc4ee26364e`. The reconstructed tree reuses the exact blob SHAs that passed the pre-clean semantic qualification rather than regenerating source.

### Exact-head qualification receipt

Qualified stacked head: `721886d8d07fb1d614306e88c0e3fa4b028a3df0`

All required workflows are green on that exact reconstructed head:

- **dogOS Intelligence Evidence Projection CI** — run `32921586599` — success
  - exact add-only database ownership — success
  - full 18-migration PostgreSQL chain — success
  - read-only formatting + whitespace — success
  - zero-warning lint — success
  - structural privacy/authority invariants — success
  - API type-check — success
  - baseline/normalization/replay/correction/retraction/CareEvent PostgreSQL contracts — success
  - production API build — success
- **Adventure System CI** — run `32921586596` — success
  - Prisma validation + migrated-database drift check — success
  - monorepo lint + type-check — success
  - Adventure web contracts — success
  - reward policy + reward ledger integrity — success
  - quest engine + full API tests — success
  - production API + Web builds — success

GitHub reports the PR mergeable with exactly one commit and 13 changed files.

### Still required before #33 is complete

- canonical Daily Signals capture DTO/service
- one logical pet + household-local-day check-in policy across multiple household members
- IANA timezone validation + DST/local-day identity fixtures
- replay from canonical CareEvents after partial projection failure
- source redaction/repair orchestration
- canonical Activity/Coach replay wiring
- `/api/v1/intelligence/*` endpoints
- Docker + production HTTP retry/isolation proof

### Restack requirement

#37 is stacked on #36 and must not merge before #36. After #36 merges, retarget #37 to `main` and rerun the inherited/root qualification matrix on the new exact head before merge.