### PR TITLE
Adventure learning v2: separate preference evidence from rewards

### DIFF
--- a/.github/workflows/dogos-adventure-learning-ci.yml
+++ b/.github/workflows/dogos-adventure-learning-ci.yml
@@ -1,0 +1,157 @@
+name: dogOS Adventure Learning Authority CI
+
+on:
+  pull_request:
+    paths:
+      - 'apps/api/src/adventure/**'
+      - 'apps/api/src/care-events/**'
+      - '.github/workflows/dogos-adventure-learning-ci.yml'
+      - 'docs/DOGOS_ADVENTURE_LEARNING_V2.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-adventure-learning-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  qualify:
+    name: Adventure learning authority
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+      SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_shadow
+      JWT_SECRET: ci-only-adventure-learning-secret
+      NODE_ENV: test
+      ML_SERVICE_ENABLED: 'false'
+      ENABLE_ADVENTURE_SYSTEM: 'true'
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Apply canonical database migrations
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Enforce learning authority invariants
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const policy = fs.readFileSync('apps/api/src/adventure/adventure-learning-policy.ts', 'utf8');
+          const care = fs.readFileSync('apps/api/src/care-events/care-events.service.ts', 'utf8');
+          const adventure = fs.readFileSync('apps/api/src/adventure/adventure.service.ts', 'utf8');
+
+          for (const forbidden of ['bondXp', 'bond_xp', 'reward_ledger', 'RewardReceipt']) {
+            if (policy.includes(forbidden)) {
+              throw new Error(`Adventure learning policy must not consume reward authority: ${forbidden}`);
+            }
+          }
+
+          const start = care.indexOf('async getAdventureLearningEvents(');
+          const end = care.indexOf('async getSummary(', start);
+          if (start < 0 || end < 0) throw new Error('Missing isolated Adventure learning evidence query');
+          const evidenceQuery = care.slice(start, end);
+
+          for (const required of [
+            "source = 'QUEST_ENGINE'",
+            "event_type = 'SAFE_OPT_OUT'",
+            "LEFT(event_type, 6) = 'QUEST_'",
+            "INTERVAL '28 days'",
+            'Number.isFinite(limit)',
+            'LIMIT ${boundedLimit}',
+          ]) {
+            if (!evidenceQuery.includes(required)) {
+              throw new Error(`Missing Adventure learning evidence invariant: ${required}`);
+            }
+          }
+          for (const forbidden of ['reward_ledger', 'bond_xp', 'bondXp']) {
+            if (evidenceQuery.includes(forbidden)) {
+              throw new Error(`Learning evidence query must remain reward-free: ${forbidden}`);
+            }
+          }
+
+          for (const required of [
+            'originalPathway: quest.primaryPathway',
+            'rewardPathway',
+            'ADVENTURE_LEARNING_POLICY_VERSION',
+            'getAdventureLearningEvents',
+            'learningScoreAdjustment',
+          ]) {
+            if (!adventure.includes(required)) {
+              throw new Error(`Missing Adventure provenance invariant: ${required}`);
+            }
+          }
+          NODE
+
+      - name: Check Adventure learning formatting
+        run: >-
+          pnpm exec prettier --check
+          .github/workflows/dogos-adventure-learning-ci.yml
+          docs/DOGOS_ADVENTURE_LEARNING_V2.md
+          apps/api/src/adventure/adventure-learning-policy.ts
+          apps/api/src/adventure/adventure-learning-policy.spec.ts
+          apps/api/src/adventure/adventure-learning-ranking.spec.ts
+          apps/api/src/adventure/adventure.service.ts
+          apps/api/src/adventure/adventure.service.spec.ts
+          apps/api/src/care-events/care-event.types.ts
+          apps/api/src/care-events/care-events.service.ts
+          apps/api/src/care-events/care-events.integration.spec.ts
+
+      - name: Type-check monorepo
+        run: pnpm type-check
+
+      - name: Run deterministic learning and ranking contracts
+        run: >-
+          pnpm --filter @woof/api exec jest
+          src/adventure/adventure-learning-policy.spec.ts
+          src/adventure/adventure-learning-ranking.spec.ts
+          --runInBand
+
+      - name: Run Adventure reward and completion contracts
+        run: >-
+          pnpm --filter @woof/api exec jest
+          src/care-events/reward-policy.spec.ts
+          src/adventure/adventure.service.spec.ts
+          --runInBand
+
+      - name: Run canonical learning evidence integration contract
+        run: >-
+          pnpm --filter @woof/api exec jest
+          src/care-events/care-events.integration.spec.ts
+          --runInBand
+
+      - name: Build API
+        run: pnpm --filter @woof/api build

