### PR TITLE
Replay-safe email registration for First Adventure onboarding

### DIFF
--- a/.github/workflows/dogos-registration-replay-ci.yml
+++ b/.github/workflows/dogos-registration-replay-ci.yml
@@ -7,6 +7,7 @@ on:
       - 'apps/api/src/auth/auth.service.ts'
       - 'apps/api/src/auth/auth.service.spec.ts'
       - 'apps/api/src/auth/dto/register.dto.ts'
+      - 'apps/api/test/auth.e2e-spec.ts'
       - 'apps/web/src/app/onboarding/page.tsx'
       - 'apps/web/e2e/first-adventure-onboarding.spec.ts'
       - 'docs/FIRST_ADVENTURE_RELEASE.md'
@@ -24,12 +25,30 @@ env:
   PNPM_VERSION: '8.15.1'
   NODE_ENV: test
   ENABLE_ADVENTURE_SYSTEM: 'true'
+  DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+  JWT_SECRET: ci-only-registration-replay-secret
+  ML_SERVICE_ENABLED: 'false'
 
 jobs:
   qualify:
     name: Replay-safe registration qualification
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v7
         with:
@@ -50,6 +69,9 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @woof/database db:generate
 
+      - name: Apply database migrations
+        run: pnpm --filter @woof/database db:migrate:deploy
+
       - name: Reject client-only registration recovery
         shell: bash
         run: |
@@ -63,6 +85,7 @@ jobs:
             apps/api/src/auth/auth.service.ts \
             apps/api/src/auth/auth.service.spec.ts \
             apps/api/src/auth/dto/register.dto.ts \
+            apps/api/test/auth.e2e-spec.ts \
             apps/web/src/app/onboarding/page.tsx \
             apps/web/e2e/first-adventure-onboarding.spec.ts \
             docs/FIRST_ADVENTURE_RELEASE.md \
@@ -71,6 +94,7 @@ jobs:
             apps/api/src/auth/auth.service.ts \
             apps/api/src/auth/auth.service.spec.ts \
             apps/api/src/auth/dto/register.dto.ts \
+            apps/api/test/auth.e2e-spec.ts \
             apps/web/src/app/onboarding/page.tsx \
             apps/web/e2e/first-adventure-onboarding.spec.ts \
             docs/FIRST_ADVENTURE_RELEASE.md \
@@ -82,6 +106,7 @@ jobs:
           src/auth/auth.service.ts
           src/auth/auth.service.spec.ts
           src/auth/dto/register.dto.ts
+          test/auth.e2e-spec.ts
 
       - name: Lint onboarding replay surface
         run: >-
@@ -95,8 +120,11 @@ jobs:
       - name: Type-check Web
         run: pnpm --filter @woof/web type-check
 
-      - name: Run auth replay contracts
+      - name: Run auth replay unit contracts
         run: pnpm --filter @woof/api exec jest src/auth/auth.service.spec.ts --runInBand
+
+      - name: Run auth replay API contracts
+        run: pnpm --filter @woof/api exec jest --config ./test/jest-e2e.json test/auth.e2e-spec.ts --runInBand
 
       - name: Install Playwright Chromium
         run: pnpm --filter @woof/web exec playwright install --with-deps chromium

