### PR TITLE
Adaptive Adventure: household-aware profile persistence

### DIFF
--- a/.github/workflows/dogos-adaptive-profile-persistence-ci.yml
+++ b/.github/workflows/dogos-adaptive-profile-persistence-ci.yml
@@ -1,0 +1,105 @@
+name: dogOS Adaptive Profile Persistence CI
+
+on:
+  pull_request:
+    paths:
+      - 'apps/api/src/adventure/adaptive-profile*.ts'
+      - 'apps/api/src/adventure/dto/adaptive-profile.dto.ts'
+      - 'apps/api/src/adventure/adventure.module.ts'
+      - 'packages/database/prisma/schema.prisma'
+      - 'packages/database/prisma/migrations/20260826055200_add_adaptive_profile_persistence/**'
+      - 'docs/DOGOS_ADAPTIVE_PROFILE_PERSISTENCE_V1.md'
+      - '.github/workflows/dogos-adaptive-profile-persistence-ci.yml'
+
+permissions:
+  contents: read
+
+env:
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_profile_ci
+  SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_profile_shadow
+
+jobs:
+  profile-persistence:
+    name: Pair-scoped profile persistence qualification
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 8.15.1
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20.20.2
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Restrict database ownership to the profile schema slice
+        shell: bash
+        run: |
+          unexpected="$({
+            git diff --name-only '${{ github.event.pull_request.base.sha }}'...HEAD -- packages/database || true
+          } | grep -Ev '^(packages/database/prisma/schema\.prisma|packages/database/prisma/migrations/20260826055200_add_adaptive_profile_persistence/migration\.sql)$' || true)"
+          if [ -n "$unexpected" ]; then
+            echo 'Adaptive Profile persistence changed unrelated database files:'
+            printf '%s\n' "$unexpected"
+            exit 1
+          fi
+
+      - name: Reject game-currency authority in profile runtime
+        shell: bash
+        run: |
+          if grep -En 'bondXp|RewardLedger|rewardLedger|totalPoints|pathwayXp' \
+            apps/api/src/adventure/adaptive-profile*.ts \
+            apps/api/src/adventure/dto/adaptive-profile.dto.ts; then
+            echo 'Adaptive Profile may not read or write the game reward economy.'
+            exit 1
+          fi
+
+      - name: Validate and canonically format Prisma schema
+        shell: bash
+        run: |
+          pnpm --filter @woof/database exec prisma validate --schema prisma/schema.prisma
+          pnpm --filter @woof/database exec prisma format --schema prisma/schema.prisma
+          git diff --exit-code -- packages/database/prisma/schema.prisma
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Check canonical source formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/adventure/adaptive-profile-v1.ts
+          apps/api/src/adventure/adaptive-profile-v1.spec.ts
+          apps/api/src/adventure/adaptive-profile.service.ts
+          apps/api/src/adventure/adaptive-profile.service.spec.ts
+          apps/api/src/adventure/adaptive-profile.controller.ts
+          apps/api/src/adventure/dto/adaptive-profile.dto.ts
+          apps/api/src/adventure/adventure.module.ts
+          docs/DOGOS_ADAPTIVE_PROFILE_PERSISTENCE_V1.md
+
+      - name: Lint profile runtime and contracts with zero warnings
+        run: >-
+          pnpm --filter @woof/api exec eslint
+          'src/adventure/adaptive-profile*.ts'
+          'src/adventure/dto/adaptive-profile.dto.ts'
+          --max-warnings=0
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api exec tsc --noEmit
+
+      - name: Run Adaptive Profile contracts
+        run: >-
+          pnpm --filter @woof/api exec jest
+          src/adventure/adaptive-profile-v1.spec.ts
+          src/adventure/adaptive-profile.service.spec.ts
+          --runInBand