--- a/apps/api/src/adventure/adventure-learning-policy.spec.ts
+++ b/apps/api/src/adventure/adventure-learning-policy.spec.ts
@@ -1,0 +1,293 @@
+import {
+  deriveAdventureLearningSignals,
+  type AdventureLearningEvent,
+} from './adventure-learning-policy';
+
+const NOW = new Date('2026-08-26T12:00:00.000Z');
+
+function event(
+  overrides: Partial<AdventureLearningEvent> & Pick<AdventureLearningEvent, 'id'>
+): AdventureLearningEvent {
+  return {
+    id: overrides.id,
+    eventType: overrides.eventType ?? 'QUEST_BOND',
+    pathway: overrides.pathway ?? 'BOND',
+    occurredAt: overrides.occurredAt ?? '2026-08-26T10:00:00.000Z',
+    context: overrides.context ?? {},
+    outcome: overrides.outcome ?? {},
+  };
+}
+
+describe('Adventure learning v2', () => {
+  it('keeps a safe LEARN opt-out out of durable BOND and LEARN preference', () => {
+    const result = deriveAdventureLearningSignals(
+      [
+        event({
+          id: 'safe-stop',
+          pathway: 'BOND',
+          context: { originalPathway: 'LEARN' },
+          outcome: {
+            dogExperience: 'not_their_thing',
+            ownerExperience: 'fine',
+            safeOptOut: true,
+          },
+        }),
+      ],
+      NOW
+    );
+
+    expect(result.durablePathwayPreference.BOND).toBeUndefined();
+    expect(result.durablePathwayPreference.LEARN).toBeUndefined();
+    expect(result.temporaryPathwayModifier.LEARN).toBeLessThan(0);
+    expect(result.temporaryPathwayModifier.RECOVER).toBeGreaterThan(0);
+    expect(result.temporaryPace).toBe('easy');
+  });
+
+  it('recognizes legacy SAFE_OPT_OUT event identity even when the boolean flag is absent', () => {
+    const result = deriveAdventureLearningSignals(
+      [
+        event({
+          id: 'legacy-safe-stop',
+          eventType: 'SAFE_OPT_OUT',
+          pathway: 'BOND',
+          context: { originalPathway: 'CONNECT' },
+          outcome: { dogExperience: 'not_their_thing', ownerExperience: 'fine' },
+        }),
+      ],
+      NOW
+    );
+
+    expect(result.durablePathwayPreference).toEqual({});
+    expect(result.temporaryPathwayModifier.CONNECT).toBeLessThan(0);
+    expect(result.temporaryPathwayModifier.RECOVER).toBeGreaterThan(0);
+    expect(result.temporaryPace).toBe('easy');
+  });
+
+  it('targets non-safe dog mismatch at the original pathway, never the BOND reward pathway', () => {
+    const result = deriveAdventureLearningSignals(
+      [
+        event({
+          id: 'mismatch',
+          pathway: 'BOND',
+          context: { originalPathway: 'CONNECT' },
+          outcome: {
+            dogExperience: 'not_their_thing',
+            ownerExperience: 'fine',
+            safeOptOut: false,
+          },
+        }),
+      ],
+      NOW
+    );
+
+    expect(result.durablePathwayPreference.CONNECT).toBeLessThan(0);
+    expect(result.durablePathwayPreference.BOND).toBeUndefined();
+  });
+
+  it('keeps dog preference durable while owner overload remains temporary context', () => {
+    const result = deriveAdventureLearningSignals(
+      [
+        event({
+          id: 'busy-owner',
+          pathway: 'MOVE',
+          context: { originalPathway: 'MOVE' },
+          outcome: {
+            dogExperience: 'loved_it',
+            ownerExperience: 'a_lot_today',
+            safeOptOut: false,
+          },
+        }),
+      ],
+      NOW
+    );
+
+    expect(result.durablePathwayPreference.MOVE).toBeGreaterThan(0);
+    expect(result.temporaryPathwayModifier.MOVE).toBeLessThan(0);
+    expect(result.temporaryPathwayModifier.RECOVER).toBeGreaterThan(0);
+    expect(result.temporaryPace).toBe('easy');
+  });
+
+  it('expires temporary owner-load context without erasing durable dog history', () => {
+    const result = deriveAdventureLearningSignals(
+      [
+        event({
+          id: 'old-owner-load',
+          pathway: 'MOVE',
+          occurredAt: '2026-08-22T12:00:00.000Z',
+          context: { originalPathway: 'MOVE' },
+          outcome: {
+            dogExperience: 'comfortable',
+            ownerExperience: 'a_lot_today',
+            safeOptOut: false,
+          },
+        }),
+      ],
+      NOW
+    );
+
+    expect(result.durablePathwayPreference.MOVE).toBeGreaterThan(0);
+    expect(result.temporaryPathwayModifier).toEqual({});
+    expect(result.temporaryPace).toBe('normal');
+  });
+
+  it('accumulates repeated positive dog outcomes monotonically while remaining bounded', () => {
+    const one = deriveAdventureLearningSignals(
+      [
+        event({
+          id: 'positive-1',
+          pathway: 'LEARN',
+          context: { originalPathway: 'LEARN' },
+          outcome: { dogExperience: 'loved_it', ownerExperience: 'great', safeOptOut: false },
+        }),
+      ],
+      NOW
+    );
+    const many = deriveAdventureLearningSignals(
+      Array.from({ length: 12 }, (_, index) =>
+        event({
+          id: `positive-${index}`,
+          pathway: 'LEARN',
+          context: { originalPathway: 'LEARN' },
+          outcome: { dogExperience: 'loved_it', ownerExperience: 'great', safeOptOut: false },
+        })
+      ),
+      NOW
+    );
+
+    expect(one.durablePathwayPreference.LEARN).toBeGreaterThan(0);
+    expect(many.durablePathwayPreference.LEARN).toBeGreaterThan(
+      one.durablePathwayPreference.LEARN ?? 0
+    );
+    expect(many.durablePathwayPreference.LEARN).toBeLessThanOrEqual(0.08);
+  });
+
+  it('does not let one mismatch erase several recent positive outcomes', () => {
+    const result = deriveAdventureLearningSignals(
+      [
+        ...Array.from({ length: 3 }, (_, index) =>
+          event({
+            id: `liked-${index}`,
+            pathway: 'LEARN',
+            context: { originalPathway: 'LEARN' },
+            outcome: { dogExperience: 'loved_it', ownerExperience: 'fine', safeOptOut: false },
+          })
+        ),
+        event({
+          id: 'one-mismatch',
+          pathway: 'BOND',
+          context: { originalPathway: 'LEARN' },
+          outcome: {
+            dogExperience: 'not_their_thing',
+            ownerExperience: 'fine',
+            safeOptOut: false,
+          },
+        }),
+      ],
+      NOW
+    );
+
+    expect(result.durablePathwayPreference.LEARN).toBeGreaterThan(0);
+  });
+
+  it('ignores ambiguous legacy BOND mismatch rather than corrupting Bond preference', () => {
+    const result = deriveAdventureLearningSignals(
+      [
+        event({
+          id: 'legacy-mismatch',
+          pathway: 'BOND',
+          context: {},
+          outcome: {
+            dogExperience: 'not_their_thing',
+            ownerExperience: 'fine',
+            safeOptOut: false,
+          },
+        }),
+      ],
+      NOW
+    );
+
+    expect(result.durablePathwayPreference).toEqual({});
+  });
+
+  it('falls back to the event pathway for unambiguous legacy positive outcomes', () => {
+    const result = deriveAdventureLearningSignals(
+      [
+        event({
+          id: 'legacy-positive',
+          pathway: 'EXPLORE',
+          context: {},
+          outcome: {
+            dogExperience: 'comfortable',
+            ownerExperience: 'fine',
+            safeOptOut: false,
+          },
+        }),
+      ],
+      NOW
+    );
+
+    expect(result.durablePathwayPreference.EXPLORE).toBeGreaterThan(0);
+  });
+
+  it('is deterministic under input permutation', () => {
+    const events = [
+      event({
+        id: 'a',
+        pathway: 'MOVE',
+        occurredAt: '2026-08-26T08:00:00.000Z',
+        context: { originalPathway: 'MOVE' },
+        outcome: { dogExperience: 'loved_it', ownerExperience: 'fine', safeOptOut: false },
+      }),
+      event({
+        id: 'b',
+        pathway: 'BOND',
+        occurredAt: '2026-08-25T08:00:00.000Z',
+        context: { originalPathway: 'LEARN' },
+        outcome: { dogExperience: 'not_their_thing', ownerExperience: 'fine', safeOptOut: true },
+      }),
+    ];
+
+    expect(deriveAdventureLearningSignals(events, NOW)).toEqual(
+      deriveAdventureLearningSignals([...events].reverse(), NOW)
+    );
+  });
+
+  it('ignores non-Adventure CareEvents even when their JSON reuses outcome-like keys', () => {
+    const result = deriveAdventureLearningSignals(
+      [
+        event({
+          id: 'unrelated-care-event',
+          eventType: 'DAILY_SIGNALS_CHECKIN',
+          pathway: 'CARE',
+          context: { originalPathway: 'LEARN' },
+          outcome: {
+            dogExperience: 'not_their_thing',
+            ownerExperience: 'a_lot_today',
+            safeOptOut: false,
+          },
+        }),
+      ],
+      NOW
+    );
+
+    expect(result.durablePathwayPreference).toEqual({});
+    expect(result.temporaryPathwayModifier).toEqual({});
+    expect(result.temporaryPace).toBe('normal');
+  });
+
+  it('does not use reward XP as a learning input', () => {
+    const lowReward = event({
+      id: 'xp-invariant',
+      pathway: 'LEARN',
+      context: { originalPathway: 'LEARN' },
+      outcome: { dogExperience: 'loved_it', ownerExperience: 'great', safeOptOut: false },
+    });
+    const highReward = { ...lowReward, bondXp: 10_000 } as AdventureLearningEvent & {
+      bondXp: number;
+    };
+
+    expect(deriveAdventureLearningSignals([lowReward], NOW)).toEqual(
+      deriveAdventureLearningSignals([highReward], NOW)
+    );
+  });
+});

