### PR TITLE
dogOS Adaptive Adventure 1A: add progressive-question policy oracle

### DIFF
--- a/.github/workflows/dogos-progressive-question-policy-ci.yml
+++ b/.github/workflows/dogos-progressive-question-policy-ci.yml
@@ -1,0 +1,102 @@
+name: dogOS Progressive Question Policy CI
+
+on:
+  pull_request:
+    paths:
+      - 'apps/api/src/adventure/profile-question-policy-v1*.ts'
+      - 'docs/DOGOS_PROGRESSIVE_QUESTION_POLICY_V1.md'
+      - '.github/workflows/dogos-progressive-question-policy-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  policy:
+    name: Deterministic progressive-question policy qualification
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 8.15.1
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20.20.2
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Reject database ownership
+        shell: bash
+        run: |
+          changed="$(git diff --name-only '${{ github.event.pull_request.base.sha }}'...HEAD)"
+          if printf '%s\n' "$changed" | grep -E '^packages/database/'; then
+            echo 'profile-question-policy-v1 must not own database changes'
+            exit 1
+          fi
+
+      - name: Check canonical formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/adventure/profile-question-policy-v1.ts
+          apps/api/src/adventure/profile-question-policy-v1.types.ts
+          apps/api/src/adventure/profile-question-policy-v1.receipt.ts
+          apps/api/src/adventure/profile-question-policy-v1.spec.ts
+          docs/DOGOS_PROGRESSIVE_QUESTION_POLICY_V1.md
+
+      - name: Reject infrastructure and implicit authority
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          files = [
+              Path('apps/api/src/adventure/profile-question-policy-v1.ts'),
+              Path('apps/api/src/adventure/profile-question-policy-v1.types.ts'),
+              Path('apps/api/src/adventure/profile-question-policy-v1.receipt.ts'),
+          ]
+          forbidden = {
+              '@nestjs/': 'Nest dependency',
+              '../prisma': 'Prisma dependency',
+              '@woof/database': 'database dependency',
+              'process.env': 'environment dependency',
+              'Date.now(': 'implicit clock',
+              'new Date()': 'implicit clock',
+              'Math.random(': 'randomness',
+              'fetch(': 'network dependency',
+              'bondXp': 'game currency as policy authority',
+              'RewardLedger': 'game reward ledger as policy authority',
+          }
+          for path in files:
+              text = path.read_text()
+              for needle, label in forbidden.items():
+                  if needle in text:
+                      raise SystemExit(f'{path}: forbidden {label}: {needle}')
+          PY
+
+      - name: Lint policy with zero warnings
+        run: >-
+          pnpm --filter @woof/api exec eslint
+          'src/adventure/profile-question-policy-v1*.ts'
+          --max-warnings=0
+
+      - name: Generate Prisma client for API qualification
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api exec tsc --noEmit
+
+      - name: Run policy oracle contracts
+        run: >-
+          pnpm --filter @woof/api exec jest
+          src/adventure/profile-question-policy-v1.spec.ts
+          --runInBand

--- a/apps/api/src/adventure/profile-question-policy-v1.receipt.ts
+++ b/apps/api/src/adventure/profile-question-policy-v1.receipt.ts
@@ -1,0 +1,25 @@
+import type { ProfileQuestionPolicyReceipt } from './profile-question-policy-v1.types';
+
+export const PROFILE_QUESTION_POLICY_V1: ProfileQuestionPolicyReceipt = Object.freeze({
+  version: 'profile-question-policy-v1',
+  knownConfidenceThreshold: 0.8,
+  interactionWindowDays: 14,
+  sessionFollowupWindowHours: 24,
+  answeredCooldownDays: 7,
+  notSureCooldownDays: 7,
+  skippedCooldownDays: 14,
+  dismissalsForClarification: 2,
+  scoreWeights: Object.freeze({
+    decisionValue: 3,
+    uncertainty: 2,
+    contextTrigger: 2,
+    safetyRelevance: 1,
+    burden: -1,
+  }),
+});
+
+export const PROFILE_QUESTION_POLICY_V1_CANONICAL_RECEIPT =
+  '{"answeredCooldownDays":7,"dismissalsForClarification":2,"interactionWindowDays":14,"knownConfidenceThreshold":0.8,"notSureCooldownDays":7,"scoreWeights":{"burden":-1,"contextTrigger":2,"decisionValue":3,"safetyRelevance":1,"uncertainty":2},"sessionFollowupWindowHours":24,"skippedCooldownDays":14,"version":"profile-question-policy-v1"}';
+
+export const PROFILE_QUESTION_POLICY_V1_SHA256 =
+  'dca2936d547338e58d5911006e575d8394d685e7679c2d52ad5cb24e07cd0483';