--- a/apps/api/src/adventure/adaptive-profile-v1.spec.ts
+++ b/apps/api/src/adventure/adaptive-profile-v1.spec.ts
@@ -1,0 +1,100 @@
+import {
+  ADAPTIVE_PROFILE_SCHEMA_VERSION,
+  normalizeQuestionAnswer,
+  resolveCurrentProfileEvidence,
+  type PersistedProfileEvidenceLike,
+} from './adaptive-profile-v1';
+
+function evidence(
+  overrides: Partial<PersistedProfileEvidenceLike> & Pick<PersistedProfileEvidenceLike, 'id'>
+): PersistedProfileEvidenceLike {
+  return {
+    dimension: 'DOG_SOCIAL_COMFORT',
+    subject: 'DOG',
+    state: 'KNOWN',
+    value: ['SELECTIVELY_SOCIAL'],
+    confidence: 1,
+    provenance: 'OWNER_EXPLICIT',
+    schemaVersion: ADAPTIVE_PROFILE_SCHEMA_VERSION,
+    occurredAt: new Date('2026-08-25T18:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('adaptive-profile-v1', () => {
+  it('keeps owner correction authoritative over newer inferred evidence', () => {
+    const projected = resolveCurrentProfileEvidence([
+      evidence({
+        id: 'correction',
+        provenance: 'OWNER_CORRECTION',
+        value: ['PREFERS_SPACE'],
+        occurredAt: new Date('2026-08-24T18:00:00.000Z'),
+      }),
+      evidence({
+        id: 'inference',
+        provenance: 'OUTCOME_INFERENCE',
+        value: ['OFTEN_SOCIAL'],
+        occurredAt: new Date('2026-08-25T18:00:00.000Z'),
+      }),
+    ]);
+
+    expect(projected).toHaveLength(1);
+    expect(projected[0]?.id).toBe('correction');
+  });
+
+  it('lets the newest correction explicitly clear an older known correction', () => {
+    const projected = resolveCurrentProfileEvidence([
+      evidence({
+        id: 'older-known',
+        provenance: 'OWNER_CORRECTION',
+        state: 'KNOWN',
+        confidence: 1,
+        occurredAt: new Date('2026-08-24T18:00:00.000Z'),
+      }),
+      evidence({
+        id: 'newer-unknown',
+        provenance: 'OWNER_CORRECTION',
+        state: 'UNKNOWN',
+        value: null,
+        confidence: 0,
+        occurredAt: new Date('2026-08-25T18:00:00.000Z'),
+      }),
+    ]);
+
+    expect(projected[0]?.id).toBe('newer-unknown');
+    expect(projected[0]?.state).toBe('UNKNOWN');
+  });
+
+  it('ignores evidence from another schema version or mismatched subject', () => {
+    const projected = resolveCurrentProfileEvidence([
+      evidence({ id: 'future', schemaVersion: 'adaptive-profile-v2' }),
+      evidence({ id: 'wrong-subject', subject: 'OWNER' }),
+    ]);
+
+    expect(projected).toEqual([]);
+  });
+
+  it('canonicalizes multi-select answers independently of click order', () => {
+    expect(
+      normalizeQuestionAnswer('profile-owner-goals-v1', 'ANSWERED', [
+        'TRAINING',
+        'MORE_ADVENTURES',
+        'TRAINING',
+      ])
+    ).toEqual({
+      dimension: 'OWNER_GOALS',
+      values: ['MORE_ADVENTURES', 'TRAINING'],
+    });
+  });
+
+  it('does not convert skip or not-sure into a preference value', () => {
+    expect(normalizeQuestionAnswer('profile-dog-energy-v1', 'SKIPPED', undefined)).toEqual({
+      dimension: 'DOG_ENERGY_PATTERN',
+      values: null,
+    });
+    expect(normalizeQuestionAnswer('profile-dog-energy-v1', 'NOT_SURE', undefined)).toEqual({
+      dimension: 'DOG_ENERGY_PATTERN',
+      values: null,
+    });
+  });
+});

--- a/apps/api/src/adventure/adaptive-profile-v1.ts
+++ b/apps/api/src/adventure/adaptive-profile-v1.ts
@@ -1,0 +1,237 @@
+import { PROFILE_QUESTION_POLICY_V1 } from './profile-question-policy-v1.receipt';
+import {
+  PROFILE_DIMENSIONS,
+  type ProfileDimension,
+  type ProfileEvidence,
+  type ProfileEvidenceProvenance,
+  type QuestionHistoryOutcome,
+} from './profile-question-policy-v1.types';
+
+export const ADAPTIVE_PROFILE_SCHEMA_VERSION = 'adaptive-profile-v1' as const;
+
+export type AdaptiveProfileSubject = 'DOG' | 'OWNER' | 'PAIR';
+
+export type PersistedProfileEvidenceLike = {
+  id: string;
+  dimension: string;
+  subject: string;
+  state: string;
+  value: unknown;
+  confidence: number;
+  provenance: string;
+  schemaVersion: string;
+  occurredAt: Date;
+};
+
+type StaticProfileQuestionDefinition = {
+  dimension: ProfileDimension;
+  answers: readonly string[];
+  maxSelections: number;
+};
+
+const QUESTION_DEFINITIONS: Readonly<Record<string, StaticProfileQuestionDefinition>> = {
+  'profile-owner-goals-v1': {
+    dimension: 'OWNER_GOALS',
+    answers: [
+      'MORE_ADVENTURES',
+      'TRAINING',
+      'CALMER_ROUTINES',
+      'SOCIAL_CONFIDENCE',
+      'CARE_ROUTINES',
+      'JUST_HAVE_FUN',
+    ],
+    maxSelections: 3,
+  },
+  'profile-owner-time-budget-v1': {
+    dimension: 'OWNER_TIME_BUDGET',
+    answers: ['FIVE_MIN', 'TEN_TO_FIFTEEN', 'TWENTY_TO_THIRTY', 'FORTY_PLUS', 'VARIES'],
+    maxSelections: 1,
+  },
+  'profile-owner-effort-v1': {
+    dimension: 'OWNER_EFFORT_PREFERENCE',
+    answers: ['KEEP_IT_EASY', 'MODERATE', 'UP_FOR_A_CHALLENGE', 'VARIES'],
+    maxSelections: 1,
+  },
+  'profile-available-environments-v1': {
+    dimension: 'AVAILABLE_ENVIRONMENTS',
+    answers: ['INDOORS', 'YARD', 'NEIGHBORHOOD', 'PARK', 'TRAIL', 'VARIES'],
+    maxSelections: 6,
+  },
+  'profile-dog-energy-v1': {
+    dimension: 'DOG_ENERGY_PATTERN',
+    answers: ['MOSTLY_RESTFUL', 'MIXED', 'OFTEN_ACTIVE', 'HIGHLY_VARIABLE'],
+    maxSelections: 1,
+  },
+  'profile-dog-social-comfort-v1': {
+    dimension: 'DOG_SOCIAL_COMFORT',
+    answers: ['PREFERS_SPACE', 'CALM_AT_DISTANCE', 'SELECTIVELY_SOCIAL', 'OFTEN_SOCIAL'],
+    maxSelections: 1,
+  },
+  'profile-dog-novelty-v1': {
+    dimension: 'DOG_NOVELTY_COMFORT',
+    answers: ['PREFERS_FAMILIAR', 'WARMS_UP_SLOWLY', 'USUALLY_CURIOUS', 'HIGHLY_VARIABLE'],
+    maxSelections: 1,
+  },
+  'profile-dog-reinforcers-v1': {
+    dimension: 'DOG_REINFORCERS',
+    answers: ['FOOD', 'TOYS_PLAY', 'SNIFFING_EXPLORING', 'PRAISE_CONTACT', 'VARIES'],
+    maxSelections: 5,
+  },
+  'profile-dog-dislikes-v1': {
+    dimension: 'DOG_OBVIOUS_DISLIKES',
+    answers: ['YES', 'NO_OBVIOUS_DISLIKES'],
+    maxSelections: 1,
+  },
+  'profile-training-experience-v1': {
+    dimension: 'TRAINING_EXPERIENCE',
+    answers: ['NEW_TO_IT', 'SOME_PRACTICE', 'REGULAR_PRACTICE', 'VERY_EXPERIENCED'],
+    maxSelections: 1,
+  },
+};
+
+const SUBJECT_BY_DIMENSION: Record<ProfileDimension, AdaptiveProfileSubject> = {
+  OWNER_GOALS: 'OWNER',
+  OWNER_TIME_BUDGET: 'OWNER',
+  OWNER_EFFORT_PREFERENCE: 'OWNER',
+  AVAILABLE_ENVIRONMENTS: 'PAIR',
+  DOG_ENERGY_PATTERN: 'DOG',
+  DOG_SOCIAL_COMFORT: 'DOG',
+  DOG_NOVELTY_COMFORT: 'DOG',
+  DOG_REINFORCERS: 'DOG',
+  DOG_OBVIOUS_DISLIKES: 'DOG',
+  TRAINING_EXPERIENCE: 'PAIR',
+};
+
+const PROVENANCE_RANK: Record<ProfileEvidenceProvenance, number> = {
+  OWNER_CORRECTION: 5,
+  OWNER_EXPLICIT: 4,
+  HOUSEHOLD_EXPLICIT: 3,
+  HISTORICAL_QUIZ: 2,
+  OUTCOME_INFERENCE: 1,
+};
+
+const STATE_RANK: Record<ProfileEvidence['state'], number> = {
+  KNOWN: 3,
+  LEARNING: 2,
+  UNKNOWN: 1,
+};
+
+export function isProfileDimension(value: string): value is ProfileDimension {
+  return (PROFILE_DIMENSIONS as readonly string[]).includes(value);
+}
+
+export function profileSubjectForDimension(dimension: ProfileDimension): AdaptiveProfileSubject {
+  return SUBJECT_BY_DIMENSION[dimension];
+}
+
+export function staticProfileQuestion(questionId: string): StaticProfileQuestionDefinition | null {
+  return QUESTION_DEFINITIONS[questionId] ?? null;
+}
+
+export function normalizeQuestionAnswer(
+  questionId: string,
+  outcome: QuestionHistoryOutcome,
+  answers: readonly string[] | undefined
+): { dimension: ProfileDimension; values: string[] | null } | null {
+  const definition = staticProfileQuestion(questionId);
+  if (!definition) return null;
+
+  if (outcome !== 'ANSWERED') {
+    if (answers?.length) throw new Error('Non-answered profile questions cannot carry answers');
+    return { dimension: definition.dimension, values: null };
+  }
+
+  const values = [...new Set(answers ?? [])].sort();
+  if (!values.length || values.length > definition.maxSelections) {
+    throw new Error('Profile answer count is outside the allowed range');
+  }
+  if (values.some((value) => !definition.answers.includes(value))) {
+    throw new Error('Profile answer is not valid for this question');
+  }
+  return { dimension: definition.dimension, values };
+}
+
+export function resolveCurrentProfileEvidence(
+  evidence: readonly PersistedProfileEvidenceLike[]
+): PersistedProfileEvidenceLike[] {
+  const valid = evidence.filter(
+    (entry) =>
+      entry.schemaVersion === ADAPTIVE_PROFILE_SCHEMA_VERSION &&
+      isProfileDimension(entry.dimension) &&
+      entry.subject === profileSubjectForDimension(entry.dimension) &&
+      ['UNKNOWN', 'LEARNING', 'KNOWN'].includes(entry.state) &&
+      [
+        'OWNER_CORRECTION',
+        'OWNER_EXPLICIT',
+        'HOUSEHOLD_EXPLICIT',
+        'HISTORICAL_QUIZ',
+        'OUTCOME_INFERENCE',
+      ].includes(entry.provenance) &&
+      Number.isFinite(entry.confidence) &&
+      entry.confidence >= 0 &&
+      entry.confidence <= 1 &&
+      Number.isFinite(entry.occurredAt.getTime())
+  );
+
+  const sorted = [...valid].sort((left, right) => {
+    const dimension = left.dimension.localeCompare(right.dimension);
+    if (dimension !== 0) return dimension;
+
+    const leftProvenance = left.provenance as ProfileEvidenceProvenance;
+    const rightProvenance = right.provenance as ProfileEvidenceProvenance;
+    const provenance = PROVENANCE_RANK[rightProvenance] - PROVENANCE_RANK[leftProvenance];
+    if (provenance !== 0) return provenance;
+
+    // Records are append-only snapshots. Within the same authority class, the latest
+    // explicit statement supersedes the older one, including an explicit UNKNOWN
+    // correction that clears a previously known value.
+    const occurredAt = right.occurredAt.getTime() - left.occurredAt.getTime();
+    if (occurredAt !== 0) return occurredAt;
+
+    const leftState = left.state as ProfileEvidence['state'];
+    const rightState = right.state as ProfileEvidence['state'];
+    const state = STATE_RANK[rightState] - STATE_RANK[leftState];
+    if (state !== 0) return state;
+    if (right.confidence !== left.confidence) return right.confidence - left.confidence;
+    return left.id.localeCompare(right.id);
+  });
+
+  const byDimension = new Map<ProfileDimension, PersistedProfileEvidenceLike>();
+  for (const entry of sorted) {
+    const dimension = entry.dimension as ProfileDimension;
+    if (!byDimension.has(dimension)) byDimension.set(dimension, entry);
+  }
+
+  return PROFILE_DIMENSIONS.flatMap((dimension) => {
+    const entry = byDimension.get(dimension);
+    return entry ? [entry] : [];
+  });
+}
+
+export function toPolicyEvidence(entry: PersistedProfileEvidenceLike): ProfileEvidence | null {
+  if (entry.schemaVersion !== ADAPTIVE_PROFILE_SCHEMA_VERSION) return null;
+  if (!isProfileDimension(entry.dimension)) return null;
+  if (!['UNKNOWN', 'LEARNING', 'KNOWN'].includes(entry.state)) return null;
+  if (
+    ![
+      'OWNER_CORRECTION',
+      'OWNER_EXPLICIT',
+      'HOUSEHOLD_EXPLICIT',
+      'HISTORICAL_QUIZ',
+      'OUTCOME_INFERENCE',
+    ].includes(entry.provenance)
+  ) {
+    return null;
+  }
+  return {
+    dimension: entry.dimension,
+    state: entry.state as ProfileEvidence['state'],
+    confidence: entry.confidence,
+    provenance: entry.provenance as ProfileEvidenceProvenance,
+    updatedAt: entry.occurredAt.toISOString(),
+  };
+}
+
+export function profileQuestionPolicyVersion(): string {
+  return PROFILE_QUESTION_POLICY_V1.version;
+}

--- a/apps/api/src/adventure/adaptive-profile.controller.ts
+++ b/apps/api/src/adventure/adaptive-profile.controller.ts
@@ -1,0 +1,52 @@
+import { Body, Controller, Get, Param, Post, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { AuthenticatedRequest } from '../auth/authenticated-request';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { AdaptiveProfileService } from './adaptive-profile.service';
+import { AdventureEnabledGuard } from './adventure-enabled.guard';
+import {
+  CorrectAdaptiveProfileDto,
+  RecordProfileQuestionResponseDto,
+} from './dto/adaptive-profile.dto';
+
+@ApiTags('adventure-profile')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, AdventureEnabledGuard)
+@Controller('adventure/profile/:householdId/:petId')
+export class AdaptiveProfileController {
+  constructor(private readonly adaptiveProfile: AdaptiveProfileService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get the authorized household/pet Adaptive Adventure profile state' })
+  getState(
+    @Request() req: AuthenticatedRequest,
+    @Param('householdId') householdId: string,
+    @Param('petId') petId: string
+  ) {
+    return this.adaptiveProfile.getState(req.user.sub, householdId, petId);
+  }
+
+  @Post('questions/respond')
+  @ApiOperation({
+    summary: 'Record a replay-safe progressive-profile question response without awarding XP',
+  })
+  recordQuestionResponse(
+    @Request() req: AuthenticatedRequest,
+    @Param('householdId') householdId: string,
+    @Param('petId') petId: string,
+    @Body() dto: RecordProfileQuestionResponseDto
+  ) {
+    return this.adaptiveProfile.recordQuestionResponse(req.user.sub, householdId, petId, dto);
+  }
+
+  @Post('correct')
+  @ApiOperation({ summary: 'Append an authoritative owner correction to the pair profile' })
+  correct(
+    @Request() req: AuthenticatedRequest,
+    @Param('householdId') householdId: string,
+    @Param('petId') petId: string,
+    @Body() dto: CorrectAdaptiveProfileDto
+  ) {
+    return this.adaptiveProfile.correct(req.user.sub, householdId, petId, dto);
+  }
+}

--- a/apps/api/src/adventure/adaptive-profile.service.spec.ts
+++ b/apps/api/src/adventure/adaptive-profile.service.spec.ts
@@ -1,0 +1,336 @@
+import { BadRequestException, ConflictException } from '@nestjs/common';
+import type { HouseholdsService } from '../households/households.service';
+import type { PrismaService } from '../prisma/prisma.service';
+import { ADAPTIVE_PROFILE_SCHEMA_VERSION } from './adaptive-profile-v1';
+import { AdaptiveProfileService } from './adaptive-profile.service';
+
+const HOUSEHOLD_ID = 'household-1';
+const PET_ID = 'pet-1';
+const USER_ID = 'user-1';
+
+type StoredEvidence = {
+  id: string;
+  householdId: string;
+  petId: string;
+  dimension: string;
+  subject: string;
+  state: string;
+  value: unknown;
+  confidence: number;
+  provenance: string;
+  schemaVersion: string;
+  sourceUserId: string | null;
+  occurredAt: Date;
+  createdAt: Date;
+};
+
+type StoredQuestion = {
+  id: string;
+  householdId: string;
+  petId: string;
+  userId: string;
+  questionId: string;
+  policyVersion: string;
+  outcome: string;
+  answer: unknown;
+  askedAt: Date;
+  respondedAt: Date;
+  createdAt: Date;
+};
+
+function makeHarness() {
+  const evidence: StoredEvidence[] = [];
+  const questions: StoredQuestion[] = [];
+
+  const adaptiveProfileEvidence = {
+    findUnique: jest.fn(async ({ where }: { where: { id: string } }) =>
+      evidence.find((entry) => entry.id === where.id)
+    ),
+    findMany: jest.fn(
+      async ({ where }: { where: { householdId: string; petId: string; schemaVersion: string } }) =>
+        evidence.filter(
+          (entry) =>
+            entry.householdId === where.householdId &&
+            entry.petId === where.petId &&
+            entry.schemaVersion === where.schemaVersion
+        )
+    ),
+    create: jest.fn(async ({ data }: { data: Record<string, unknown> }) => {
+      const row: StoredEvidence = {
+        id: String(data.id),
+        householdId: String(data.householdId),
+        petId: String(data.petId),
+        dimension: String(data.dimension),
+        subject: String(data.subject),
+        state: String(data.state),
+        value: data.value === undefined ? null : data.value,
+        confidence: Number(data.confidence),
+        provenance: String(data.provenance),
+        schemaVersion: String(data.schemaVersion),
+        sourceUserId: data.sourceUserId === null ? null : String(data.sourceUserId),
+        occurredAt: data.occurredAt as Date,
+        createdAt: new Date(),
+      };
+      if (evidence.some((entry) => entry.id === row.id)) throw new Error('duplicate evidence');
+      evidence.push(row);
+      return row;
+    }),
+  };
+
+  const adaptiveProfileQuestionResponse = {
+    findUnique: jest.fn(async ({ where }: { where: { id: string } }) =>
+      questions.find((entry) => entry.id === where.id)
+    ),
+    findMany: jest.fn(async ({ where }: { where: { householdId: string; petId: string } }) =>
+      questions
+        .filter((entry) => entry.householdId === where.householdId && entry.petId === where.petId)
+        .sort((left, right) => right.askedAt.getTime() - left.askedAt.getTime())
+    ),
+    create: jest.fn(async ({ data }: { data: Record<string, unknown> }) => {
+      const row: StoredQuestion = {
+        id: String(data.id),
+        householdId: String(data.householdId),
+        petId: String(data.petId),
+        userId: String(data.userId),
+        questionId: String(data.questionId),
+        policyVersion: String(data.policyVersion),
+        outcome: String(data.outcome),
+        answer: data.answer === undefined ? null : data.answer,
+        askedAt: data.askedAt as Date,
+        respondedAt: data.respondedAt as Date,
+        createdAt: new Date(),
+      };
+      if (questions.some((entry) => entry.id === row.id)) throw new Error('duplicate question');
+      questions.push(row);
+      return row;
+    }),
+  };
+
+  const tx = { adaptiveProfileEvidence, adaptiveProfileQuestionResponse };
+  const prisma = {
+    adaptiveProfileEvidence,
+    adaptiveProfileQuestionResponse,
+    $transaction: jest.fn(async (callback: (client: typeof tx) => Promise<unknown>) =>
+      callback(tx)
+    ),
+  };
+  const households = {
+    assertHouseholdPetAccessible: jest.fn(async () => ({
+      householdId: HOUSEHOLD_ID,
+      petId: PET_ID,
+      timezone: 'UTC',
+    })),
+  };
+
+  return {
+    evidence,
+    questions,
+    prisma,
+    households,
+    service: new AdaptiveProfileService(
+      prisma as unknown as PrismaService,
+      households as unknown as HouseholdsService
+    ),
+  };
+}
+
+describe('AdaptiveProfileService', () => {
+  it('authorizes and reads only the requested household/pet pair', async () => {
+    const harness = makeHarness();
+    harness.evidence.push({
+      id: 'other-pet',
+      householdId: HOUSEHOLD_ID,
+      petId: 'pet-2',
+      dimension: 'DOG_ENERGY_PATTERN',
+      subject: 'DOG',
+      state: 'KNOWN',
+      value: ['OFTEN_ACTIVE'],
+      confidence: 1,
+      provenance: 'OWNER_EXPLICIT',
+      schemaVersion: ADAPTIVE_PROFILE_SCHEMA_VERSION,
+      sourceUserId: USER_ID,
+      occurredAt: new Date(),
+      createdAt: new Date(),
+    });
+
+    const result = await harness.service.getState(USER_ID, HOUSEHOLD_ID, PET_ID);
+
+    expect(harness.households.assertHouseholdPetAccessible).toHaveBeenCalledWith(
+      USER_ID,
+      HOUSEHOLD_ID,
+      PET_ID
+    );
+    expect(harness.prisma.adaptiveProfileEvidence.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          householdId: HOUSEHOLD_ID,
+          petId: PET_ID,
+          schemaVersion: ADAPTIVE_PROFILE_SCHEMA_VERSION,
+        },
+      })
+    );
+    expect(result.coverage.known).toEqual([]);
+    expect(result.coverage.unknown).toContain('DOG_ENERGY_PATTERN');
+  });
+
+  it('records a static answer and its durable evidence atomically', async () => {
+    const harness = makeHarness();
+
+    const result = await harness.service.recordQuestionResponse(USER_ID, HOUSEHOLD_ID, PET_ID, {
+      responseId: 'response-1',
+      questionId: 'profile-owner-goals-v1',
+      outcome: 'ANSWERED',
+      answers: ['TRAINING', 'MORE_ADVENTURES'],
+    });
+
+    expect(result.duplicate).toBe(false);
+    expect(harness.prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(harness.questions).toHaveLength(1);
+    expect(harness.evidence).toHaveLength(1);
+    expect(harness.evidence[0]).toEqual(
+      expect.objectContaining({
+        householdId: HOUSEHOLD_ID,
+        petId: PET_ID,
+        dimension: 'OWNER_GOALS',
+        subject: 'OWNER',
+        state: 'KNOWN',
+        confidence: 1,
+        provenance: 'OWNER_EXPLICIT',
+        schemaVersion: ADAPTIVE_PROFILE_SCHEMA_VERSION,
+        sourceUserId: USER_ID,
+      })
+    );
+    expect(result.profile.coverage.known).toContain('OWNER_GOALS');
+  });
+
+  it('records skip as question history only', async () => {
+    const harness = makeHarness();
+
+    await harness.service.recordQuestionResponse(USER_ID, HOUSEHOLD_ID, PET_ID, {
+      responseId: 'skip-1',
+      questionId: 'profile-dog-energy-v1',
+      outcome: 'SKIPPED',
+    });
+
+    expect(harness.questions).toHaveLength(1);
+    expect(harness.evidence).toHaveLength(0);
+  });
+
+  it('records not-sure as explicit unknown rather than a negative preference', async () => {
+    const harness = makeHarness();
+
+    const result = await harness.service.recordQuestionResponse(USER_ID, HOUSEHOLD_ID, PET_ID, {
+      responseId: 'not-sure-1',
+      questionId: 'profile-dog-social-comfort-v1',
+      outcome: 'NOT_SURE',
+    });
+
+    expect(harness.evidence[0]).toEqual(
+      expect.objectContaining({
+        dimension: 'DOG_SOCIAL_COMFORT',
+        state: 'UNKNOWN',
+        value: expect.anything(),
+        confidence: 0,
+        provenance: 'OWNER_EXPLICIT',
+      })
+    );
+    const dimension = result.profile.dimensions.find(
+      (entry) => entry.dimension === 'DOG_SOCIAL_COMFORT'
+    );
+    expect(dimension?.state).toBe('UNKNOWN');
+    expect(dimension?.confidence).toBe(0);
+  });
+
+  it('logs dynamic micro-question history without inventing durable profile evidence', async () => {
+    const harness = makeHarness();
+
+    await harness.service.recordQuestionResponse(USER_ID, HOUSEHOLD_ID, PET_ID, {
+      responseId: 'dynamic-1',
+      questionId: 'quest-difficulty:training-v1',
+      outcome: 'ANSWERED',
+      answers: ['ABOUT_RIGHT'],
+    });
+
+    expect(harness.questions).toHaveLength(1);
+    expect(harness.evidence).toHaveLength(0);
+  });
+
+  it('deduplicates exact response replays and fails closed on divergent identity reuse', async () => {
+    const harness = makeHarness();
+    const original = {
+      responseId: 'replay-1',
+      questionId: 'profile-owner-time-budget-v1',
+      outcome: 'ANSWERED' as const,
+      answers: ['FIVE_MIN'],
+    };
+
+    await harness.service.recordQuestionResponse(USER_ID, HOUSEHOLD_ID, PET_ID, original);
+    const replay = await harness.service.recordQuestionResponse(
+      USER_ID,
+      HOUSEHOLD_ID,
+      PET_ID,
+      original
+    );
+
+    expect(replay.duplicate).toBe(true);
+    expect(harness.questions).toHaveLength(1);
+    expect(harness.evidence).toHaveLength(1);
+
+    await expect(
+      harness.service.recordQuestionResponse(USER_ID, HOUSEHOLD_ID, PET_ID, {
+        ...original,
+        answers: ['FORTY_PLUS'],
+      })
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('makes corrections replay-safe and owner-authoritative', async () => {
+    const harness = makeHarness();
+    const correction = {
+      mutationId: 'correction-1',
+      dimension: 'DOG_NOVELTY_COMFORT' as const,
+      state: 'KNOWN' as const,
+      values: ['PREFERS_FAMILIAR'],
+    };
+
+    const first = await harness.service.correct(USER_ID, HOUSEHOLD_ID, PET_ID, correction);
+    const replay = await harness.service.correct(USER_ID, HOUSEHOLD_ID, PET_ID, correction);
+
+    expect(first.duplicate).toBe(false);
+    expect(replay.duplicate).toBe(true);
+    expect(harness.evidence).toHaveLength(1);
+    expect(harness.evidence[0]?.provenance).toBe('OWNER_CORRECTION');
+
+    await expect(
+      harness.service.correct(USER_ID, HOUSEHOLD_ID, PET_ID, {
+        ...correction,
+        values: ['USUALLY_CURIOUS'],
+      })
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('rejects malformed static answers as a client error', async () => {
+    const harness = makeHarness();
+
+    await expect(
+      harness.service.recordQuestionResponse(USER_ID, HOUSEHOLD_ID, PET_ID, {
+        responseId: 'bad-answer',
+        questionId: 'profile-dog-energy-v1',
+        outcome: 'ANSWERED',
+        answers: ['IMPOSSIBLE_ENUM'],
+      })
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('does not touch persistence when household authorization fails', async () => {
+    const harness = makeHarness();
+    harness.households.assertHouseholdPetAccessible.mockRejectedValueOnce(
+      new Error('not authorized')
+    );
+
+    await expect(harness.service.getState(USER_ID, HOUSEHOLD_ID, PET_ID)).rejects.toThrow(
+      'not authorized'
+    );
+    expect(harness.prisma.adaptiveProfileEvidence.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/adventure/adaptive-profile.service.ts
+++ b/apps/api/src/adventure/adaptive-profile.service.ts
@@ -1,0 +1,474 @@
+import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { HouseholdsService } from '../households/households.service';
+import { PrismaService } from '../prisma/prisma.service';
+import type {
+  CorrectAdaptiveProfileDto,
+  RecordProfileQuestionResponseDto,
+} from './dto/adaptive-profile.dto';
+import {
+  ADAPTIVE_PROFILE_SCHEMA_VERSION,
+  normalizeQuestionAnswer,
+  profileQuestionPolicyVersion,
+  profileSubjectForDimension,
+  resolveCurrentProfileEvidence,
+  toPolicyEvidence,
+  type PersistedProfileEvidenceLike,
+} from './adaptive-profile-v1';
+import {
+  PROFILE_DIMENSIONS,
+  type ProfileDimension,
+  type QuestionHistoryEntry,
+} from './profile-question-policy-v1.types';
+
+type EvidenceRow = PersistedProfileEvidenceLike & {
+  schemaVersion: string;
+};
+
+type QuestionResponseRow = {
+  id: string;
+  householdId: string;
+  petId: string;
+  userId: string;
+  questionId: string;
+  policyVersion: string;
+  outcome: string;
+  answer: Prisma.JsonValue | null;
+  askedAt: Date;
+  respondedAt: Date;
+};
+
+type ProfileDimensionState = {
+  dimension: ProfileDimension;
+  subject: 'DOG' | 'OWNER' | 'PAIR';
+  state: 'UNKNOWN' | 'LEARNING' | 'KNOWN';
+  value: unknown;
+  confidence: number;
+  provenance: string | null;
+  updatedAt: string | null;
+};
+
+export type AdaptiveProfileState = {
+  schemaVersion: typeof ADAPTIVE_PROFILE_SCHEMA_VERSION;
+  householdId: string;
+  petId: string;
+  dimensions: ProfileDimensionState[];
+  coverage: {
+    known: ProfileDimension[];
+    learning: ProfileDimension[];
+    unknown: ProfileDimension[];
+  };
+};
+
+export type AdaptiveProfilePolicySnapshot = {
+  profile: NonNullable<ReturnType<typeof toPolicyEvidence>>[];
+  questionHistory: QuestionHistoryEntry[];
+};
+
+function normalizeBoundedValues(values: readonly string[] | undefined): string[] {
+  const normalized = [
+    ...new Set((values ?? []).map((value) => value.trim()).filter(Boolean)),
+  ].sort();
+  if (normalized.length > 8 || normalized.some((value) => value.length > 80)) {
+    throw new BadRequestException('Adaptive profile values exceed the bounded payload contract');
+  }
+  return normalized;
+}
+
+function jsonMatches(value: Prisma.JsonValue | null, expected: readonly string[] | null): boolean {
+  if (expected === null) return value === null;
+  if (!Array.isArray(value)) return false;
+  return JSON.stringify([...value].sort()) === JSON.stringify([...expected].sort());
+}
+
+function isQuestionOutcome(value: string): value is QuestionHistoryEntry['outcome'] {
+  return value === 'ANSWERED' || value === 'NOT_SURE' || value === 'SKIPPED';
+}
+
+@Injectable()
+export class AdaptiveProfileService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly households: HouseholdsService
+  ) {}
+
+  async getState(
+    userId: string,
+    householdId: string,
+    petId: string
+  ): Promise<AdaptiveProfileState> {
+    await this.assertAccessible(userId, householdId, petId);
+    return this.readState(householdId, petId);
+  }
+
+  async getPolicySnapshot(
+    userId: string,
+    householdId: string,
+    petId: string
+  ): Promise<AdaptiveProfilePolicySnapshot> {
+    await this.assertAccessible(userId, householdId, petId);
+    const [evidence, responses] = await Promise.all([
+      this.readEvidence(householdId, petId),
+      this.prisma.adaptiveProfileQuestionResponse.findMany({
+        where: { householdId, petId },
+        orderBy: [{ askedAt: 'desc' }, { id: 'desc' }],
+        take: 200,
+        select: { questionId: true, outcome: true, askedAt: true },
+      }),
+    ]);
+
+    return {
+      profile: resolveCurrentProfileEvidence(evidence).flatMap((entry) => {
+        const projected = toPolicyEvidence(entry);
+        return projected ? [projected] : [];
+      }),
+      questionHistory: responses.flatMap((response) =>
+        isQuestionOutcome(response.outcome)
+          ? [
+              {
+                questionId: response.questionId,
+                outcome: response.outcome,
+                askedAt: response.askedAt.toISOString(),
+              },
+            ]
+          : []
+      ),
+    };
+  }
+
+  async recordQuestionResponse(
+    userId: string,
+    householdId: string,
+    petId: string,
+    dto: RecordProfileQuestionResponseDto
+  ): Promise<{ duplicate: boolean; profile: AdaptiveProfileState }> {
+    await this.assertAccessible(userId, householdId, petId);
+
+    const responseId = `profile-question:${dto.responseId}`;
+    const evidenceId = `profile-evidence:question:${dto.responseId}`;
+    const now = new Date();
+    const policyVersion = profileQuestionPolicyVersion();
+
+    if (dto.outcome !== 'ANSWERED' && dto.answers?.length) {
+      throw new BadRequestException('Skip and not-sure responses cannot carry answers');
+    }
+
+    let staticAnswer: ReturnType<typeof normalizeQuestionAnswer>;
+    try {
+      staticAnswer = normalizeQuestionAnswer(dto.questionId, dto.outcome, dto.answers);
+    } catch (error) {
+      throw new BadRequestException(
+        error instanceof Error ? error.message : 'Profile answer is invalid for this question'
+      );
+    }
+    const normalizedAnswers = staticAnswer
+      ? staticAnswer.values
+      : dto.outcome === 'ANSWERED'
+        ? normalizeBoundedValues(dto.answers)
+        : null;
+
+    if (dto.outcome === 'ANSWERED' && !normalizedAnswers?.length) {
+      throw new BadRequestException('Answered profile questions require at least one answer');
+    }
+
+    const execute = async () =>
+      this.prisma.$transaction(async (tx) => {
+        const existing = await tx.adaptiveProfileQuestionResponse.findUnique({
+          where: { id: responseId },
+        });
+        if (existing) {
+          this.assertQuestionReplayMatches(existing, {
+            householdId,
+            petId,
+            userId,
+            questionId: dto.questionId,
+            policyVersion,
+            outcome: dto.outcome,
+            answers: normalizedAnswers,
+          });
+          return true;
+        }
+
+        await tx.adaptiveProfileQuestionResponse.create({
+          data: {
+            id: responseId,
+            householdId,
+            petId,
+            userId,
+            questionId: dto.questionId,
+            policyVersion,
+            outcome: dto.outcome,
+            answer: normalizedAnswers === null ? Prisma.JsonNull : normalizedAnswers,
+            askedAt: now,
+            respondedAt: now,
+          },
+        });
+
+        if (staticAnswer && dto.outcome !== 'SKIPPED') {
+          await tx.adaptiveProfileEvidence.create({
+            data: {
+              id: evidenceId,
+              householdId,
+              petId,
+              dimension: staticAnswer.dimension,
+              subject: profileSubjectForDimension(staticAnswer.dimension),
+              state: dto.outcome === 'ANSWERED' ? 'KNOWN' : 'UNKNOWN',
+              value: normalizedAnswers === null ? Prisma.JsonNull : normalizedAnswers,
+              confidence: dto.outcome === 'ANSWERED' ? 1 : 0,
+              provenance: 'OWNER_EXPLICIT',
+              schemaVersion: ADAPTIVE_PROFILE_SCHEMA_VERSION,
+              sourceUserId: userId,
+              occurredAt: now,
+            },
+          });
+        }
+        return false;
+      });
+
+    let duplicate: boolean;
+    try {
+      duplicate = await execute();
+    } catch (error) {
+      if (!this.isUniqueViolation(error)) throw error;
+      const existing = await this.prisma.adaptiveProfileQuestionResponse.findUnique({
+        where: { id: responseId },
+      });
+      if (!existing) throw error;
+      this.assertQuestionReplayMatches(existing, {
+        householdId,
+        petId,
+        userId,
+        questionId: dto.questionId,
+        policyVersion,
+        outcome: dto.outcome,
+        answers: normalizedAnswers,
+      });
+      duplicate = true;
+    }
+
+    return { duplicate, profile: await this.readState(householdId, petId) };
+  }
+
+  async correct(
+    userId: string,
+    householdId: string,
+    petId: string,
+    dto: CorrectAdaptiveProfileDto
+  ): Promise<{ duplicate: boolean; profile: AdaptiveProfileState }> {
+    await this.assertAccessible(userId, householdId, petId);
+
+    const values = normalizeBoundedValues(dto.values);
+    if (dto.state === 'KNOWN' && values.length === 0) {
+      throw new BadRequestException('Known profile corrections require a value');
+    }
+    if (dto.state === 'UNKNOWN' && values.length > 0) {
+      throw new BadRequestException('Unknown profile corrections cannot carry values');
+    }
+    if (values.some((value) => value === 'SKIP' || value === 'NOT_SURE')) {
+      throw new BadRequestException(
+        'Use explicit UNKNOWN instead of skip/not-sure correction values'
+      );
+    }
+
+    const evidenceId = `profile-evidence:correction:${dto.mutationId}`;
+    const now = new Date();
+    const expectedValues = dto.state === 'KNOWN' ? values : null;
+
+    const execute = async () =>
+      this.prisma.$transaction(async (tx) => {
+        const existing = await tx.adaptiveProfileEvidence.findUnique({ where: { id: evidenceId } });
+        if (existing) {
+          this.assertCorrectionReplayMatches(existing, {
+            householdId,
+            petId,
+            userId,
+            dimension: dto.dimension,
+            state: dto.state,
+            values: expectedValues,
+          });
+          return true;
+        }
+
+        await tx.adaptiveProfileEvidence.create({
+          data: {
+            id: evidenceId,
+            householdId,
+            petId,
+            dimension: dto.dimension,
+            subject: profileSubjectForDimension(dto.dimension),
+            state: dto.state,
+            value: expectedValues === null ? Prisma.JsonNull : expectedValues,
+            confidence: dto.state === 'KNOWN' ? 1 : 0,
+            provenance: 'OWNER_CORRECTION',
+            schemaVersion: ADAPTIVE_PROFILE_SCHEMA_VERSION,
+            sourceUserId: userId,
+            occurredAt: now,
+          },
+        });
+        return false;
+      });
+
+    let duplicate: boolean;
+    try {
+      duplicate = await execute();
+    } catch (error) {
+      if (!this.isUniqueViolation(error)) throw error;
+      const existing = await this.prisma.adaptiveProfileEvidence.findUnique({
+        where: { id: evidenceId },
+      });
+      if (!existing) throw error;
+      this.assertCorrectionReplayMatches(existing, {
+        householdId,
+        petId,
+        userId,
+        dimension: dto.dimension,
+        state: dto.state,
+        values: expectedValues,
+      });
+      duplicate = true;
+    }
+
+    return { duplicate, profile: await this.readState(householdId, petId) };
+  }
+
+  private async assertAccessible(
+    userId: string,
+    householdId: string,
+    petId: string
+  ): Promise<void> {
+    await this.households.assertHouseholdPetAccessible(userId, householdId, petId);
+  }
+
+  private async readEvidence(householdId: string, petId: string): Promise<EvidenceRow[]> {
+    return this.prisma.adaptiveProfileEvidence.findMany({
+      where: { householdId, petId, schemaVersion: ADAPTIVE_PROFILE_SCHEMA_VERSION },
+      orderBy: [{ occurredAt: 'desc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        dimension: true,
+        subject: true,
+        state: true,
+        value: true,
+        confidence: true,
+        provenance: true,
+        schemaVersion: true,
+        occurredAt: true,
+      },
+    });
+  }
+
+  private async readState(householdId: string, petId: string): Promise<AdaptiveProfileState> {
+    const evidence = await this.readEvidence(householdId, petId);
+    const current = new Map(
+      resolveCurrentProfileEvidence(evidence).map((entry) => [
+        entry.dimension as ProfileDimension,
+        entry,
+      ])
+    );
+
+    const dimensions = PROFILE_DIMENSIONS.map<ProfileDimensionState>((dimension) => {
+      const entry = current.get(dimension);
+      if (!entry) {
+        return {
+          dimension,
+          subject: profileSubjectForDimension(dimension),
+          state: 'UNKNOWN',
+          value: null,
+          confidence: 0,
+          provenance: null,
+          updatedAt: null,
+        };
+      }
+      return {
+        dimension,
+        subject: profileSubjectForDimension(dimension),
+        state: entry.state as ProfileDimensionState['state'],
+        value: entry.value,
+        confidence: entry.confidence,
+        provenance: entry.provenance,
+        updatedAt: entry.occurredAt.toISOString(),
+      };
+    });
+
+    return {
+      schemaVersion: ADAPTIVE_PROFILE_SCHEMA_VERSION,
+      householdId,
+      petId,
+      dimensions,
+      coverage: {
+        known: dimensions
+          .filter((entry) => entry.state === 'KNOWN')
+          .map((entry) => entry.dimension),
+        learning: dimensions
+          .filter((entry) => entry.state === 'LEARNING')
+          .map((entry) => entry.dimension),
+        unknown: dimensions
+          .filter((entry) => entry.state === 'UNKNOWN')
+          .map((entry) => entry.dimension),
+      },
+    };
+  }
+
+  private assertQuestionReplayMatches(
+    existing: QuestionResponseRow,
+    expected: {
+      householdId: string;
+      petId: string;
+      userId: string;
+      questionId: string;
+      policyVersion: string;
+      outcome: string;
+      answers: readonly string[] | null;
+    }
+  ): void {
+    const matches =
+      existing.householdId === expected.householdId &&
+      existing.petId === expected.petId &&
+      existing.userId === expected.userId &&
+      existing.questionId === expected.questionId &&
+      existing.policyVersion === expected.policyVersion &&
+      existing.outcome === expected.outcome &&
+      jsonMatches(existing.answer, expected.answers);
+    if (!matches) {
+      throw new ConflictException('Profile response identity was replayed with divergent content');
+    }
+  }
+
+  private assertCorrectionReplayMatches(
+    existing: EvidenceRow & { sourceUserId?: string | null },
+    expected: {
+      householdId: string;
+      petId: string;
+      userId: string;
+      dimension: ProfileDimension;
+      state: 'KNOWN' | 'UNKNOWN';
+      values: readonly string[] | null;
+    }
+  ): void {
+    const row = existing as EvidenceRow & {
+      householdId?: string;
+      petId?: string;
+      sourceUserId?: string | null;
+      value: Prisma.JsonValue | null;
+    };
+    const matches =
+      row.householdId === expected.householdId &&
+      row.petId === expected.petId &&
+      row.sourceUserId === expected.userId &&
+      row.dimension === expected.dimension &&
+      row.subject === profileSubjectForDimension(expected.dimension) &&
+      row.state === expected.state &&
+      row.provenance === 'OWNER_CORRECTION' &&
+      row.schemaVersion === ADAPTIVE_PROFILE_SCHEMA_VERSION &&
+      jsonMatches(row.value, expected.values);
+    if (!matches) {
+      throw new ConflictException(
+        'Profile correction identity was replayed with divergent content'
+      );
+    }
+  }
+
+  private isUniqueViolation(error: unknown): boolean {
+    return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002';
+  }
+}

--- a/apps/api/src/adventure/adventure.module.ts
+++ b/apps/api/src/adventure/adventure.module.ts
@@ -1,6 +1,9 @@
 import { Module } from '@nestjs/common';
 import { CareEventsModule } from '../care-events/care-events.module';
+import { HouseholdsModule } from '../households/households.module';
 import { InsightsModule } from '../insights/insights.module';
+import { AdaptiveProfileController } from './adaptive-profile.controller';
+import { AdaptiveProfileService } from './adaptive-profile.service';
 import { AdventureEnabledGuard } from './adventure-enabled.guard';
 import { AdventureController } from './adventure.controller';
 import { AdventureService } from './adventure.service';
@@ -8,9 +11,14 @@ import { PackChallengesController } from './pack-challenges.controller';
 import { PackChallengesService } from './pack-challenges.service';
 
 @Module({
-  imports: [InsightsModule, CareEventsModule],
-  controllers: [AdventureController, PackChallengesController],
-  providers: [AdventureEnabledGuard, AdventureService, PackChallengesService],
-  exports: [AdventureService],
+  imports: [InsightsModule, CareEventsModule, HouseholdsModule],
+  controllers: [AdventureController, AdaptiveProfileController, PackChallengesController],
+  providers: [
+    AdventureEnabledGuard,
+    AdventureService,
+    AdaptiveProfileService,
+    PackChallengesService,
+  ],
+  exports: [AdventureService, AdaptiveProfileService],
 })
 export class AdventureModule {}

--- a/apps/api/src/adventure/dto/adaptive-profile.dto.ts
+++ b/apps/api/src/adventure/dto/adaptive-profile.dto.ts
@@ -1,0 +1,44 @@
+import { ArrayMaxSize, IsArray, IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
+import { PROFILE_DIMENSIONS } from '../profile-question-policy-v1.types';
+
+const PROFILE_STATES = ['KNOWN', 'UNKNOWN'] as const;
+const QUESTION_OUTCOMES = ['ANSWERED', 'NOT_SURE', 'SKIPPED'] as const;
+
+export class RecordProfileQuestionResponseDto {
+  @IsString()
+  @MaxLength(128)
+  responseId!: string;
+
+  @IsString()
+  @MaxLength(128)
+  questionId!: string;
+
+  @IsIn(QUESTION_OUTCOMES)
+  outcome!: (typeof QUESTION_OUTCOMES)[number];
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(8)
+  @IsString({ each: true })
+  @MaxLength(80, { each: true })
+  answers?: string[];
+}
+
+export class CorrectAdaptiveProfileDto {
+  @IsString()
+  @MaxLength(128)
+  mutationId!: string;
+
+  @IsIn(PROFILE_DIMENSIONS)
+  dimension!: (typeof PROFILE_DIMENSIONS)[number];
+
+  @IsIn(PROFILE_STATES)
+  state!: (typeof PROFILE_STATES)[number];
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(8)
+  @IsString({ each: true })
+  @MaxLength(80, { each: true })
+  values?: string[];
+}

--- a/docs/DOGOS_ADAPTIVE_PROFILE_PERSISTENCE_V1.md
+++ b/docs/DOGOS_ADAPTIVE_PROFILE_PERSISTENCE_V1.md
@@ -1,0 +1,113 @@
+# dogOS Adaptive Profile Persistence v1
+
+Adaptive Profile is the durable personalization substrate for Adaptive Adventure. It stores what Woof has evidence for about a specific dog-human household pair without turning game rewards, temporary context, or opaque legacy profile JSON into personalization authority.
+
+## Product boundary
+
+The learning unit is a `(householdId, petId)` pair. Profile state helps Woof choose and adapt safe Adventures for that pair. It does not award Bond XP, set levels, unlock chapters, or otherwise own the game economy.
+
+The profile is intentionally sparse. Unknown is a valid state. Missing information does not block play, and the application should ask a question only when resolving that uncertainty is worth the interruption.
+
+## Storage model
+
+Two append-only tables keep durable meaning separate from interaction history:
+
+- `adaptive_profile_evidence` stores versioned profile statements with dimension, subject, state, bounded value, confidence, provenance, source user, and occurrence time.
+- `adaptive_profile_question_responses` stores replay-safe question outcomes and cooldown history. A skip can therefore suppress nagging without becoming a negative preference label.
+
+Both tables carry `household_id` and `pet_id` and reference the composite `HouseholdPet` identity. A row cannot claim a dog belongs to a household where that pair does not exist.
+
+`Pet.temperament` remains legacy metadata. It is not Adaptive Profile authority.
+
+## Authorization
+
+Every public profile operation is addressed by household and pet and must call `HouseholdsService.assertHouseholdPetAccessible(userId, householdId, petId)` before reading or writing profile data.
+
+This preserves shared-household behavior without silently mutating or falling back to an unrelated personal household.
+
+## Evidence authority
+
+Profile evidence is append-only. Current state is a deterministic projection.
+
+Authority order is:
+
+1. `OWNER_CORRECTION`
+2. `OWNER_EXPLICIT`
+3. `HOUSEHOLD_EXPLICIT`
+4. `HISTORICAL_QUIZ`
+5. `OUTCOME_INFERENCE`
+
+A higher-authority statement outranks a newer lower-authority inference. Within the same authority class, the newest statement wins before confidence or state. This allows an owner to correct or clear an earlier statement without deleting audit history.
+
+The v1 subject classes are `DOG`, `OWNER`, and `PAIR`. A dimension with the wrong subject is ignored by the projection rather than being repaired implicitly.
+
+## Question semantics
+
+Static progressive-profile questions have fixture-locked answer vocabularies and bounded selection counts.
+
+- `ANSWERED` records question history and explicit `KNOWN` evidence for a recognized static profile question.
+- `NOT_SURE` records question history and explicit `UNKNOWN` evidence.
+- `SKIPPED` records question history only.
+- Dynamic gameplay questions may be logged for cooldown and analysis, but they do not automatically write durable profile evidence.
+
+Temporary context such as a difficult day, bad timing, or one tiring session must not silently become a permanent dog preference.
+
+## Owner corrections
+
+Owner corrections are explicit Adaptive Profile mutations. They use `OWNER_CORRECTION` provenance and immediately become the highest-authority evidence for their dimension.
+
+A correction may set a dimension to `KNOWN` with bounded values or to `UNKNOWN` with no value. `SKIP` and `NOT_SURE` are question outcomes, not durable correction values.
+
+## Replay and concurrency behavior
+
+Question responses and corrections use client-supplied mutation identities that are namespaced on the server.
+
+An exact replay is treated as a duplicate. Reusing the same identity with divergent household, pet, user, question, dimension, outcome, state, or value fails closed with a conflict. Unique-constraint races are re-read and checked against the same semantic identity before being accepted as duplicates.
+
+No retry can mint Bond XP because Adaptive Profile has no reward authority.
+
+## Schema version
+
+The initial schema version is `adaptive-profile-v1`. Reads project only evidence from the active schema version. Database dimensions are stored as strings so later versions can add dimensions without destructive migrations, while the v1 API accepts only fixture-locked dimensions.
+
+## Current v1 dimensions
+
+- owner goals
+- owner time budget
+- owner effort preference
+- available environments
+- dog energy pattern
+- dog social comfort
+- dog novelty comfort
+- dog reinforcers
+- dog obvious dislikes
+- pair training experience
+
+Canonical pet facts such as name, species, breed, and birthdate remain on the `Pet` model instead of being copied into profile evidence.
+
+## Progressive-question adapter
+
+The service can return a policy snapshot containing current projected profile evidence and recent question history. `profile-question-policy-v1` remains the sole deterministic authority for deciding which optional question, if any, is worth asking next.
+
+The persistence layer does not rank questions and does not infer that more questions are better.
+
+## Safety and reward separation
+
+Adaptive Profile runtime code must not read or write `Bond XP`, `RewardLedger`, `totalPoints`, or pathway XP. A user can skip, answer `not sure`, or correct Woof without changing progression rewards.
+
+Dog comfort, owner burden, safe stops, and later training outcomes belong in outcome and decision ledgers as evidence. They are not game scores.
+
+## Qualification
+
+The dedicated `dogOS Adaptive Profile Persistence CI` lane:
+
+- restricts database ownership to the profile schema and migration slice;
+- rejects game-currency authority in profile runtime code;
+- validates and checks canonical Prisma formatting;
+- generates Prisma Client;
+- checks source formatting;
+- lints profile runtime and contracts with zero warnings;
+- type-checks the full API; and
+- runs focused projection, authorization, replay, skip, unknown, correction, and bounded-payload contracts.
+
+The normal Adventure, root, Foundation, and Action Runtime qualification lanes remain required before merge.

--- a/packages/database/prisma/migrations/20260826055200_add_adaptive_profile_persistence/migration.sql
+++ b/packages/database/prisma/migrations/20260826055200_add_adaptive_profile_persistence/migration.sql
@@ -1,0 +1,72 @@
+-- Adaptive Adventure 1B: append-only, household/pet-scoped personalization evidence.
+-- The pair foreign key prevents profile rows from referring to a pet outside the
+-- declared household. Durable profile evidence and question-response history are
+-- intentionally separate so cooldown/skip semantics never become preference labels.
+
+CREATE TABLE "adaptive_profile_evidence" (
+    "id" TEXT NOT NULL,
+    "household_id" TEXT NOT NULL,
+    "pet_id" TEXT NOT NULL,
+    "dimension" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "state" TEXT NOT NULL,
+    "value" JSONB,
+    "confidence" DOUBLE PRECISION NOT NULL,
+    "provenance" TEXT NOT NULL,
+    "schema_version" TEXT NOT NULL DEFAULT 'adaptive-profile-v1',
+    "source_user_id" TEXT,
+    "occurred_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "adaptive_profile_evidence_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "adaptive_profile_question_responses" (
+    "id" TEXT NOT NULL,
+    "household_id" TEXT NOT NULL,
+    "pet_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "question_id" TEXT NOT NULL,
+    "policy_version" TEXT NOT NULL,
+    "outcome" TEXT NOT NULL,
+    "answer" JSONB,
+    "asked_at" TIMESTAMP(3) NOT NULL,
+    "responded_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "adaptive_profile_question_responses_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "adaptive_profile_evidence_pair_dimension_occurred_at_idx"
+    ON "adaptive_profile_evidence"("household_id", "pet_id", "dimension", "occurred_at" DESC);
+
+CREATE INDEX "adaptive_profile_evidence_source_user_occurred_at_idx"
+    ON "adaptive_profile_evidence"("source_user_id", "occurred_at" DESC);
+
+CREATE INDEX "adaptive_profile_question_pair_asked_at_idx"
+    ON "adaptive_profile_question_responses"("household_id", "pet_id", "asked_at" DESC);
+
+CREATE INDEX "adaptive_profile_question_user_responded_at_idx"
+    ON "adaptive_profile_question_responses"("user_id", "responded_at" DESC);
+
+ALTER TABLE "adaptive_profile_evidence"
+    ADD CONSTRAINT "adaptive_profile_evidence_household_id_pet_id_fkey"
+    FOREIGN KEY ("household_id", "pet_id")
+    REFERENCES "household_pets"("household_id", "pet_id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "adaptive_profile_evidence"
+    ADD CONSTRAINT "adaptive_profile_evidence_source_user_id_fkey"
+    FOREIGN KEY ("source_user_id") REFERENCES "users"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "adaptive_profile_question_responses"
+    ADD CONSTRAINT "adaptive_profile_question_responses_household_id_pet_id_fkey"
+    FOREIGN KEY ("household_id", "pet_id")
+    REFERENCES "household_pets"("household_id", "pet_id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "adaptive_profile_question_responses"
+    ADD CONSTRAINT "adaptive_profile_question_responses_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -62,6 +62,9 @@ model User {
   rewardLedgerEntries       RewardLedger[]
   questInteractions         QuestInteraction[]
 
+  adaptiveProfileEvidenceSources   AdaptiveProfileEvidence[]         @relation("AdaptiveProfileEvidenceSource")
+  adaptiveProfileQuestionResponses AdaptiveProfileQuestionResponse[] @relation("AdaptiveProfileQuestionResponder")
+
   @@map("users")
 }
 
@@ -160,6 +163,9 @@ model HouseholdPet {
 
   household Household @relation(fields: [householdId], references: [id], onDelete: Cascade)
   pet       Pet       @relation(fields: [petId], references: [id], onDelete: Cascade)
+
+  adaptiveProfileEvidence          AdaptiveProfileEvidence[]
+  adaptiveProfileQuestionResponses AdaptiveProfileQuestionResponse[]
 
   @@unique([householdId, petId])
   @@index([petId, status])
@@ -1147,4 +1153,52 @@ model QuestInteraction {
   @@index([userId, petId, createdAt(sort: Desc)], map: "quest_interactions_user_pet_created_at_idx")
   @@index([questId], map: "quest_interactions_quest_id_idx")
   @@map("quest_interactions")
+}
+
+// ============================================
+// ADAPTIVE ADVENTURE PROFILE
+// ============================================
+
+model AdaptiveProfileEvidence {
+  id            String   @id
+  householdId   String   @map("household_id")
+  petId         String   @map("pet_id")
+  dimension     String
+  subject       String
+  state         String
+  value         Json?
+  confidence    Float
+  provenance    String
+  schemaVersion String   @default("adaptive-profile-v1") @map("schema_version")
+  sourceUserId  String?  @map("source_user_id")
+  occurredAt    DateTime @map("occurred_at")
+  createdAt     DateTime @default(now()) @map("created_at")
+
+  householdPet HouseholdPet @relation(fields: [householdId, petId], references: [householdId, petId], onDelete: Cascade)
+  sourceUser   User?        @relation("AdaptiveProfileEvidenceSource", fields: [sourceUserId], references: [id], onDelete: SetNull)
+
+  @@index([householdId, petId, dimension, occurredAt(sort: Desc)], map: "adaptive_profile_evidence_pair_dimension_occurred_at_idx")
+  @@index([sourceUserId, occurredAt(sort: Desc)], map: "adaptive_profile_evidence_source_user_occurred_at_idx")
+  @@map("adaptive_profile_evidence")
+}
+
+model AdaptiveProfileQuestionResponse {
+  id            String   @id
+  householdId   String   @map("household_id")
+  petId         String   @map("pet_id")
+  userId        String   @map("user_id")
+  questionId    String   @map("question_id")
+  policyVersion String   @map("policy_version")
+  outcome       String
+  answer        Json?
+  askedAt       DateTime @map("asked_at")
+  respondedAt   DateTime @map("responded_at")
+  createdAt     DateTime @default(now()) @map("created_at")
+
+  householdPet HouseholdPet @relation(fields: [householdId, petId], references: [householdId, petId], onDelete: Cascade)
+  user         User         @relation("AdaptiveProfileQuestionResponder", fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([householdId, petId, askedAt(sort: Desc)], map: "adaptive_profile_question_pair_asked_at_idx")
+  @@index([userId, respondedAt(sort: Desc)], map: "adaptive_profile_question_user_responded_at_idx")
+  @@map("adaptive_profile_question_responses")
 }


### PR DESCRIPTION
Parent: #42
Roadmap: #41

Implements the durable persistence substrate for progressive profiling before First Adventure UX.

## Product invariants

- Profile state is scoped to the actual `(householdId, petId)` pair.
- Durable evidence is append-only and separate from question/cooldown history.
- Missing information remains unknown; sparse profiles do not block play.
- `Skip` records cooldown/history only and never becomes a negative preference.
- `Not sure` becomes explicit unknown rather than a dislike.
- Dynamic session questions never silently become durable dog traits.
- Owner corrections outrank explicit, historical, and inferred evidence.
- Within one authority class, the newest statement supersedes older evidence.
- Temporary context is not promoted into permanent preference without appropriate evidence.

## Trust + integrity

- Database-enforced pair scope through the composite `HouseholdPet` identity.
- Every API read/write passes through household+pet authorization.
- Replay-safe question/correction identities deduplicate exact retries and fail closed on divergent content.
- Bounded values and explicit schema versioning.
- Malformed static answers are translated to a client `BadRequest` at the persistence boundary while the pure question oracle remains framework-free.

## Economy separation

Adaptive Profile owns personalization evidence only. It has no authority over Bond XP, RewardLedger, pathway XP, levels, streaks, chapters, or client-visible game rewards.

## Qualification

The final candidate is a single commit directly parented on the qualified `main` boundary. Merge is blocked until the exact head is green in:

- dogOS Adaptive Profile Persistence CI
- Adventure System CI
- dogOS Foundation CI
- root CI including Playwright and production builds
- CI Action Runtime Qualification

The dedicated profile lane additionally validates database ownership, Prisma/schema formatting, generated client compatibility, zero-warning lint, whole-API TypeScript, and focused projection/authorization/replay/skip/correction contracts.