--- a/apps/api/src/adventure/adventure-learning-policy.ts
+++ b/apps/api/src/adventure/adventure-learning-policy.ts
@@ -1,0 +1,151 @@
+import {
+  WELLBEING_PATHWAYS,
+  type AdventureLearningCareEvent,
+  type WellbeingPathway,
+} from '../care-events/care-event.types';
+
+export const ADVENTURE_LEARNING_POLICY_VERSION = 'adventure-learning-v2';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DURABLE_WINDOW_DAYS = 28;
+const TEMPORARY_WINDOW_DAYS = 3;
+
+export type AdventureLearningEvent = AdventureLearningCareEvent;
+
+export type AdventureLearningSignals = {
+  policyVersion: typeof ADVENTURE_LEARNING_POLICY_VERSION;
+  durablePathwayPreference: Partial<Record<WellbeingPathway, number>>;
+  temporaryPathwayModifier: Partial<Record<WellbeingPathway, number>>;
+  temporaryPace: 'normal' | 'easy';
+};
+
+export function deriveAdventureLearningSignals(
+  events: AdventureLearningEvent[],
+  now = new Date()
+): AdventureLearningSignals {
+  const durable: Partial<Record<WellbeingPathway, number>> = {};
+  const temporary: Partial<Record<WellbeingPathway, number>> = {};
+  let temporaryPace: 'normal' | 'easy' = 'normal';
+
+  const canonical = [...events]
+    .filter((event) => Number.isFinite(new Date(event.occurredAt).getTime()))
+    .sort(
+      (left, right) =>
+        new Date(right.occurredAt).getTime() - new Date(left.occurredAt).getTime() ||
+        left.id.localeCompare(right.id)
+    )
+    .slice(0, 24);
+
+  for (const event of canonical) {
+    if (!isAdventureOutcomeEvent(event.eventType)) continue;
+
+    const ageDays = Math.max(0, (now.getTime() - new Date(event.occurredAt).getTime()) / DAY_MS);
+    const outcome = event.outcome ?? {};
+    const dogExperience = stringValue(outcome.dogExperience);
+    const ownerExperience = stringValue(outcome.ownerExperience);
+    const safeOptOut = outcome.safeOptOut === true || event.eventType === 'SAFE_OPT_OUT';
+    const originalPathway = learningPathway(event);
+
+    // Durable fit is dog-level evidence only. Owner load is tracked independently as
+    // temporary context, so "the dog loved it but today was a lot for me" can teach
+    // both truths without one suppressing the other. Welfare-respecting opt-outs are
+    // never interpreted as durable dislike evidence.
+    if (originalPathway && ageDays <= DURABLE_WINDOW_DAYS && !safeOptOut) {
+      const recency = Math.max(0.2, 1 - ageDays / DURABLE_WINDOW_DAYS);
+      const delta = durableDelta(dogExperience) * recency;
+      addSignal(durable, originalPathway, delta, -0.08, 0.08);
+    }
+
+    if (ageDays > TEMPORARY_WINDOW_DAYS) continue;
+    const temporaryRecency = Math.max(0, 1 - ageDays / TEMPORARY_WINDOW_DAYS);
+
+    if (ownerExperience === 'a_lot_today') {
+      temporaryPace = ageDays <= 1 ? 'easy' : temporaryPace;
+      for (const pathway of ['MOVE', 'EXPLORE', 'ENRICH', 'LEARN', 'CONNECT'] as const) {
+        addSignal(temporary, pathway, -0.018 * temporaryRecency, -0.06, 0.06);
+      }
+      addSignal(temporary, 'RECOVER', 0.03 * temporaryRecency, -0.06, 0.06);
+      addSignal(temporary, 'BOND', 0.012 * temporaryRecency, -0.06, 0.06);
+    }
+
+    if (safeOptOut) {
+      temporaryPace = ageDays <= 1 ? 'easy' : temporaryPace;
+      if (originalPathway) {
+        addSignal(temporary, originalPathway, -0.028 * temporaryRecency, -0.06, 0.06);
+      }
+      addSignal(temporary, 'RECOVER', 0.025 * temporaryRecency, -0.06, 0.06);
+      addSignal(temporary, 'BOND', 0.01 * temporaryRecency, -0.06, 0.06);
+    }
+  }
+
+  return {
+    policyVersion: ADVENTURE_LEARNING_POLICY_VERSION,
+    durablePathwayPreference: stableRecord(durable),
+    temporaryPathwayModifier: stableRecord(temporary),
+    temporaryPace,
+  };
+}
+
+function isAdventureOutcomeEvent(eventType: string) {
+  return eventType === 'SAFE_OPT_OUT' || eventType.startsWith('QUEST_');
+}
+
+function learningPathway(event: AdventureLearningEvent): WellbeingPathway | null {
+  const original = event.context?.originalPathway;
+  if (isWellbeingPathway(original)) return original;
+
+  // A mismatch can intentionally earn a BOND reward. Without original-pathway
+  // provenance, treating that reward pathway as the disliked target would corrupt
+  // long-term Bond preference. Ignore that legacy ambiguity rather than guess.
+  if (event.pathway === 'BOND' && event.outcome?.dogExperience === 'not_their_thing') {
+    return null;
+  }
+
+  return event.pathway;
+}
+
+function durableDelta(dogExperience: string | null) {
+  if (dogExperience === 'loved_it') return 0.018;
+  if (dogExperience === 'comfortable') return 0.01;
+  if (dogExperience === 'not_their_thing') return -0.025;
+  return 0;
+}
+
+function isWellbeingPathway(value: unknown): value is WellbeingPathway {
+  return (
+    typeof value === 'string' &&
+    WELLBEING_PATHWAYS.includes(value as (typeof WELLBEING_PATHWAYS)[number])
+  );
+}
+
+function stringValue(value: unknown) {
+  return typeof value === 'string' ? value : null;
+}
+
+function addSignal(
+  signals: Partial<Record<WellbeingPathway, number>>,
+  pathway: WellbeingPathway,
+  delta: number,
+  min: number,
+  max: number
+) {
+  if (!Number.isFinite(delta) || delta === 0) return;
+  signals[pathway] = clamp((signals[pathway] ?? 0) + delta, min, max);
+}
+
+function stableRecord(signals: Partial<Record<WellbeingPathway, number>>) {
+  return Object.fromEntries(
+    WELLBEING_PATHWAYS.filter((pathway) => signals[pathway] !== undefined).map((pathway) => [
+      pathway,
+      round4(signals[pathway] ?? 0),
+    ])
+  ) as Partial<Record<WellbeingPathway, number>>;
+}
+
+function round4(value: number) {
+  return Math.round(value * 10_000) / 10_000;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}