--- a/apps/api/src/adventure/profile-question-policy-v1.spec.ts
+++ b/apps/api/src/adventure/profile-question-policy-v1.spec.ts
@@ -1,0 +1,377 @@
+import { createHash } from 'node:crypto';
+import {
+  PROFILE_QUESTION_POLICY_V1,
+  PROFILE_QUESTION_POLICY_V1_CANONICAL_RECEIPT,
+  PROFILE_QUESTION_POLICY_V1_SHA256,
+} from './profile-question-policy-v1.receipt';
+import { selectProfileQuestion } from './profile-question-policy-v1';
+import {
+  PROFILE_DIMENSIONS,
+  type ProfileDimension,
+  type ProfileEvidence,
+  type ProfileQuestionPolicyInput,
+} from './profile-question-policy-v1.types';
+
+const NOW = '2026-08-25T20:00:00.000Z';
+
+function evidence(
+  dimension: ProfileDimension,
+  overrides: Partial<ProfileEvidence> = {}
+): ProfileEvidence {
+  return {
+    dimension,
+    state: 'KNOWN',
+    confidence: 0.95,
+    provenance: 'OWNER_EXPLICIT',
+    updatedAt: '2026-08-25T18:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function allKnown(except: readonly ProfileDimension[] = []): ProfileEvidence[] {
+  return PROFILE_DIMENSIONS.filter((dimension) => !except.includes(dimension)).map((dimension) =>
+    evidence(dimension)
+  );
+}
+
+function input(overrides: Partial<ProfileQuestionPolicyInput> = {}): ProfileQuestionPolicyInput {
+  return {
+    profileEvidence: [],
+    questionHistory: [],
+    interactions: [],
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe('profile-question-policy-v1', () => {
+  it('pins the complete policy receipt to its SHA-256', () => {
+    expect(JSON.parse(PROFILE_QUESTION_POLICY_V1_CANONICAL_RECEIPT)).toEqual(
+      PROFILE_QUESTION_POLICY_V1
+    );
+    expect(
+      createHash('sha256').update(PROFILE_QUESTION_POLICY_V1_CANONICAL_RECEIPT).digest('hex')
+    ).toBe(PROFILE_QUESTION_POLICY_V1_SHA256);
+  });
+
+  it('starts sparse profiles with one high-value foundational question', () => {
+    const question = selectProfileQuestion(input());
+
+    expect(question?.id).toBe('profile-owner-goals-v1');
+    expect(question?.reasonCodes).toContain('FOUNDATIONAL_COLD_START');
+  });
+
+  it('returns no question when every durable dimension is already known', () => {
+    expect(selectProfileQuestion(input({ profileEvidence: allKnown() }))).toBeNull();
+  });
+
+  it('respects a recent skip without blocking the rest of the experience', () => {
+    const question = selectProfileQuestion(
+      input({
+        questionHistory: [
+          {
+            questionId: 'profile-owner-goals-v1',
+            askedAt: '2026-08-20T20:00:00.000Z',
+            outcome: 'SKIPPED',
+          },
+        ],
+      })
+    );
+
+    expect(question).not.toBeNull();
+    expect(question?.id).not.toBe('profile-owner-goals-v1');
+  });
+
+  it('allows a skipped question to become eligible again after its cooldown', () => {
+    const question = selectProfileQuestion(
+      input({
+        profileEvidence: allKnown(['OWNER_GOALS']),
+        questionHistory: [
+          {
+            questionId: 'profile-owner-goals-v1',
+            askedAt: '2026-08-10T20:00:00.000Z',
+            outcome: 'SKIPPED',
+          },
+        ],
+      })
+    );
+
+    expect(question?.id).toBe('profile-owner-goals-v1');
+  });
+
+  it('uses the most conservative cooldown outcome when duplicate history timestamps conflict', () => {
+    const question = selectProfileQuestion(
+      input({
+        profileEvidence: allKnown(['OWNER_GOALS']),
+        questionHistory: [
+          {
+            questionId: 'profile-owner-goals-v1',
+            askedAt: '2026-08-16T20:00:00.000Z',
+            outcome: 'ANSWERED',
+          },
+          {
+            questionId: 'profile-owner-goals-v1',
+            askedAt: '2026-08-16T20:00:00.000Z',
+            outcome: 'SKIPPED',
+          },
+        ],
+      })
+    );
+
+    expect(question).toBeNull();
+  });
+
+  it('does not turn one declined scent quest into a durable preference question', () => {
+    const question = selectProfileQuestion(
+      input({
+        interactions: [
+          {
+            id: 'dismiss-1',
+            occurredAt: '2026-08-25T18:00:00.000Z',
+            kind: 'DISMISSED',
+            questFamily: 'SCENT',
+          },
+        ],
+      })
+    );
+
+    expect(question?.target.kind).toBe('PROFILE');
+  });
+
+  it('does not count a replayed interaction id as two independent dismissals', () => {
+    const replayedDismissal = {
+      id: 'dismiss-1',
+      occurredAt: '2026-08-25T18:00:00.000Z',
+      kind: 'DISMISSED' as const,
+      questFamily: 'SCENT' as const,
+    };
+    const question = selectProfileQuestion(
+      input({ interactions: [replayedDismissal, { ...replayedDismissal }] })
+    );
+
+    expect(question?.target.kind).toBe('PROFILE');
+  });
+
+  it('fails closed on a divergent replay sharing one interaction id', () => {
+    const question = selectProfileQuestion(
+      input({
+        interactions: [
+          {
+            id: 'interaction-1',
+            occurredAt: '2026-08-25T18:00:00.000Z',
+            kind: 'DISMISSED',
+            questFamily: 'SOCIAL',
+          },
+          {
+            id: 'interaction-1',
+            occurredAt: '2026-08-25T18:00:00.000Z',
+            kind: 'COMPLETED',
+            questFamily: 'SOCIAL',
+            dogExperience: 'comfortable',
+          },
+        ],
+      })
+    );
+
+    expect(question?.target.kind).toBe('PROFILE');
+  });
+
+  it('asks preference-versus-timing only after repeated related dismissals', () => {
+    const question = selectProfileQuestion(
+      input({
+        interactions: [
+          {
+            id: 'dismiss-1',
+            occurredAt: '2026-08-24T18:00:00.000Z',
+            kind: 'DISMISSED',
+            questFamily: 'SCENT',
+          },
+          {
+            id: 'dismiss-2',
+            occurredAt: '2026-08-25T18:00:00.000Z',
+            kind: 'DISMISSED',
+            questFamily: 'SCENT',
+          },
+        ],
+      })
+    );
+
+    expect(question?.target).toEqual({ kind: 'QUEST_FAMILY_PREFERENCE', questFamily: 'SCENT' });
+    expect(question?.reasonCodes).toContain('REPEATED_RELATED_DISMISSALS');
+  });
+
+  it('never treats safe opt-outs as evidence of a durable dislike', () => {
+    const question = selectProfileQuestion(
+      input({
+        interactions: [
+          {
+            id: 'stop-1',
+            occurredAt: '2026-08-24T18:00:00.000Z',
+            kind: 'SAFE_OPT_OUT',
+            questFamily: 'SOCIAL',
+          },
+          {
+            id: 'stop-2',
+            occurredAt: '2026-08-25T18:00:00.000Z',
+            kind: 'SAFE_OPT_OUT',
+            questFamily: 'SOCIAL',
+          },
+        ],
+      })
+    );
+
+    expect(question?.target.kind).toBe('PROFILE');
+  });
+
+  it('can prefer one timely training-difficulty question after a positive session', () => {
+    const question = selectProfileQuestion(
+      input({
+        interactions: [
+          {
+            id: 'training-1',
+            occurredAt: '2026-08-25T19:30:00.000Z',
+            kind: 'COMPLETED',
+            questFamily: 'TRAINING',
+            dogExperience: 'comfortable',
+          },
+        ],
+      })
+    );
+
+    expect(question?.target).toEqual({ kind: 'SESSION_DIFFICULTY', questFamily: 'TRAINING' });
+  });
+
+  it('lets repeated positive social outcomes suppress a redundant social-comfort question', () => {
+    const socialOutcomes = [1, 2, 3, 4].map((index) => ({
+      id: `social-${index}`,
+      occurredAt: `2026-08-${20 + index}T18:00:00.000Z`,
+      kind: 'COMPLETED' as const,
+      questFamily: 'SOCIAL' as const,
+      dogExperience: 'comfortable' as const,
+    }));
+
+    expect(
+      selectProfileQuestion(
+        input({
+          profileEvidence: allKnown(['DOG_SOCIAL_COMFORT']),
+          interactions: socialOutcomes,
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('does not let one replayed positive interaction inflate social confidence', () => {
+    const socialOutcome = {
+      id: 'social-1',
+      occurredAt: '2026-08-25T18:00:00.000Z',
+      kind: 'COMPLETED' as const,
+      questFamily: 'SOCIAL' as const,
+      dogExperience: 'comfortable' as const,
+    };
+    const question = selectProfileQuestion(
+      input({
+        profileEvidence: allKnown(['DOG_SOCIAL_COMFORT']),
+        interactions: [socialOutcome, socialOutcome, socialOutcome, socialOutcome],
+      })
+    );
+
+    expect(question?.target).toEqual({ kind: 'PROFILE', dimension: 'DOG_SOCIAL_COMFORT' });
+  });
+
+  it('keeps an explicit owner correction authoritative over inferred positive history', () => {
+    const socialOutcomes = [1, 2, 3, 4].map((index) => ({
+      id: `social-${index}`,
+      occurredAt: `2026-08-${20 + index}T18:00:00.000Z`,
+      kind: 'COMPLETED' as const,
+      questFamily: 'SOCIAL' as const,
+      dogExperience: 'comfortable' as const,
+    }));
+
+    const question = selectProfileQuestion(
+      input({
+        profileEvidence: [
+          ...allKnown(['DOG_SOCIAL_COMFORT']),
+          evidence('DOG_SOCIAL_COMFORT', {
+            state: 'LEARNING',
+            confidence: 0.4,
+            provenance: 'OWNER_CORRECTION',
+          }),
+        ],
+        interactions: socialOutcomes,
+      })
+    );
+
+    expect(question?.target).toEqual({ kind: 'PROFILE', dimension: 'DOG_SOCIAL_COMFORT' });
+    expect(question?.reasonCodes).toContain('OWNER_CORRECTION_UNCERTAIN');
+  });
+
+  it('ignores future and malformed profile evidence instead of letting it suppress a question', () => {
+    const question = selectProfileQuestion(
+      input({
+        profileEvidence: [
+          evidence('OWNER_GOALS', { updatedAt: '2026-08-26T20:00:00.000Z' }),
+          evidence('OWNER_GOALS', { confidence: Number.NaN }),
+        ],
+      })
+    );
+
+    expect(question?.id).toBe('profile-owner-goals-v1');
+  });
+
+  it('uses deterministic profile-state authority when otherwise identical evidence conflicts', () => {
+    const question = selectProfileQuestion(
+      input({
+        profileEvidence: [
+          evidence('OWNER_GOALS', { state: 'UNKNOWN', confidence: 0.95 }),
+          evidence('OWNER_GOALS', { state: 'KNOWN', confidence: 0.95 }),
+          ...allKnown(['OWNER_GOALS']),
+        ],
+      })
+    );
+
+    expect(question).toBeNull();
+  });
+
+  it('is byte-stable under input permutation', () => {
+    const profileEvidence = [
+      evidence('OWNER_GOALS', { confidence: 0.6, state: 'LEARNING' }),
+      evidence('OWNER_TIME_BUDGET'),
+    ];
+    const interactions = [
+      {
+        id: 'dismiss-b',
+        occurredAt: '2026-08-25T18:00:00.000Z',
+        kind: 'DISMISSED' as const,
+        questFamily: 'SCENT' as const,
+      },
+      {
+        id: 'dismiss-a',
+        occurredAt: '2026-08-24T18:00:00.000Z',
+        kind: 'DISMISSED' as const,
+        questFamily: 'SCENT' as const,
+      },
+    ];
+
+    const first = selectProfileQuestion(input({ profileEvidence, interactions }));
+    const second = selectProfileQuestion(
+      input({
+        profileEvidence: [...profileEvidence].reverse(),
+        interactions: [...interactions].reverse(),
+      })
+    );
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+
+  it('requires an explicit valid clock', () => {
+    expect(() => selectProfileQuestion(input({ now: 'not-a-time' }))).toThrow(
+      'profile-question-policy-v1 requires a valid explicit now timestamp'
+    );
+  });
+
+  it('does not expose game currency as a model/question-policy target', () => {
+    const serialized = JSON.stringify(selectProfileQuestion(input()));
+
+    expect(serialized).not.toMatch(/\b(?:xp|reward)\b/i);
+  });
+});

--- a/apps/api/src/adventure/profile-question-policy-v1.ts
+++ b/apps/api/src/adventure/profile-question-policy-v1.ts
@@ -1,0 +1,511 @@
+import { PROFILE_QUESTION_POLICY_V1 } from './profile-question-policy-v1.receipt';
+import type {
+  ProfileDimension,
+  ProfileEvidence,
+  ProfileEvidenceProvenance,
+  ProfileInteraction,
+  ProfileQuestion,
+  ProfileQuestionPolicyInput,
+  ProfileQuestionTarget,
+  QuestFamily,
+  QuestionHistoryEntry,
+} from './profile-question-policy-v1.types';
+
+const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
+
+const PROVENANCE_RANK: Record<ProfileEvidenceProvenance, number> = {
+  OWNER_CORRECTION: 5,
+  OWNER_EXPLICIT: 4,
+  HOUSEHOLD_EXPLICIT: 3,
+  HISTORICAL_QUIZ: 2,
+  OUTCOME_INFERENCE: 1,
+};
+
+const PROFILE_STATE_RANK: Record<ProfileEvidence['state'], number> = {
+  KNOWN: 3,
+  LEARNING: 2,
+  UNKNOWN: 1,
+};
+
+const QUESTION_OUTCOME_RANK: Record<QuestionHistoryEntry['outcome'], number> = {
+  SKIPPED: 3,
+  NOT_SURE: 2,
+  ANSWERED: 1,
+};
+
+type Candidate = {
+  id: string;
+  target: ProfileQuestionTarget;
+  prompt: string;
+  whyAsk: string;
+  answers: readonly string[];
+  decisionValue: number;
+  burden: number;
+  safetyRelevance: number;
+  contextTrigger: number;
+  uncertainty: number;
+  reasonCodes: string[];
+};
+
+type StaticQuestion = Omit<Candidate, 'uncertainty' | 'reasonCodes'> & {
+  target: { kind: 'PROFILE'; dimension: ProfileDimension };
+};
+
+const STATIC_QUESTIONS: readonly StaticQuestion[] = [
+  {
+    id: 'profile-owner-goals-v1',
+    target: { kind: 'PROFILE', dimension: 'OWNER_GOALS' },
+    prompt: 'What would make Woof most useful for you and your dog right now?',
+    whyAsk:
+      'Goals help Woof choose between equally safe adventures instead of assuming everyone wants the same thing.',
+    answers: [
+      'MORE_ADVENTURES',
+      'TRAINING',
+      'CALMER_ROUTINES',
+      'SOCIAL_CONFIDENCE',
+      'CARE_ROUTINES',
+      'JUST_HAVE_FUN',
+      'NOT_SURE',
+      'SKIP',
+    ],
+    decisionValue: 3,
+    burden: 1,
+    safetyRelevance: 0,
+    contextTrigger: 1,
+  },
+  {
+    id: 'profile-owner-time-budget-v1',
+    target: { kind: 'PROFILE', dimension: 'OWNER_TIME_BUDGET' },
+    prompt: 'How much time usually feels realistic for one Woof adventure?',
+    whyAsk:
+      'A five-minute win can be a better recommendation than a thirty-minute plan that never fits the day.',
+    answers: ['FIVE_MIN', 'TEN_TO_FIFTEEN', 'TWENTY_TO_THIRTY', 'FORTY_PLUS', 'VARIES', 'SKIP'],
+    decisionValue: 3,
+    burden: 1,
+    safetyRelevance: 0,
+    contextTrigger: 0,
+  },
+  {
+    id: 'profile-owner-effort-v1',
+    target: { kind: 'PROFILE', dimension: 'OWNER_EFFORT_PREFERENCE' },
+    prompt: 'What effort level usually works best for you?',
+    whyAsk:
+      'Woof should fit the human half of the team too, rather than treating completion as the only outcome.',
+    answers: ['KEEP_IT_EASY', 'MODERATE', 'UP_FOR_A_CHALLENGE', 'VARIES', 'SKIP'],
+    decisionValue: 3,
+    burden: 1,
+    safetyRelevance: 0,
+    contextTrigger: 0,
+  },
+  {
+    id: 'profile-available-environments-v1',
+    target: { kind: 'PROFILE', dimension: 'AVAILABLE_ENVIRONMENTS' },
+    prompt: 'Where can adventures realistically happen most often?',
+    whyAsk:
+      'Environment changes which quests are possible and which training steps can generalize safely.',
+    answers: ['INDOORS', 'YARD', 'NEIGHBORHOOD', 'PARK', 'TRAIL', 'VARIES', 'SKIP'],
+    decisionValue: 2,
+    burden: 1,
+    safetyRelevance: 0,
+    contextTrigger: 0,
+  },
+  {
+    id: 'profile-dog-energy-v1',
+    target: { kind: 'PROFILE', dimension: 'DOG_ENERGY_PATTERN' },
+    prompt: 'Which broad energy pattern sounds most like your dog on an ordinary day?',
+    whyAsk:
+      'This is a starting prior only. Daily Signals and real outcomes can teach Woof when the pattern changes.',
+    answers: ['MOSTLY_RESTFUL', 'MIXED', 'OFTEN_ACTIVE', 'HIGHLY_VARIABLE', 'NOT_SURE', 'SKIP'],
+    decisionValue: 2,
+    burden: 1,
+    safetyRelevance: 0,
+    contextTrigger: 0,
+  },
+  {
+    id: 'profile-dog-social-comfort-v1',
+    target: { kind: 'PROFILE', dimension: 'DOG_SOCIAL_COMFORT' },
+    prompt: 'How does your dog usually feel about being near unfamiliar dogs?',
+    whyAsk:
+      'Social quests should start from known comfort and choice, not from an assumption that more interaction is better.',
+    answers: [
+      'PREFERS_SPACE',
+      'CALM_AT_DISTANCE',
+      'SELECTIVELY_SOCIAL',
+      'OFTEN_SOCIAL',
+      'NOT_SURE',
+      'SKIP',
+    ],
+    decisionValue: 3,
+    burden: 2,
+    safetyRelevance: 1,
+    contextTrigger: 0,
+  },
+  {
+    id: 'profile-dog-novelty-v1',
+    target: { kind: 'PROFILE', dimension: 'DOG_NOVELTY_COMFORT' },
+    prompt: 'How does your dog usually respond to new places or unfamiliar activities?',
+    whyAsk:
+      'Novelty can be exciting for one dog and too much for another, so Woof should not use one exploration default.',
+    answers: [
+      'PREFERS_FAMILIAR',
+      'WARMS_UP_SLOWLY',
+      'USUALLY_CURIOUS',
+      'HIGHLY_VARIABLE',
+      'NOT_SURE',
+      'SKIP',
+    ],
+    decisionValue: 2,
+    burden: 1,
+    safetyRelevance: 0,
+    contextTrigger: 0,
+  },
+  {
+    id: 'profile-dog-reinforcers-v1',
+    target: { kind: 'PROFILE', dimension: 'DOG_REINFORCERS' },
+    prompt: 'What tends to be most rewarding for your dog?',
+    whyAsk:
+      'Training is easier to personalize when Woof knows whether food, play, sniffing, praise, or another reinforcer actually matters to this dog.',
+    answers: [
+      'FOOD',
+      'TOYS_PLAY',
+      'SNIFFING_EXPLORING',
+      'PRAISE_CONTACT',
+      'VARIES',
+      'NOT_SURE',
+      'SKIP',
+    ],
+    decisionValue: 3,
+    burden: 1,
+    safetyRelevance: 0,
+    contextTrigger: 0,
+  },
+  {
+    id: 'profile-dog-dislikes-v1',
+    target: { kind: 'PROFILE', dimension: 'DOG_OBVIOUS_DISLIKES' },
+    prompt: 'Are there activity types or situations your dog clearly prefers to avoid?',
+    whyAsk:
+      'Explicit dislikes should remove poor-fit suggestions instead of forcing the model to rediscover them through bad experiences.',
+    answers: ['YES', 'NO_OBVIOUS_DISLIKES', 'NOT_SURE', 'SKIP'],
+    decisionValue: 3,
+    burden: 2,
+    safetyRelevance: 1,
+    contextTrigger: 0,
+  },
+  {
+    id: 'profile-training-experience-v1',
+    target: { kind: 'PROFILE', dimension: 'TRAINING_EXPERIENCE' },
+    prompt: 'How much reward-based training have you and your dog done together?',
+    whyAsk:
+      'Training quests should start at a useful step for both halves of the team, not at a generic beginner or advanced level.',
+    answers: [
+      'NEW_TO_IT',
+      'SOME_PRACTICE',
+      'REGULAR_PRACTICE',
+      'VERY_EXPERIENCED',
+      'NOT_SURE',
+      'SKIP',
+    ],
+    decisionValue: 2,
+    burden: 1,
+    safetyRelevance: 0,
+    contextTrigger: 0,
+  },
+];
+
+function parseTimestamp(value: string): number | null {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function validProfileEvidence(
+  evidence: readonly ProfileEvidence[],
+  nowMs: number
+): Map<ProfileDimension, ProfileEvidence> {
+  const valid = evidence
+    .map((entry) => ({ entry, updatedAtMs: parseTimestamp(entry.updatedAt) }))
+    .filter(
+      (item): item is { entry: ProfileEvidence; updatedAtMs: number } =>
+        item.updatedAtMs !== null &&
+        item.updatedAtMs <= nowMs &&
+        Number.isFinite(item.entry.confidence) &&
+        item.entry.confidence >= 0 &&
+        item.entry.confidence <= 1
+    )
+    .sort((left, right) => {
+      const dimension = left.entry.dimension.localeCompare(right.entry.dimension);
+      if (dimension !== 0) return dimension;
+      const provenance =
+        PROVENANCE_RANK[right.entry.provenance] - PROVENANCE_RANK[left.entry.provenance];
+      if (provenance !== 0) return provenance;
+      const state = PROFILE_STATE_RANK[right.entry.state] - PROFILE_STATE_RANK[left.entry.state];
+      if (state !== 0) return state;
+      if (right.entry.confidence !== left.entry.confidence) {
+        return right.entry.confidence - left.entry.confidence;
+      }
+      if (right.updatedAtMs !== left.updatedAtMs) return right.updatedAtMs - left.updatedAtMs;
+      return left.entry.provenance.localeCompare(right.entry.provenance);
+    });
+
+  const byDimension = new Map<ProfileDimension, ProfileEvidence>();
+  for (const item of valid) {
+    if (!byDimension.has(item.entry.dimension)) byDimension.set(item.entry.dimension, item.entry);
+  }
+  return byDimension;
+}
+
+function interactionSignature(interaction: ProfileInteraction): string {
+  return [
+    interaction.occurredAt,
+    interaction.kind,
+    interaction.questFamily,
+    interaction.dogExperience ?? '',
+  ].join('|');
+}
+
+function recentInteractions(
+  interactions: readonly ProfileInteraction[],
+  nowMs: number
+): Array<ProfileInteraction & { occurredAtMs: number }> {
+  const windowStart = nowMs - PROFILE_QUESTION_POLICY_V1.interactionWindowDays * DAY_MS;
+  const valid = interactions
+    .map((interaction) => ({
+      ...interaction,
+      occurredAtMs: parseTimestamp(interaction.occurredAt),
+    }))
+    .filter(
+      (interaction): interaction is ProfileInteraction & { occurredAtMs: number } =>
+        interaction.occurredAtMs !== null &&
+        interaction.occurredAtMs >= windowStart &&
+        interaction.occurredAtMs <= nowMs
+    )
+    .sort((left, right) => {
+      const id = left.id.localeCompare(right.id);
+      if (id !== 0) return id;
+      return interactionSignature(left).localeCompare(interactionSignature(right));
+    });
+
+  const byId = new Map<string, Array<ProfileInteraction & { occurredAtMs: number }>>();
+  for (const interaction of valid) {
+    const group = byId.get(interaction.id) ?? [];
+    group.push(interaction);
+    byId.set(interaction.id, group);
+  }
+
+  return [...byId.values()]
+    .flatMap((group) => {
+      const first = group[0];
+      if (!first) return [];
+      const signature = interactionSignature(first);
+      if (group.some((interaction) => interactionSignature(interaction) !== signature)) return [];
+      return [first];
+    })
+    .sort((left, right) => {
+      if (left.occurredAtMs !== right.occurredAtMs) return left.occurredAtMs - right.occurredAtMs;
+      return left.id.localeCompare(right.id);
+    });
+}
+
+function inferredConfidence(
+  dimension: ProfileDimension,
+  interactions: readonly (ProfileInteraction & { occurredAtMs: number })[]
+): number {
+  const matching = interactions.filter((interaction) => {
+    if (interaction.kind !== 'COMPLETED') return false;
+    if (interaction.dogExperience !== 'loved_it' && interaction.dogExperience !== 'comfortable') {
+      return false;
+    }
+    if (dimension === 'DOG_SOCIAL_COMFORT') return interaction.questFamily === 'SOCIAL';
+    if (dimension === 'TRAINING_EXPERIENCE') return interaction.questFamily === 'TRAINING';
+    return false;
+  }).length;
+
+  return Math.min(0.88, matching * 0.22);
+}
+
+function profileUncertainty(
+  dimension: ProfileDimension,
+  profile: Map<ProfileDimension, ProfileEvidence>,
+  interactions: readonly (ProfileInteraction & { occurredAtMs: number })[]
+): { uncertainty: number; known: boolean; reason: string } {
+  const explicit = profile.get(dimension);
+  const inferred = inferredConfidence(dimension, interactions);
+
+  if (explicit?.provenance === 'OWNER_CORRECTION') {
+    const known =
+      explicit.state === 'KNOWN' &&
+      explicit.confidence >= PROFILE_QUESTION_POLICY_V1.knownConfidenceThreshold;
+    return {
+      uncertainty: known ? 0 : 1 - explicit.confidence,
+      known,
+      reason: known ? 'OWNER_CORRECTION_KNOWN' : 'OWNER_CORRECTION_UNCERTAIN',
+    };
+  }
+
+  const explicitConfidence = explicit?.state === 'UNKNOWN' ? 0 : (explicit?.confidence ?? 0);
+  const effectiveConfidence = Math.max(explicitConfidence, inferred);
+  const knownFromProfile =
+    explicit?.state === 'KNOWN' &&
+    explicit.confidence >= PROFILE_QUESTION_POLICY_V1.knownConfidenceThreshold;
+  const knownFromOutcomes = inferred >= PROFILE_QUESTION_POLICY_V1.knownConfidenceThreshold;
+
+  return {
+    uncertainty: Math.max(0, 1 - effectiveConfidence),
+    known: knownFromProfile || knownFromOutcomes,
+    reason: knownFromProfile
+      ? 'PROFILE_KNOWN'
+      : knownFromOutcomes
+        ? 'REPEATED_POSITIVE_OUTCOMES'
+        : explicit
+          ? 'PROFILE_LOW_CONFIDENCE'
+          : 'PROFILE_UNKNOWN',
+  };
+}
+
+function cooldownDays(entry: QuestionHistoryEntry): number {
+  if (entry.outcome === 'SKIPPED') return PROFILE_QUESTION_POLICY_V1.skippedCooldownDays;
+  if (entry.outcome === 'NOT_SURE') return PROFILE_QUESTION_POLICY_V1.notSureCooldownDays;
+  return PROFILE_QUESTION_POLICY_V1.answeredCooldownDays;
+}
+
+function isInCooldown(
+  questionId: string,
+  history: readonly QuestionHistoryEntry[],
+  nowMs: number
+): boolean {
+  const latest = history
+    .filter((entry) => entry.questionId === questionId)
+    .map((entry) => ({ entry, askedAtMs: parseTimestamp(entry.askedAt) }))
+    .filter(
+      (item): item is { entry: QuestionHistoryEntry; askedAtMs: number } =>
+        item.askedAtMs !== null && item.askedAtMs <= nowMs
+    )
+    .sort((left, right) => {
+      if (right.askedAtMs !== left.askedAtMs) return right.askedAtMs - left.askedAtMs;
+      return QUESTION_OUTCOME_RANK[right.entry.outcome] - QUESTION_OUTCOME_RANK[left.entry.outcome];
+    })[0];
+
+  if (!latest) return false;
+  return nowMs - latest.askedAtMs < cooldownDays(latest.entry) * DAY_MS;
+}
+
+function repeatedDismissalCandidates(
+  interactions: readonly (ProfileInteraction & { occurredAtMs: number })[]
+): Candidate[] {
+  const counts = new Map<QuestFamily, number>();
+  for (const interaction of interactions) {
+    if (interaction.kind !== 'DISMISSED') continue;
+    counts.set(interaction.questFamily, (counts.get(interaction.questFamily) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .filter(([, count]) => count >= PROFILE_QUESTION_POLICY_V1.dismissalsForClarification)
+    .map(([questFamily, count]) => ({
+      id: `profile-clarify-${questFamily.toLowerCase()}-preference-v1`,
+      target: { kind: 'QUEST_FAMILY_PREFERENCE' as const, questFamily },
+      prompt: `When ${questFamily.toLowerCase()} quests get passed over, is that usually preference or timing?`,
+      whyAsk:
+        'Woof should not turn a few declined suggestions into a permanent dislike when the day or timing may have been the real reason.',
+      answers: ['NOT_A_FAVORITE', 'BAD_TIMING_LATELY', 'DEPENDS', 'NOT_SURE', 'SKIP'],
+      decisionValue: 3,
+      burden: 1,
+      safetyRelevance: questFamily === 'SOCIAL' ? 1 : 0,
+      contextTrigger: 3,
+      uncertainty: 1,
+      reasonCodes: ['REPEATED_RELATED_DISMISSALS', `DISMISSAL_COUNT_${count}`],
+    }));
+}
+
+function trainingDifficultyCandidate(
+  interactions: readonly (ProfileInteraction & { occurredAtMs: number })[],
+  nowMs: number
+): Candidate | null {
+  const recentBoundary = nowMs - PROFILE_QUESTION_POLICY_V1.sessionFollowupWindowHours * HOUR_MS;
+  const latest = [...interactions]
+    .reverse()
+    .find(
+      (interaction) =>
+        interaction.occurredAtMs >= recentBoundary &&
+        interaction.kind === 'COMPLETED' &&
+        interaction.questFamily === 'TRAINING' &&
+        (interaction.dogExperience === 'loved_it' || interaction.dogExperience === 'comfortable')
+    );
+
+  if (!latest) return null;
+  return {
+    id: 'profile-training-session-difficulty-v1',
+    target: { kind: 'SESSION_DIFFICULTY', questFamily: 'TRAINING' },
+    prompt: 'How did that training step feel for the two of you?',
+    whyAsk:
+      'Difficulty feedback helps Woof distinguish a useful next step from an exercise that was technically completed but too easy or too demanding.',
+    answers: ['EASY', 'ABOUT_RIGHT', 'CHALLENGING', 'NOT_SURE', 'SKIP'],
+    decisionValue: 2,
+    burden: 1,
+    safetyRelevance: 0,
+    contextTrigger: 3,
+    uncertainty: 1,
+    reasonCodes: ['RECENT_POSITIVE_TRAINING_COMPLETION'],
+  };
+}
+
+function candidateScore(candidate: Candidate): number {
+  const weights = PROFILE_QUESTION_POLICY_V1.scoreWeights;
+  const raw =
+    candidate.decisionValue * weights.decisionValue +
+    candidate.uncertainty * weights.uncertainty +
+    candidate.contextTrigger * weights.contextTrigger +
+    candidate.safetyRelevance * weights.safetyRelevance +
+    candidate.burden * weights.burden;
+  return Math.round(raw * 1000) / 1000;
+}
+
+export function selectProfileQuestion(input: ProfileQuestionPolicyInput): ProfileQuestion | null {
+  const nowMs = parseTimestamp(input.now);
+  if (nowMs === null) {
+    throw new Error('profile-question-policy-v1 requires a valid explicit now timestamp');
+  }
+
+  const profile = validProfileEvidence(input.profileEvidence, nowMs);
+  const interactions = recentInteractions(input.interactions, nowMs);
+  const candidates: Candidate[] = [];
+
+  for (const question of STATIC_QUESTIONS) {
+    const state = profileUncertainty(question.target.dimension, profile, interactions);
+    if (state.known || isInCooldown(question.id, input.questionHistory, nowMs)) continue;
+
+    const reasonCodes = [state.reason];
+    if (question.contextTrigger > 0) reasonCodes.push('FOUNDATIONAL_COLD_START');
+    if (question.safetyRelevance > 0) reasonCodes.push('ELIGIBILITY_RELEVANT_CONTEXT');
+    candidates.push({ ...question, uncertainty: state.uncertainty, reasonCodes });
+  }
+
+  for (const candidate of repeatedDismissalCandidates(interactions)) {
+    if (!isInCooldown(candidate.id, input.questionHistory, nowMs)) candidates.push(candidate);
+  }
+
+  const trainingCandidate = trainingDifficultyCandidate(interactions, nowMs);
+  if (trainingCandidate && !isInCooldown(trainingCandidate.id, input.questionHistory, nowMs)) {
+    candidates.push(trainingCandidate);
+  }
+
+  const ranked = candidates
+    .map((candidate) => ({ candidate, score: candidateScore(candidate) }))
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score;
+      return left.candidate.id.localeCompare(right.candidate.id);
+    });
+
+  const winner = ranked[0];
+  if (!winner) return null;
+
+  return {
+    policyVersion: PROFILE_QUESTION_POLICY_V1.version,
+    id: winner.candidate.id,
+    target: winner.candidate.target,
+    prompt: winner.candidate.prompt,
+    whyAsk: winner.candidate.whyAsk,
+    answers: winner.candidate.answers,
+    score: winner.score,
+    reasonCodes: winner.candidate.reasonCodes,
+  };
+}

--- a/apps/api/src/adventure/profile-question-policy-v1.types.ts
+++ b/apps/api/src/adventure/profile-question-policy-v1.types.ts
@@ -1,0 +1,89 @@
+export const PROFILE_DIMENSIONS = [
+  'OWNER_GOALS',
+  'OWNER_TIME_BUDGET',
+  'OWNER_EFFORT_PREFERENCE',
+  'AVAILABLE_ENVIRONMENTS',
+  'DOG_ENERGY_PATTERN',
+  'DOG_SOCIAL_COMFORT',
+  'DOG_NOVELTY_COMFORT',
+  'DOG_REINFORCERS',
+  'DOG_OBVIOUS_DISLIKES',
+  'TRAINING_EXPERIENCE',
+] as const;
+
+export type ProfileDimension = (typeof PROFILE_DIMENSIONS)[number];
+export type ProfileEvidenceState = 'UNKNOWN' | 'LEARNING' | 'KNOWN';
+export type ProfileEvidenceProvenance =
+  | 'OWNER_CORRECTION'
+  | 'OWNER_EXPLICIT'
+  | 'HOUSEHOLD_EXPLICIT'
+  | 'HISTORICAL_QUIZ'
+  | 'OUTCOME_INFERENCE';
+
+export type ProfileEvidence = {
+  dimension: ProfileDimension;
+  state: ProfileEvidenceState;
+  confidence: number;
+  provenance: ProfileEvidenceProvenance;
+  updatedAt: string;
+};
+
+export type QuestionHistoryOutcome = 'ANSWERED' | 'NOT_SURE' | 'SKIPPED';
+
+export type QuestionHistoryEntry = {
+  questionId: string;
+  askedAt: string;
+  outcome: QuestionHistoryOutcome;
+};
+
+export type QuestFamily =
+  'ACTIVITY' | 'SCENT' | 'TRAINING' | 'SOCIAL' | 'RECOVERY' | 'BOND' | 'OTHER';
+
+export type ProfileInteraction = {
+  id: string;
+  occurredAt: string;
+  kind: 'DISMISSED' | 'COMPLETED' | 'SAFE_OPT_OUT';
+  questFamily: QuestFamily;
+  dogExperience?: 'loved_it' | 'comfortable' | 'not_their_thing';
+};
+
+export type ProfileQuestionTarget =
+  | { kind: 'PROFILE'; dimension: ProfileDimension }
+  | { kind: 'QUEST_FAMILY_PREFERENCE'; questFamily: QuestFamily }
+  | { kind: 'SESSION_DIFFICULTY'; questFamily: 'TRAINING' };
+
+export type ProfileQuestion = {
+  policyVersion: string;
+  id: string;
+  target: ProfileQuestionTarget;
+  prompt: string;
+  whyAsk: string;
+  answers: readonly string[];
+  score: number;
+  reasonCodes: readonly string[];
+};
+
+export type ProfileQuestionPolicyInput = {
+  profileEvidence: readonly ProfileEvidence[];
+  questionHistory: readonly QuestionHistoryEntry[];
+  interactions: readonly ProfileInteraction[];
+  now: string;
+};
+
+export type ProfileQuestionPolicyReceipt = {
+  version: string;
+  knownConfidenceThreshold: number;
+  interactionWindowDays: number;
+  sessionFollowupWindowHours: number;
+  answeredCooldownDays: number;
+  notSureCooldownDays: number;
+  skippedCooldownDays: number;
+  dismissalsForClarification: number;
+  scoreWeights: {
+    decisionValue: number;
+    uncertainty: number;
+    contextTrigger: number;
+    safetyRelevance: number;
+    burden: number;
+  };
+};

--- a/docs/DOGOS_PROGRESSIVE_QUESTION_POLICY_V1.md
+++ b/docs/DOGOS_PROGRESSIVE_QUESTION_POLICY_V1.md
@@ -1,0 +1,93 @@
+# dogOS Progressive Question Policy v1
+
+`profile-question-policy-v1` is the first executable policy under Adaptive Adventure issue #47 / parent #42.
+
+Its job is intentionally narrow:
+
+> Given bounded profile evidence, recent quest interactions, question history, and an explicit clock, decide whether **one optional question** is worth asking now.
+
+It does not persist profile state, rank quests, award Bond XP, call ML, or decide medical/safety advice.
+
+## Why this exists
+
+The current onboarding quiz is already small, but its three questions are broad: schedule, general activity level, and preferred activities. Adaptive Adventure needs higher-value state such as goals, realistic time/effort, social and novelty comfort, reinforcers, obvious dislikes, available environments, and training experience without expanding onboarding into a long form.
+
+The intended product loop is therefore:
+
+`small First Adventure profile -> useful quest -> observed outcome -> optional high-value micro-question -> stronger pair model`
+
+A missing fact does not automatically justify a question. User attention has a cost.
+
+## Inputs
+
+The policy receives only explicit data:
+
+- profile evidence by dimension;
+- provenance and confidence;
+- recent bounded quest interactions;
+- previous question outcomes;
+- explicit `now`.
+
+There is no implicit clock, database, environment variable, network call, random number, or ML inference.
+
+### Durable dimensions
+
+- owner goals
+- owner time budget
+- owner effort preference
+- available environments
+- dog energy pattern
+- dog social comfort
+- dog novelty comfort
+- dog reinforcers
+- dog obvious dislikes
+- training experience
+
+Known restrictions and safety exclusions are deliberately outside this casual question policy. They belong to explicit safety/profile capture and hard eligibility gates.
+
+## Authority rules
+
+1. Invalid or future-dated evidence cannot suppress a question.
+2. Explicit owner corrections outrank inferred behavioral confidence.
+3. High-confidence known dimensions are not re-asked.
+4. Repeated positive social/training outcomes may eventually provide enough evidence to suppress a redundant generic question.
+5. A single dismissal never becomes a durable dislike.
+6. Two related dismissals may trigger a preference-versus-timing clarification.
+7. Safe opt-outs are never counted as dislike evidence.
+8. A recent positive training completion may trigger one low-burden difficulty question.
+9. Recent `SKIPPED` and `NOT_SURE` answers enter cooldowns so Woof does not nag.
+10. The policy returns at most one question.
+
+## Value-of-information proxy
+
+Eligible candidates receive a deterministic score from:
+
+- decision value;
+- remaining uncertainty;
+- contextual trigger strength;
+- eligibility relevance;
+- burden penalty.
+
+The score is a ranking receipt, not a probability and not a user-facing quality grade. Equal scores tie-break by stable question ID.
+
+## Two economies remain separate
+
+This policy has no Bond XP, reward amount, streak, retention, click-through, or game-currency target.
+
+Game rewards can make Adventure fun. Training labels must describe what actually happened for the dog and human. Feeding our own XP schedule back into personalization would create a self-referential objective.
+
+## Version receipt
+
+Policy version: `profile-question-policy-v1`
+
+Canonical receipt SHA-256:
+
+`dca2936d547338e58d5911006e575d8394d685e7679c2d52ad5cb24e07cd0483`
+
+The Jest contract recomputes this hash and verifies that the canonical receipt and exported policy object remain equivalent.
+
+## Non-goals
+
+This release does not add profile persistence, a REST endpoint, First Adventure UI, learned active questioning, a skill graph, contextual-bandit exploration, or a deep personalization model.
+
+Those layers should consume this oracle after it qualifies, not duplicate its decision semantics in UI code.


### PR DESCRIPTION
## Adaptive Adventure 1A

Implements the pure decision-policy slice from #47, under #42 / #41.

### Purpose

Define one deterministic answer before persistence or UI depends on it:

`bounded pair/profile evidence + recent quest outcomes + question history + explicit now -> at most one optional question or NONE`

This is deliberately **not** the full First Adventure/profile release yet.

### What this slice owns

- versioned `profile-question-policy-v1`
- typed durable profile dimensions for the high-information cold-start surface
- explicit provenance/confidence state
- owner-correction authority over inferred behavior
- invalid/future evidence rejection from decision authority
- skip / not-sure / answered cooldowns
- repeated-dismissal `preference vs timing` clarification only after multiple related declines
- safe opt-outs never treated as durable dislike evidence
- bounded repeated-positive-outcome inference for social/training confidence
- timely training-difficulty follow-up
- deterministic value-of-information proxy with stable tie-breaking
- at most one returned question
- no Bond XP or Reward Ledger authority in the policy
- SHA-256 pinned policy receipt

### Dedicated qualification

`.github/workflows/dogos-progressive-question-policy-ci.yml` proves:

- zero database ownership
- frozen-lockfile install
- read-only formatting
- no Nest/Prisma/database/env/network/random/implicit-clock dependencies in production policy files
- no Bond XP / Reward Ledger authority
- zero-warning lint
- API type-check
- focused Jest oracle contracts including receipt hash, cooldown, safe-stop, correction, repeated outcomes, future/malformed evidence, and permutation determinism

### Explicit non-goals

No schema migration, REST endpoint, profile persistence, onboarding redesign, learned active-question model, skill graph, contextual bandit, or deep model is introduced here.

After this oracle qualifies, #42 can add household-aware profile persistence and the First Adventure UX without duplicating question-selection semantics.