### PR TITLE
dogOS Intelligence 1B: add canonical Daily Signals capture

### DIFF
--- a/.github/workflows/dogos-daily-signals-capture-ci.yml
+++ b/.github/workflows/dogos-daily-signals-capture-ci.yml
@@ -1,0 +1,421 @@
+name: dogOS Daily Signals Capture CI
+
+on:
+  pull_request:
+    branches: [main, agent/dogos-intelligence-evidence-projection-v1]
+    paths:
+      - 'apps/api/src/app.module.ts'
+      - 'apps/api/src/care-events/**'
+      - 'apps/api/src/common/time/**'
+      - 'apps/api/src/households/**'
+      - 'apps/api/src/intelligence/**'
+      - '.github/workflows/dogos-daily-signals-capture-ci.yml'
+      - 'docs/DOGOS_DAILY_SIGNALS_CAPTURE_V1.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-daily-signals-capture-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  JWT_SECRET: ci-only-daily-signals-secret-12345678901234567890
+  NODE_ENV: test
+  ML_SERVICE_ENABLED: 'false'
+
+jobs:
+  qualify:
+    name: Canonical local-day capture + replay qualification
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject database ownership in capture slice
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: python .github/scripts/assert-database-ownership.py "$BASE_SHA"
+
+      - name: Apply full database migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check capture release formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/app.module.ts
+          apps/api/src/care-events/care-event.types.ts
+          apps/api/src/care-events/care-events.service.ts
+          apps/api/src/common/time/iana-timezone.ts
+          apps/api/src/common/time/iana-timezone.spec.ts
+          apps/api/src/households/households.service.ts
+          apps/api/src/intelligence/daily-signals-local-day-policy-v1.ts
+          apps/api/src/intelligence/daily-signals-local-day-policy-v1.spec.ts
+          apps/api/src/intelligence/daily-signals.types.ts
+          apps/api/src/intelligence/dto/daily-signals.dto.ts
+          apps/api/src/intelligence/daily-signals.service.ts
+          apps/api/src/intelligence/daily-signals.integration.spec.ts
+          apps/api/src/intelligence/intelligence.controller.ts
+          apps/api/src/intelligence/intelligence.module.ts
+          docs/DOGOS_DAILY_SIGNALS_CAPTURE_V1.md
+          .github/workflows/dogos-daily-signals-capture-ci.yml
+
+      - name: Reject whitespace errors
+        run: git diff --check ${{ github.event.pull_request.base.sha }}...HEAD
+
+      - name: Lint capture surfaces with zero warnings
+        run: |
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish \
+            src/app.module.ts \
+            src/care-events/care-event.types.ts \
+            src/care-events/care-events.service.ts \
+            src/common/time/iana-timezone.ts \
+            src/common/time/iana-timezone.spec.ts \
+            src/households/households.service.ts \
+            src/intelligence/daily-signals-local-day-policy-v1.ts \
+            src/intelligence/daily-signals-local-day-policy-v1.spec.ts \
+            src/intelligence/daily-signals.types.ts \
+            src/intelligence/dto/daily-signals.dto.ts \
+            src/intelligence/daily-signals.service.ts \
+            src/intelligence/daily-signals.integration.spec.ts \
+            src/intelligence/intelligence.controller.ts \
+            src/intelligence/intelligence.module.ts
+
+      - name: Enforce capture authority, privacy and local-day invariants
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          controller = Path('apps/api/src/intelligence/intelligence.controller.ts').read_text()
+          dto = Path('apps/api/src/intelligence/dto/daily-signals.dto.ts').read_text()
+          service = Path('apps/api/src/intelligence/daily-signals.service.ts').read_text()
+          local_day = Path('apps/api/src/intelligence/daily-signals-local-day-policy-v1.ts').read_text()
+          care_types = Path('apps/api/src/care-events/care-event.types.ts').read_text()
+          care_service = Path('apps/api/src/care-events/care-events.service.ts').read_text()
+          household = Path('apps/api/src/households/households.service.ts').read_text()
+          timezone = Path('apps/api/src/common/time/iana-timezone.ts').read_text()
+          spec = Path('apps/api/src/intelligence/daily-signals.integration.spec.ts').read_text()
+
+          required_controller = [
+              "@Controller('intelligence')",
+              "@Post('daily-signals')",
+              '@UseGuards(JwtAuthGuard)',
+              'dailySignals.capture(req.user.sub, dto)',
+          ]
+          missing = [token for token in required_controller if token not in controller]
+          if missing:
+              raise SystemExit(f'missing Daily Signals HTTP authority invariant: {missing}')
+
+          if 'localDate' in dto or 'timezone' in dto:
+              raise SystemExit('client DTO must never accept authoritative localDate/timezone')
+          dto_required = ['householdId', 'petId', 'observedAt', '@MaxLength(500)', 'signals']
+          missing = [token for token in dto_required if token not in dto]
+          if missing:
+              raise SystemExit(f'Daily Signals DTO contract drifted: {missing}')
+
+          local_day_required = [
+              "version: 'daily-signals-local-day-v1'",
+              "futureTimestampPolicy: 'CLAMP_TO_SERVER_NOW'",
+              "timezoneAuthority: 'HOUSEHOLD_IANA'",
+              'canonicalIanaTimeZone(input.householdTimezone)',
+              'requestedMs > nowMs',
+              'localDateInTimeZone(observedAt, timezone)',
+              'householdId',
+              'petId',
+              'localDate',
+          ]
+          missing = [token for token in local_day_required if token not in local_day]
+          if missing:
+              raise SystemExit(f'local-day authority contract drifted: {missing}')
+
+          timezone_required = ['Intl.DateTimeFormat', 'timeZone', 'formatToParts']
+          missing = [token for token in timezone_required if token not in timezone]
+          if missing:
+              raise SystemExit(f'IANA timezone utility drifted: {missing}')
+
+          if "export type CareEventDedupeScope = 'USER' | 'PET'" not in care_types:
+              raise SystemExit('CareEvent PET dedupe scope is missing')
+          care_required = [
+              "dedupeScope === 'PET'",
+              'pg_advisory_xact_lock',
+              'petDedupeIdentity',
+              'pet_id = ${input.petId}',
+              'event_type = ${input.eventType}',
+              'dedupe_key = ${input.dedupeKey}',
+              'getAuthorizedEvent',
+          ]
+          missing = [token for token in care_required if token not in care_service]
+          if missing:
+              raise SystemExit(f'cross-member canonical CareEvent dedupe is incomplete: {missing}')
+
+          household_required = [
+              'assertHouseholdPetAccessible',
+              'canonicalIanaTimeZone(dto.timezone)',
+              "throw new NotFoundException('Pet not found')",
+              'dogos-personal-household:',
+              'pg_advisory_xact_lock',
+              'householdId === this.personalHouseholdId(userId)',
+          ]
+          missing = [token for token in household_required if token not in household]
+          if missing:
+              raise SystemExit(f'household/timezone/bootstrap authority drifted: {missing}')
+
+          capture_required = [
+              "version: 'daily-signals-capture-v1'",
+              "eventType: 'DAILY_SIGNALS_CHECKIN'",
+              "visibility: 'PRIVATE'",
+              "dedupeScope: 'PET'",
+              'canonicalPayloadHash',
+              'payloadHash',
+              "safetyEligible: false",
+              "evidenceType: 'SELF_REPORT'",
+              'replayCanonicalDailySignalsEvent',
+              'normalizeOwnerCheckinObservation',
+              "choice === 'UNSURE'",
+          ]
+          missing = [token for token in capture_required if token not in service]
+          if missing:
+              raise SystemExit(f'canonical capture/replay contract drifted: {missing}')
+
+          if 'note,' in service[service.index('normalizeOwnerCheckinObservation'):]:
+              raise SystemExit('private free-form note must not enter normalized projection candidates')
+
+          regression_required = [
+              '20 simultaneous cross-member retries',
+              'conflicts on different answers',
+              'repairs a partially missing projection',
+              "!('note' in row.context)",
+              'keeps two pets isolated',
+              'removed household members',
+              'clamps future timestamps',
+          ]
+          missing = [token for token in regression_required if token not in spec]
+          if missing:
+              raise SystemExit(f'missing capture concurrency/privacy regression: {missing}')
+          PY
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Run local-day, capture, projection and CareEvent contracts
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/common/time/iana-timezone.spec.ts
+          src/intelligence/daily-signals-local-day-policy-v1.spec.ts
+          src/intelligence/daily-signals.integration.spec.ts
+          src/intelligence/evidence-normalization-v1.spec.ts
+          src/intelligence/intelligence-projection.integration.spec.ts
+          src/care-events/care-events.integration.spec.ts
+
+      - name: Build production API
+        run: pnpm --filter @woof/api build
+
+      - name: Build production API image
+        run: docker build --pull -f infra/docker/Dockerfile.api -t woof-api-daily-signals:ci .
+
+      - name: Boot production API image
+        run: |
+          docker rm -f woof-api-daily-signals-ci >/dev/null 2>&1 || true
+          docker run -d \
+            --name woof-api-daily-signals-ci \
+            --network host \
+            -e DATABASE_URL="$DATABASE_URL" \
+            -e SHADOW_DATABASE_URL="$SHADOW_DATABASE_URL" \
+            -e JWT_SECRET="$JWT_SECRET" \
+            -e NODE_ENV=production \
+            -e API_DOCS_ENABLED=false \
+            -e ML_SERVICE_ENABLED=false \
+            woof-api-daily-signals:ci
+
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent --show-error \
+              http://127.0.0.1:4000/api/v1/ops/health/live >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          docker logs woof-api-daily-signals-ci
+          exit 1
+
+      - name: Prove production HTTP retry identity and conflict semantics
+        run: |
+          node <<'NODE'
+          const base = 'http://127.0.0.1:4000/api/v1';
+          const paceMs = 450;
+          const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+          async function request(path, { token, ...options } = {}) {
+            await sleep(paceMs);
+            const response = await fetch(`${base}${path}`, {
+              ...options,
+              headers: {
+                'content-type': 'application/json',
+                ...(token ? { authorization: `Bearer ${token}` } : {}),
+                ...(options.headers ?? {}),
+              },
+            });
+            const text = await response.text();
+            let body = null;
+            if (text) {
+              try {
+                body = JSON.parse(text);
+              } catch {
+                body = text;
+              }
+            }
+            return { status: response.status, body };
+          }
+
+          function requireStatus(result, accepted, label) {
+            if (!accepted.includes(result.status)) {
+              throw new Error(`${label} expected ${accepted.join('/')} but got ${result.status}: ${JSON.stringify(result.body)}`);
+            }
+          }
+
+          const suffix = Date.now().toString(36);
+          const registered = await request('/auth/register', {
+            method: 'POST',
+            body: JSON.stringify({
+              handle: `dailyci${suffix}`.slice(0, 30),
+              email: `daily-ci-${suffix}@example.test`,
+              password: 'DailySignalsCI123!',
+            }),
+          });
+          requireStatus(registered, [200, 201], 'register');
+          const token = registered.body?.access_token;
+          if (!token) throw new Error('register did not return access_token');
+
+          const petResult = await request('/pets', {
+            token,
+            method: 'POST',
+            body: JSON.stringify({ name: 'Daily Signals CI Dog', species: 'DOG' }),
+          });
+          requireStatus(petResult, [200, 201], 'create pet');
+          const petId = petResult.body?.id;
+          if (!petId) throw new Error('create pet did not return pet id');
+
+          const householdResult = await request('/households/me', { token });
+          requireStatus(householdResult, [200], 'get households');
+          if (!Array.isArray(householdResult.body)) {
+            throw new Error('households/me did not return an array');
+          }
+          const household =
+            householdResult.body.find((candidate) =>
+              candidate?.pets?.some((link) => link?.pet?.id === petId)
+            ) ?? householdResult.body[0];
+          const householdId = household?.id;
+          if (!householdId) throw new Error('could not resolve personal household');
+
+          const timezoneResult = await request(`/households/${householdId}`, {
+            token,
+            method: 'PATCH',
+            body: JSON.stringify({ timezone: 'America/Los_Angeles' }),
+          });
+          requireStatus(timezoneResult, [200], 'set household timezone');
+          if (timezoneResult.body?.timezone !== 'America/Los_Angeles') {
+            throw new Error(`household timezone was not canonical: ${JSON.stringify(timezoneResult.body)}`);
+          }
+
+          const captureBody = {
+            householdId,
+            petId,
+            observedAt: '2026-08-25T18:00:00.000Z',
+            signals: {
+              appetite: 'USUAL',
+              energy: 'MORE',
+              mobilityComfort: 'USUAL',
+              sleepRest: 'UNSURE',
+            },
+            note: 'production retry proof',
+          };
+
+          const first = await request('/intelligence/daily-signals', {
+            token,
+            method: 'POST',
+            body: JSON.stringify(captureBody),
+          });
+          requireStatus(first, [200, 201], 'first Daily Signals capture');
+          if (first.body?.duplicate !== false) {
+            throw new Error(`first capture must be canonical: ${JSON.stringify(first.body)}`);
+          }
+          if (first.body?.localDate !== '2026-08-25') {
+            throw new Error(`server-derived local date drifted: ${JSON.stringify(first.body)}`);
+          }
+          if (first.body?.timezone !== 'America/Los_Angeles') {
+            throw new Error(`capture timezone drifted: ${JSON.stringify(first.body)}`);
+          }
+
+          const retry = await request('/intelligence/daily-signals', {
+            token,
+            method: 'POST',
+            body: JSON.stringify(captureBody),
+          });
+          requireStatus(retry, [200, 201], 'Daily Signals retry');
+          if (retry.body?.duplicate !== true || retry.body?.careEventId !== first.body?.careEventId) {
+            throw new Error(`retry did not converge on canonical CareEvent: ${JSON.stringify({ first: first.body, retry: retry.body })}`);
+          }
+
+          const divergent = await request('/intelligence/daily-signals', {
+            token,
+            method: 'POST',
+            body: JSON.stringify({
+              ...captureBody,
+              signals: { ...captureBody.signals, appetite: 'MORE' },
+            }),
+          });
+          requireStatus(divergent, [409], 'divergent same-day capture');
+
+          console.log(
+            JSON.stringify({
+              event: 'daily_signals_production_http_proof',
+              careEventId: first.body.careEventId,
+              retryDuplicate: retry.body.duplicate,
+              localDate: first.body.localDate,
+              divergentStatus: divergent.status,
+            })
+          );
+          NODE
+
+      - name: Show production API logs on failure
+        if: failure()
+        run: docker logs woof-api-daily-signals-ci || true
+
+      - name: Remove production API container
+        if: always()
+        run: docker rm -f woof-api-daily-signals-ci >/dev/null 2>&1 || true

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -27,6 +27,7 @@ import { GoalsModule } from './goals/goals.module';
 import { HealthLensModule } from './health-lens/health-lens.module';
 import { HouseholdsModule } from './households/households.module';
 import { InsightsModule } from './insights/insights.module';