--- a/apps/api/src/adventure/adventure-learning-ranking.spec.ts
+++ b/apps/api/src/adventure/adventure-learning-ranking.spec.ts
@@ -1,0 +1,89 @@
+import { CareEventsService } from '../care-events/care-events.service';
+import {
+  WELLBEING_PATHWAYS,
+  type AdventureLearningCareEvent,
+  type CareSummary,
+} from '../care-events/care-event.types';
+import { InsightsService } from '../insights/insights.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AdventureService } from './adventure.service';
+
+type RankedQuest = {
+  key: string;
+  primaryPathway: string;
+  personalRelevance: number;
+};
+
+type QuestBuilder = {
+  buildQuests: (
+    userId: string,
+    insights: object,
+    summary: CareSummary,
+    learningEvents: AdventureLearningCareEvent[]
+  ) => RankedQuest[];
+};
+
+const insights = {
+  pet: { id: 'pet-1', name: 'Shasta' },
+  recommendations: [],
+  algorithm: { confidence: 0.7 },
+};
+
+function summary(): CareSummary {
+  return {
+    bondXp: 0,
+    rhythm: { activeWeeks: 0, windowWeeks: 5, label: 'Every useful moment can start a rhythm' },
+    pathways: WELLBEING_PATHWAYS.map((pathway) => ({
+      pathway,
+      label: pathway,
+      recentDays: 0,
+      coverage: pathway === 'BOND' ? 68.18 : 100,
+      xp: 0,
+      lastEventAt: null,
+    })),
+    recentEvents: [],
+  };
+}
+
+describe('Adventure learning ranking integration', () => {
+  it('lets original-pathway mismatch change ranking without punishing the BOND reward pathway', () => {
+    const service = new AdventureService(
+      {} as PrismaService,
+      {} as InsightsService,
+      {} as CareEventsService
+    );
+    const buildQuests = (service as unknown as QuestBuilder).buildQuests.bind(service);
+
+    const neutral = buildQuests('user-1', insights, summary(), []);
+    const mismatch = buildQuests('user-1', insights, summary(), [
+      {
+        id: 'mismatch-1',
+        eventType: 'QUEST_BOND',
+        pathway: 'BOND',
+        occurredAt: new Date().toISOString(),
+        context: { originalPathway: 'LEARN' },
+        outcome: {
+          dogExperience: 'not_their_thing',
+          ownerExperience: 'fine',
+          safeOptOut: false,
+        },
+      },
+    ]);
+
+    expect(neutral.map((quest) => quest.key)).toEqual([
+      'sniffari',
+      'skill-spark',
+      'favorite-ritual',
+    ]);
+    expect(mismatch.map((quest) => quest.key)).toEqual([
+      'sniffari',
+      'favorite-ritual',
+      'skill-spark',
+    ]);
+
+    const learnedSkill = mismatch.find((quest) => quest.key === 'skill-spark');
+    const bondRitual = mismatch.find((quest) => quest.key === 'favorite-ritual');
+    expect(learnedSkill?.personalRelevance).toBeLessThan(1);
+    expect(bondRitual?.personalRelevance).toBe(1);
+  });
+});