--- a/.github/workflows/dogos-registration-replay-ci.yml
+++ b/.github/workflows/dogos-registration-replay-ci.yml
@@ -1,0 +1,119 @@
+name: dogOS Registration Replay CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/auth/auth.service.ts'
+      - 'apps/api/src/auth/auth.service.spec.ts'
+      - 'apps/api/src/auth/dto/register.dto.ts'
+      - 'apps/web/src/app/onboarding/page.tsx'
+      - 'apps/web/e2e/first-adventure-onboarding.spec.ts'
+      - 'docs/FIRST_ADVENTURE_RELEASE.md'
+      - '.github/workflows/dogos-registration-replay-ci.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-registration-replay-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  NODE_ENV: test
+  ENABLE_ADVENTURE_SYSTEM: 'true'
+
+jobs:
+  qualify:
+    name: Replay-safe registration qualification
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Reject client-only registration recovery
+        shell: bash
+        run: |
+          grep -q 'registrationKey: getRegistrationKey()' apps/web/src/app/onboarding/page.tsx
+          grep -q 'resumeRegistrationReplay' apps/api/src/auth/auth.service.ts
+          grep -q 'replaySafeRegistrationId' apps/api/src/auth/auth.service.ts
+
+      - name: Check replay surface formatting
+        run: |
+          pnpm exec prettier --write \
+            apps/api/src/auth/auth.service.ts \
+            apps/api/src/auth/auth.service.spec.ts \
+            apps/api/src/auth/dto/register.dto.ts \
+            apps/web/src/app/onboarding/page.tsx \
+            apps/web/e2e/first-adventure-onboarding.spec.ts \
+            docs/FIRST_ADVENTURE_RELEASE.md \
+            .github/workflows/dogos-registration-replay-ci.yml
+          git diff --exit-code -- \
+            apps/api/src/auth/auth.service.ts \
+            apps/api/src/auth/auth.service.spec.ts \
+            apps/api/src/auth/dto/register.dto.ts \
+            apps/web/src/app/onboarding/page.tsx \
+            apps/web/e2e/first-adventure-onboarding.spec.ts \
+            docs/FIRST_ADVENTURE_RELEASE.md \
+            .github/workflows/dogos-registration-replay-ci.yml
+
+      - name: Lint auth replay boundary
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0
+          src/auth/auth.service.ts
+          src/auth/auth.service.spec.ts
+          src/auth/dto/register.dto.ts
+
+      - name: Lint onboarding replay surface
+        run: >-
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives
+          src/app/onboarding/page.tsx
+          e2e/first-adventure-onboarding.spec.ts
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api exec tsc --noEmit
+
+      - name: Type-check Web
+        run: pnpm --filter @woof/web type-check
+
+      - name: Run auth replay contracts
+        run: pnpm --filter @woof/api exec jest src/auth/auth.service.spec.ts --runInBand
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @woof/web exec playwright install --with-deps chromium
+
+      - name: Run lost-response onboarding journey on desktop and mobile
+        env:
+          NEXT_PUBLIC_API_URL: http://127.0.0.1:59999/api/v1
+        run: >-
+          pnpm --filter @woof/web exec playwright test
+          e2e/first-adventure-onboarding.spec.ts
+          --project=chromium
+          --project='Mobile Chrome'
+
+      - name: Build API
+        run: pnpm --filter @woof/api build
+
+      - name: Build Web
+        env:
+          NEXT_PUBLIC_API_URL: https://api.example.com/api/v1
+        run: pnpm --filter @woof/web build

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -244,9 +244,7 @@ describe('AuthService', () => {
       await service.register(registration);
 
       usersService.findByEmail.mockResolvedValue(storedUser);
-      await expect(
-        service.register({ ...registration, handle: 'differentuser' })
-      ).rejects.toThrow(
+      await expect(service.register({ ...registration, handle: 'differentuser' })).rejects.toThrow(
         new ConflictException('Registration key was replayed with divergent account fields')
       );
       expect(sessionAuthority.createSession).toHaveBeenCalledTimes(1);

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -1,4 +1,4 @@
-import { UnauthorizedException } from '@nestjs/common';
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { hash } from 'bcrypt';
@@ -140,7 +140,7 @@ describe('AuthService', () => {
   });
 
   describe('register', () => {
-    it('delegates uniqueness and persists a server-owned session', async () => {
+    it('delegates uniqueness and persists a server-owned session for legacy one-shot registration', async () => {
       usersService.create.mockResolvedValue({
         id: '456',
         email: 'new@example.com',
@@ -174,7 +174,140 @@ describe('AuthService', () => {
       expect(result.user).not.toHaveProperty('passwordHash');
     });
 
-    it('propagates user-creation conflicts', async () => {
+    it('canonicalizes new email and handle identity at the auth boundary', async () => {
+      usersService.create.mockImplementation(async (input) => ({
+        ...input,
+        id: 'canonical-user',
+      }));
+
+      await service.register({
+        email: '  New.User@Example.COM ',
+        handle: ' TrailPaws ',
+        password: 'password123',
+        bio: '  weekend hikes  ',
+      });
+
+      expect(usersService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'new.user@example.com',
+          handle: 'trailpaws',
+          bio: 'weekend hikes',
+        })
+      );
+    });
+
+    it('recovers an exact registration replay and issues a fresh server session', async () => {
+      const registration = {
+        email: 'new@example.com',
+        handle: 'newuser',
+        password: 'password123',
+        bio: 'hikes together',
+        registrationKey: '7efc01f2-0f7e-45e1-b923-748d6f727ef0',
+      };
+      let storedUser: Record<string, unknown> | null = null;
+
+      usersService.findByEmail.mockResolvedValueOnce(null);
+      usersService.create.mockImplementationOnce(async (input) => {
+        storedUser = { ...input };
+        return input;
+      });
+
+      const first = await service.register(registration);
+      expect(first.user.id).toEqual(expect.any(String));
+      expect(usersService.create).toHaveBeenCalledTimes(1);
+
+      usersService.findByEmail.mockResolvedValue(storedUser);
+      const second = await service.register(registration);
+
+      expect(second.user.id).toBe(first.user.id);
+      expect(usersService.create).toHaveBeenCalledTimes(1);
+      expect(sessionAuthority.createSession).toHaveBeenCalledTimes(2);
+      const firstSession = sessionAuthority.createSession.mock.calls[0][0].id as string;
+      const secondSession = sessionAuthority.createSession.mock.calls[1][0].id as string;
+      expect(secondSession).not.toBe(firstSession);
+    });
+
+    it('fails closed when the same registration key is replayed with divergent fields', async () => {
+      const registration = {
+        email: 'new@example.com',
+        handle: 'newuser',
+        password: 'password123',
+        registrationKey: '7efc01f2-0f7e-45e1-b923-748d6f727ef0',
+      };
+      let storedUser: Record<string, unknown> | null = null;
+
+      usersService.findByEmail.mockResolvedValueOnce(null);
+      usersService.create.mockImplementationOnce(async (input) => {
+        storedUser = { ...input };
+        return input;
+      });
+      await service.register(registration);
+
+      usersService.findByEmail.mockResolvedValue(storedUser);
+      await expect(
+        service.register({ ...registration, handle: 'differentuser' })
+      ).rejects.toThrow(
+        new ConflictException('Registration key was replayed with divergent account fields')
+      );
+      expect(sessionAuthority.createSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not treat the same email under a different key as an authorized replay', async () => {
+      const original = {
+        email: 'new@example.com',
+        handle: 'newuser',
+        password: 'password123',
+        registrationKey: '7efc01f2-0f7e-45e1-b923-748d6f727ef0',
+      };
+      let storedUser: Record<string, unknown> | null = null;
+
+      usersService.findByEmail.mockResolvedValueOnce(null);
+      usersService.create.mockImplementationOnce(async (input) => {
+        storedUser = { ...input };
+        return input;
+      });
+      await service.register(original);
+
+      usersService.findByEmail.mockResolvedValue(storedUser);
+      await expect(
+        service.register({
+          ...original,
+          registrationKey: 'a4fddf1f-1a06-4ea7-b9f1-54ca772ef5dc',
+        })
+      ).rejects.toThrow(new ConflictException('User with this email already exists'));
+      expect(usersService.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('recovers an exact replay after a unique-insert race', async () => {
+      const registration = {
+        email: 'new@example.com',
+        handle: 'newuser',
+        password: 'password123',
+        registrationKey: '7efc01f2-0f7e-45e1-b923-748d6f727ef0',
+      };
+      const passwordHash = await hash(registration.password, 4);
+      let deterministicId = '';
+
+      usersService.findByEmail.mockResolvedValueOnce(null).mockImplementationOnce(async () => ({
+        id: deterministicId,
+        email: registration.email,
+        handle: registration.handle,
+        passwordHash,
+        bio: null,
+        authProvider: 'EMAIL',
+      }));
+      usersService.create.mockImplementationOnce(async (input) => {
+        deterministicId = input.id as string;
+        throw new Error('simulated unique race');
+      });
+
+      const result = await service.register(registration);
+
+      expect(result.user.id).toBe(deterministicId);
+      expect(sessionAuthority.createSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates ordinary user-creation conflicts when no replay key exists', async () => {
       usersService.create.mockRejectedValue(new Error('duplicate account'));
 
       await expect(

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,8 +1,8 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConflictException, Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import type { User } from '@woof/database';
 import { compare, hash } from 'bcrypt';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { UsersService } from '../users/users.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
@@ -15,6 +15,13 @@ type AccessTokenClaims = {
   email: string;
   handle: string;
   sid: string;
+};
+
+type CanonicalRegistration = {
+  email: string;
+  handle: string;
+  password: string;
+  bio: string | null;
 };
 
 function withoutPassword(user: User): SafeUser {
@@ -32,7 +39,7 @@ export class AuthService {
   ) {}
 
   async validateUser(email: string, password: string): Promise<SafeUser> {
-    const user = await this.usersService.findByEmail(email);
+    const user = await this.usersService.findByEmail(email.trim().toLowerCase());
 
     if (!user || !user.passwordHash) {
       throw new UnauthorizedException('Invalid credentials');
@@ -65,23 +72,41 @@ export class AuthService {
   }
 
   async register(registerDto: RegisterDto) {
-    const hashedPassword = await hash(registerDto.password, 10);
+    const canonical = this.canonicalRegistration(registerDto);
+    const replaySafeId = registerDto.registrationKey
+      ? this.replaySafeRegistrationId(canonical.email, registerDto.registrationKey)
+      : null;
 
-    const user = await this.usersService.create({
-      email: registerDto.email,
-      handle: registerDto.handle,
-      passwordHash: hashedPassword,
-      bio: registerDto.bio,
-      authProvider: 'EMAIL',
-    });
+    if (replaySafeId) {
+      const existing = await this.usersService.findByEmail(canonical.email);
+      if (existing) {
+        return this.resumeRegistrationReplay(existing, replaySafeId, canonical);
+      }
+    }
 
-    const userWithoutPassword = withoutPassword(user);
-    const accessToken = await this.issueAccessToken(userWithoutPassword);
+    const hashedPassword = await hash(canonical.password, 10);
 
-    return {
-      access_token: accessToken,
-      user: userWithoutPassword,
-    };
+    try {
+      const user = await this.usersService.create({
+        ...(replaySafeId ? { id: replaySafeId } : {}),
+        email: canonical.email,
+        handle: canonical.handle,
+        passwordHash: hashedPassword,
+        bio: canonical.bio,
+        authProvider: 'EMAIL',
+      });
+
+      return this.finishRegistration(user);
+    } catch (error) {
+      if (!replaySafeId) throw error;
+
+      // A concurrent/exact retry can race the initial unique insert. Re-read the
+      // canonical email and only recover if the deterministic transaction identity
+      // and every supplied account field prove this is the same registration.
+      const existing = await this.usersService.findByEmail(canonical.email);
+      if (!existing) throw error;
+      return this.resumeRegistrationReplay(existing, replaySafeId, canonical);
+    }
   }
 
   async logout(userId: string, sessionId: string) {
@@ -100,6 +125,65 @@ export class AuthService {
     } catch {
       throw new UnauthorizedException('User not found');
     }
+  }
+
+  private canonicalRegistration(registerDto: RegisterDto): CanonicalRegistration {
+    return {
+      email: registerDto.email.trim().toLowerCase(),
+      handle: registerDto.handle.trim().toLowerCase(),
+      password: registerDto.password,
+      bio: registerDto.bio?.trim() || null,
+    };
+  }
+
+  private async resumeRegistrationReplay(
+    existing: User,
+    replaySafeId: string,
+    canonical: CanonicalRegistration
+  ) {
+    if (existing.id !== replaySafeId) {
+      throw new ConflictException('User with this email already exists');
+    }
+
+    const passwordMatches =
+      existing.authProvider === 'EMAIL' &&
+      Boolean(existing.passwordHash) &&
+      (await compare(canonical.password, existing.passwordHash as string));
+    const fieldsMatch =
+      existing.email.trim().toLowerCase() === canonical.email &&
+      existing.handle === canonical.handle &&
+      (existing.bio?.trim() || null) === canonical.bio;
+
+    if (!passwordMatches || !fieldsMatch) {
+      throw new ConflictException(
+        'Registration key was replayed with divergent account fields'
+      );
+    }
+
+    return this.finishRegistration(existing);
+  }
+
+  private replaySafeRegistrationId(email: string, registrationKey: string): string {
+    const digest = createHash('sha256')
+      .update(`woof-email-registration-v1:${email}:${registrationKey.trim()}`)
+      .digest('hex');
+    const uuid = digest.slice(0, 32).split('');
+
+    // UUIDv8 reserves the version nibble for application-defined deterministic IDs.
+    uuid[12] = '8';
+    uuid[16] = ((Number.parseInt(uuid[16] ?? '0', 16) & 0x3) | 0x8).toString(16);
+    const value = uuid.join('');
+    return `${value.slice(0, 8)}-${value.slice(8, 12)}-${value.slice(12, 16)}-${value.slice(16, 20)}-${value.slice(20, 32)}`;
+  }
+
+  private async finishRegistration(user: User) {
+    const userWithoutPassword = withoutPassword(user);
+    const accessToken = await this.issueAccessToken(userWithoutPassword);
+
+    return {
+      access_token: accessToken,
+      user: userWithoutPassword,
+    };
   }
 
   private async issueAccessToken(user: SafeUser) {

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -39,7 +39,15 @@ export class AuthService {
   ) {}
 
   async validateUser(email: string, password: string): Promise<SafeUser> {
-    const user = await this.usersService.findByEmail(email.trim().toLowerCase());
+    const submittedEmail = email.trim();
+    const canonicalEmail = submittedEmail.toLowerCase();
+    let user = await this.usersService.findByEmail(canonicalEmail);
+
+    // New email registrations are canonicalized. Preserve sign-in compatibility
+    // for any older account that was stored with mixed-case email before that rule.
+    if (!user && submittedEmail !== canonicalEmail) {
+      user = await this.usersService.findByEmail(submittedEmail);
+    }
 
     if (!user || !user.passwordHash) {
       throw new UnauthorizedException('Invalid credentials');

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -163,9 +163,7 @@ export class AuthService {
       (existing.bio?.trim() || null) === canonical.bio;
 
     if (!passwordMatches || !fieldsMatch) {
-      throw new ConflictException(
-        'Registration key was replayed with divergent account fields'
-      );
+      throw new ConflictException('Registration key was replayed with divergent account fields');
     }
 
     return this.finishRegistration(existing);

--- a/apps/api/src/auth/dto/register.dto.ts
+++ b/apps/api/src/auth/dto/register.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString, MinLength, MaxLength, IsOptional } from 'class-validator';
+import { IsEmail, IsOptional, IsString, IsUUID, MaxLength, MinLength } from 'class-validator';
 
 export class RegisterDto {
   @ApiProperty({ example: 'petlover2024' })
@@ -22,4 +22,14 @@ export class RegisterDto {
   @IsString()
   @MaxLength(500)
   bio?: string;
+
+  @ApiProperty({
+    example: '7efc01f2-0f7e-45e1-b923-748d6f727ef0',
+    required: false,
+    description:
+      'Client-generated transaction key. Exact retries recover the same email registration; divergent replays fail closed.',
+  })
+  @IsOptional()
+  @IsUUID()
+  registrationKey?: string;
 }

--- a/apps/api/test/auth.e2e-spec.ts
+++ b/apps/api/test/auth.e2e-spec.ts
@@ -54,6 +54,89 @@ describe('Auth (e2e)', () => {
         });
     });
 
+    it('canonicalizes new email and handle identity', () => {
+      return request(app.getHttpServer())
+        .post('/api/v1/auth/register')
+        .send({
+          email: 'Canonical.User@Example.COM',
+          handle: 'TrailPaws',
+          password: 'password123',
+        })
+        .expect(201)
+        .expect((res) => {
+          expect(res.body.user.email).toBe('canonical.user@example.com');
+          expect(res.body.user.handle).toBe('trailpaws');
+        });
+    });
+
+    it('recovers an exact replay as the same account with a fresh session', async () => {
+      const payload = {
+        email: 'replay@example.com',
+        handle: 'replayuser',
+        password: 'password123',
+        bio: 'weekend hikes',
+        registrationKey: '7efc01f2-0f7e-45e1-b923-748d6f727ef0',
+      };
+
+      const first = await request(app.getHttpServer())
+        .post('/api/v1/auth/register')
+        .send(payload)
+        .expect(201);
+      const second = await request(app.getHttpServer())
+        .post('/api/v1/auth/register')
+        .send(payload)
+        .expect(201);
+
+      expect(second.body.user.id).toBe(first.body.user.id);
+      expect(second.body.access_token).not.toBe(first.body.access_token);
+      await expect(prisma.user.count({ where: { email: payload.email } })).resolves.toBe(1);
+    });
+
+    it('fails closed when the original replay key is reused with changed account fields', async () => {
+      const payload = {
+        email: 'divergent@example.com',
+        handle: 'originaluser',
+        password: 'password123',
+        registrationKey: '7efc01f2-0f7e-45e1-b923-748d6f727ef0',
+      };
+
+      await request(app.getHttpServer()).post('/api/v1/auth/register').send(payload).expect(201);
+
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/register')
+        .send({ ...payload, handle: 'changeduser' })
+        .expect(409);
+      await expect(prisma.user.count({ where: { email: payload.email } })).resolves.toBe(1);
+    });
+
+    it('does not authorize replay recovery for the same email under a different key', async () => {
+      const payload = {
+        email: 'wrong-key@example.com',
+        handle: 'originaluser',
+        password: 'password123',
+        registrationKey: '7efc01f2-0f7e-45e1-b923-748d6f727ef0',
+      };
+
+      await request(app.getHttpServer()).post('/api/v1/auth/register').send(payload).expect(201);
+
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/register')
+        .send({ ...payload, registrationKey: 'a4fddf1f-1a06-4ea7-b9f1-54ca772ef5dc' })
+        .expect(409);
+    });
+
+    it('rejects malformed registration replay keys at validation', () => {
+      return request(app.getHttpServer())
+        .post('/api/v1/auth/register')
+        .send({
+          email: 'bad-key@example.com',
+          handle: 'badkeyuser',
+          password: 'password123',
+          registrationKey: 'not-a-uuid',
+        })
+        .expect(400);
+    });
+
     it('should fail with invalid email', () => {
       return request(app.getHttpServer())
         .post('/api/v1/auth/register')

--- a/apps/web/e2e/first-adventure-onboarding.spec.ts
+++ b/apps/web/e2e/first-adventure-onboarding.spec.ts
@@ -22,10 +22,28 @@ const createdPet = {
 };
 
 async function fillOwner(page: Page) {
-  await page.getByLabel(/public handle/i).fill('trailpaws');
-  await page.getByLabel(/^email$/i).fill('trailpaws@example.com');
-  await page.getByLabel(/^password$/i).fill('relationship123');
-  await page.getByRole('button', { name: /continue to pet profile/i }).click();
+  const handle = page.getByLabel(/public handle/i);
+  const email = page.getByLabel(/^email$/i);
+  const password = page.getByLabel(/^password$/i);
+  const continueButton = page.getByRole('button', { name: /continue to pet profile/i });
+
+  // The onboarding page is server-rendered. On a hot retry, Playwright can reach
+  // the inputs before React has attached controlled-input handlers. Prove the
+  // client state owns the values before continuing rather than relying on timing.
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await handle.fill('trailpaws');
+    await email.fill('trailpaws@example.com');
+    await password.fill('relationship123');
+
+    try {
+      await expect(continueButton).toBeEnabled({ timeout: 1_500 });
+      break;
+    } catch (error) {
+      if (attempt === 2) throw error;
+    }
+  }
+
+  await continueButton.click();
 }
 
 async function fillPet(page: Page) {
@@ -146,7 +164,7 @@ test.describe('relationship-first First Adventure onboarding', () => {
     await fillOwner(page);
     await fillPet(page);
 
-    await expect(page.getByRole('alert')).toContainText(/transaction keys/i);
+    await expect(page.locator('#main-content [role="alert"]')).toContainText(/transaction keys/i);
     expect(registrationBodies).toHaveLength(1);
     expect(petCreateCount).toBe(0);
 

--- a/apps/web/e2e/first-adventure-onboarding.spec.ts
+++ b/apps/web/e2e/first-adventure-onboarding.spec.ts
@@ -108,6 +108,60 @@ test.describe('relationship-first First Adventure onboarding', () => {
     expect(profileWrites.every((write) => write.outcome === 'SKIPPED')).toBe(true);
   });
 
+  test('reuses the registration transaction key after a lost response before pet creation', async ({
+    page,
+  }) => {
+    await page.unroute('**/auth/register');
+    const registrationBodies: Array<Record<string, unknown>> = [];
+    let petCreateCount = 0;
+
+    await page.route('**/auth/register', async (route) => {
+      registrationBodies.push(route.request().postDataJSON() as Record<string, unknown>);
+      if (registrationBodies.length === 1) {
+        await route.abort('failed');
+        return;
+      }
+
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ access_token: 'recovered-registration-token', user: apiUser }),
+      });
+    });
+
+    await page.route('**/pets', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.fallback();
+        return;
+      }
+      petCreateCount += 1;
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify(createdPet),
+      });
+    });
+
+    await page.goto('/onboarding');
+    await fillOwner(page);
+    await fillPet(page);
+
+    await expect(page.getByRole('alert')).toContainText(/transaction keys/i);
+    expect(registrationBodies).toHaveLength(1);
+    expect(petCreateCount).toBe(0);
+
+    await page.getByRole('button', { name: /continue to first adventure/i }).click();
+    await expect(page.getByRole('heading', { name: /make the first suggestion/i })).toBeVisible();
+
+    expect(registrationBodies).toHaveLength(2);
+    expect(petCreateCount).toBe(1);
+    const firstKey = registrationBodies[0]!.registrationKey;
+    const secondKey = registrationBodies[1]!.registrationKey;
+    expect(firstKey).toEqual(expect.any(String));
+    expect(firstKey).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(secondKey).toBe(firstKey);
+  });
+
   test('editing from First Adventure updates the same pet instead of creating another one', async ({
     page,
   }) => {

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -30,6 +30,7 @@ type DurablePair = {
   petName: string;
 };
 
+const REGISTRATION_KEY_STORAGE = 'woof:first-adventure:registration-key';
 const CREATION_KEY_STORAGE = 'woof:first-adventure:pet-creation-key';
 const PAIR_STORAGE = 'woof:first-adventure:durable-pair';
 
@@ -70,6 +71,7 @@ export default function OnboardingPage() {
   const [durablePair, setDurablePair] = useState<DurablePair | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
+  const registrationKeyRef = useRef<string | null>(null);
   const creationKeyRef = useRef<string | null>(null);
   const recoveryCheckRef = useRef(false);
   const authUser = useAuthStore((state) => state.user);
@@ -129,6 +131,21 @@ export default function OnboardingPage() {
     };
   }, [authUser, currentStep, isAuthenticated, ownerData]);
 
+  const getRegistrationKey = () => {
+    if (registrationKeyRef.current) return registrationKeyRef.current;
+
+    const stored = window.sessionStorage.getItem(REGISTRATION_KEY_STORAGE);
+    if (stored) {
+      registrationKeyRef.current = stored;
+      return stored;
+    }
+
+    const next = crypto.randomUUID();
+    window.sessionStorage.setItem(REGISTRATION_KEY_STORAGE, next);
+    registrationKeyRef.current = next;
+    return next;
+  };
+
   const getCreationKey = () => {
     if (creationKeyRef.current) return creationKeyRef.current;
 
@@ -144,12 +161,18 @@ export default function OnboardingPage() {
     return next;
   };
 
+  const clearRegistrationReplayKey = () => {
+    window.sessionStorage.removeItem(REGISTRATION_KEY_STORAGE);
+    registrationKeyRef.current = null;
+  };
+
   const rememberPair = (pair: DurablePair) => {
     setDurablePair(pair);
     window.sessionStorage.setItem(PAIR_STORAGE, JSON.stringify(pair));
   };
 
   const clearRecoveryHints = () => {
+    clearRegistrationReplayKey();
     window.sessionStorage.removeItem(CREATION_KEY_STORAGE);
     window.sessionStorage.removeItem(PAIR_STORAGE);
     creationKeyRef.current = null;
@@ -203,12 +226,15 @@ export default function OnboardingPage() {
             'Your account password is missing. Return to the first step and try again.'
           );
         }
-        await authApi.register({
+        const registrationRequest = {
           handle: ownerData.handle,
           email: ownerData.email,
           password: ownerData.password,
           bio: ownerData.bio || undefined,
-        });
+          registrationKey: getRegistrationKey(),
+        };
+        await authApi.register(registrationRequest);
+        clearRegistrationReplayKey();
 
         // The credential has done its job. Do not retain plaintext password for the rest of onboarding.
         setOwnerData((current) => (current ? { ...current, password: '' } : current));
@@ -248,7 +274,7 @@ export default function OnboardingPage() {
       console.error('Durable onboarding setup failed', err);
       const message = apiErrorMessage(
         err,
-        'We could not finish creating the pair. Your completed account step is preserved, and this retry will not create a duplicate pet.'
+        'We could not finish creating the pair. Your completed details are preserved, and exact retries reuse transaction keys instead of creating duplicate accounts or pets.'
       );
       setError(message);
       toast.error(message);

--- a/docs/FIRST_ADVENTURE_RELEASE.md
+++ b/docs/FIRST_ADVENTURE_RELEASE.md
@@ -32,11 +32,16 @@ Every field may be skipped. `Not sure` is explicit uncertainty, not dislike. The
 
 ## Retry and trust rules
 
+- Canonical email registration carries a client-generated UUID `registrationKey`.
+- The server canonicalizes the new email/handle and derives a deterministic user UUID from `(canonical email, registrationKey)`.
+- An exact registration retry must prove the deterministic account identity, original account fields, and original password hash before it can recover. A successful recovery issues a fresh server-owned session; it never resurrects a lost token.
+- Replaying a registration key with divergent fields, or presenting the same email under a different key, fails closed as a conflict.
+- Older registration clients that do not send a replay key retain ordinary one-shot uniqueness behavior.
 - Minimal onboarding pet creation may carry a replay-safe `creationKey`.
 - The API derives one deterministic pet identity from `(owner, creationKey)`.
-- Exact retries converge on the existing pet.
-- Replaying the key with different identity fields fails closed.
-- Media and mutable JSON are not accepted in replay-safe creation. Pet photos attach only after the pet exists and are best effort.
+- Exact pet retries converge on the existing pet.
+- Replaying the pet key with different identity fields fails closed.
+- Media and mutable JSON are not accepted in replay-safe pet creation. Pet photos attach only after the pet exists and are best effort.
 - A browser-stored `(household, pet)` pair is only a recovery hint. The server must authorize it again before First Adventure resumes.
 - Editing pet details from First Adventure updates the durable pet; it does not create another pet.
 - Adaptive Profile write failures are non-blocking. The pair still enters Today and Woof can learn optional context later.
@@ -58,13 +63,14 @@ First Adventure should feel calm rather than evaluative:
 The release is qualified with:
 
 - a dedicated First Adventure CI lane,
+- a dedicated registration-replay CI lane,
 - zero-warning targeted Web and API lint,
 - Web and API TypeScript,
-- focused First Adventure, Adaptive Profile, pet transport, and replay-safe service contracts,
-- desktop and mobile Playwright onboarding journeys,
+- focused First Adventure, Adaptive Profile, authentication replay, pet transport, and replay-safe service contracts,
+- desktop and mobile Playwright onboarding journeys, including a simulated lost registration response,
 - root browser/accessibility/visual contracts,
 - API and Web production builds.
 
-## Known next hardening boundary
+## Transaction boundary
 
-Email registration itself predates the replay-safe pet contract. If the server commits a new account but its success response is lost before the browser receives the session token, an exact registration retry currently encounters the existing-email conflict. This should be fixed as a separate auth-authority slice so registration retries converge server-side without turning the client into an ambiguous auto-login flow.
+Account and pet creation now use separate replay identities because they are separate durable transactions. The browser keeps each key only as long as that transaction may need recovery. A successful registration response clears the account replay key; completing onboarding clears any remaining recovery hints. This keeps retries recoverable without turning browser storage into account authority.


### PR DESCRIPTION
Parent: #51
Roadmap: #41

Hardens the remaining onboarding transaction boundary: exact email-registration retries can now recover server-side after a lost success response without treating an existing account as a generic conflict.

## Server authority
- Canonical email registration may include a client-generated UUID `registrationKey`.
- The API canonicalizes new email/handle identity and derives a deterministic user UUID from `(canonical email, registrationKey)`.
- Exact retries only recover when the deterministic account identity, original account fields, auth provider, and original password hash all match.
- Recovery issues a fresh server-owned session; it never reuses a lost token.
- Same email under a different key remains an ordinary conflict.
- Same key with divergent fields fails closed.
- Legacy registration callers without a replay key retain one-shot uniqueness behavior.
- Login keeps an exact-case fallback for pre-canonicalization mixed-case accounts.

## Client recovery
- First Adventure onboarding stores the registration UUID only while registration may need recovery.
- A failed/lost response preserves the same key for retry.
- A successful authenticated response clears the registration key before pet creation continues.
- Account and pet use separate replay identities because they are separate durable transactions.

## Qualification
Exact head `ee071ca4d16100b15f71000cf387d0ab77e9afdc` is fully green across all five triggered workflows:
- `dogOS Registration Replay CI`
- repository `CI`
- `dogOS First Adventure CI`
- `dogOS Session Authority CI`
- `CI Action Runtime Qualification`

The dedicated replay lane passed:
- migrated Postgres/pgvector boot
- server-authority guard
- canonical formatting
- zero-warning targeted API/Web lint
- full API + Web TypeScript
- adversarial AuthService replay contracts
- database-backed Nest + Prisma `/auth/register` replay contracts
- malformed replay-key validation rejection
- simulated lost-registration-response browser journey on desktop and mobile
- API + Web production builds

The full repository browser/accessibility/visual suite also passed on the same head. Session Authority independently built and booted the production API image and proved logout, realtime revocation, and logout-all against it.

The branch is based directly on #51's production squash boundary `403d4a10324565d69770cb45147d4b75b20fe06b` and contains only eight intended files.