+import { IntelligenceModule } from './intelligence/intelligence.module';
 import { MediaLibraryModule } from './media-library/media-library.module';
 import { MeetupProposalsModule } from './meetup-proposals/meetup-proposals.module';
 import { MeetupsModule } from './meetups/meetups.module';
@@ -73,6 +74,7 @@ export const throttlerOptions: ThrottlerModuleOptions = {
     UsersModule,
     PetsModule,
     HouseholdsModule,
+    IntelligenceModule,
     ActivitiesModule,
     AdventureModule,
     AutopilotModule,

--- a/apps/api/src/care-events/care-event.types.ts
+++ b/apps/api/src/care-events/care-event.types.ts
@@ -32,6 +32,8 @@ export type EvidenceType =
   | 'CLINIC'
   | 'WEARABLE';
 
+export type CareEventDedupeScope = 'USER' | 'PET';
+
 export type CareEventInput = {
   userId: string;
   petId?: string | null;
@@ -44,8 +46,25 @@ export type CareEventInput = {
   context?: Record<string, unknown>;
   outcome?: Record<string, unknown>;
   dedupeKey: string;
+  dedupeScope?: CareEventDedupeScope;
   visibility?: 'PRIVATE' | 'HOUSEHOLD' | 'FRIENDS';
   safetyEligible?: boolean;
+};
+
+export type CanonicalCareEventRecord = {
+  id: string;
+  userId: string;
+  petId: string | null;
+  eventType: string;
+  pathway: WellbeingPathway;
+  occurredAt: string;
+  source: string;
+  evidenceType: EvidenceType | null;
+  evidenceConfidence: number;
+  context: Record<string, unknown>;
+  outcome: Record<string, unknown>;
+  dedupeKey: string;
+  visibility: 'PRIVATE' | 'HOUSEHOLD' | 'FRIENDS';
 };
 
 export type RewardReceipt = {

--- a/apps/api/src/care-events/care-events.service.ts
+++ b/apps/api/src/care-events/care-events.service.ts
@@ -1,12 +1,14 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@woof/database';
 import { randomUUID } from 'node:crypto';
 import { HouseholdsService } from '../households/households.service';
 import { PrismaService } from '../prisma/prisma.service';
 import {
   WELLBEING_PATHWAYS,
+  type CanonicalCareEventRecord,
   type CareEventInput,
   type CareSummary,
+  type EvidenceType,
   type RewardReceipt,
   type WellbeingPathway,
 } from './care-event.types';
@@ -18,6 +20,22 @@ type EventRow = {
   pathway: WellbeingPathway;
   occurred_at: Date;
   outcome: Record<string, unknown> | null;
+};
+
+type CanonicalEventRow = {
+  id: string;
+  user_id: string;
+  pet_id: string | null;
+  event_type: string;
+  pathway: WellbeingPathway;
+  occurred_at: Date;
+  source: string;
+  evidence_type: EvidenceType | null;
+  evidence_confidence: number;
+  context: Record<string, unknown> | null;
+  outcome: Record<string, unknown> | null;
+  dedupe_key: string;
+  visibility: 'PRIVATE' | 'HOUSEHOLD' | 'FRIENDS';
 };
 
 type LedgerRow = {
@@ -69,6 +87,11 @@ export class CareEventsService {
   async record(input: CareEventInput): Promise<RewardReceipt> {
     if (input.petId) await this.households.assertPetAccessible(input.userId, input.petId);
 
+    const dedupeScope = input.dedupeScope ?? 'USER';
+    if (dedupeScope === 'PET' && !input.petId) {
+      throw new BadRequestException('Pet-scoped CareEvent dedupe requires a pet');
+    }
+
     const now = new Date();
     const requestedOccurrenceMs = input.occurredAt?.getTime();
     const occurrenceTimestampNormalized =
@@ -82,8 +105,23 @@ export class CareEventsService {
     const visibility = input.visibility ?? 'PRIVATE';
 
     const receipt = await this.prisma.$transaction(async (tx) => {
+      if (dedupeScope === 'PET') {
+        // Cross-member Daily Signals retries can arrive under different user IDs and
+        // even on different API processes. Serialize the logical pet-scoped identity
+        // in PostgreSQL before looking for an existing event. This lock is acquired
+        // before the per-user reward lock everywhere PET scope is used, avoiding a
+        // reverse lock ordering cycle.
+        const petDedupeIdentity = `care-event:pet:${input.petId}:${input.eventType}:${input.dedupeKey}`;
+        await tx.$queryRaw<Array<{ acquired: number }>>(Prisma.sql`
+          WITH lock_row AS MATERIALIZED (
+            SELECT pg_advisory_xact_lock(hashtextextended(${petDedupeIdentity}, 0))
+          )
+          SELECT 1::int AS acquired FROM lock_row
+        `);
+      }
+
       // Serialize reward issuance for one user so concurrent legitimate requests cannot
-      // race daily/pathway caps or a shared dedupe key. pg_advisory_xact_lock returns
+      // race daily/pathway caps or a user-scoped dedupe key. pg_advisory_xact_lock returns
       // PostgreSQL's `void` pseudo-type, which Prisma cannot deserialize directly, so
       // materialize the lock call and expose only a supported integer scalar.
       await tx.$queryRaw<Array<{ acquired: number }>>(Prisma.sql`
@@ -93,10 +131,14 @@ export class CareEventsService {
         SELECT 1::int AS acquired FROM lock_row
       `);
 
+      const existingPredicate =
+        dedupeScope === 'PET'
+          ? Prisma.sql`pet_id = ${input.petId} AND event_type = ${input.eventType} AND dedupe_key = ${input.dedupeKey}`
+          : Prisma.sql`user_id = ${input.userId} AND dedupe_key = ${input.dedupeKey}`;
       const existing = await tx.$queryRaw<EventRow[]>(Prisma.sql`
         SELECT id, event_type, pathway, occurred_at, outcome
         FROM care_events
-        WHERE user_id = ${input.userId} AND dedupe_key = ${input.dedupeKey}
+        WHERE ${existingPredicate}
         LIMIT 1
       `);
 
@@ -208,12 +250,59 @@ export class CareEventsService {
         pathway: receipt.pathway,
         bondXp: receipt.bondXp,
         duplicate: receipt.duplicate,
+        dedupeScope,
         policyVersion: receipt.policyVersion,
         occurrenceTimestampNormalized,
       })
     );
 
     return receipt;
+  }
+
+  async getAuthorizedEvent(userId: string, eventId: string): Promise<CanonicalCareEventRecord> {
+    const rows = await this.prisma.$queryRaw<CanonicalEventRow[]>(Prisma.sql`
+      SELECT
+        id,
+        user_id,
+        pet_id,
+        event_type,
+        pathway,
+        occurred_at,
+        source,
+        evidence_type,
+        evidence_confidence,
+        context,
+        outcome,
+        dedupe_key,
+        visibility
+      FROM care_events
+      WHERE id = ${eventId}
+      LIMIT 1
+    `);
+    const row = rows[0];
+    if (!row) throw new NotFoundException('CareEvent not found');
+
+    if (row.pet_id) {
+      await this.households.assertPetAccessible(userId, row.pet_id);
+    } else if (row.user_id !== userId) {
+      throw new NotFoundException('CareEvent not found');
+    }
+
+    return {
+      id: row.id,
+      userId: row.user_id,
+      petId: row.pet_id,
+      eventType: row.event_type,
+      pathway: row.pathway,
+      occurredAt: row.occurred_at.toISOString(),
+      source: row.source,
+      evidenceType: row.evidence_type,
+      evidenceConfidence: row.evidence_confidence,
+      context: row.context ?? {},
+      outcome: row.outcome ?? {},
+      dedupeKey: row.dedupe_key,
+      visibility: row.visibility,
+    };
   }
 
   async recordQuestInteraction(input: {

--- a/apps/api/src/common/time/iana-timezone.spec.ts
+++ b/apps/api/src/common/time/iana-timezone.spec.ts
@@ -1,0 +1,45 @@
+import { canonicalIanaTimeZone, localDateInTimeZone } from './iana-timezone';
+
+describe('IANA timezone utilities', () => {
+  it('canonicalizes valid zones and rejects invalid zones', () => {
+    expect(canonicalIanaTimeZone(' America/Los_Angeles ')).toBe('America/Los_Angeles');
+    expect(() => canonicalIanaTimeZone('Mars/Olympus')).toThrow('valid IANA timezone');
+    expect(() => canonicalIanaTimeZone('')).toThrow('valid IANA timezone');
+  });
+
+  it('derives calendar dates across the spring DST jump', () => {
+    expect(localDateInTimeZone('2026-03-08T09:59:59.000Z', 'America/Los_Angeles')).toBe(
+      '2026-03-08'
+    );
+    expect(localDateInTimeZone('2026-03-08T10:00:00.000Z', 'America/Los_Angeles')).toBe(
+      '2026-03-08'
+    );
+  });
+
+  it('keeps both repeated fall-back hours on the same local day', () => {
+    expect(localDateInTimeZone('2026-11-01T08:30:00.000Z', 'America/Los_Angeles')).toBe(
+      '2026-11-01'
+    );
+    expect(localDateInTimeZone('2026-11-01T09:30:00.000Z', 'America/Los_Angeles')).toBe(
+      '2026-11-01'
+    );
+  });
+
+  it('changes the date exactly at local midnight', () => {
+    expect(localDateInTimeZone('2026-08-25T06:59:59.999Z', 'America/Los_Angeles')).toBe(
+      '2026-08-24'
+    );
+    expect(localDateInTimeZone('2026-08-25T07:00:00.000Z', 'America/Los_Angeles')).toBe(
+      '2026-08-25'
+    );
+  });
+
+  it('works for non-US timezone boundaries', () => {
+    expect(localDateInTimeZone('2026-08-25T14:59:59.999Z', 'Asia/Tokyo')).toBe('2026-08-25');
+    expect(localDateInTimeZone('2026-08-25T15:00:00.000Z', 'Asia/Tokyo')).toBe('2026-08-26');
+  });
+
+  it('rejects invalid instants', () => {
+    expect(() => localDateInTimeZone('not-a-date', 'America/Los_Angeles')).toThrow('valid instant');
+  });
+});

--- a/apps/api/src/common/time/iana-timezone.ts
+++ b/apps/api/src/common/time/iana-timezone.ts
@@ -1,0 +1,38 @@
+const MAX_TIMEZONE_LENGTH = 80;
+
+export function canonicalIanaTimeZone(value: string): string {
+  const timezone = value.trim();
+  if (!timezone || timezone.length > MAX_TIMEZONE_LENGTH) {
+    throw new RangeError('A valid IANA timezone is required');
+  }
+
+  try {
+    return new Intl.DateTimeFormat('en-US', { timeZone: timezone }).resolvedOptions().timeZone;
+  } catch {
+    throw new RangeError('A valid IANA timezone is required');
+  }
+}
+
+export function localDateInTimeZone(instant: Date | string, timezone: string): string {
+  const date = instant instanceof Date ? new Date(instant.getTime()) : new Date(instant);
+  if (!Number.isFinite(date.getTime())) {
+    throw new RangeError('A valid instant is required');
+  }
+
+  const canonicalTimezone = canonicalIanaTimeZone(timezone);
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: canonicalTimezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+
+  const year = parts.find((part) => part.type === 'year')?.value;
+  const month = parts.find((part) => part.type === 'month')?.value;
+  const day = parts.find((part) => part.type === 'day')?.value;
+  if (!year || !month || !day) {
+    throw new RangeError('Unable to derive a local calendar date');
+  }
+
+  return `${year}-${month}-${day}`;
+}

--- a/apps/api/src/households/households.service.spec.ts
+++ b/apps/api/src/households/households.service.spec.ts
@@ -15,6 +15,7 @@ describe('HouseholdsService', () => {
 
   function createHarness() {
     const tx = {
+      $queryRaw: jest.fn().mockResolvedValue([{ acquired: 1 }]),
       household: {
         upsert: jest.fn().mockResolvedValue({}),
       },
@@ -76,7 +77,7 @@ describe('HouseholdsService', () => {
     expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
-  it('bootstraps the owner and all existing owned pets into a missing personal household', async () => {
+  it('serializes bootstrap before creating the owner and existing pets', async () => {
     const { prisma, service, tx } = createHarness();
     const expectedId = deterministicHouseholdId(userId);
     prisma.householdMember.findUnique.mockResolvedValue(null);
@@ -84,6 +85,10 @@ describe('HouseholdsService', () => {
 
     await expect(service.ensurePersonalHousehold(userId)).resolves.toBe(expectedId);
 
+    expect(tx.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(tx.$queryRaw.mock.invocationCallOrder[0]).toBeLessThan(
+      tx.household.upsert.mock.invocationCallOrder[0]!
+    );
     expect(tx.household.upsert).toHaveBeenCalledWith({
       where: { id: expectedId },
       update: {},

--- a/apps/api/src/households/households.service.ts
+++ b/apps/api/src/households/households.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { createHash } from 'crypto';
 import { Prisma } from '@woof/database';
+import { canonicalIanaTimeZone } from '../common/time/iana-timezone';
 import { PrismaService } from '../prisma/prisma.service';
 import { UpdateHouseholdDto } from './dto/household.dto';
 
@@ -73,7 +74,7 @@ export class HouseholdsService {
     // A dogOS account always owns one deterministic personal household. Do not
     // use the user's first active membership here: once household invitations
     // exist, that could attach a newly created pet to somebody else's household.
-    const householdId = this.deterministicUuid(`dogos-household:${userId}`);
+    const householdId = this.personalHouseholdId(userId);
     const existing = await this.prisma.householdMember.findUnique({
       where: {
         householdId_userId: {
@@ -89,6 +90,17 @@ export class HouseholdsService {
     }
 
     await this.prisma.$transaction(async (tx) => {
+      // Prisma's read-then-write upsert path can race when the deterministic
+      // household does not exist yet. Serialize bootstrap across API workers so
+      // only one transaction can create/repair this user's personal household.
+      const bootstrapIdentity = `dogos-personal-household:${userId}`;
+      await tx.$queryRaw<Array<{ acquired: number }>>(Prisma.sql`
+        WITH lock_row AS MATERIALIZED (
+          SELECT pg_advisory_xact_lock(hashtextextended(${bootstrapIdentity}, 0))
+        )
+        SELECT 1::int AS acquired FROM lock_row
+      `);
+
       await tx.household.upsert({
         where: { id: householdId },
         update: {},
@@ -143,11 +155,20 @@ export class HouseholdsService {
   async update(userId: string, householdId: string, dto: UpdateHouseholdDto) {
     await this.assertCanManage(userId, householdId);
 
+    let timezone: string | undefined;
+    if (dto.timezone !== undefined) {
+      try {
+        timezone = canonicalIanaTimeZone(dto.timezone);
+      } catch {
+        throw new BadRequestException('Household timezone must be a valid IANA timezone');
+      }
+    }
+
     return this.prisma.household.update({
       where: { id: householdId },
       data: {
         ...(dto.name !== undefined ? { name: dto.name.trim() } : {}),
-        ...(dto.timezone !== undefined ? { timezone: dto.timezone.trim() } : {}),
+        ...(timezone !== undefined ? { timezone } : {}),
       },
     });
   }
@@ -257,6 +278,46 @@ export class HouseholdsService {
     return pet;
   }
 
+  async assertHouseholdPetAccessible(userId: string, householdId: string, petId: string) {
+    // Legacy owner/pet rows need repair only when the caller explicitly targets
+    // that user's deterministic personal household. Checking a shared household
+    // must not create or mutate the member's unrelated personal household.
+    if (householdId === this.personalHouseholdId(userId)) {
+      await this.ensurePersonalHousehold(userId);
+    }
+
+    const membership = await this.prisma.householdMember.findFirst({
+      where: {
+        userId,
+        householdId,
+        status: 'ACTIVE',
+        household: {
+          pets: {
+            some: {
+              petId,
+              status: 'ACTIVE',
+            },
+          },
+        },
+      },
+      select: {
+        household: {
+          select: {
+            id: true,
+            timezone: true,
+          },
+        },
+      },
+    });
+
+    if (!membership) throw new NotFoundException('Pet not found');
+    return {
+      householdId: membership.household.id,
+      petId,
+      timezone: membership.household.timezone,
+    };
+  }
+
   async resolveActivityHousehold(
     userId: string,
     petIds: string[],
@@ -341,6 +402,10 @@ export class HouseholdsService {
     if (!['OWNER', 'ADMIN'].includes(membership.role)) {
       throw new ForbiddenException('Household manager access required');
     }
+  }
+
+  private personalHouseholdId(userId: string) {
+    return this.deterministicUuid(`dogos-household:${userId}`);
   }
 
   private deterministicUuid(input: string) {

--- a/apps/api/src/intelligence/daily-signals-local-day-policy-v1.spec.ts
+++ b/apps/api/src/intelligence/daily-signals-local-day-policy-v1.spec.ts
@@ -1,0 +1,105 @@
+import {
+  DAILY_SIGNALS_LOCAL_DAY_POLICY_V1,
+  dailySignalsDedupeKey,
+  resolveDailySignalsTime,
+} from './daily-signals-local-day-policy-v1';
+
+describe('daily-signals-local-day-v1', () => {
+  const now = new Date('2026-08-26T18:00:00.000Z');
+
+  it('pins the server-authoritative household clock policy', () => {
+    expect(DAILY_SIGNALS_LOCAL_DAY_POLICY_V1).toEqual({
+      version: 'daily-signals-local-day-v1',
+      dedupePrefix: 'daily-signals-v1',
+      futureTimestampPolicy: 'CLAMP_TO_SERVER_NOW',
+      timezoneAuthority: 'HOUSEHOLD_IANA',
+    });
+  });
+
+  it('preserves an offline observation on its historical household-local day', () => {
+    expect(
+      resolveDailySignalsTime({
+        requestedObservedAt: '2026-08-25T18:00:00.000Z',
+        householdTimezone: 'America/Los_Angeles',
+        now,
+      })
+    ).toEqual({
+      observedAt: '2026-08-25T18:00:00.000Z',
+      localDate: '2026-08-25',
+      timezone: 'America/Los_Angeles',
+      futureTimestampNormalized: false,
+    });
+  });
+
+  it('clamps a future client timestamp before deriving the local day', () => {
+    expect(
+      resolveDailySignalsTime({
+        requestedObservedAt: '2026-09-01T00:00:00.000Z',
+        householdTimezone: 'America/Los_Angeles',
+        now,
+      })
+    ).toEqual({
+      observedAt: '2026-08-26T18:00:00.000Z',
+      localDate: '2026-08-26',
+      timezone: 'America/Los_Angeles',
+      futureTimestampNormalized: true,
+    });
+  });
+
+  it('derives the default observation from server now rather than the client', () => {
+    expect(
+      resolveDailySignalsTime({
+        householdTimezone: 'Asia/Tokyo',
+        now: new Date('2026-08-25T15:00:00.000Z'),
+      })
+    ).toEqual({
+      observedAt: '2026-08-25T15:00:00.000Z',
+      localDate: '2026-08-26',
+      timezone: 'Asia/Tokyo',
+      futureTimestampNormalized: false,
+    });
+  });
+
+  it('keeps the same logical date through both fall-back repeated hours', () => {
+    const first = resolveDailySignalsTime({
+      requestedObservedAt: '2026-11-01T08:30:00.000Z',
+      householdTimezone: 'America/Los_Angeles',
+      now: new Date('2026-11-02T00:00:00.000Z'),
+    });
+    const second = resolveDailySignalsTime({
+      requestedObservedAt: '2026-11-01T09:30:00.000Z',
+      householdTimezone: 'America/Los_Angeles',
+      now: new Date('2026-11-02T00:00:00.000Z'),
+    });
+    expect(first.localDate).toBe('2026-11-01');
+    expect(second.localDate).toBe('2026-11-01');
+  });
+
+  it('makes actor-independent pet + household + local-day identities', () => {
+    expect(
+      dailySignalsDedupeKey({
+        householdId: '11111111-1111-1111-1111-111111111111',
+        petId: '22222222-2222-2222-2222-222222222222',
+        localDate: '2026-08-25',
+      })
+    ).toBe(
+      'daily-signals-v1:11111111-1111-1111-1111-111111111111:22222222-2222-2222-2222-222222222222:2026-08-25'
+    );
+  });
+
+  it('rejects invalid household clocks and malformed observedAt inputs', () => {
+    expect(() =>
+      resolveDailySignalsTime({
+        householdTimezone: 'Mars/Olympus',
+        now,
+      })
+    ).toThrow('valid IANA timezone');
+    expect(() =>
+      resolveDailySignalsTime({
+        requestedObservedAt: 'yesterday-ish',
+        householdTimezone: 'America/Los_Angeles',
+        now,
+      })
+    ).toThrow('valid ISO timestamp');
+  });
+});

--- a/apps/api/src/intelligence/daily-signals-local-day-policy-v1.ts
+++ b/apps/api/src/intelligence/daily-signals-local-day-policy-v1.ts
@@ -1,0 +1,51 @@
+import { canonicalIanaTimeZone, localDateInTimeZone } from '../common/time/iana-timezone';
+
+export const DAILY_SIGNALS_LOCAL_DAY_POLICY_V1 = Object.freeze({
+  version: 'daily-signals-local-day-v1' as const,
+  dedupePrefix: 'daily-signals-v1' as const,
+  futureTimestampPolicy: 'CLAMP_TO_SERVER_NOW' as const,
+  timezoneAuthority: 'HOUSEHOLD_IANA' as const,
+});
+
+export type DailySignalsResolvedTime = {
+  observedAt: string;
+  localDate: string;
+  timezone: string;
+  futureTimestampNormalized: boolean;
+};
+
+export function resolveDailySignalsTime(input: {
+  requestedObservedAt?: string;
+  householdTimezone: string;
+  now: Date;
+}): DailySignalsResolvedTime {
+  const nowMs = input.now.getTime();
+  if (!Number.isFinite(nowMs)) throw new RangeError('A valid server now is required');
+
+  const timezone = canonicalIanaTimeZone(input.householdTimezone);
+  const requestedMs =
+    input.requestedObservedAt === undefined ? nowMs : Date.parse(input.requestedObservedAt);
+  if (!Number.isFinite(requestedMs)) {
+    throw new RangeError('Daily Signals observedAt must be a valid ISO timestamp');
+  }
+
+  const futureTimestampNormalized = requestedMs > nowMs;
+  const observedAt = new Date(futureTimestampNormalized ? nowMs : requestedMs);
+  return {
+    observedAt: observedAt.toISOString(),
+    localDate: localDateInTimeZone(observedAt, timezone),
+    timezone,
+    futureTimestampNormalized,
+  };
+}
+
+export function dailySignalsDedupeKey(input: {
+  householdId: string;
+  petId: string;
+  localDate: string;
+}): string {
+  if (!input.householdId || !input.petId || !/^\d{4}-\d{2}-\d{2}$/.test(input.localDate)) {
+    throw new RangeError('Daily Signals dedupe identity is invalid');
+  }
+  return `${DAILY_SIGNALS_LOCAL_DAY_POLICY_V1.dedupePrefix}:${input.householdId}:${input.petId}:${input.localDate}`;
+}

--- a/apps/api/src/intelligence/daily-signals.integration.spec.ts
+++ b/apps/api/src/intelligence/daily-signals.integration.spec.ts
@@ -1,0 +1,357 @@
+import { randomUUID } from 'node:crypto';
+import { Prisma } from '@woof/database';
+import { CareEventsService } from '../care-events/care-events.service';
+import { HouseholdsService } from '../households/households.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { DailySignalsService } from './daily-signals.service';
+import type { CreateDailySignalsDto } from './dto/daily-signals.dto';
+import { IntelligenceProjectionService } from './intelligence-projection.service';
+
+type Fixture = {
+  ownerId: string;
+  memberId: string;
+  petId: string;
+  householdId: string;
+};
+
+describe('DailySignalsService integration', () => {
+  const prisma = new PrismaService();
+  const households = new HouseholdsService(prisma);
+  const careEvents = new CareEventsService(prisma, households);
+  const projection = new IntelligenceProjectionService(prisma, households);
+  const service = new DailySignalsService(households, careEvents, projection);
+  const usersToDelete: string[] = [];
+  const householdsToDelete: string[] = [];
+
+  beforeAll(async () => {
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    if (householdsToDelete.length > 0) {
+      await prisma.household.deleteMany({ where: { id: { in: householdsToDelete } } });
+    }
+    if (usersToDelete.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: usersToDelete } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  async function createUser(label: string) {
+    const suffix = randomUUID().slice(0, 8);
+    const user = await prisma.user.create({
+      data: {
+        handle: `daily-${label}-${suffix}`,
+        email: `daily-${label}-${suffix}@example.test`,
+      },
+      select: { id: true },
+    });
+    usersToDelete.push(user.id);
+    return user.id;
+  }
+
+  async function fixture(label: string, timezone: string | null = 'America/Los_Angeles') {
+    const ownerId = await createUser(`${label}-owner`);
+    const memberId = await createUser(`${label}-member`);
+    const pet = await prisma.pet.create({
+      data: {
+        ownerId,
+        name: `Daily ${label}`,
+        species: 'DOG',
+      },
+      select: { id: true },
+    });
+    const householdId = await households.ensurePersonalHousehold(ownerId);
+    householdsToDelete.push(householdId);
+
+    await prisma.household.update({
+      where: { id: householdId },
+      data: { timezone },
+    });
+    await prisma.householdMember.upsert({
+      where: { householdId_userId: { householdId, userId: memberId } },
+      update: { status: 'ACTIVE', role: 'MEMBER' },
+      create: { householdId, userId: memberId, status: 'ACTIVE', role: 'MEMBER' },
+    });
+
+    return { ownerId, memberId, petId: pet.id, householdId } satisfies Fixture;
+  }
+
+  function dto(
+    fixtureValue: Pick<Fixture, 'petId' | 'householdId'>,
+    overrides: Partial<CreateDailySignalsDto> = {}
+  ): CreateDailySignalsDto {
+    return {
+      householdId: fixtureValue.householdId,
+      petId: fixtureValue.petId,
+      observedAt: '2026-08-25T18:00:00.000Z',
+      signals: {
+        appetite: 'USUAL',
+        energy: 'MORE',
+        bathroomRoutine: 'USUAL',
+        mobilityComfort: 'LESS',
+        engagementSocialComfort: 'USUAL',
+        sleepRest: 'UNSURE',
+      },
+      note: 'A quiet morning after breakfast.',
+      ...overrides,
+    } as CreateDailySignalsDto;
+  }
+
+  it('converges 20 simultaneous cross-member retries on one private, zero-XP canonical event', async () => {
+    const value = await fixture('cross-member-race');
+    const input = dto(value);
+    const now = new Date('2026-08-26T00:00:00.000Z');
+
+    const receipts = await Promise.all(
+      Array.from({ length: 20 }, (_, index) =>
+        service.capture(index % 2 === 0 ? value.ownerId : value.memberId, input, now)
+      )
+    );
+
+    expect(receipts.filter((receipt) => !receipt.duplicate)).toHaveLength(1);
+    expect(receipts.filter((receipt) => receipt.duplicate)).toHaveLength(19);
+    expect(new Set(receipts.map((receipt) => receipt.careEventId)).size).toBe(1);
+    expect(new Set(receipts.map((receipt) => receipt.localDate)).size).toBe(1);
+
+    const careEventId = receipts[0]!.careEventId;
+    const eventRows = await prisma.$queryRaw<
+      Array<{
+        count: number;
+        bond_xp: number;
+        visibility: string;
+        event_type: string;
+        evidence_type: string | null;
+      }>
+    >(Prisma.sql`
+      SELECT
+        COUNT(*)::int AS count,
+        COALESCE(MAX(rl.bond_xp), 0)::int AS bond_xp,
+        MAX(ce.visibility) AS visibility,
+        MAX(ce.event_type) AS event_type,
+        MAX(ce.evidence_type) AS evidence_type
+      FROM care_events ce
+      LEFT JOIN reward_ledger rl ON rl.care_event_id = ce.id
+      WHERE ce.id = ${careEventId}
+    `);
+    expect(eventRows[0]).toMatchObject({
+      count: 1,
+      bond_xp: 0,
+      visibility: 'PRIVATE',
+      event_type: 'DAILY_SIGNALS_CHECKIN',
+      evidence_type: 'SELF_REPORT',
+    });
+
+    const sameDayRows = await prisma.$queryRaw<Array<{ count: number }>>(Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM care_events
+      WHERE pet_id = ${value.petId}
+        AND event_type = 'DAILY_SIGNALS_CHECKIN'
+        AND context->>'householdId' = ${value.householdId}
+        AND context->>'localDate' = '2026-08-25'
+    `);
+    expect(sameDayRows[0]?.count).toBe(1);
+
+    const projectionRows = await prisma.$queryRaw<
+      Array<{ dimension: string; context: Record<string, unknown> }>
+    >(Prisma.sql`
+      SELECT dimension, context
+      FROM dogos_intelligence.observations
+      WHERE source_event_id = ${careEventId}
+      ORDER BY dimension
+    `);
+    expect(projectionRows).toHaveLength(5);
+    expect(projectionRows.map((row) => row.dimension)).not.toContain('SLEEP_REST');
+    expect(projectionRows.every((row) => !('note' in row.context))).toBe(true);
+  });
+
+  it('makes the first accepted same-day payload canonical and conflicts on different answers', async () => {
+    const value = await fixture('payload-conflict');
+    const now = new Date('2026-08-26T00:00:00.000Z');
+    const ownerInput = dto(value, {
+      signals: { appetite: 'USUAL', energy: 'USUAL' },
+      note: 'Owner view',
+    });
+    const memberInput = dto(value, {
+      signals: { appetite: 'MORE', energy: 'USUAL' },
+      note: 'Member view',
+    });
+
+    const settled = await Promise.allSettled([
+      service.capture(value.ownerId, ownerInput, now),
+      service.capture(value.memberId, memberInput, now),
+    ]);
+    expect(settled.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+    expect(settled.filter((result) => result.status === 'rejected')).toHaveLength(1);
+
+    const rejected = settled.find((result) => result.status === 'rejected');
+    expect(rejected && rejected.status === 'rejected' ? String(rejected.reason) : '').toContain(
+      'different answers'
+    );
+
+    const rows = await prisma.$queryRaw<Array<{ count: number }>>(Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM care_events
+      WHERE pet_id = ${value.petId}
+        AND event_type = 'DAILY_SIGNALS_CHECKIN'
+    `);
+    expect(rows[0]?.count).toBe(1);
+  });
+
+  it('keeps two pets isolated on the same household-local day', async () => {
+    const value = await fixture('two-pet-isolation');
+    const secondPet = await prisma.pet.create({
+      data: {
+        ownerId: value.ownerId,
+        name: 'Daily second pet',
+        species: 'DOG',
+      },
+      select: { id: true },
+    });
+    await households.addOwnedPet(value.ownerId, value.householdId, secondPet.id);
+    const now = new Date('2026-08-26T00:00:00.000Z');
+
+    const first = await service.capture(value.ownerId, dto(value), now);
+    const second = await service.capture(
+      value.ownerId,
+      dto({ householdId: value.householdId, petId: secondPet.id }),
+      now
+    );
+
+    expect(first.careEventId).not.toBe(second.careEventId);
+    expect(first.localDate).toBe(second.localDate);
+
+    const rows = await prisma.$queryRaw<Array<{ pet_id: string }>>(Prisma.sql`
+      SELECT pet_id
+      FROM care_events
+      WHERE event_type = 'DAILY_SIGNALS_CHECKIN'
+        AND context->>'householdId' = ${value.householdId}
+        AND context->>'localDate' = '2026-08-25'
+      ORDER BY pet_id
+    `);
+    expect(new Set(rows.map((row) => row.pet_id))).toEqual(new Set([value.petId, secondPet.id]));
+  });
+
+  it('repairs a partially missing projection from the canonical CareEvent on retry', async () => {
+    const value = await fixture('replay-repair');
+    const input = dto(value, {
+      signals: { appetite: 'USUAL', energy: 'MORE', mobilityComfort: 'LESS' },
+      note: undefined,
+    });
+    const now = new Date('2026-08-26T00:00:00.000Z');
+    const first = await service.capture(value.ownerId, input, now);
+
+    await prisma.$executeRaw(Prisma.sql`
+      DELETE FROM dogos_intelligence.observations
+      WHERE source_event_id = ${first.careEventId}
+        AND dimension = 'ENERGY'
+    `);
+    const afterDelete = await prisma.$queryRaw<Array<{ count: number }>>(Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM dogos_intelligence.observations
+      WHERE source_event_id = ${first.careEventId}
+    `);
+    expect(afterDelete[0]?.count).toBe(2);
+
+    const retry = await service.capture(value.ownerId, input, now);
+    expect(retry.duplicate).toBe(true);
+    expect(retry.careEventId).toBe(first.careEventId);
+
+    const repaired = await prisma.$queryRaw<Array<{ count: number }>>(Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM dogos_intelligence.observations
+      WHERE source_event_id = ${first.careEventId}
+    `);
+    expect(repaired[0]?.count).toBe(3);
+  });
+
+  it('clamps future timestamps before choosing the household-local identity', async () => {
+    const value = await fixture('future-time');
+    const now = new Date();
+    const requested = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    const input = dto(value, { observedAt: requested, signals: { appetite: 'USUAL' } });
+
+    const receipt = await service.capture(value.ownerId, input, now);
+    expect(receipt.futureTimestampNormalized).toBe(true);
+    expect(receipt.timezone).toBe('America/Los_Angeles');
+
+    const canonical = await careEvents.getAuthorizedEvent(value.ownerId, receipt.careEventId);
+    expect(canonical.context.localDate).toBe(receipt.localDate);
+    expect(new Date(canonical.occurredAt).getTime()).toBeLessThanOrEqual(Date.now() + 1000);
+  });
+
+  it('fails closed for missing or invalid household timezone configuration', async () => {
+    const missing = await fixture('missing-zone', null);
+    await expect(service.capture(missing.ownerId, dto(missing))).rejects.toThrow(
+      'Household timezone is required'
+    );
+
+    const invalid = await fixture('invalid-zone');
+    await prisma.household.update({
+      where: { id: invalid.householdId },
+      data: { timezone: 'Mars/Olympus' },
+    });
+    await expect(service.capture(invalid.ownerId, dto(invalid))).rejects.toThrow(
+      'valid IANA timezone'
+    );
+  });
+
+  it('rejects unrelated and removed household members without a pet-existence leak', async () => {
+    const value = await fixture('authorization');
+    const outsiderId = await createUser('outsider');
+
+    await expect(service.capture(outsiderId, dto(value))).rejects.toThrow('Pet not found');
+
+    await prisma.householdMember.update({
+      where: {
+        householdId_userId: {
+          householdId: value.householdId,
+          userId: value.memberId,
+        },
+      },
+      data: { status: 'INACTIVE' },
+    });
+    await expect(service.capture(value.memberId, dto(value))).rejects.toThrow('Pet not found');
+
+    const ownerReceipt = await service.capture(value.ownerId, dto(value));
+    expect(ownerReceipt.petId).toBe(value.petId);
+  });
+
+  it('rejects invalid direct-service payloads', async () => {
+    const value = await fixture('payload-validation');
+
+    await expect(
+      service.capture(
+        value.ownerId,
+        dto(value, { signals: {} }),
+        new Date('2026-08-26T00:00:00.000Z')
+      )
+    ).rejects.toThrow('at least one answered dimension');
+    await expect(
+      service.capture(
+        value.ownerId,
+        dto(value, { note: 'x'.repeat(501) }),
+        new Date('2026-08-26T00:00:00.000Z')
+      )
+    ).rejects.toThrow('500 characters or fewer');
+  });
+
+  it('validates newly configured household timezones before persistence', async () => {
+    const value = await fixture('timezone-update');
+    await expect(
+      households.update(value.ownerId, value.householdId, { timezone: 'Mars/Olympus' })
+    ).rejects.toThrow('valid IANA timezone');
+
+    const updated = await households.update(value.ownerId, value.householdId, {
+      timezone: 'Asia/Tokyo',
+    });
+    expect(updated.timezone).toBe('Asia/Tokyo');
+  });
+
+  it('fails closed when asked to replay an orphan source ID', async () => {
+    const value = await fixture('orphan-replay');
+    await expect(service.replay(value.ownerId, randomUUID())).rejects.toThrow(
+      'CareEvent not found'
+    );
+  });
+});

--- a/apps/api/src/intelligence/daily-signals.service.ts
+++ b/apps/api/src/intelligence/daily-signals.service.ts
@@ -1,0 +1,269 @@
+import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import type { CanonicalCareEventRecord } from '../care-events/care-event.types';
+import { CareEventsService } from '../care-events/care-events.service';
+import { HouseholdsService } from '../households/households.service';
+import type { SignalDimension } from './baseline-policy-v1.types';
+import { normalizeOwnerCheckinObservation } from './evidence-normalization-v1';
+import { IntelligenceProjectionService } from './intelligence-projection.service';
+import {
+  dailySignalsDedupeKey,
+  resolveDailySignalsTime,
+} from './daily-signals-local-day-policy-v1';
+import {
+  DAILY_SIGNAL_CHOICES,
+  DAILY_SIGNAL_DIMENSION_BY_FIELD,
+  DAILY_SIGNAL_FIELDS,
+  type DailySignalChoice,
+  type DailySignalsAnswers,
+  type DailySignalsCaptureReceipt,
+} from './daily-signals.types';
+import type { CreateDailySignalsDto } from './dto/daily-signals.dto';
+
+export const DAILY_SIGNALS_CAPTURE_POLICY_V1 = Object.freeze({
+  version: 'daily-signals-capture-v1' as const,
+  eventType: 'DAILY_SIGNALS_CHECKIN' as const,
+  source: 'INTELLIGENCE' as const,
+  evidenceConfidence: 0.8,
+  visibility: 'PRIVATE' as const,
+  dedupeScope: 'PET' as const,
+  noteMaxLength: 500,
+});
+
+type CanonicalDailySignalsPayload = {
+  signals: DailySignalsAnswers;
+  note?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isDailySignalChoice(value: unknown): value is DailySignalChoice {
+  return DAILY_SIGNAL_CHOICES.includes(value as DailySignalChoice);
+}
+
+function normalizedAnswers(input: CreateDailySignalsDto['signals']): DailySignalsAnswers {
+  if (!input || !isRecord(input)) {
+    throw new BadRequestException('Daily Signals requires a signals object');
+  }
+
+  const answers: DailySignalsAnswers = {};
+  for (const field of DAILY_SIGNAL_FIELDS) {
+    const value = input[field];
+    if (value === undefined) continue;
+    if (!isDailySignalChoice(value)) {
+      throw new BadRequestException(`Daily Signals contains an invalid ${field} answer`);
+    }
+    answers[field] = value;
+  }
+  if (Object.keys(answers).length === 0) {
+    throw new BadRequestException('Daily Signals requires at least one answered dimension');
+  }
+  return answers;
+}
+
+function normalizedNote(note?: string): string | undefined {
+  if (note === undefined) return undefined;
+  if (typeof note !== 'string') throw new BadRequestException('Daily Signals note must be text');
+  const trimmed = note.trim();
+  if (trimmed.length > DAILY_SIGNALS_CAPTURE_POLICY_V1.noteMaxLength) {
+    throw new BadRequestException(
+      `Daily Signals note must be ${DAILY_SIGNALS_CAPTURE_POLICY_V1.noteMaxLength} characters or fewer`
+    );
+  }
+  return trimmed || undefined;
+}
+
+function canonicalPayloadHash(payload: CanonicalDailySignalsPayload): string {
+  const orderedSignals: DailySignalsAnswers = {};
+  for (const field of DAILY_SIGNAL_FIELDS) {
+    const value = payload.signals[field];
+    if (value !== undefined) orderedSignals[field] = value;
+  }
+  return createHash('sha256')
+    .update(JSON.stringify({ signals: orderedSignals, note: payload.note ?? null }))
+    .digest('hex');
+}
+
+function parseCanonicalAnswers(event: CanonicalCareEventRecord): DailySignalsAnswers {
+  const rawSignals = event.outcome.signals;
+  if (!isRecord(rawSignals)) {
+    throw new ConflictException('Canonical Daily Signals event is missing structured answers');
+  }
+
+  const answers: DailySignalsAnswers = {};
+  for (const field of DAILY_SIGNAL_FIELDS) {
+    const value = rawSignals[field];
+    if (value === undefined) continue;
+    if (!isDailySignalChoice(value)) {
+      throw new ConflictException('Canonical Daily Signals event contains an invalid answer');
+    }
+    answers[field] = value;
+  }
+  if (Object.keys(answers).length === 0) {
+    throw new ConflictException('Canonical Daily Signals event has no usable answers');
+  }
+  return answers;
+}
+
+@Injectable()
+export class DailySignalsService {
+  constructor(
+    private readonly households: HouseholdsService,
+    private readonly careEvents: CareEventsService,
+    private readonly projection: IntelligenceProjectionService
+  ) {}
+
+  async capture(
+    userId: string,
+    dto: CreateDailySignalsDto,
+    now: Date = new Date()
+  ): Promise<DailySignalsCaptureReceipt> {
+    const household = await this.households.assertHouseholdPetAccessible(
+      userId,
+      dto.householdId,
+      dto.petId
+    );
+    if (!household.timezone) {
+      throw new BadRequestException(
+        'Household timezone is required before Daily Signals can be recorded'
+      );
+    }
+
+    let resolvedTime;
+    try {
+      resolvedTime = resolveDailySignalsTime({
+        requestedObservedAt: dto.observedAt,
+        householdTimezone: household.timezone,
+        now,
+      });
+    } catch (error) {
+      throw new BadRequestException(
+        error instanceof Error ? error.message : 'Invalid Daily Signals time'
+      );
+    }
+
+    const signals = normalizedAnswers(dto.signals);
+    const note = normalizedNote(dto.note);
+    const payloadHash = canonicalPayloadHash({ signals, ...(note ? { note } : {}) });
+    const dedupeKey = dailySignalsDedupeKey({
+      householdId: household.householdId,
+      petId: dto.petId,
+      localDate: resolvedTime.localDate,
+    });
+
+    const rewardReceipt = await this.careEvents.record({
+      userId,
+      petId: dto.petId,
+      eventType: DAILY_SIGNALS_CAPTURE_POLICY_V1.eventType,
+      pathway: 'CARE',
+      occurredAt: new Date(resolvedTime.observedAt),
+      source: DAILY_SIGNALS_CAPTURE_POLICY_V1.source,
+      evidenceType: 'SELF_REPORT',
+      evidenceConfidence: DAILY_SIGNALS_CAPTURE_POLICY_V1.evidenceConfidence,
+      dedupeKey,
+      dedupeScope: DAILY_SIGNALS_CAPTURE_POLICY_V1.dedupeScope,
+      visibility: DAILY_SIGNALS_CAPTURE_POLICY_V1.visibility,
+      safetyEligible: false,
+      context: {
+        householdId: household.householdId,
+        localDate: resolvedTime.localDate,
+        timezone: resolvedTime.timezone,
+        capturePolicyVersion: DAILY_SIGNALS_CAPTURE_POLICY_V1.version,
+        payloadHash,
+      },
+      outcome: {
+        signals,
+        ...(note ? { note } : {}),
+      },
+    });
+
+    const canonical = await this.careEvents.getAuthorizedEvent(userId, rewardReceipt.careEventId);
+    const canonicalHash = canonical.context.payloadHash;
+    if (canonicalHash !== payloadHash) {
+      throw new ConflictException(
+        'Daily Signals is already recorded for this pet and local day with different answers'
+      );
+    }
+    if (
+      canonical.eventType !== DAILY_SIGNALS_CAPTURE_POLICY_V1.eventType ||
+      canonical.source !== DAILY_SIGNALS_CAPTURE_POLICY_V1.source ||
+      canonical.evidenceType !== 'SELF_REPORT' ||
+      canonical.petId !== dto.petId ||
+      canonical.context.householdId !== household.householdId ||
+      canonical.context.localDate !== resolvedTime.localDate
+    ) {
+      throw new ConflictException(
+        'Canonical Daily Signals identity does not match the requested capture'
+      );
+    }
+
+    const projectedDimensions = await this.replayCanonicalDailySignalsEvent(userId, canonical);
+    const canonicalTimezone = canonical.context.timezone;
+    if (typeof canonicalTimezone !== 'string') {
+      throw new ConflictException(
+        'Canonical Daily Signals event is missing its household timezone'
+      );
+    }
+
+    return {
+      careEventId: canonical.id,
+      householdId: household.householdId,
+      petId: dto.petId,
+      localDate: resolvedTime.localDate,
+      timezone: canonicalTimezone,
+      duplicate: rewardReceipt.duplicate,
+      futureTimestampNormalized: resolvedTime.futureTimestampNormalized,
+      projectedDimensions,
+    };
+  }
+
+  async replay(userId: string, careEventId: string): Promise<SignalDimension[]> {
+    const canonical = await this.careEvents.getAuthorizedEvent(userId, careEventId);
+    return this.replayCanonicalDailySignalsEvent(userId, canonical);
+  }
+
+  private async replayCanonicalDailySignalsEvent(
+    requestingUserId: string,
+    event: CanonicalCareEventRecord
+  ): Promise<SignalDimension[]> {
+    if (
+      event.eventType !== DAILY_SIGNALS_CAPTURE_POLICY_V1.eventType ||
+      event.source !== DAILY_SIGNALS_CAPTURE_POLICY_V1.source ||
+      event.evidenceType !== 'SELF_REPORT' ||
+      !event.petId
+    ) {
+      throw new ConflictException('CareEvent is not a canonical Daily Signals source');
+    }
+
+    const localDate = event.context.localDate;
+    const householdId = event.context.householdId;
+    if (typeof localDate !== 'string' || typeof householdId !== 'string') {
+      throw new ConflictException('Canonical Daily Signals event is missing capture context');
+    }
+    await this.households.assertHouseholdPetAccessible(requestingUserId, householdId, event.petId);
+
+    const answers = parseCanonicalAnswers(event);
+    const projectedDimensions: SignalDimension[] = [];
+    for (const field of DAILY_SIGNAL_FIELDS) {
+      const choice = answers[field];
+      if (choice === undefined || choice === 'UNSURE') continue;
+      const dimension = DAILY_SIGNAL_DIMENSION_BY_FIELD[field];
+      const candidate = normalizeOwnerCheckinObservation({
+        userId: event.userId,
+        petId: event.petId,
+        careEventId: event.id,
+        dimension,
+        choice,
+        observedAt: event.occurredAt,
+        localDate,
+        confidence: event.evidenceConfidence,
+      });
+      if (!candidate) continue;
+      await this.projection.projectObservation(candidate);
+      projectedDimensions.push(dimension);
+    }
+    return projectedDimensions;
+  }
+}

--- a/apps/api/src/intelligence/daily-signals.types.ts
+++ b/apps/api/src/intelligence/daily-signals.types.ts
@@ -1,0 +1,36 @@
+import type { SignalDimension } from './baseline-policy-v1.types';
+
+export const DAILY_SIGNAL_CHOICES = ['LESS', 'USUAL', 'MORE', 'UNSURE'] as const;
+export type DailySignalChoice = (typeof DAILY_SIGNAL_CHOICES)[number];
+
+export const DAILY_SIGNAL_FIELDS = [
+  'appetite',
+  'energy',
+  'bathroomRoutine',
+  'mobilityComfort',
+  'engagementSocialComfort',
+  'sleepRest',
+] as const;
+export type DailySignalField = (typeof DAILY_SIGNAL_FIELDS)[number];
+
+export const DAILY_SIGNAL_DIMENSION_BY_FIELD: Record<DailySignalField, SignalDimension> = {
+  appetite: 'APPETITE',
+  energy: 'ENERGY',
+  bathroomRoutine: 'BATHROOM_ROUTINE',
+  mobilityComfort: 'MOBILITY_COMFORT',
+  engagementSocialComfort: 'ENGAGEMENT_SOCIAL_COMFORT',
+  sleepRest: 'SLEEP_REST',
+};
+
+export type DailySignalsAnswers = Partial<Record<DailySignalField, DailySignalChoice>>;
+
+export type DailySignalsCaptureReceipt = {
+  careEventId: string;
+  householdId: string;
+  petId: string;
+  localDate: string;
+  timezone: string;
+  duplicate: boolean;
+  futureTimestampNormalized: boolean;
+  projectedDimensions: SignalDimension[];
+};

--- a/apps/api/src/intelligence/dto/daily-signals.dto.spec.ts
+++ b/apps/api/src/intelligence/dto/daily-signals.dto.spec.ts
@@ -1,0 +1,29 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { CreateDailySignalsDto, DailySignalsAnswersDto } from './daily-signals.dto';
+
+function validPayload(householdId: string) {
+  const signals = new DailySignalsAnswersDto();
+  signals.appetite = 'USUAL';
+
+  const dto = new CreateDailySignalsDto();
+  dto.householdId = householdId;
+  dto.petId = '7dd7de8d-42af-4a70-8398-bd572c3bea34';
+  dto.observedAt = '2026-08-25T18:00:00.000Z';
+  dto.signals = signals;
+  return dto;
+}
+
+describe('Daily Signals DTO household identity', () => {
+  it('accepts legacy deterministic UUID-shaped household identifiers', async () => {
+    const errors = await validate(validPayload('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects malformed household identifiers', async () => {
+    const errors = await validate(validPayload('not-a-household-id'));
+
+    expect(errors.some((error) => error.property === 'householdId')).toBe(true);
+  });
+});

--- a/apps/api/src/intelligence/dto/daily-signals.dto.ts
+++ b/apps/api/src/intelligence/dto/daily-signals.dto.ts
@@ -1,0 +1,67 @@
+import { Type } from 'class-transformer';
+import {
+  IsIn,
+  IsISO8601,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Matches,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+import { DAILY_SIGNAL_CHOICES, type DailySignalChoice } from '../daily-signals.types';
+
+const HOUSEHOLD_IDENTIFIER_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class DailySignalsAnswersDto {
+  @IsOptional()
+  @IsIn(DAILY_SIGNAL_CHOICES)
+  appetite?: DailySignalChoice;
+
+  @IsOptional()
+  @IsIn(DAILY_SIGNAL_CHOICES)
+  energy?: DailySignalChoice;
+
+  @IsOptional()
+  @IsIn(DAILY_SIGNAL_CHOICES)
+  bathroomRoutine?: DailySignalChoice;
+
+  @IsOptional()
+  @IsIn(DAILY_SIGNAL_CHOICES)
+  mobilityComfort?: DailySignalChoice;
+
+  @IsOptional()
+  @IsIn(DAILY_SIGNAL_CHOICES)
+  engagementSocialComfort?: DailySignalChoice;
+
+  @IsOptional()
+  @IsIn(DAILY_SIGNAL_CHOICES)
+  sleepRest?: DailySignalChoice;
+}
+
+export class CreateDailySignalsDto {
+  // Personal household IDs predate strict RFC UUID version/variant bits. Keep
+  // accepting the canonical stored 8-4-4-4-12 hexadecimal identifier without
+  // rewriting an existing household into a different identity.
+  @Matches(HOUSEHOLD_IDENTIFIER_PATTERN, {
+    message: 'householdId must be a UUID-shaped identifier',
+  })
+  householdId!: string;
+
+  @IsUUID()
+  petId!: string;
+
+  @IsOptional()
+  @IsISO8601({ strict: true })
+  observedAt?: string;
+
+  @ValidateNested()
+  @Type(() => DailySignalsAnswersDto)
+  signals!: DailySignalsAnswersDto;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  note?: string;
+}

--- a/apps/api/src/intelligence/intelligence.controller.ts
+++ b/apps/api/src/intelligence/intelligence.controller.ts
@@ -1,0 +1,22 @@
+import { Body, Controller, Post, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { AuthenticatedRequest } from '../auth/authenticated-request';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { DailySignalsService } from './daily-signals.service';
+import { CreateDailySignalsDto } from './dto/daily-signals.dto';
+
+@ApiTags('intelligence')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('intelligence')
+export class IntelligenceController {
+  constructor(private readonly dailySignals: DailySignalsService) {}
+
+  @Post('daily-signals')
+  @ApiOperation({
+    summary: 'Record one private, household-clocked Daily Signals check-in for a pet',
+  })
+  captureDailySignals(@Request() req: AuthenticatedRequest, @Body() dto: CreateDailySignalsDto) {
+    return this.dailySignals.capture(req.user.sub, dto);
+  }
+}

--- a/apps/api/src/intelligence/intelligence.module.ts
+++ b/apps/api/src/intelligence/intelligence.module.ts
@@ -1,10 +1,14 @@
 import { Module } from '@nestjs/common';
+import { CareEventsModule } from '../care-events/care-events.module';
 import { HouseholdsModule } from '../households/households.module';
+import { DailySignalsService } from './daily-signals.service';
+import { IntelligenceController } from './intelligence.controller';
 import { IntelligenceProjectionService } from './intelligence-projection.service';
 
 @Module({
-  imports: [HouseholdsModule],
-  providers: [IntelligenceProjectionService],
-  exports: [IntelligenceProjectionService],
+  imports: [HouseholdsModule, CareEventsModule],
+  controllers: [IntelligenceController],
+  providers: [IntelligenceProjectionService, DailySignalsService],
+  exports: [IntelligenceProjectionService, DailySignalsService],
 })
 export class IntelligenceModule {}

--- a/docs/DOGOS_DAILY_SIGNALS_CAPTURE_V1.md
+++ b/docs/DOGOS_DAILY_SIGNALS_CAPTURE_V1.md
@@ -1,0 +1,176 @@
+# dogOS Intelligence: Daily Signals Capture v1
+
+`daily-signals-capture-v1` is the canonical write boundary for the first user-authored longitudinal dogOS intelligence signal.
+
+It depends on the qualified `baseline-policy-v1` and Evidence Projection v1 releases. It does not own the Today UI, diagnosis, notification authority, or downstream Concierge/Health Lens behavior.
+
+## Product contract
+
+A Daily Signals check-in records how one accessible dog is doing across a small set of owner-observable dimensions:
+
+- appetite
+- energy
+- bathroom/routine
+- mobility/comfort
+- engagement/social comfort
+- sleep/rest
+
+Each answered dimension is one of `LESS`, `USUAL`, `MORE`, or `UNSURE`. `UNSURE` is missing evidence and never becomes a baseline-normal observation.
+
+A check-in may also include one optional private note of at most 500 characters. The note remains on the canonical private CareEvent and is never copied into the intelligence projection.
+
+## API
+
+Authenticated capture is exposed as:
+
+`POST /api/v1/intelligence/daily-signals`
+
+The request supplies:
+
+- `householdId`
+- `petId`
+- optional ISO `observedAt`
+- `signals`
+- optional `note`
+
+The request does **not** supply a trusted local date or timezone.
+
+## Household and pet authority
+
+Capture resolves the explicit `(user, household, pet)` triple through `HouseholdsService.assertHouseholdPetAccessible`.
+
+This is intentionally stricter than selecting the first household that happens to expose a pet. A pet may be visible in more than one household, and those households may use different clocks. Daily identity therefore belongs to one explicitly authorized household context.
+
+Authorization failures retain non-disclosing not-found behavior.
+
+## Local-day authority
+
+`daily-signals-local-day-v1` owns time normalization.
+
+The household's persisted timezone must be a valid canonical IANA timezone. Newly updated household timezones pass the same validator.
+
+The server derives local day as:
+
+`trusted observed instant -> canonical household IANA zone -> YYYY-MM-DD`
+
+Rules:
+
+1. no client-provided `localDate` is trusted;
+2. a missing `observedAt` uses server now;
+3. a future client timestamp is clamped to server now **before** local-day derivation;
+4. a historical/offline timestamp remains historical and maps to the household-local day on which it occurred;
+5. DST gaps and repeated hours are ordinary instants and therefore deterministic;
+6. an absent or invalid household timezone fails closed rather than falling back to UTC.
+
+The executable fixture suite includes America/Los_Angeles spring-forward and fall-back boundaries plus Asia/Tokyo and local-midnight cases.
+
+## One logical check-in per household + pet + local day
+
+The logical identity is:
+
+`daily-signals-v1:<householdId>:<petId>:<YYYY-MM-DD>`
+
+Daily Signals uses `CareEventDedupeScope = PET`.
+
+The canonical CareEvent write acquires a PostgreSQL transaction-scoped advisory lock over the pet/event/dedupe identity before lookup or insertion. This is a database authority boundary, not an in-memory mutex, so concurrent requests arriving under different household user IDs or different API processes serialize on the same logical day identity.
+
+The first accepted payload becomes canonical for that day.
+
+- same logical identity + same canonical payload hash -> duplicate success receipt;
+- same logical identity + different payload hash -> `409 Conflict`;
+- no last-write-wins update is performed.
+
+A later correction must use the explicit correction/supersession path rather than mutating the day's source record.
+
+## Canonical truth before projection
+
+Capture writes one canonical CareEvent first:
+
+- event type `DAILY_SIGNALS_CHECKIN`
+- pathway `CARE`
+- source `INTELLIGENCE`
+- evidence type `SELF_REPORT`
+- bounded evidence confidence `0.8`
+- `PRIVATE` visibility
+- `safetyEligible = false`
+- zero Bond XP
+- household/timezone/local-day/capture-version/payload-hash context
+- structured signal answers and optional private note in outcome
+
+The projection is derived only after the CareEvent transaction commits.
+
+This preserves the authority chain:
+
+`owner capture -> canonical private CareEvent -> normalization receipt -> replayable projection -> baseline-policy-v1`
+
+## Partial-failure repair
+
+Projection failure does not create a second source event on retry.
+
+A retry first resolves the existing pet-scoped CareEvent. If its canonical payload hash matches, the service replays the canonical structured answers through `evidence-normalization-v1` and repairs any missing derived observations idempotently.
+
+Projection identity remains source-event based, so already-created dimensions are duplicates and missing dimensions are inserted.
+
+An orphan CareEvent ID or non-Daily-Signals source fails closed.
+
+## Provenance versus repair authorization
+
+Projection rows currently preserve the original CareEvent actor as their provenance user.
+
+The qualified v1 repair path assumes that source actor remains authorized for the pet. A future release should split **current repair requester authority** from **historical source actor provenance** so a current owner can repair an old check-in after the original household member has left without rewriting source identity.
+
+This release does not weaken pet authorization to paper over that distinction.
+
+## Privacy boundary
+
+The canonical CareEvent may hold the bounded private note because it is the source record.
+
+The intelligence projection must not contain:
+
+- the free-form note;
+- raw image/video;
+- access or refresh tokens;
+- IP address or device fingerprint;
+- precise location trail;
+- model trace.
+
+Projection context remains bounded and normalization-specific.
+
+## Reward integrity
+
+Daily Signals is data capture, not an XP-farming mechanic.
+
+The canonical CareEvent is recorded with `safetyEligible = false`; the release contract requires zero Bond XP and zero effect on subsequent legitimate reward decay semantics.
+
+## PostgreSQL qualification
+
+The dedicated capture CI must prove against the real database:
+
+- the complete historical migration chain still deploys;
+- this slice owns no migration or Prisma schema change;
+- IANA/timezone/DST fixtures pass;
+- 20 concurrent identical submissions across two authorized household members converge to one canonical CareEvent;
+- divergent same-day submissions serialize into one winner plus conflict, never last-write-wins;
+- retry after partial projection deletion repairs from the same source event;
+- `UNSURE` creates no baseline-authoritative projection row;
+- the private note never appears in projection context;
+- unrelated users and wrong household/pet combinations fail closed;
+- missing/invalid timezone, invalid signals, empty signals, and oversized note fail deterministically;
+- canonical event is private and zero reward;
+- API type-check and production build pass.
+
+## Not yet owned
+
+This slice does not complete issue #33. Still separate:
+
+- `GET /api/v1/intelligence/daily-signals/today`
+- baseline summary endpoint
+- dimension trends endpoint
+- public correction UI/API
+- current-requester repair after historical source actor loses access
+- Activity and Coach replay orchestration
+- source redaction orchestration
+- Today UI integration
+- Concierge or Health Lens authority
+- learned anomaly models
+- diagnosis or disease probability


### PR DESCRIPTION
## dogOS Intelligence 1B capture slice

Part of #33. This PR owns the first canonical Daily Signals write path. It does **not** yet complete #33 or add the Today/baseline/trends read surfaces.

### What ships

- authenticated `POST /api/v1/intelligence/daily-signals`
- explicit `(householdId, petId)` household authorization
- IANA household timezone authority with server-derived local day
- future client timestamps clamped before local-day derivation
- offline/historical observed time preserved
- one logical `household + pet + local-day` check-in identity
- PostgreSQL advisory locking for cross-member/process serialization
- first accepted same-day payload is canonical
- identical retries converge on the same private CareEvent
- divergent same-day payloads return `409` rather than last-write-wins
- `PRIVATE`, `SELF_REPORT`, zero-XP canonical CareEvent before projection
- replayable projection repair after partial projection failure
- `UNSURE` remains missing evidence rather than normal evidence
- free-form note remains only on the private canonical CareEvent and never enters projection context
- household timezone updates validate/canonicalize IANA zones
- compatibility with deterministic legacy personal-household IDs without rewriting household identity

### Concurrency + compatibility hardening discovered during qualification

The 20-way cross-member capture test exposed a pre-existing race in deterministic personal-household bootstrap. This PR serializes that bootstrap with a transaction-scoped PostgreSQL advisory lock and prevents shared-household access from mutating the caller's unrelated personal household.

The production HTTP proof also exposed that deterministic historical personal-household IDs are UUID-shaped but do not necessarily satisfy RFC UUID version/variant bits. The DTO now validates the actual persisted household-ID invariant without rewriting household identity; pet IDs remain strict RFC UUIDs.

### Final exact-head qualification receipt

Final main-target head: `b55aced33c95a2b3909e60e96d35552f3cc8777b`

The branch is **one commit / 18 changed files** directly on merged #37 main boundary `7df883c468f46227e97f5ba2c8a8ba7ae1f6889f`. Its source tree is byte-identical to the previously qualified stacked candidate, then all required workflows were rerun from a fresh pull-request checkout.

Green on this exact final head:

- **dogOS Daily Signals Capture CI** — run `32931478934`
  - frozen-lockfile install
  - Prisma generation
  - zero database ownership in this slice
  - complete migration chain
  - read-only formatting + whitespace checks
  - zero-warning capture lint
  - structural clock/privacy/authorization/idempotency guards
  - API type-check
  - real PostgreSQL local-day/capture/projection/CareEvent contracts
  - production API build
  - production Docker image build + boot
  - black-box HTTP proof: register -> create pet -> resolve household -> set timezone -> canonical capture -> identical retry to same CareEvent -> divergent same-day payload returns `409`
- **dogOS Foundation CI** — run `32931478883`
  - migrations/schema drift
  - API/mobile lint + type-check
  - household + multi-pet contracts
  - API build
- **Adventure System CI** — run `32931478913`
  - migration/schema-drift checks
  - monorepo lint + type-check
  - web contracts
  - reward policy / Reward Ledger / quest contracts
  - complete API suite
  - API + web production builds

### Explicit boundary

Projection rows preserve the original source actor. Repair is qualified while that source actor remains pet-authorized. Repair after the original source actor later leaves the household requires a separate requester-vs-provenance authorization boundary and is intentionally not solved by weakening pet authorization here.

### Follow-up

Runner-dependent `@woof/ui` ESLint ownership is isolated as #39. No lint rule is bypassed or weakened in this release.

#36 and #37 are now merged. This PR has been fully restacked and requalified against `main`.