--- a/apps/api/src/adventure/adventure.service.spec.ts
+++ b/apps/api/src/adventure/adventure.service.spec.ts
@@ -97,6 +97,7 @@ describe('AdventureService', () => {
         interaction: 'SELECTED',
         pathway: 'LEARN',
         context: expect.objectContaining({
+          learningPolicyVersion: 'adventure-learning-v2',
           questSnapshot: {
             id: quest.id,
             key: quest.key,
@@ -130,6 +131,30 @@ describe('AdventureService', () => {
         eventType: 'SAFE_OPT_OUT',
         pathway: 'BOND',
         safetyEligible: true,
+        context: expect.objectContaining({ originalPathway: 'LEARN' }),
+      })
+    );
+    expect(careHarness.recordQuestInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interaction: 'COMPLETED',
+        pathway: 'BOND',
+        context: expect.objectContaining({
+          originalPathway: 'LEARN',
+          rewardPathway: 'BOND',
+          learningPolicyVersion: 'adventure-learning-v2',
+        }),
+      })
+    );
+    expect(prismaHarness.telemetry.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          data: expect.objectContaining({
+            pathway: 'BOND',
+            originalPathway: 'LEARN',
+            rewardPathway: 'BOND',
+            learningPolicyVersion: 'adventure-learning-v2',
+          }),
+        }),
       })
     );
   });
@@ -144,7 +169,22 @@ describe('AdventureService', () => {
     );
 
     expect(careHarness.record).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'QUEST_BOND', pathway: 'BOND' })
+      expect.objectContaining({
+        eventType: 'QUEST_BOND',
+        pathway: 'BOND',
+        context: expect.objectContaining({ originalPathway: 'LEARN' }),
+      })
+    );
+    expect(careHarness.recordQuestInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interaction: 'COMPLETED',
+        pathway: 'BOND',
+        context: expect.objectContaining({
+          originalPathway: 'LEARN',
+          rewardPathway: 'BOND',
+          learningPolicyVersion: 'adventure-learning-v2',
+        }),
+      })
     );
   });
 

--- a/apps/api/src/adventure/adventure.service.ts
+++ b/apps/api/src/adventure/adventure.service.ts
@@ -4,11 +4,17 @@ import { CareEventsService } from '../care-events/care-events.service';
 import {
   QUEST_EVENT_TYPES,
   WELLBEING_PATHWAYS,
+  type AdventureLearningCareEvent,
   type CareSummary,
   type WellbeingPathway,
 } from '../care-events/care-event.types';
 import { baseXpForEvent } from '../care-events/reward-policy';
 import { InsightsService } from '../insights/insights.service';
+import {
+  ADVENTURE_LEARNING_POLICY_VERSION,
+  deriveAdventureLearningSignals,
+  type AdventureLearningSignals,
+} from './adventure-learning-policy';
 import { PrismaService } from '../prisma/prisma.service';
 import { CompleteQuestDto } from './dto/adventure.dto';
 
