### PR TITLE
Harden Health Lens model authority and provenance

### DIFF
--- a/.github/workflows/dogos-health-lens-ci.yml
+++ b/.github/workflows/dogos-health-lens-ci.yml
@@ -1,0 +1,91 @@
+name: dogOS Health Lens Model Authority CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/health-lens/**'
+      - '.github/workflows/dogos-health-lens-ci.yml'
+  workflow_dispatch:
+
+# This qualification lane is intentionally read-only; model safety policy may fail a release but never rewrite it.
+permissions:
+  contents: read
+
+concurrency:
+  group: health-lens-authority-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  authority:
+    name: Deterministic triage + bounded model authority
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Enforce Health Lens authority invariants
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const lens = fs.readFileSync('apps/api/src/health-lens/health-lens.service.ts', 'utf8');
+          const model = fs.readFileSync('apps/api/src/health-lens/health-ai.service.ts', 'utf8');
+          const requiredLens = ['screenEmergencyText', 'deterministic-emergency-screen', 'modelProvenance'];
+          const requiredModel = [
+            'store: false',
+            'normalizeHealthModelResult',
+            'UNSAFE_OWNER_ACTION_PATTERNS',
+            'HEALTH_MODEL_POLICY_VERSION',
+          ];
+          for (const token of requiredLens) {
+            if (!lens.includes(token)) throw new Error(`Missing Health Lens authority invariant: ${token}`);
+          }
+          for (const token of requiredModel) {
+            if (!model.includes(token)) throw new Error(`Missing Health model authority invariant: ${token}`);
+          }
+          NODE
+
+      - name: Check Health Lens formatting
+        run: >-
+          pnpm exec prettier --check
+          .github/workflows/dogos-health-lens-ci.yml
+          apps/api/src/health-lens/health-ai.service.ts
+          apps/api/src/health-lens/health-ai.service.spec.ts
+          apps/api/src/health-lens/health-lens.service.ts
+          apps/api/src/health-lens/health-lens.service.spec.ts
+          apps/api/src/health-lens/health-triage.ts
+          apps/api/src/health-lens/health-triage.spec.ts
+
+      - name: Lint Health Lens boundary
+        run: pnpm --filter @woof/api exec eslint src/health-lens --max-warnings=0
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Run Health Lens safety contracts
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/health-lens/health-ai.service.spec.ts
+          src/health-lens/health-lens.service.spec.ts
+          src/health-lens/health-triage.spec.ts
+
+      - name: Build API
+        run: pnpm --filter @woof/api build

--- a/apps/api/src/health-lens/health-ai.service.spec.ts
+++ b/apps/api/src/health-lens/health-ai.service.spec.ts
@@ -1,0 +1,170 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { normalizeHealthModelResult, type PetHealthModelResult } from './health-ai.service';
+
+function assessment(overrides: Partial<PetHealthModelResult> = {}): PetHealthModelResult {
+  return {
+    triage: 'monitor',
+    confidence: 0.72,
+    summary: 'A localized visible change is present, but the cause cannot be determined here.',
+    visibleFindings: ['small area of redness'],
+    possibleCategories: ['dermatologic irritation'],
+    photoFeedback: {
+      usable: true,
+      reason: 'The area is visible.',
+      betterPhotoInstructions: [],
+    },
+    questions: ['Is it changing quickly?'],
+    ownerActions: ['Document whether the area changes over the next several hours.'],
+    avoid: ['Do not use human medication based on an automated screening result.'],
+    vetHandoff: {
+      recommended: false,
+      timing: 'not-yet',
+      summary: 'Monitor and contact your veterinarian if the concern persists or worsens.',
+      bring: [],
+    },
+    ...overrides,
+  };
+}
+
+describe('Health Lens model output authority', () => {
+  it('raises an emergency model result to an authoritative immediate handoff', () => {
+    const normalized = normalizeHealthModelResult(
+      assessment({
+        triage: 'emergency_now',
+        vetHandoff: {
+          recommended: false,
+          timing: 'not-yet',
+          summary: 'Model handoff was internally inconsistent.',
+          bring: [],
+        },
+      })
+    );
+
+    expect(normalized.vetHandoff.recommended).toBe(true);
+    expect(normalized.vetHandoff.timing).toBe('now');
+    expect(normalized.ownerActions[0]).toMatch(/emergency veterinarian now/i);
+  });
+
+  it('does not let vet-today or vet-soon triage carry a lower-urgency handoff', () => {
+    const today = normalizeHealthModelResult(
+      assessment({
+        triage: 'vet_today',
+        vetHandoff: {
+          recommended: false,
+          timing: 'routine',
+          summary: 'Needs assessment.',
+          bring: [],
+        },
+      })
+    );
+    const soon = normalizeHealthModelResult(
+      assessment({
+        triage: 'vet_soon',
+        vetHandoff: {
+          recommended: false,
+          timing: 'not-yet',
+          summary: 'Needs assessment.',
+          bring: [],
+        },
+      })
+    );
+
+    expect(today.vetHandoff).toMatchObject({ recommended: true, timing: 'today' });
+    expect(soon.vetHandoff).toMatchObject({
+      recommended: true,
+      timing: 'within-2-days',
+    });
+  });
+
+  it('makes better-image triage authoritative over a contradictory usable-photo flag', () => {
+    const normalized = normalizeHealthModelResult(
+      assessment({
+        triage: 'better_image',
+        photoFeedback: {
+          usable: true,
+          reason: 'The model nevertheless requested a better image.',
+          betterPhotoInstructions: ['Use even lighting and include the surrounding area.'],
+        },
+      })
+    );
+
+    expect(normalized.photoFeedback.usable).toBe(false);
+  });
+
+  it('fails closed on positive medication, dosing, prescription, vomiting, or invasive directives', () => {
+    const unsafe = [
+      'Give 25 mg of a painkiller now.',
+      'Administer the medication twice today.',
+      'Stop the prescription until the swelling improves.',
+      'Induce vomiting at home.',
+      'Drain the lesion and keep it clean.',
+    ];
+
+    for (const directive of unsafe) {
+      expect(() => normalizeHealthModelResult(assessment({ ownerActions: [directive] }))).toThrow(
+        ServiceUnavailableException
+      );
+    }
+  });
+
+  it('fails closed when unsafe treatment instructions migrate into other visible fields', () => {
+    const unsafeCases: Array<Partial<PetHealthModelResult>> = [
+      { summary: 'Give 25 mg of aspirin now.' },
+      { questions: ['Could you administer the medication now?'] },
+      {
+        photoFeedback: {
+          usable: false,
+          reason: 'Apply ibuprofen before taking the next photo.',
+          betterPhotoInstructions: [],
+        },
+      },
+      {
+        vetHandoff: {
+          recommended: true,
+          timing: 'today',
+          summary: 'Give aspirin while waiting for the appointment.',
+          bring: [],
+        },
+      },
+      {
+        vetHandoff: {
+          recommended: true,
+          timing: 'today',
+          summary: 'Arrange veterinary assessment today.',
+          bring: ['Administer the medication before travel.'],
+        },
+      },
+    ];
+
+    for (const overrides of unsafeCases) {
+      expect(() => normalizeHealthModelResult(assessment(overrides))).toThrow(
+        ServiceUnavailableException
+      );
+    }
+  });
+
+  it('allows explicit avoid/negated safety language while bounding generated arrays', () => {
+    const normalized = normalizeHealthModelResult(
+      assessment({
+        ownerActions: ['Do not give human medication without veterinary guidance.'],
+        visibleFindings: Array.from({ length: 20 }, (_, index) => `finding-${index}`),
+      })
+    );
+
+    expect(normalized.ownerActions).toEqual([
+      'Do not give human medication without veterinary guidance.',
+    ]);
+    expect(normalized.visibleFindings).toHaveLength(8);
+  });
+
+  it('rejects malformed nested contracts even when top-level triage is valid', () => {
+    expect(() =>
+      normalizeHealthModelResult({
+        ...assessment(),
+        vetHandoff: null,
+      })
+    ).toThrow(
+      new ServiceUnavailableException('Health screening model returned an invalid assessment')
+    );
+  });
+});

--- a/apps/api/src/health-lens/health-ai.service.ts
+++ b/apps/api/src/health-lens/health-ai.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config';
 import type { HealthTriageLevel } from './health-triage';
 
+export const HEALTH_MODEL_POLICY_VERSION = 'woof-health-model-policy-v2';
+
 export type PetHealthModelResult = {
   triage: HealthTriageLevel;
   confidence: number;
@@ -46,6 +48,46 @@ export type PetHealthModelInput = {
     bytes: Buffer;
   };
 };
+
+type VetHandoffTiming = PetHealthModelResult['vetHandoff']['timing'];
+
+type ModelRecord = Record<string, unknown>;
+
+const TRIAGE_LEVELS = new Set<HealthTriageLevel>([
+  'emergency_now',
+  'vet_today',
+  'vet_soon',
+  'monitor',
+  'better_image',
+  'insufficient_information',
+]);
+
+const HANDOFF_TIMINGS = new Set<VetHandoffTiming>([
+  'now',
+  'today',
+  'within-2-days',
+  'routine',
+  'not-yet',
+]);
+
+const HANDOFF_URGENCY: Record<VetHandoffTiming, number> = {
+  now: 5,
+  today: 4,
+  'within-2-days': 3,
+  routine: 2,
+  'not-yet': 1,
+};
+
+const UNSAFE_OWNER_ACTION_PATTERNS = [
+  /\binduce vomiting\b/i,
+  /\b(?:lance|drain|puncture|incise)\b/i,
+  /\b(?:start|stop|change|adjust)\b.{0,60}\bprescription/i,
+  /\b\d+(?:\.\d+)?\s*(?:mg|mcg|g|ml)\b/i,
+  /\b(?:give|administer|dose|apply)\b.{0,80}\b(?:medication|medicine|drug|antibiotic|steroid|painkiller|aspirin|ibuprofen|acetaminophen|paracetamol|benadryl|diphenhydramine)\b/i,
+] as const;
+
+const NEGATED_TREATMENT_DIRECTIVE =
+  /\b(?:do not|don't|avoid|never)\b.{0,30}\b(?:give|administer|dose|apply|start|stop|change|adjust|induce|lance|drain|puncture|incise)\b/i;
 
 const HEALTH_RESULT_SCHEMA = {
   type: 'object',
@@ -131,6 +173,145 @@ Safety rules:
 
 Return only the requested structured JSON.`;
 
+function asRecord(value: unknown): ModelRecord | null {
+  if (!value || Array.isArray(value) || typeof value !== 'object') return null;
+  return value as ModelRecord;
+}
+
+function boundedText(value: unknown, maxChars: number) {
+  return typeof value === 'string' ? value.trim().slice(0, maxChars) : '';
+}
+
+function boundedStrings(value: unknown, maxItems: number, maxChars: number) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim().slice(0, maxChars))
+    .filter(Boolean)
+    .slice(0, maxItems);
+}
+
+function clamp01(value: unknown) {
+  const number = Number(value);
+  return Math.max(0, Math.min(1, Number.isFinite(number) ? number : 0));
+}
+
+function minimumHandoff(
+  triage: HealthTriageLevel
+): { recommended: boolean; timing: VetHandoffTiming; action: string } | null {
+  if (triage === 'emergency_now') {
+    return {
+      recommended: true,
+      timing: 'now',
+      action: 'Contact an emergency veterinarian now and follow their transport instructions.',
+    };
+  }
+  if (triage === 'vet_today') {
+    return {
+      recommended: true,
+      timing: 'today',
+      action: 'Arrange veterinary assessment today, especially if the change is worsening.',
+    };
+  }
+  if (triage === 'vet_soon') {
+    return {
+      recommended: true,
+      timing: 'within-2-days',
+      action: 'Arrange a veterinary appointment soon and keep documenting any change.',
+    };
+  }
+  return null;
+}
+
+function containsUnsafeOwnerDirective(action: string) {
+  if (NEGATED_TREATMENT_DIRECTIVE.test(action)) return false;
+  return UNSAFE_OWNER_ACTION_PATTERNS.some((pattern) => pattern.test(action));
+}
+
+export function normalizeHealthModelResult(value: unknown): PetHealthModelResult {
+  const result = asRecord(value);
+  const photoFeedback = asRecord(result?.photoFeedback);
+  const vetHandoff = asRecord(result?.vetHandoff);
+  const triage = result?.triage;
+  const timing = vetHandoff?.timing;
+
+  if (
+    !result ||
+    typeof triage !== 'string' ||
+    !TRIAGE_LEVELS.has(triage as HealthTriageLevel) ||
+    typeof result.summary !== 'string' ||
+    !photoFeedback ||
+    typeof photoFeedback.usable !== 'boolean' ||
+    typeof photoFeedback.reason !== 'string' ||
+    !vetHandoff ||
+    typeof vetHandoff.recommended !== 'boolean' ||
+    typeof timing !== 'string' ||
+    !HANDOFF_TIMINGS.has(timing as VetHandoffTiming) ||
+    typeof vetHandoff.summary !== 'string'
+  ) {
+    throw new ServiceUnavailableException('Health screening model returned an invalid assessment');
+  }
+
+  const normalizedTriage = triage as HealthTriageLevel;
+  const summary = boundedText(result.summary, 1200);
+  const photoReason = boundedText(photoFeedback.reason, 500);
+  const betterPhotoInstructions = boundedStrings(photoFeedback.betterPhotoInstructions, 5, 320);
+  const questions = boundedStrings(result.questions, 6, 360);
+  const ownerActions = boundedStrings(result.ownerActions, 6, 500);
+  const vetHandoffSummary = boundedText(vetHandoff.summary, 1200);
+  const handoffBring = boundedStrings(vetHandoff.bring, 6, 320);
+  const instructionalText = [
+    summary,
+    photoReason,
+    ...betterPhotoInstructions,
+    ...questions,
+    ...ownerActions,
+    vetHandoffSummary,
+    ...handoffBring,
+  ];
+  if (instructionalText.some(containsUnsafeOwnerDirective)) {
+    throw new ServiceUnavailableException(
+      'Health screening model returned an unsafe treatment directive'
+    );
+  }
+
+  const requiredHandoff = minimumHandoff(normalizedTriage);
+  let normalizedTiming = timing as VetHandoffTiming;
+  let recommended = Boolean(vetHandoff.recommended);
+  if (requiredHandoff) {
+    recommended = true;
+    if (HANDOFF_URGENCY[normalizedTiming] < HANDOFF_URGENCY[requiredHandoff.timing]) {
+      normalizedTiming = requiredHandoff.timing;
+    }
+    if (!ownerActions.some((action) => /veterinar/i.test(action))) {
+      ownerActions.unshift(requiredHandoff.action);
+      ownerActions.splice(6);
+    }
+  }
+
+  return {
+    triage: normalizedTriage,
+    confidence: clamp01(result.confidence),
+    summary,
+    visibleFindings: boundedStrings(result.visibleFindings, 8, 360),
+    possibleCategories: boundedStrings(result.possibleCategories, 6, 160),
+    photoFeedback: {
+      usable: normalizedTriage === 'better_image' ? false : Boolean(photoFeedback.usable),
+      reason: photoReason,
+      betterPhotoInstructions,
+    },
+    questions,
+    ownerActions,
+    avoid: boundedStrings(result.avoid, 6, 500),
+    vetHandoff: {
+      recommended,
+      timing: normalizedTiming,
+      summary: vetHandoffSummary,
+      bring: handoffBring,
+    },
+  };
+}
+
 @Injectable()
 export class HealthAiService {
   private readonly logger = new Logger(HealthAiService.name);
@@ -149,6 +330,15 @@ export class HealthAiService {
 
   isConfigured() {
     return Boolean(this.apiKey);
+  }
+
+  provenance() {
+    return {
+      provider: 'openai' as const,
+      model: this.model,
+      policyVersion: HEALTH_MODEL_POLICY_VERSION,
+      responseContract: 'woof-pet-health-lens-json-schema-v1' as const,
+    };
   }
 
   async analyze(input: PetHealthModelInput): Promise<PetHealthModelResult> {
@@ -234,7 +424,7 @@ export class HealthAiService {
         );
       }
 
-      return this.validateResult(JSON.parse(text) as PetHealthModelResult);
+      return normalizeHealthModelResult(JSON.parse(text) as unknown);
     } catch (error) {
       if (error instanceof ServiceUnavailableException) throw error;
       if (error instanceof Error && error.name === 'AbortError') {
@@ -266,35 +456,5 @@ export class HealthAiService {
       recentContext: [],
       priorHealthObservations: [],
     });
-  }
-
-  private validateResult(result: PetHealthModelResult): PetHealthModelResult {
-    const allowed = new Set<HealthTriageLevel>([
-      'emergency_now',
-      'vet_today',
-      'vet_soon',
-      'monitor',
-      'better_image',
-      'insufficient_information',
-    ]);
-    if (!result || !allowed.has(result.triage) || typeof result.summary !== 'string') {
-      throw new ServiceUnavailableException(
-        'Health screening model returned an invalid assessment'
-      );
-    }
-
-    return {
-      ...result,
-      confidence: Math.max(0, Math.min(1, Number(result.confidence) || 0)),
-      visibleFindings: Array.isArray(result.visibleFindings)
-        ? result.visibleFindings.slice(0, 8)
-        : [],
-      possibleCategories: Array.isArray(result.possibleCategories)
-        ? result.possibleCategories.slice(0, 6)
-        : [],
-      questions: Array.isArray(result.questions) ? result.questions.slice(0, 6) : [],
-      ownerActions: Array.isArray(result.ownerActions) ? result.ownerActions.slice(0, 6) : [],
-      avoid: Array.isArray(result.avoid) ? result.avoid.slice(0, 6) : [],
-    };
   }
 }

--- a/apps/api/src/health-lens/health-lens.service.spec.ts
+++ b/apps/api/src/health-lens/health-lens.service.spec.ts
@@ -30,6 +30,13 @@ const safeModelResult: PetHealthModelResult = {
   },
 };
 
+const modelProvenance = {
+  provider: 'openai' as const,
+  model: 'health-model-snapshot',
+  policyVersion: 'woof-health-model-policy-v2',
+  responseContract: 'woof-pet-health-lens-json-schema-v1' as const,
+};
+
 type PrismaMock = {
   pet: { findFirst: jest.Mock };
   activity: { findMany: jest.Mock };
@@ -44,6 +51,7 @@ type PrismaMock = {
 type AiMock = {
   isConfigured: jest.Mock;
   analyze: jest.Mock;
+  provenance: jest.Mock;
 };
 
 function createHarness() {
@@ -60,6 +68,7 @@ function createHarness() {
   const ai: AiMock = {
     isConfigured: jest.fn().mockReturnValue(true),
     analyze: jest.fn().mockResolvedValue(safeModelResult),
+    provenance: jest.fn().mockReturnValue(modelProvenance),
   };
   const service = new HealthLensService(
     prisma as unknown as PrismaService,
@@ -80,7 +89,9 @@ describe('HealthLensService safety boundary', () => {
 
     expect(result.assessment.triage).toBe('emergency_now');
     expect(result.provenance.pathway).toBe('deterministic-emergency-screen');
+    expect(result.provenance.model).toBeNull();
     expect(ai.analyze).not.toHaveBeenCalled();
+    expect(ai.provenance).not.toHaveBeenCalled();
   });
 
   it('treats a structured major breathing change as an emergency without model arbitration', async () => {
@@ -94,6 +105,7 @@ describe('HealthLensService safety boundary', () => {
     });
 
     expect(result.assessment.triage).toBe('emergency_now');
+    expect(result.provenance.model).toBeNull();
     expect(ai.analyze).not.toHaveBeenCalled();
   });
 
@@ -114,7 +126,25 @@ describe('HealthLensService safety boundary', () => {
     expect(result.assessment.triage).toBe('insufficient_information');
     expect(result.assessment.confidence).toBe(0);
     expect(result.provenance.imageAnalyzed).toBe(false);
+    expect(result.provenance.model).toBeNull();
     expect(ai.analyze).not.toHaveBeenCalled();
+  });
+
+  it('records the exact model-policy identity for a model-backed assessment', async () => {
+    const { service, prisma, ai } = createHarness();
+
+    const result = await service.analyze('user-1', {
+      petId: 'pet-1',
+      concern: 'A small red patch appeared on the paw this morning',
+      saveToTimeline: true,
+    });
+
+    expect(result.provenance.model).toEqual(modelProvenance);
+    expect(ai.provenance).toHaveBeenCalledTimes(1);
+    const call = prisma.telemetry.create.mock.calls[0][0] as {
+      data: { data: Record<string, unknown> };
+    };
+    expect(call.data.data.model).toEqual(modelProvenance);
   });
 
   it('stores only derived assessment data and an irreversible image fingerprint', async () => {
@@ -139,6 +169,7 @@ describe('HealthLensService safety boundary', () => {
     const stored = call.data.data;
     expect(stored.hadImage).toBe(true);
     expect(stored.imageSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(stored.model).toEqual(modelProvenance);
     expect(JSON.stringify(stored)).not.toContain(image.buffer.toString('base64'));
     expect(stored).not.toHaveProperty('image');
     expect(stored).not.toHaveProperty('imageUrl');

--- a/apps/api/src/health-lens/health-lens.service.ts
+++ b/apps/api/src/health-lens/health-lens.service.ts
@@ -17,6 +17,8 @@ const FOLLOW_UP_EVENT = 'HEALTH_FOLLOW_UP';
 const ASSESSMENT_VERSION = 'pet-health-lens-v1';
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+type HealthModelProvenance = ReturnType<HealthAiService['provenance']>;
+
 @Injectable()
 export class HealthLensService {
   constructor(
@@ -47,6 +49,7 @@ export class HealthLensService {
     let result: PetHealthModelResult;
     let provenance:
       'deterministic-emergency-screen' | 'multimodal-model' | 'rules-only-unavailable';
+    let modelProvenance: HealthModelProvenance | null = null;
 
     if (deterministic) {
       result = {
@@ -130,6 +133,7 @@ export class HealthLensService {
         image: image ? { mimeType: image.mimetype, bytes: image.buffer } : undefined,
       });
       provenance = 'multimodal-model';
+      modelProvenance = this.ai.provenance();
     }
 
     const shouldSave = dto.saveToTimeline !== false;
@@ -140,6 +144,7 @@ export class HealthLensService {
           dto,
           result,
           provenance,
+          modelProvenance,
           imageFingerprint,
           hadImage: Boolean(image),
         })
@@ -153,6 +158,7 @@ export class HealthLensService {
       provenance: {
         version: ASSESSMENT_VERSION,
         pathway: provenance,
+        model: modelProvenance,
         imageAnalyzed: Boolean(image) && provenance === 'multimodal-model',
         modelConfigured: this.ai.isConfigured(),
         savedToTimeline: Boolean(saved),
@@ -198,6 +204,7 @@ export class HealthLensService {
     const emergency = screenEmergencyText(dto.message);
     let result: PetHealthModelResult;
     let pathway: string;
+    let modelProvenance: HealthModelProvenance | null = null;
 
     if (emergency) {
       result = {
@@ -240,6 +247,7 @@ export class HealthLensService {
         priorHealthObservations: [],
       });
       pathway = 'multimodal-model-follow-up';
+      modelProvenance = this.ai.provenance();
     }
 
     const saved = await this.prisma.telemetry.create({
@@ -253,6 +261,7 @@ export class HealthLensService {
           assessmentId: previous.id,
           ownerMessage: dto.message,
           pathway,
+          model: modelProvenance,
           result,
         } as Prisma.InputJsonValue,
       },
@@ -264,7 +273,12 @@ export class HealthLensService {
       assessmentId: previous.id,
       generatedAt: saved.createdAt.toISOString(),
       assessment: result,
-      provenance: { version: ASSESSMENT_VERSION, pathway, imageReused: false },
+      provenance: {
+        version: ASSESSMENT_VERSION,
+        pathway,
+        model: modelProvenance,
+        imageReused: false,
+      },
       safety:
         'A follow-up chat can use the prior structured findings, but Woof does not retain the original image. Upload a new image when a visual change needs reassessment.',
     };
@@ -321,6 +335,7 @@ export class HealthLensService {
     dto: AnalyzePetHealthDto;
     result: PetHealthModelResult;
     provenance: string;
+    modelProvenance: HealthModelProvenance | null;
     imageFingerprint: string | null;
     hadImage: boolean;
   }) {
@@ -340,6 +355,7 @@ export class HealthLensService {
           breathing: input.dto.breathing ?? null,
           bathroom: input.dto.bathroom ?? null,
           pathway: input.provenance,
+          model: input.modelProvenance,
           hadImage: input.hadImage,
           imageSha256: input.imageFingerprint,
           result: input.result,


### PR DESCRIPTION
Parent: #53
Roadmap: #41

Hardens the highest-stakes user-facing inference path so veterinary screening safety does not depend on prompt obedience alone.

## Deterministic authority
- The existing emergency text/structured-symptom screen remains authoritative and bypasses model analysis entirely.
- Model triage may escalate urgency, but internally contradictory vet-handoff timing is normalized upward by server policy.
- `better_image` cannot simultaneously claim the image was usable.
- Model-generated arrays/text are bounded before they reach persistence or clients.

## Treatment boundary
- Positive treatment directives containing medication administration, explicit doses, prescription changes, induced vomiting, or invasive lesion handling are rejected fail-closed.
- The guard applies across instructional user-visible model text: summary, photo guidance, follow-up questions, owner actions, and vet-handoff text.
- Explicit negated safety language such as “do not give human medication” remains allowed.
- The prompt remains conservative, but server policy independently enforces the boundary.

## Provenance
- Every model-backed assessment records provider, configured model identity, Woof health-model policy version, and response-contract version.
- Deterministic emergency and model-unavailable paths explicitly carry no model provenance.
- Provenance is persisted with derived timeline data; raw images remain transient and are never stored by Woof.

## Qualification
Final release candidate: `44f7a9c6891dc72f0ae4752fadd960ab4a70b4bc`.

The PR was clean-restacked to one commit directly parented on production `7e9b649aa7c4a6cdf16a7f06b4512550f1e36064`. Because GitHub stopped attaching pull-request runs after the restack, an isolated read-only exact-SHA qualifier checked out and verified that exact candidate before running qualification. Exact-head qualifier run: `33020423105`.

Passed on the exact candidate:
- canonical Postgres migration chain on pgvector Postgres
- exact checkout SHA assertion
- Health Lens deterministic/model authority invariants
- canonical Health Lens formatting
- whole-monorepo lint
- whole-monorepo TypeScript
- adversarial Health Lens safety contracts
- full API unit + integration suite
- production API build
- ML Python compilation

The temporary qualification workflow used `contents: read`, checked out the candidate SHA explicitly, and has been removed from its helper branch after success. The permanent Health Lens CI lane in this PR is also read-only.

Branch boundary: five intended files only, no schema migration and no reward/personalization authority changes.