@@ -62,8 +68,11 @@ export class AdventureService {
 
   async getDashboard(userId: string, requestedPetId?: string) {
     const insights = await this.insights.getForUser(userId, requestedPetId);
-    const summary = await this.careEvents.getSummary(userId, insights.pet.id);
-    const quests = this.buildQuests(userId, insights, summary);
+    const [summary, learningEvents] = await Promise.all([
+      this.careEvents.getSummary(userId, insights.pet.id),
+      this.careEvents.getAdventureLearningEvents(userId, insights.pet.id),
+    ]);
+    const quests = this.buildQuests(userId, insights, summary, learningEvents);
 
     return {
       pet: insights.pet,
@@ -104,6 +113,7 @@ export class AdventureService {
       context: {
         questKey: quest.key,
         confidence: quest.confidence,
+        learningPolicyVersion: ADVENTURE_LEARNING_POLICY_VERSION,
         ...(interaction === 'SELECTED' ? { questSnapshot: this.questSnapshot(quest) } : {}),
       },
     });
@@ -160,6 +170,7 @@ export class AdventureService {
         questKey: quest.key,
         questTitle: quest.title,
         originalPathway: quest.primaryPathway,
+        learningPolicyVersion: ADVENTURE_LEARNING_POLICY_VERSION,
         personalRelevance: quest.personalRelevance,
         memoryAdded: Boolean(verifiedMemory),
         memoryAssetId: verifiedMemory?.id ?? null,
@@ -185,6 +196,9 @@ export class AdventureService {
         pathway: rewardPathway,
         context: {
           questKey: quest.key,
+          originalPathway: quest.primaryPathway,
+          rewardPathway,
+          learningPolicyVersion: ADVENTURE_LEARNING_POLICY_VERSION,
           dogExperience: dto.dogExperience,
           ownerExperience: dto.ownerExperience,
           safeOptOut,
@@ -213,6 +227,9 @@ export class AdventureService {
           data: {
             questId,
             pathway: rewardPathway,
+            originalPathway: quest.primaryPathway,
+            rewardPathway,
+            learningPolicyVersion: ADVENTURE_LEARNING_POLICY_VERSION,
             bondXp: receipt.bondXp,
             duplicate: receipt.duplicate,
             dogExperience: dto.dogExperience,
@@ -292,17 +309,18 @@ export class AdventureService {
   private buildQuests(
     userId: string,
     insights: Awaited<ReturnType<InsightsService['getForUser']>>,
-    summary: CareSummary
+    summary: CareSummary,
+    learningEvents: AdventureLearningCareEvent[]
   ): Quest[] {
     const dateKey = new Date().toISOString().slice(0, 10);
     const coverage = new Map(summary.pathways.map((item) => [item.pathway, item.coverage]));
-    const preference = this.preferenceSignals(summary);
+    const learning = deriveAdventureLearningSignals(learningEvents);
 
     const candidates: Candidate[] = insights.recommendations.map((recommendation) => {
       const pathway = CATEGORY_PATHWAYS[recommendation.category] ?? 'BOND';
       const eventType = QUEST_EVENT_TYPES[pathway];
       const gap = 1 - (coverage.get(pathway) ?? 0) / 100;
-      const personalRelevance = this.clamp(1 + (preference[pathway] ?? 0), 0.9, 1.08);
+      const personalRelevance = this.pathwayRelevance(learning, pathway);
       return {
         key: `insight-${recommendation.id}`,
         title: recommendation.title,
@@ -333,8 +351,11 @@ export class AdventureService {
         href: '/activity',
         actionLabel: 'Start an exploration',
         safeStopEligible: false,
-        personalRelevance: this.clamp(1 + (preference.EXPLORE ?? 0), 0.9, 1.08),
-        score: 0.62 + (1 - (coverage.get('EXPLORE') ?? 0) / 100) * 0.28,
+        personalRelevance: this.pathwayRelevance(learning, 'EXPLORE'),
+        score:
+          0.62 +
+          (1 - (coverage.get('EXPLORE') ?? 0) / 100) * 0.28 +
+          this.learningScoreAdjustment(learning, 'EXPLORE'),
       },
       {
         key: 'skill-spark',
@@ -349,8 +370,11 @@ export class AdventureService {
         href: '/coach',
         actionLabel: 'Open Coach',
         safeStopEligible: true,
-        personalRelevance: this.clamp(1 + (preference.LEARN ?? 0), 0.9, 1.08),
-        score: 0.58 + (1 - (coverage.get('LEARN') ?? 0) / 100) * 0.3,
+        personalRelevance: this.pathwayRelevance(learning, 'LEARN'),
+        score:
+          0.58 +
+          (1 - (coverage.get('LEARN') ?? 0) / 100) * 0.3 +
+          this.learningScoreAdjustment(learning, 'LEARN'),
       },
       {
         key: 'easy-day',
@@ -365,8 +389,12 @@ export class AdventureService {
         href: '/activity',
         actionLabel: 'Log an easy session',
         safeStopEligible: false,
-        personalRelevance: this.clamp(1 + (preference.RECOVER ?? 0), 0.9, 1.08),
-        score: 0.48 + (1 - (coverage.get('RECOVER') ?? 0) / 100) * 0.24,
+        personalRelevance: this.pathwayRelevance(learning, 'RECOVER'),
+        score:
+          0.48 +
+          (1 - (coverage.get('RECOVER') ?? 0) / 100) * 0.24 +
+          this.learningScoreAdjustment(learning, 'RECOVER') +
+          (learning.temporaryPace === 'easy' ? 0.06 : 0),
       },
       {
         key: 'favorite-ritual',
@@ -381,8 +409,11 @@ export class AdventureService {
         href: '/activity',
         actionLabel: 'Log the moment',
         safeStopEligible: false,
-        personalRelevance: this.clamp(1 + (preference.BOND ?? 0), 0.9, 1.08),
-        score: 0.5 + (1 - (coverage.get('BOND') ?? 0) / 100) * 0.22,
+        personalRelevance: this.pathwayRelevance(learning, 'BOND'),
+        score:
+          0.5 +
+          (1 - (coverage.get('BOND') ?? 0) / 100) * 0.22 +
+          this.learningScoreAdjustment(learning, 'BOND'),
       },
     ];
 
@@ -414,18 +445,14 @@ export class AdventureService {
     }));
   }
 
-  private preferenceSignals(summary: CareSummary) {
-    const signals: Partial<Record<WellbeingPathway, number>> = {};
-    for (const event of summary.recentEvents.slice(0, 10)) {
-      const dog = event.outcome?.dogExperience;
-      const owner = event.outcome?.ownerExperience;
-      const positiveDog = dog === 'loved_it' || dog === 'comfortable';
-      const positiveOwner = owner === 'great' || owner === 'fine';
-      const negative = dog === 'not_their_thing' || owner === 'a_lot_today';
-      const delta = negative ? -0.025 : positiveDog && positiveOwner ? 0.018 : 0;
-      signals[event.pathway] = this.clamp((signals[event.pathway] ?? 0) + delta, -0.1, 0.08);
-    }
-    return signals;
+  private pathwayRelevance(learning: AdventureLearningSignals, pathway: WellbeingPathway) {
+    const durable = learning.durablePathwayPreference[pathway] ?? 0;
+    const temporary = learning.temporaryPathwayModifier[pathway] ?? 0;
+    return this.clamp(1 + durable + temporary, 0.9, 1.08);
+  }
+
+  private learningScoreAdjustment(learning: AdventureLearningSignals, pathway: WellbeingPathway) {
+    return (this.pathwayRelevance(learning, pathway) - 0.9) * 0.5;
   }
 
   private secondaryPathways(primary: WellbeingPathway): WellbeingPathway[] {

--- a/apps/api/src/care-events/care-event.types.ts
+++ b/apps/api/src/care-events/care-event.types.ts
@@ -86,6 +86,15 @@ export type PathwayProgress = {
   lastEventAt: string | null;
 };
 
+export type AdventureLearningCareEvent = {
+  id: string;
+  eventType: string;
+  pathway: WellbeingPathway;
+  occurredAt: string;
+  context: Record<string, unknown> | null;
+  outcome: Record<string, unknown> | null;
+};
+
 export type CareSummary = {
   bondXp: number;
   rhythm: {

--- a/apps/api/src/care-events/care-events.integration.spec.ts
+++ b/apps/api/src/care-events/care-events.integration.spec.ts
@@ -188,6 +188,69 @@ describe('CareEventsService integration', () => {
     expect(new Date(moveSummary!.lastEventAt!).getTime()).toBeLessThanOrEqual(Date.now() + 1000);
   });
 
+  it('preserves original quest pathway separately from the reward pathway in summaries', async () => {
+    const { userId, petId } = await fixture('learning-provenance');
+    const receipt = await service.record({
+      userId,
+      petId,
+      eventType: 'QUEST_BOND',
+      pathway: 'BOND',
+      source: 'QUEST_ENGINE',
+      evidenceType: 'SELF_REPORT',
+      evidenceConfidence: 0.68,
+      dedupeKey: `learning-provenance:${randomUUID()}`,
+      safetyEligible: true,
+      context: {
+        originalPathway: 'LEARN',
+        learningPolicyVersion: 'adventure-learning-v2',
+      },
+      outcome: {
+        dogExperience: 'not_their_thing',
+        ownerExperience: 'fine',
+        safeOptOut: false,
+      },
+    });
+
+    for (let index = 0; index < 14; index += 1) {
+      await service.record({
+        userId,
+        petId,
+        eventType: 'DAILY_SIGNALS_CHECKIN',
+        pathway: 'CARE',
+        source: 'INTELLIGENCE',
+        evidenceType: 'SELF_REPORT',
+        dedupeKey: `learning-crowd:${index}:${randomUUID()}`,
+        safetyEligible: false,
+      });
+    }
+
+    const learningEvents = await service.getAdventureLearningEvents(userId, petId);
+    const nonFiniteLimitEvents = await service.getAdventureLearningEvents(
+      userId,
+      petId,
+      Number.NaN
+    );
+    const stored = learningEvents.find((entry) => entry.id === receipt.careEventId);
+
+    expect(stored).toEqual(
+      expect.objectContaining({
+        pathway: 'BOND',
+        context: expect.objectContaining({
+          originalPathway: 'LEARN',
+          learningPolicyVersion: 'adventure-learning-v2',
+        }),
+        outcome: expect.objectContaining({ dogExperience: 'not_their_thing' }),
+      })
+    );
+    expect(stored).not.toHaveProperty('bondXp');
+    expect(nonFiniteLimitEvents).toEqual(learningEvents);
+    expect(
+      learningEvents.every(
+        (entry) => entry.eventType.startsWith('QUEST_') || entry.eventType === 'SAFE_OPT_OUT'
+      )
+    ).toBe(true);
+  });
+
   it('does not let a zero-XP safety event decay the next legitimate reward', async () => {
     const { userId, petId } = await fixture('safety-zero');
     const common = {

--- a/apps/api/src/care-events/care-events.service.ts
+++ b/apps/api/src/care-events/care-events.service.ts
@@ -5,6 +5,7 @@ import { HouseholdsService } from '../households/households.service';
 import { PrismaService } from '../prisma/prisma.service';
 import {
   WELLBEING_PATHWAYS,
+  type AdventureLearningCareEvent,
   type CanonicalCareEventRecord,
   type CareEventInput,
   type CareSummary,
@@ -20,6 +21,10 @@ type EventRow = {
   pathway: WellbeingPathway;
   occurred_at: Date;
   outcome: Record<string, unknown> | null;
+};
+
+type AdventureLearningEventRow = EventRow & {
+  context: Record<string, unknown> | null;
 };
 
 type CanonicalEventRow = {
@@ -346,6 +351,36 @@ export class CareEventsService {
       LIMIT 1
     `);
     return rows[0] ?? null;
+  }
+
+  async getAdventureLearningEvents(
+    userId: string,
+    petId: string,
+    limit = 24
+  ): Promise<AdventureLearningCareEvent[]> {
+    await this.households.assertPetAccessible(userId, petId);
+    const requestedLimit = Number.isFinite(limit) ? Math.round(limit) : 24;
+    const boundedLimit = Math.max(1, Math.min(24, requestedLimit));
+    const rows = await this.prisma.$queryRaw<AdventureLearningEventRow[]>(Prisma.sql`
+      SELECT id, event_type, pathway, occurred_at, context, outcome
+      FROM care_events
+      WHERE user_id = ${userId}
+        AND pet_id = ${petId}
+        AND source = 'QUEST_ENGINE'
+        AND (event_type = 'SAFE_OPT_OUT' OR LEFT(event_type, 6) = 'QUEST_')
+        AND occurred_at >= NOW() - INTERVAL '28 days'
+      ORDER BY occurred_at DESC, id ASC
+      LIMIT ${boundedLimit}
+    `);
+
+    return rows.map((row) => ({
+      id: row.id,
+      eventType: row.event_type,
+      pathway: row.pathway,
+      occurredAt: row.occurred_at.toISOString(),
+      context: row.context,
+      outcome: row.outcome,
+    }));
   }
 
   async getSummary(userId: string, petId?: string): Promise<CareSummary> {

--- a/docs/DOGOS_ADVENTURE_LEARNING_V2.md
+++ b/docs/DOGOS_ADVENTURE_LEARNING_V2.md
@@ -1,0 +1,104 @@
+# dogOS Adventure Learning v2
+
+Adventure learning v2 separates three authorities that must not collapse into one another:
+
+1. **Reward authority** decides whether a trusted action earns Bond XP and which reward pathway receives it.
+2. **Learning authority** derives bounded recommendation-fit signals from canonical Adventure outcomes.
+3. **Temporary context** adapts the next few recommendations to handler load and welfare-respecting stops without rewriting durable dog preference.
+
+The purpose of this release is not to make personalization more aggressive. It is to make the evidence semantics correct enough that stronger ranking methods can be introduced later without learning the wrong target.
+
+## Canonical evidence boundary
+
+Adventure learning reads from `care_events`, but through a dedicated projection rather than the general Care Summary.
+
+`CareEventsService.getAdventureLearningEvents()` is:
+
+- authorized for the exact `userId + petId` handling pair;
+- restricted to `source = QUEST_ENGINE`;
+- restricted to `QUEST_*` and `SAFE_OPT_OUT` outcomes;
+- limited to the last 28 days and at most 24 events;
+- independent of `reward_ledger`;
+- intentionally free of Bond XP or reward values.
+
+Frequent activity logs, Daily Signals, health events, or unrelated CareEvents therefore cannot crowd the relevant Adventure outcomes out of the learning window.
+
+Interaction-derived recommendation fit remains handler-pair scoped. Shared durable facts about the dog belong in Adaptive Profile rather than being inferred by pooling every household member's handling outcomes.
+
+## Original pathway versus reward pathway
+
+A welfare-respecting safe opt-out or an explicit mismatch can intentionally earn a BOND reward even when the attempted Adventure was LEARN or CONNECT.
+
+That reward pathway is not the learning target.
+
+Completion persists both concepts separately:
+
+- `originalPathway`: what Woof actually recommended and the pair attempted;
+- `rewardPathway`: where the reward policy placed the resulting XP.
+
+`originalPathway` is the only pathway provenance used for recommendation-fit learning when it is available. Ambiguous legacy BOND mismatch events without original-pathway provenance are ignored rather than guessed.
+
+## Durable dog fit
+
+Durable fit is based only on explicit dog-experience outcomes:
+
+- `loved_it`: positive evidence;
+- `comfortable`: smaller positive evidence;
+- `not_their_thing`: negative evidence when it was not a safe opt-out.
+
+Signals decay with age across a 28-day window and remain bounded to a small `[-0.08, 0.08]` pathway modifier. A single mismatch cannot erase several recent positive outcomes.
+
+Owner effort does not suppress dog evidence. If the dog loved an activity while the handler reports that it was a lot today, Woof can learn both truths simultaneously: durable positive dog fit and temporary lower-effort context.
+
+## Temporary handling context
+
+Owner load and safe opt-outs are deliberately not durable dog preference labels.
+
+`ownerExperience = a_lot_today` temporarily:
+
+- reduces the relative weight of higher-effort MOVE, EXPLORE, ENRICH, LEARN, and CONNECT options;
+- increases RECOVER and BOND relevance;
+- marks the immediate pace as `easy` for roughly the next day.
+
+A safe opt-out temporarily lowers immediate repetition of the original attempted pathway and raises RECOVER/BOND options. It never creates durable dislike evidence.
+
+Temporary modifiers decay across three days and disappear completely after the window.
+
+## Ranking influence
+
+Adventure keeps the existing conservative relevance envelope. Durable and temporary modifiers are combined and clamped so `personalRelevance` stays between `0.90` and `1.08`.
+
+When temporary pace is `easy`, the explicit Recovery template receives only a small additional score nudge. The system becomes gentler for the moment rather than rewriting the entire recommendation order.
+
+This release intentionally does not introduce a learned bandit, neural ranker, or unconstrained optimization loop. It establishes the evidence contract those systems would need to respect.
+
+## Policy provenance
+
+The current policy identifier is:
+
+`adventure-learning-v2`
+
+Selection and completion observability record the policy version alongside original/reward pathway provenance so later audits can reconstruct which learning policy produced and interpreted a recommendation.
+
+## Hard prohibitions
+
+Adventure learning must never use the following as recommendation targets or features:
+
+- Bond XP;
+- reward-ledger values;
+- total points;
+- streak pressure;
+- repetition volume by itself;
+- safe stopping as negative preference evidence;
+- temporary owner load as permanent dog preference;
+- unrelated CareEvent JSON fields that merely resemble Adventure outcomes.
+
+The dedicated `dogOS Adventure Learning Authority CI` lane enforces these architecture boundaries in addition to running deterministic policy contracts, reward-regression tests, the Postgres evidence-projection integration test, TypeScript, formatting, and API build.
+
+## Product interpretation
+
+The intended loop is:
+
+**Recommend → practice/play → observe the dog → report the pair's experience → preserve welfare-respecting choices → adapt tomorrow without overreacting.**
+
+The learning system should become more useful because it understands the difference between _the dog did not enjoy this_, _this was too much for me today_, and _we correctly chose to stop_. Those are different facts, and dogOS now stores and learns from them as different facts.


### PR DESCRIPTION
Roadmap: #41
Related relationship-first progression: #44, #50

This release fixes the recommendation-authority leak where Adventure outcome learning could accidentally treat the reward pathway as the preference target.

## Authority split

- Reward authority remains unchanged and continues to decide Bond XP/pathway accounting.
- Recommendation learning derives only from canonical Adventure outcome evidence.
- Temporary handler load and welfare-respecting safe stops are modeled separately from durable dog fit.
- Bond XP, reward-ledger values, total points, and repetition volume are not learning features or targets.

## Canonical learning evidence

Adds `CareEventsService.getAdventureLearningEvents()` as a dedicated read-only evidence projection:

- exact `userId + petId` handling pair authorization
- `source = QUEST_ENGINE` only
- `QUEST_*` / `SAFE_OPT_OUT` only
- 28-day window, max 24 events
- non-finite internal limit input safely falls back to 24
- no reward-ledger join
- no Bond XP field
- unrelated activity, Daily Signals, and health CareEvents cannot crowd Adventure outcomes out of the learning window

## Original versus reward pathway

Adventure completion keeps `originalPathway` and `rewardPathway` distinct in provenance. Safe opt-outs and explicit mismatches may still receive BOND reward credit, but recommendation learning targets the original attempted pathway. Ambiguous legacy BOND mismatch evidence is ignored rather than guessed.

## Durable dog fit

- `loved_it` and `comfortable` provide bounded positive fit evidence.
- `not_their_thing` provides bounded negative fit evidence only when the outcome was not a safe opt-out.
- signals decay across 28 days and remain within a small ±0.08 envelope
- one mismatch cannot erase several recent positive outcomes
- owner overload does not suppress dog-level evidence

Example: if the dog loved a MOVE activity but the handler reports `a_lot_today`, Woof learns durable positive MOVE fit while simultaneously making the next few recommendations easier.

## Temporary context

`a_lot_today` and safe opt-outs create decaying three-day context rather than permanent dog labels. They reduce immediate repetition of higher-effort choices, increase RECOVER/BOND relevance, and can temporarily nudge the explicit easy-day option without rewriting the long-term profile.

## Ranking integration

Template quests now use the same bounded relevance contribution as insight-backed candidates. A dedicated ranking contract proves that a LEARN mismatch whose reward pathway is BOND can lower the actual LEARN template ordering while leaving BOND relevance unpunished.

## Provenance

Policy version: `adventure-learning-v2`.

Selection/completion observability records the learning policy version plus original/reward pathway provenance for later audits.

Architecture contract: `docs/DOGOS_ADVENTURE_LEARNING_V2.md`.

## Final release boundary

Release candidate: `3d50790979e02a0d7fd35fc7f170a9db84afdf6e`.

- one commit
- direct parent: production `4c9416450dae12737751a208adaf380ce733e6af`
- 10 intended files
- all temporary write-capable formatter/patch helpers isolated to helper branches and removed before this candidate
- no schema migration
- no reward-policy semantic changes

## Exact-head qualification

All pull-request workflows attached to `3d50790979e02a0d7fd35fc7f170a9db84afdf6e` completed successfully:

- `dogOS Adventure Learning Authority CI` — run `33027945084`
  - reward-free learning architecture invariants
  - canonical formatting
  - whole-monorepo TypeScript
  - deterministic policy contracts
  - ranking-integration contract
  - unchanged reward/completion contracts
  - Postgres evidence projection, crowding, and non-finite-limit contracts
  - production API build
- `Adventure System CI` — run `33027945075`
  - Prisma validation/migration chain
  - formatting, lint, TypeScript
  - Adventure web contracts
  - reward policy + ledger integrity
  - quest engine contracts
  - full API tests
  - production API + web builds
- root `CI` — run `33027945082`
  - static quality gates
  - ML compilation/policy contracts
  - backend unit/API tests
  - frontend unit tests
  - Playwright smoke/accessibility/visual contracts
  - production API + web builds
- `CI Action Runtime Qualification` — run `33027945073`
- `dogOS Autopilot CI` — run `33027945109`
- `dogOS Daily Signals Capture CI` — run `33027945094`
- `dogOS Intelligence Evidence Projection CI` — run `33027945090`

Before release, `main` was rechecked unchanged at `4c9416450dae12737751a208adaf380ce733e6af`. There are no submitted reviews or unresolved review threads on this PR.