### PR TITLE
Behavior Vision: attest active model releases before learning

### DIFF
--- a/.github/workflows/dogos-behavior-moments-ci.yml
+++ b/.github/workflows/dogos-behavior-moments-ci.yml
@@ -5,13 +5,18 @@ on:
     branches: [main]
     paths:
       - 'apps/api/src/behavior-vision/**'
+      - 'apps/api/src/config/env.validation.ts'
+      - 'apps/api/src/config/env.validation.spec.ts'
+      - 'apps/api/.env.example'
       - 'apps/web/src/lib/api/behavior-vision.ts'
       - 'apps/web/src/lib/api/behavior-vision.spec.ts'
       - 'apps/web/src/app/coach/layout.tsx'
       - 'apps/web/src/app/coach/observe/shadow/**'
       - 'apps/web/e2e/behavior-moments-shadow.spec.ts'
+      - 'ml/behavior_vision/**'
       - '.github/workflows/dogos-behavior-moments-ci.yml'
       - 'docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md'
+      - 'docs/DOGOS_BEHAVIOR_VISION_RELEASE_AUTHORITY.md'
 
 permissions:
   contents: read
@@ -56,6 +61,8 @@ jobs:
         run: >-
           pnpm exec prettier --check
           apps/api/src/behavior-vision
+          apps/api/src/config/env.validation.ts
+          apps/api/src/config/env.validation.spec.ts
           apps/web/src/lib/api/behavior-vision.ts
           apps/web/src/lib/api/behavior-vision.spec.ts
           apps/web/src/app/coach/layout.tsx
@@ -63,11 +70,14 @@ jobs:
           apps/web/e2e/behavior-moments-shadow.spec.ts
           .github/workflows/dogos-behavior-moments-ci.yml
           docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md
+          docs/DOGOS_BEHAVIOR_VISION_RELEASE_AUTHORITY.md
 
       - name: Lint Behavior Moments API surface
         run: >-
           pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
           src/behavior-vision
+          src/config/env.validation.ts
+          src/config/env.validation.spec.ts
 
       - name: Lint Behavior Moments web surface
         run: >-
@@ -92,7 +102,7 @@ jobs:
             exit 1
           fi
 
-      - name: Require literal zero-authority policy
+      - name: Require literal zero-authority and release-qualification policy
         run: |
           grep -q "mode: 'shadow-evidence-only'" apps/api/src/behavior-vision/behavior-shadow.service.ts
           grep -q 'canInfluenceCompatibility: false' apps/api/src/behavior-vision/behavior-shadow.service.ts
@@ -100,6 +110,14 @@ jobs:
           grep -q 'canMakeSafetyDecision: false' apps/api/src/behavior-vision/behavior-shadow.service.ts
           grep -q 'promotionEnabled: false' apps/api/src/behavior-vision/behavior-shadow.service.ts
           grep -q 'promotionRequiresSeparateQualifiedRelease: true' apps/api/src/behavior-vision/behavior-shadow.service.ts
+          grep -q 'requiresQualifiedModelRelease: true' apps/api/src/behavior-vision/behavior-shadow.service.ts
+          grep -q "learningScope: 'active-qualified-release-only'" apps/api/src/behavior-vision/behavior-shadow.service.ts
+          grep -q 'activeReleaseQualification' apps/api/src/behavior-vision/behavior-vision.service.ts
+          grep -q 'releaseQualification?.qualified !== true' apps/api/src/behavior-vision/behavior-profile.ts
+          grep -q 'expectedRelease' apps/api/src/behavior-vision/behavior-vision.model.ts
+          grep -q 'BEHAVIOR_VISION_ARTIFACT_SHA256' apps/api/src/config/env.validation.ts
+          grep -q 'require_matching_release' ml/behavior_vision/serve.py
+          grep -q 'WOOF_BEHAVIOR_ARTIFACT_SHA256' ml/behavior_vision/release.py
 
       - name: Type-check API
         run: pnpm --filter @woof/api type-check
@@ -107,12 +125,20 @@ jobs:
       - name: Type-check web
         run: pnpm --filter @woof/web type-check
 
-      - name: Run Behavior Moments shadow contracts
+      - name: Run Behavior Vision release and shadow contracts
         run: >-
           pnpm --filter @woof/api exec jest --runInBand
+          src/behavior-vision/behavior-vision.model.spec.ts
           src/behavior-vision/behavior-shadow.service.spec.ts
           src/behavior-vision/behavior-vision.service.spec.ts
           src/behavior-vision/behavior-profile.spec.ts
+          src/config/env.validation.spec.ts
+
+      - name: Compile Behavior Vision worker
+        run: python -m compileall -q ml/behavior_vision
+
+      - name: Run Behavior Vision worker contracts
+        run: python -m unittest ml.behavior_vision.test_pipeline ml.behavior_vision.test_release
 
       - name: Run Behavior Moments web transport contract
         run: pnpm --filter @woof/web exec vitest run src/lib/api/behavior-vision.spec.ts

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -61,9 +61,16 @@ OPENAI_HEALTH_TIMEOUT_MS=12000
 # Specialized behavior-video worker (optional)
 # Recommended production deployment: private service network + bearer token.
 # Woof fails closed when this worker is absent; it does not invent video observations.
+# When SERVICE_URL is configured, all four release-pin fields below are required.
+# They must exactly match the worker's WOOF_BEHAVIOR_* release identity. The artifact
+# SHA-256 identifies the immutable deployed model bundle; do not use a placeholder hash.
 BEHAVIOR_VISION_SERVICE_URL=
 BEHAVIOR_VISION_SERVICE_TOKEN=
 BEHAVIOR_VISION_TIMEOUT_MS=45000
+BEHAVIOR_VISION_RELEASE_ID=
+BEHAVIOR_VISION_MODEL_VERSION=
+BEHAVIOR_VISION_FEATURE_VERSION=
+BEHAVIOR_VISION_ARTIFACT_SHA256=
 
 # Monitoring (optional)
 # Backend error telemetry is scrubbed of request headers, query strings, user identity,

--- a/apps/api/src/behavior-vision/behavior-profile.spec.ts
+++ b/apps/api/src/behavior-vision/behavior-profile.spec.ts
@@ -1,10 +1,13 @@
 import { deriveIndividualBehaviorProfile } from './behavior-profile';
 import {
+  BEHAVIOR_MODEL_RELEASE_QUALIFICATION_VERSION,
   BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
   type BehaviorDimension,
   type HandlerAction,
   type StoredBehaviorObservation,
 } from './behavior-vision.types';
+
+const ARTIFACT_SHA256 = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
 function makeObservation(input: {
   id: string;
@@ -15,8 +18,10 @@ function makeObservation(input: {
   context?: 'street' | 'park' | 'home';
   values?: Partial<Record<BehaviorDimension, number>>;
   accurate?: boolean;
+  qualified?: boolean;
 }): StoredBehaviorObservation {
   const values = input.values ?? {};
+  const qualified = input.qualified !== false;
   return {
     id: input.id,
     petId: 'pet-1',
@@ -36,6 +41,21 @@ function makeObservation(input: {
       schemaVersion: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
       modelVersion: 'test-model',
       featureVersion: 'test-features',
+      ...(qualified
+        ? {
+            releaseId: 'test-release',
+            artifactSha256: ARTIFACT_SHA256,
+            releaseQualification: {
+              qualificationVersion: BEHAVIOR_MODEL_RELEASE_QUALIFICATION_VERSION,
+              qualified: true as const,
+              releaseId: 'test-release',
+              modelVersion: 'test-model',
+              featureVersion: 'test-features',
+              artifactSha256: ARTIFACT_SHA256,
+              responseContract: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+            },
+          }
+        : {}),
       mediaQuality: {
         usable: true,
         confidence: 0.9,
@@ -149,6 +169,29 @@ describe('individual behavior profile', () => {
       }),
     ]);
 
+    const arousal = profile.baselines.find((entry) => entry.dimension === 'arousal');
+    expect(arousal?.sampleCount).toBe(1);
+    expect(arousal?.mean).toBeCloseTo(0.2);
+  });
+
+  it('does not let owner confirmation promote a legacy unqualified model observation', () => {
+    const profile = deriveIndividualBehaviorProfile('pet-1', [
+      makeObservation({
+        id: 'legacy-confirmed',
+        createdAt: new Date(2026, 2, 3).toISOString(),
+        accurate: true,
+        qualified: false,
+        values: { arousal: 0.95, 'body-tension': 0.9 },
+      }),
+      makeObservation({
+        id: 'qualified-current',
+        createdAt: new Date(2026, 2, 4).toISOString(),
+        accurate: true,
+        values: { arousal: 0.2, 'body-tension': 0.25 },
+      }),
+    ]);
+
+    expect(profile.sampleCount).toBe(1);
     const arousal = profile.baselines.find((entry) => entry.dimension === 'arousal');
     expect(arousal?.sampleCount).toBe(1);
     expect(arousal?.mean).toBeCloseTo(0.2);

--- a/apps/api/src/behavior-vision/behavior-profile.ts
+++ b/apps/api/src/behavior-vision/behavior-profile.ts
@@ -38,6 +38,7 @@ function dimensionValue(
 }
 
 function observationWeight(observation: StoredBehaviorObservation) {
+  if (observation.analysis.releaseQualification?.qualified !== true) return 0;
   if (!observation.analysis.mediaQuality.usable) return 0;
   if (observation.ownerFeedback?.accurate === false) return 0;
   const modelConfidence = clamp01(observation.analysis.mediaQuality.confidence);

--- a/apps/api/src/behavior-vision/behavior-shadow.service.spec.ts
+++ b/apps/api/src/behavior-vision/behavior-shadow.service.spec.ts
@@ -1,6 +1,24 @@
 import { BehaviorShadowService } from './behavior-shadow.service';
 import { BehaviorVisionService } from './behavior-vision.service';
-import type { StoredBehaviorObservation } from './behavior-vision.types';
+import {
+  BEHAVIOR_MODEL_RELEASE_QUALIFICATION_VERSION,
+  BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+  type BehaviorVisionReleaseQualification,
+  type StoredBehaviorObservation,
+} from './behavior-vision.types';
+
+const ARTIFACT_SHA256 = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const OLD_ARTIFACT_SHA256 = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+const ACTIVE_RELEASE: BehaviorVisionReleaseQualification = {
+  qualificationVersion: BEHAVIOR_MODEL_RELEASE_QUALIFICATION_VERSION,
+  qualified: true,
+  releaseId: 'behavior-shadow-2026-08-27',
+  modelVersion: 'shadow-model-1',
+  featureVersion: 'features-1',
+  artifactSha256: ARTIFACT_SHA256,
+  responseContract: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+};
 
 function observation(input: {
   id: string;
@@ -9,9 +27,22 @@ function observation(input: {
   phase?: 'baseline' | 'during-intervention' | 'recovery';
   accurate?: boolean;
   usable?: boolean;
+  qualified?: boolean;
+  release?: 'active' | 'old';
   startMs?: number;
   endMs?: number;
 }): StoredBehaviorObservation {
+  const qualified = input.qualified !== false;
+  const release =
+    input.release === 'old'
+      ? {
+          ...ACTIVE_RELEASE,
+          releaseId: 'behavior-shadow-2026-07-01',
+          modelVersion: 'shadow-model-0',
+          featureVersion: 'features-0',
+          artifactSha256: OLD_ARTIFACT_SHA256,
+        }
+      : ACTIVE_RELEASE;
   return {
     id: input.id,
     petId: 'pet-1',
@@ -28,9 +59,16 @@ function observation(input: {
       audioAnalysisAllowed: false,
     },
     analysis: {
-      schemaVersion: 'woof-behavior-observation-v1',
-      modelVersion: 'shadow-model-1',
-      featureVersion: 'features-1',
+      schemaVersion: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+      modelVersion: release.modelVersion,
+      featureVersion: release.featureVersion,
+      ...(qualified
+        ? {
+            releaseId: release.releaseId,
+            artifactSha256: release.artifactSha256,
+            releaseQualification: release,
+          }
+        : {}),
       mediaQuality: {
         usable: input.usable ?? true,
         confidence: 0.9,
@@ -62,17 +100,35 @@ function observation(input: {
   };
 }
 
+function sameRelease(
+  observation: StoredBehaviorObservation,
+  active: BehaviorVisionReleaseQualification
+) {
+  const observed = observation.analysis.releaseQualification;
+  return (
+    observed?.qualified === true &&
+    observed.qualificationVersion === active.qualificationVersion &&
+    observed.releaseId === active.releaseId &&
+    observed.modelVersion === active.modelVersion &&
+    observed.featureVersion === active.featureVersion &&
+    observed.artifactSha256 === active.artifactSha256 &&
+    observed.responseContract === active.responseContract
+  );
+}
+
 function makeVision(observations: StoredBehaviorObservation[]) {
+  const active = observations.filter((entry) => sameRelease(entry, ACTIVE_RELEASE));
   return {
     timeline: jest.fn().mockResolvedValue(observations),
+    activeReleaseQualification: jest.fn().mockReturnValue(ACTIVE_RELEASE),
     profile: jest.fn().mockResolvedValue({
       schemaVersion: 'woof-individual-behavior-profile-v1',
       petId: 'pet-1',
-      sampleCount: observations.length,
-      contextsSeen: ['home', 'park', 'street'],
+      sampleCount: active.length,
+      contextsSeen: [...new Set(active.map((entry) => entry.context.context))],
       baselines: [],
       interventionEffects: [],
-      personalizationConfidence: 0.8,
+      personalizationConfidence: active.length ? 0.8 : 0,
       recommendation: {
         headline: 'Keep testing',
         explanation: 'Evidence only',
@@ -84,13 +140,15 @@ function makeVision(observations: StoredBehaviorObservation[]) {
 }
 
 describe('BehaviorShadowService', () => {
-  it('groups nearby timestamped evidence into reviewable moments', async () => {
+  it('groups nearby timestamped evidence from the active release into reviewable moments', async () => {
     const vision = makeVision([observation({ id: 'obs-1', accurate: true })]);
     const service = new BehaviorShadowService(vision as unknown as BehaviorVisionService);
 
     const result = await service.snapshot('user-1', 'pet-1');
 
     expect(result.policy.mode).toBe('shadow-evidence-only');
+    expect(result.policy.requiresQualifiedModelRelease).toBe(true);
+    expect(result.policy.learningScope).toBe('active-qualified-release-only');
     expect(result.moments).toEqual([
       expect.objectContaining({
         observationId: 'obs-1',
@@ -122,7 +180,49 @@ describe('BehaviorShadowService', () => {
     expect(result.evaluation.evidenceReady).toBe(false);
   });
 
-  it('never grants downstream authority even when evidence readiness gates are satisfied', async () => {
+  it('separates legacy unqualified observations from active release evidence', async () => {
+    const observations = [
+      observation({ id: 'active', accurate: true }),
+      observation({ id: 'legacy', accurate: true, qualified: false }),
+    ];
+    const vision = makeVision(observations);
+    const service = new BehaviorShadowService(vision as unknown as BehaviorVisionService);
+
+    const result = await service.snapshot('user-1', 'pet-1');
+
+    expect(result.evaluation.observations).toBe(2);
+    expect(result.evaluation.qualifiedObservations).toBe(1);
+    expect(result.evaluation.activeReleaseObservations).toBe(1);
+    expect(result.evaluation.inactiveQualifiedObservations).toBe(0);
+    expect(result.evaluation.unqualifiedObservations).toBe(1);
+    expect(result.evaluation.activeReleaseId).toBe(ACTIVE_RELEASE.releaseId);
+    expect(result.evaluation.qualifiedReleaseIds).toEqual([ACTIVE_RELEASE.releaseId]);
+    expect(result.moments.map((entry) => entry.observationId)).toEqual(['active']);
+  });
+
+  it('does not mix an older qualified release into current readiness or moments', async () => {
+    const observations = [
+      observation({ id: 'active', accurate: true }),
+      observation({ id: 'old-qualified', accurate: true, release: 'old' }),
+    ];
+    const vision = makeVision(observations);
+    const service = new BehaviorShadowService(vision as unknown as BehaviorVisionService);
+
+    const result = await service.snapshot('user-1', 'pet-1');
+
+    expect(result.evaluation.qualifiedObservations).toBe(2);
+    expect(result.evaluation.activeReleaseObservations).toBe(1);
+    expect(result.evaluation.inactiveQualifiedObservations).toBe(1);
+    expect(result.evaluation.unqualifiedObservations).toBe(0);
+    expect(result.evaluation.qualifiedReleaseIds).toEqual([
+      'behavior-shadow-2026-07-01',
+      'behavior-shadow-2026-08-27',
+    ]);
+    expect(result.evaluation.ownerReviewedObservations).toBe(1);
+    expect(result.moments.map((entry) => entry.observationId)).toEqual(['active']);
+  });
+
+  it('never grants downstream authority even when active-release readiness gates are satisfied', async () => {
     const observations: StoredBehaviorObservation[] = [];
     for (let index = 0; index < 10; index += 1) {
       const sessionKey = `session-${index}`;
@@ -150,6 +250,8 @@ describe('BehaviorShadowService', () => {
     const result = await service.snapshot('user-1', 'pet-1');
 
     expect(result.evaluation.evidenceReady).toBe(true);
+    expect(result.evaluation.qualifiedObservations).toBe(20);
+    expect(result.evaluation.activeReleaseObservations).toBe(20);
     expect(result.evaluation.usableObservations).toBe(20);
     expect(result.evaluation.ownerReviewedObservations).toBe(20);
     expect(result.evaluation.confirmationRate).toBe(1);
@@ -161,6 +263,8 @@ describe('BehaviorShadowService', () => {
         canMakeSafetyDecision: false,
         promotionEnabled: false,
         promotionRequiresSeparateQualifiedRelease: true,
+        requiresQualifiedModelRelease: true,
+        learningScope: 'active-qualified-release-only',
       })
     );
   });

--- a/apps/api/src/behavior-vision/behavior-shadow.service.ts
+++ b/apps/api/src/behavior-vision/behavior-shadow.service.ts
@@ -4,6 +4,7 @@ import type {
   BehaviorContext,
   BehaviorEvidenceSource,
   BehaviorPhase,
+  BehaviorVisionReleaseQualification,
   StoredBehaviorObservation,
 } from './behavior-vision.types';
 
@@ -38,8 +39,20 @@ export class BehaviorShadowService {
       this.behaviorVision.timeline(userId, petId, 100),
       this.behaviorVision.profile(userId, petId),
     ]);
-
-    const modelUsable = observations.filter((entry) => entry.analysis.mediaQuality.usable);
+    const activeRelease = this.behaviorVision.activeReleaseQualification();
+    const qualified = observations.filter(
+      (entry) => entry.analysis.releaseQualification?.qualified === true
+    );
+    const active = activeRelease
+      ? qualified.filter((entry) =>
+          this.releaseMatches(entry.analysis.releaseQualification, activeRelease)
+        )
+      : [];
+    const inactiveQualified = qualified.filter((entry) => !active.includes(entry));
+    const unqualified = observations.filter(
+      (entry) => entry.analysis.releaseQualification?.qualified !== true
+    );
+    const modelUsable = active.filter((entry) => entry.analysis.mediaQuality.usable);
     const reviewed = modelUsable.filter((entry) => entry.ownerFeedback !== undefined);
     const confirmed = reviewed.filter((entry) => entry.ownerFeedback?.accurate === true);
     const rejected = reviewed.filter((entry) => entry.ownerFeedback?.accurate === false);
@@ -63,27 +76,54 @@ export class BehaviorShadowService {
         canMakeSafetyDecision: false as const,
         promotionEnabled: false as const,
         promotionRequiresSeparateQualifiedRelease: true as const,
+        requiresQualifiedModelRelease: true as const,
+        learningScope: 'active-qualified-release-only' as const,
       },
       evaluation: {
         observations: observations.length,
+        qualifiedObservations: qualified.length,
+        activeReleaseObservations: active.length,
+        inactiveQualifiedObservations: inactiveQualified.length,
+        unqualifiedObservations: unqualified.length,
         usableObservations: usable.length,
         ownerReviewedObservations: reviewed.length,
         ownerConfirmedObservations: confirmed.length,
         ownerRejectedObservations: rejected.length,
         ownerUnreviewedObservations: modelUsable.length - reviewed.length,
         confirmationRate,
-        usableRate: observations.length ? usable.length / observations.length : 0,
+        usableRate: active.length ? usable.length / active.length : 0,
         contextsSeen: profile.contextsSeen.length,
         pairedSessions,
         personalizationConfidence: profile.personalizationConfidence,
-        modelVersions: [
-          ...new Set(observations.map((entry) => entry.analysis.modelVersion)),
+        activeReleaseId: activeRelease?.releaseId ?? null,
+        qualifiedReleaseIds: [
+          ...new Set(
+            qualified
+              .map((entry) => entry.analysis.releaseQualification?.releaseId)
+              .filter((entry): entry is string => typeof entry === 'string')
+          ),
         ].sort(),
+        modelVersions: [...new Set(active.map((entry) => entry.analysis.modelVersion))].sort(),
         evidenceReady,
         readinessGates: READINESS_GATES,
       },
-      moments: observations.flatMap((observation) => this.deriveMoments(observation)),
+      moments: active.flatMap((observation) => this.deriveMoments(observation)),
     };
+  }
+
+  private releaseMatches(
+    observed: BehaviorVisionReleaseQualification | undefined,
+    active: BehaviorVisionReleaseQualification
+  ) {
+    return (
+      observed?.qualified === true &&
+      observed.qualificationVersion === active.qualificationVersion &&
+      observed.releaseId === active.releaseId &&
+      observed.modelVersion === active.modelVersion &&
+      observed.featureVersion === active.featureVersion &&
+      observed.artifactSha256 === active.artifactSha256 &&
+      observed.responseContract === active.responseContract
+    );
   }
 
   private countPairedSessions(observations: StoredBehaviorObservation[]) {

--- a/apps/api/src/behavior-vision/behavior-vision.model.spec.ts
+++ b/apps/api/src/behavior-vision/behavior-vision.model.spec.ts
@@ -1,0 +1,152 @@
+import { ConfigService } from '@nestjs/config';
+import { BehaviorVisionModelService } from './behavior-vision.model';
+import {
+  BEHAVIOR_MODEL_RELEASE_QUALIFICATION_VERSION,
+  BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+  type BehaviorVisionModelAnalysis,
+} from './behavior-vision.types';
+
+const ARTIFACT_SHA256 = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+const releaseConfig = {
+  BEHAVIOR_VISION_SERVICE_URL: 'https://behavior.example.com',
+  BEHAVIOR_VISION_SERVICE_TOKEN: 'behavior-service-token',
+  BEHAVIOR_VISION_RELEASE_ID: 'behavior-shadow-2026-08-27',
+  BEHAVIOR_VISION_MODEL_VERSION: 'shadow-model-1',
+  BEHAVIOR_VISION_FEATURE_VERSION: 'features-1',
+  BEHAVIOR_VISION_ARTIFACT_SHA256: ARTIFACT_SHA256,
+};
+
+function service(overrides: Record<string, string | undefined> = {}) {
+  const values: Record<string, string | undefined> = { ...releaseConfig, ...overrides };
+  const config = {
+    get: jest.fn((key: string) => values[key]),
+  };
+  return new BehaviorVisionModelService(config as unknown as ConfigService);
+}
+
+function payload(
+  overrides: Partial<BehaviorVisionModelAnalysis> = {}
+): BehaviorVisionModelAnalysis {
+  return {
+    schemaVersion: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+    releaseId: releaseConfig.BEHAVIOR_VISION_RELEASE_ID,
+    modelVersion: releaseConfig.BEHAVIOR_VISION_MODEL_VERSION,
+    featureVersion: releaseConfig.BEHAVIOR_VISION_FEATURE_VERSION,
+    artifactSha256: ARTIFACT_SHA256,
+    mediaQuality: { usable: true, confidence: 0.9, issues: [], recaptureInstructions: [] },
+    evidence: [],
+    dimensions: [],
+    hypotheses: [],
+    observableSummary: 'Observable movement only.',
+    uncertainty: 'Internal state cannot be determined from video alone.',
+    ...overrides,
+  };
+}
+
+const input = {
+  pet: {
+    name: 'Nova',
+    species: 'DOG',
+    breed: null,
+    ageYears: 4,
+    temperament: null,
+  },
+  context: {
+    context: 'street' as const,
+    phase: 'baseline' as const,
+    handlerAction: 'none' as const,
+    leashState: 'loose' as const,
+    otherDogsPresent: true,
+    audioAnalysisAllowed: false,
+  },
+  media: {
+    mimeType: 'video/webm',
+    bytes: Buffer.from('transient-private-video'),
+    filename: 'nova.webm',
+  },
+};
+
+describe('BehaviorVisionModelService release qualification', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('qualifies an exact pinned release and stamps qualification on the API side', async () => {
+    const upstream = payload({
+      artifactSha256: ARTIFACT_SHA256.toUpperCase(),
+      releaseQualification: {
+        qualificationVersion: BEHAVIOR_MODEL_RELEASE_QUALIFICATION_VERSION,
+        qualified: true,
+        releaseId: 'untrusted-upstream-claim',
+        modelVersion: 'untrusted',
+        featureVersion: 'untrusted',
+        artifactSha256: 'b'.repeat(64),
+        responseContract: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+      },
+    });
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify(upstream), { status: 200 }));
+
+    const result = await service().analyze(input);
+
+    expect(result.releaseQualification).toEqual({
+      qualificationVersion: BEHAVIOR_MODEL_RELEASE_QUALIFICATION_VERSION,
+      qualified: true,
+      releaseId: releaseConfig.BEHAVIOR_VISION_RELEASE_ID,
+      modelVersion: releaseConfig.BEHAVIOR_VISION_MODEL_VERSION,
+      featureVersion: releaseConfig.BEHAVIOR_VISION_FEATURE_VERSION,
+      artifactSha256: ARTIFACT_SHA256,
+      responseContract: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+    });
+    expect(result.releaseId).toBe(releaseConfig.BEHAVIOR_VISION_RELEASE_ID);
+    expect(result.artifactSha256).toBe(ARTIFACT_SHA256);
+
+    const request = fetchMock.mock.calls[0]?.[1];
+    const form = request?.body as FormData;
+    const metadata = JSON.parse(String(form.get('metadata'))) as Record<string, unknown>;
+    expect(metadata.expectedRelease).toEqual({
+      releaseId: releaseConfig.BEHAVIOR_VISION_RELEASE_ID,
+      modelVersion: releaseConfig.BEHAVIOR_VISION_MODEL_VERSION,
+      featureVersion: releaseConfig.BEHAVIOR_VISION_FEATURE_VERSION,
+      artifactSha256: ARTIFACT_SHA256,
+      responseContract: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+    });
+  });
+
+  it('rejects a model response from a different artifact before qualification', async () => {
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify(payload({ artifactSha256: 'b'.repeat(64) })), { status: 200 })
+      );
+
+    await expect(service().analyze(input)).rejects.toThrow(/release identity/i);
+  });
+
+  it('rejects model or feature version drift even when the artifact-shaped response is valid', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify(
+          payload({
+            modelVersion: 'shadow-model-2',
+            featureVersion: 'features-2',
+          })
+        ),
+        { status: 200 }
+      )
+    );
+
+    await expect(service().analyze(input)).rejects.toThrow(/release identity/i);
+  });
+
+  it('refuses a configured service when deployment release pinning is incomplete', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch');
+
+    await expect(
+      service({ BEHAVIOR_VISION_ARTIFACT_SHA256: undefined }).analyze(input)
+    ).rejects.toThrow(/qualified model release pin/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/behavior-vision/behavior-vision.model.ts
+++ b/apps/api/src/behavior-vision/behavior-vision.model.ts
@@ -2,10 +2,12 @@ import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config';
 import {
   BEHAVIOR_DIMENSIONS,
+  BEHAVIOR_MODEL_RELEASE_QUALIFICATION_VERSION,
   BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
   type BehaviorDimension,
   type BehaviorObservationContext,
   type BehaviorVisionModelAnalysis,
+  type BehaviorVisionReleaseQualification,
 } from './behavior-vision.types';
 
 export type BehaviorVisionModelInput = {
@@ -30,12 +32,20 @@ export type BehaviorVisionModelInput = {
   };
 };
 
+type ActiveReleasePin = {
+  releaseId: string;
+  modelVersion: string;
+  featureVersion: string;
+  artifactSha256: string;
+};
+
 @Injectable()
 export class BehaviorVisionModelService {
   private readonly logger = new Logger(BehaviorVisionModelService.name);
   private readonly serviceUrl: string | null;
   private readonly serviceToken: string | null;
   private readonly timeoutMs: number;
+  private readonly activeRelease: ActiveReleasePin | null;
 
   constructor(private readonly config: ConfigService) {
     this.serviceUrl = this.config.get<string>('BEHAVIOR_VISION_SERVICE_URL') || null;
@@ -44,16 +54,38 @@ export class BehaviorVisionModelService {
       5000,
       Math.min(90000, Number(this.config.get('BEHAVIOR_VISION_TIMEOUT_MS') || 45000))
     );
+
+    const releaseId = this.config.get<string>('BEHAVIOR_VISION_RELEASE_ID')?.trim() || null;
+    const modelVersion = this.config.get<string>('BEHAVIOR_VISION_MODEL_VERSION')?.trim() || null;
+    const featureVersion =
+      this.config.get<string>('BEHAVIOR_VISION_FEATURE_VERSION')?.trim() || null;
+    const artifactSha256 =
+      this.config.get<string>('BEHAVIOR_VISION_ARTIFACT_SHA256')?.trim().toLowerCase() || null;
+
+    this.activeRelease =
+      this.serviceUrl && releaseId && modelVersion && featureVersion && artifactSha256
+        ? { releaseId, modelVersion, featureVersion, artifactSha256 }
+        : null;
   }
 
   isConfigured() {
     return Boolean(this.serviceUrl);
   }
 
+  activeReleaseQualification(): BehaviorVisionReleaseQualification | null {
+    if (!this.activeRelease || !this.isSha256(this.activeRelease.artifactSha256)) return null;
+    return this.qualifyRelease(this.activeRelease);
+  }
+
   async analyze(input: BehaviorVisionModelInput): Promise<BehaviorVisionModelAnalysis> {
     if (!this.serviceUrl) {
       throw new ServiceUnavailableException(
         'Specialized behavior-video analysis is not configured in this environment'
+      );
+    }
+    if (!this.activeRelease || !this.isSha256(this.activeRelease.artifactSha256)) {
+      throw new ServiceUnavailableException(
+        'Behavior-video analysis is configured without a qualified model release pin'
       );
     }
 
@@ -67,6 +99,10 @@ export class BehaviorVisionModelService {
         'metadata',
         JSON.stringify({
           schemaVersion: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+          expectedRelease: {
+            ...this.activeRelease,
+            responseContract: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+          },
           pet: input.pet,
           context: input.context,
           question: input.question ?? null,
@@ -106,7 +142,7 @@ export class BehaviorVisionModelService {
       }
 
       const payload = (await response.json()) as BehaviorVisionModelAnalysis;
-      return this.validate(payload, audioAllowed);
+      return this.validate(payload, audioAllowed, this.activeRelease);
     } catch (error) {
       if (error instanceof ServiceUnavailableException) throw error;
       if (error instanceof Error && error.name === 'AbortError') {
@@ -123,14 +159,18 @@ export class BehaviorVisionModelService {
 
   private validate(
     result: BehaviorVisionModelAnalysis,
-    audioAllowed: boolean
+    audioAllowed: boolean,
+    expectedRelease: ActiveReleasePin
   ): BehaviorVisionModelAnalysis {
     if (
       !result ||
       result.schemaVersion !== BEHAVIOR_OBSERVATION_SCHEMA_VERSION ||
       typeof result.modelVersion !== 'string' ||
       typeof result.featureVersion !== 'string' ||
+      typeof result.releaseId !== 'string' ||
+      typeof result.artifactSha256 !== 'string' ||
       typeof result.observableSummary !== 'string' ||
+      typeof result.uncertainty !== 'string' ||
       !result.mediaQuality ||
       !Array.isArray(result.dimensions) ||
       !Array.isArray(result.evidence) ||
@@ -140,6 +180,21 @@ export class BehaviorVisionModelService {
         'Behavior-video model returned an invalid observation contract'
       );
     }
+
+    const returnedArtifactSha256 = result.artifactSha256.toLowerCase();
+    if (
+      result.releaseId !== expectedRelease.releaseId ||
+      result.modelVersion !== expectedRelease.modelVersion ||
+      result.featureVersion !== expectedRelease.featureVersion ||
+      returnedArtifactSha256 !== expectedRelease.artifactSha256 ||
+      !this.isSha256(returnedArtifactSha256)
+    ) {
+      throw new ServiceUnavailableException(
+        'Behavior-video model release identity does not match the qualified deployment pin'
+      );
+    }
+
+    const releaseQualification = this.qualifyRelease(expectedRelease);
 
     const allowedDimensions = new Set<BehaviorDimension>(BEHAVIOR_DIMENSIONS);
     const dimensions = result.dimensions
@@ -171,6 +226,9 @@ export class BehaviorVisionModelService {
 
     return {
       ...result,
+      releaseId: expectedRelease.releaseId,
+      artifactSha256: expectedRelease.artifactSha256,
+      releaseQualification,
       mediaQuality: {
         usable: Boolean(result.mediaQuality.usable),
         confidence: this.clamp01(result.mediaQuality.confidence),
@@ -194,6 +252,19 @@ export class BehaviorVisionModelService {
           : [],
       })),
     };
+  }
+
+  private qualifyRelease(release: ActiveReleasePin): BehaviorVisionReleaseQualification {
+    return {
+      qualificationVersion: BEHAVIOR_MODEL_RELEASE_QUALIFICATION_VERSION,
+      qualified: true,
+      ...release,
+      responseContract: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+    };
+  }
+
+  private isSha256(value: string) {
+    return /^[a-f0-9]{64}$/.test(value);
   }
 
   private clamp01(value: number) {

--- a/apps/api/src/behavior-vision/behavior-vision.service.spec.ts
+++ b/apps/api/src/behavior-vision/behavior-vision.service.spec.ts
@@ -1,6 +1,22 @@
 import { PrismaService } from '../prisma/prisma.service';
 import { BehaviorVisionModelService } from './behavior-vision.model';
 import { BehaviorVisionService } from './behavior-vision.service';
+import {
+  BEHAVIOR_MODEL_RELEASE_QUALIFICATION_VERSION,
+  BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+  type BehaviorVisionReleaseQualification,
+} from './behavior-vision.types';
+
+const ARTIFACT_SHA256 = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const ACTIVE_RELEASE: BehaviorVisionReleaseQualification = {
+  qualificationVersion: BEHAVIOR_MODEL_RELEASE_QUALIFICATION_VERSION,
+  qualified: true,
+  releaseId: 'behavior-shadow-2026-08-27',
+  modelVersion: 'shadow-test',
+  featureVersion: 'features-test',
+  artifactSha256: ARTIFACT_SHA256,
+  responseContract: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+};
 
 function makePrisma() {
   return {
@@ -28,6 +44,45 @@ function makePrisma() {
   };
 }
 
+function qualifiedAnalysis() {
+  return {
+    schemaVersion: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+    releaseId: ACTIVE_RELEASE.releaseId,
+    modelVersion: ACTIVE_RELEASE.modelVersion,
+    featureVersion: ACTIVE_RELEASE.featureVersion,
+    artifactSha256: ACTIVE_RELEASE.artifactSha256,
+    releaseQualification: ACTIVE_RELEASE,
+    mediaQuality: { usable: true, confidence: 0.9, issues: [], recaptureInstructions: [] },
+    evidence: [],
+    dimensions: [
+      { dimension: 'arousal', value: 0.82, confidence: 0.9, basis: ['motion'] },
+      {
+        dimension: 'social-orientation',
+        value: 0.8,
+        confidence: 0.9,
+        basis: ['orientation'],
+      },
+      {
+        dimension: 'approach-tendency',
+        value: 0.75,
+        confidence: 0.9,
+        basis: ['movement'],
+      },
+    ],
+    hypotheses: [
+      {
+        id: 'barrier-frustration-compatible-pattern',
+        confidence: 0.6,
+        statement: 'Observed behavior is compatible with a high-arousal barrier pattern.',
+        supportingEvidence: ['orientation'],
+        contradictoryEvidence: [],
+      },
+    ],
+    observableSummary: 'Nova oriented toward the other dog and repeatedly moved forward.',
+    uncertainty: 'Internal motivation cannot be determined from this clip alone.',
+  };
+}
+
 const dto = {
   petId: '00000000-0000-4000-8000-000000000001',
   context: 'street' as const,
@@ -51,6 +106,7 @@ describe('BehaviorVisionService', () => {
     const prisma = makePrisma();
     const model = {
       isConfigured: jest.fn().mockReturnValue(false),
+      activeReleaseQualification: jest.fn().mockReturnValue(null),
       analyze: jest.fn(),
     };
     const service = new BehaviorVisionService(
@@ -61,6 +117,8 @@ describe('BehaviorVisionService', () => {
     const result = await service.analyze('user-1', dto, media);
 
     expect(result.provenance.pathway).toBe('model-unavailable');
+    expect(result.provenance.modelReleaseQualified).toBe(false);
+    expect(result.provenance.activeReleaseId).toBeNull();
     expect(result.analysis.mediaQuality.usable).toBe(false);
     expect(result.analysis.dimensions).toEqual([]);
     expect(model.analyze).not.toHaveBeenCalled();
@@ -78,39 +136,8 @@ describe('BehaviorVisionService', () => {
     const prisma = makePrisma();
     const model = {
       isConfigured: jest.fn().mockReturnValue(true),
-      analyze: jest.fn().mockResolvedValue({
-        schemaVersion: 'woof-behavior-observation-v1',
-        modelVersion: 'shadow-test',
-        featureVersion: 'features-test',
-        mediaQuality: { usable: true, confidence: 0.9, issues: [], recaptureInstructions: [] },
-        evidence: [],
-        dimensions: [
-          { dimension: 'arousal', value: 0.82, confidence: 0.9, basis: ['motion'] },
-          {
-            dimension: 'social-orientation',
-            value: 0.8,
-            confidence: 0.9,
-            basis: ['orientation'],
-          },
-          {
-            dimension: 'approach-tendency',
-            value: 0.75,
-            confidence: 0.9,
-            basis: ['movement'],
-          },
-        ],
-        hypotheses: [
-          {
-            id: 'barrier-frustration-compatible-pattern',
-            confidence: 0.6,
-            statement: 'Observed behavior is compatible with a high-arousal barrier pattern.',
-            supportingEvidence: ['orientation'],
-            contradictoryEvidence: [],
-          },
-        ],
-        observableSummary: 'Nova oriented toward the other dog and repeatedly moved forward.',
-        uncertainty: 'Internal motivation cannot be determined from this clip alone.',
-      }),
+      activeReleaseQualification: jest.fn().mockReturnValue(ACTIVE_RELEASE),
+      analyze: jest.fn().mockResolvedValue(qualifiedAnalysis()),
     };
     const service = new BehaviorVisionService(
       prisma as unknown as PrismaService,
@@ -120,10 +147,88 @@ describe('BehaviorVisionService', () => {
     const result = await service.analyze('user-1', dto, media);
 
     expect(result.profile.recommendation.neverAutoRecommendGreeting).toBe(true);
+    expect(result.provenance.modelReleaseQualified).toBe(true);
+    expect(result.provenance.activeReleaseId).toBe(ACTIVE_RELEASE.releaseId);
     expect(result.coach.socialSafety).toContain('does not infer “needs to greet”');
     expect(model.analyze).toHaveBeenCalledWith(
       expect.objectContaining({
         context: expect.objectContaining({ audioAnalysisAllowed: false }),
+      })
+    );
+  });
+
+  it('conditions the current model only on observations from the active release', async () => {
+    const prisma = makePrisma();
+    const oldRelease = {
+      ...ACTIVE_RELEASE,
+      releaseId: 'behavior-shadow-2026-07-01',
+      modelVersion: 'shadow-test-old',
+      artifactSha256: 'b'.repeat(64),
+    };
+    const observationData = (release: BehaviorVisionReleaseQualification, arousal: number) => ({
+      schemaVersion: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+      mediaType: 'video',
+      mediaSha256: `sha-${release.releaseId}`,
+      context: {
+        context: 'street',
+        phase: 'baseline',
+        handlerAction: 'none',
+        leashState: 'loose',
+        otherDogsPresent: true,
+        audioAnalysisAllowed: false,
+      },
+      analysis: {
+        schemaVersion: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
+        releaseId: release.releaseId,
+        modelVersion: release.modelVersion,
+        featureVersion: release.featureVersion,
+        artifactSha256: release.artifactSha256,
+        releaseQualification: release,
+        mediaQuality: { usable: true, confidence: 0.9, issues: [], recaptureInstructions: [] },
+        evidence: [],
+        dimensions: [{ dimension: 'arousal', value: arousal, confidence: 0.9, basis: ['fixture'] }],
+        hypotheses: [],
+        observableSummary: 'fixture',
+        uncertainty: 'fixture',
+      },
+    });
+    prisma.telemetry.findMany.mockImplementation(async (args: { where?: { event?: string } }) => {
+      if (args.where?.event === 'BEHAVIOR_OBSERVATION_FEEDBACK') return [];
+      return [
+        {
+          id: 'active-observation',
+          petId: 'pet-1',
+          createdAt: new Date('2026-08-25T12:00:00.000Z'),
+          data: observationData(ACTIVE_RELEASE, 0.2),
+        },
+        {
+          id: 'old-observation',
+          petId: 'pet-1',
+          createdAt: new Date('2026-08-24T12:00:00.000Z'),
+          data: observationData(oldRelease, 0.95),
+        },
+      ];
+    });
+    const model = {
+      isConfigured: jest.fn().mockReturnValue(true),
+      activeReleaseQualification: jest.fn().mockReturnValue(ACTIVE_RELEASE),
+      analyze: jest.fn().mockResolvedValue(qualifiedAnalysis()),
+    };
+    const service = new BehaviorVisionService(
+      prisma as unknown as PrismaService,
+      model as unknown as BehaviorVisionModelService
+    );
+
+    await service.analyze('user-1', dto, media);
+
+    expect(model.analyze).toHaveBeenCalledWith(
+      expect.objectContaining({
+        priorProfileSummary: expect.objectContaining({
+          sampleCount: 1,
+          baselines: expect.arrayContaining([
+            expect.objectContaining({ dimension: 'arousal', mean: expect.closeTo(0.2, 4) }),
+          ]),
+        }),
       })
     );
   });

--- a/apps/api/src/behavior-vision/behavior-vision.service.ts
+++ b/apps/api/src/behavior-vision/behavior-vision.service.ts
@@ -8,6 +8,7 @@ import {
   BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
   type BehaviorObservationContext,
   type BehaviorVisionModelAnalysis,
+  type BehaviorVisionReleaseQualification,
   type StoredBehaviorObservation,
 } from './behavior-vision.types';
 import { AnalyzeBehaviorMediaDto, BehaviorObservationFeedbackDto } from './dto/behavior-vision.dto';
@@ -38,7 +39,8 @@ export class BehaviorVisionService {
     });
     if (!pet) throw new ForbiddenException('You do not have access to this pet');
 
-    const previous = await this.loadStoredObservations(userId, pet.id, 80);
+    const previousHistory = await this.loadStoredObservations(userId, pet.id, 80);
+    const previous = this.activeReleaseObservations(previousHistory);
     const priorProfile = deriveIndividualBehaviorProfile(pet.id, previous);
     const context: BehaviorObservationContext = {
       context: dto.context,
@@ -120,7 +122,11 @@ export class BehaviorVisionService {
       context,
       analysis,
     };
-    const profile = deriveIndividualBehaviorProfile(pet.id, [current, ...previous]);
+    const profile = deriveIndividualBehaviorProfile(
+      pet.id,
+      this.activeReleaseObservations([current, ...previousHistory])
+    );
+    const activeRelease = this.model.activeReleaseQualification();
 
     return {
       observationId: saved?.id ?? null,
@@ -139,6 +145,8 @@ export class BehaviorVisionService {
         pathway,
         schemaVersion: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
         modelConfigured: this.model.isConfigured(),
+        modelReleaseQualified: analysis.releaseQualification?.qualified === true,
+        activeReleaseId: activeRelease?.releaseId ?? null,
         savedToTimeline: Boolean(saved),
       },
       privacy: {
@@ -155,7 +163,7 @@ export class BehaviorVisionService {
   async profile(userId: string, petId: string) {
     await this.requireOwnedPet(userId, petId);
     const observations = await this.loadStoredObservations(userId, petId, 100);
-    return deriveIndividualBehaviorProfile(petId, observations);
+    return deriveIndividualBehaviorProfile(petId, this.activeReleaseObservations(observations));
   }
 
   async timeline(userId: string, petId: string, limit = 30) {
@@ -166,6 +174,10 @@ export class BehaviorVisionService {
       Math.max(1, Math.min(100, limit))
     );
     return observations;
+  }
+
+  activeReleaseQualification() {
+    return this.model.activeReleaseQualification();
   }
 
   async recordFeedback(userId: string, dto: BehaviorObservationFeedbackDto) {
@@ -201,7 +213,7 @@ export class BehaviorVisionService {
       accurate: dto.accurate,
       createdAt: feedback.createdAt.toISOString(),
       learning:
-        'Owner corrections are treated as higher-value personalization evidence. Rejected observations are excluded from this dog’s behavioral baseline.',
+        'Owner corrections are treated as higher-value personalization evidence for the active qualified model release. Rejected observations are excluded from this dog’s behavioral baseline.',
     };
   }
 
@@ -310,6 +322,29 @@ export class BehaviorVisionService {
         };
       })
       .filter((entry): entry is StoredBehaviorObservation => entry !== null);
+  }
+
+  private activeReleaseObservations(observations: StoredBehaviorObservation[]) {
+    const activeRelease = this.model.activeReleaseQualification();
+    if (!activeRelease) return [];
+    return observations.filter((observation) =>
+      this.releaseMatches(observation.analysis.releaseQualification, activeRelease)
+    );
+  }
+
+  private releaseMatches(
+    observed: BehaviorVisionReleaseQualification | undefined,
+    active: BehaviorVisionReleaseQualification
+  ) {
+    return (
+      observed?.qualified === true &&
+      observed.qualificationVersion === active.qualificationVersion &&
+      observed.releaseId === active.releaseId &&
+      observed.modelVersion === active.modelVersion &&
+      observed.featureVersion === active.featureVersion &&
+      observed.artifactSha256 === active.artifactSha256 &&
+      observed.responseContract === active.responseContract
+    );
   }
 
   private coachResponse(

--- a/apps/api/src/behavior-vision/behavior-vision.types.ts
+++ b/apps/api/src/behavior-vision/behavior-vision.types.ts
@@ -1,5 +1,7 @@
 export const BEHAVIOR_OBSERVATION_SCHEMA_VERSION = 'woof-behavior-observation-v1';
 export const BEHAVIOR_PROFILE_SCHEMA_VERSION = 'woof-individual-behavior-profile-v1';
+export const BEHAVIOR_MODEL_RELEASE_QUALIFICATION_VERSION =
+  'woof-behavior-release-qualification-v1';
 
 export const BEHAVIOR_DIMENSIONS = [
   'arousal',
@@ -91,10 +93,23 @@ export type MediaQualityAssessment = {
   recaptureInstructions: string[];
 };
 
+export type BehaviorVisionReleaseQualification = {
+  qualificationVersion: typeof BEHAVIOR_MODEL_RELEASE_QUALIFICATION_VERSION;
+  qualified: true;
+  releaseId: string;
+  modelVersion: string;
+  featureVersion: string;
+  artifactSha256: string;
+  responseContract: typeof BEHAVIOR_OBSERVATION_SCHEMA_VERSION;
+};
+
 export type BehaviorVisionModelAnalysis = {
   schemaVersion: typeof BEHAVIOR_OBSERVATION_SCHEMA_VERSION;
   modelVersion: string;
   featureVersion: string;
+  releaseId?: string;
+  artifactSha256?: string;
+  releaseQualification?: BehaviorVisionReleaseQualification;
   mediaQuality: MediaQualityAssessment;
   evidence: BehaviorEvidence[];
   dimensions: BehaviorDimensionEstimate[];

--- a/apps/api/src/config/env.validation.spec.ts
+++ b/apps/api/src/config/env.validation.spec.ts
@@ -6,6 +6,13 @@ describe('validateEnvironment', () => {
     DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/woof_test',
     JWT_SECRET: 'test-secret-long-enough',
   };
+  const behaviorReleasePin = {
+    BEHAVIOR_VISION_RELEASE_ID: 'behavior-shadow-2026-08-27',
+    BEHAVIOR_VISION_MODEL_VERSION: 'shadow-model-1',
+    BEHAVIOR_VISION_FEATURE_VERSION: 'features-1',
+    BEHAVIOR_VISION_ARTIFACT_SHA256:
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  };
 
   it('accepts the minimal test configuration', () => {
     const config = validateEnvironment(base);
@@ -51,6 +58,40 @@ describe('validateEnvironment', () => {
     expect(config.OPS_METRICS_TOKEN).toBe('ops-8f3f89a744824fd99ee61797d67dc1023f6f7717');
   });
 
+  it('requires a complete release pin when Behavior Vision service is configured', () => {
+    expect(() =>
+      validateEnvironment({
+        ...base,
+        BEHAVIOR_VISION_SERVICE_URL: 'https://behavior.example.com',
+        BEHAVIOR_VISION_RELEASE_ID: behaviorReleasePin.BEHAVIOR_VISION_RELEASE_ID,
+      })
+    ).toThrow(
+      /release pin must include release ID, model version, feature version, and artifact SHA-256 together/i
+    );
+  });
+
+  it('accepts a fully pinned Behavior Vision service in test environments', () => {
+    const config = validateEnvironment({
+      ...base,
+      BEHAVIOR_VISION_SERVICE_URL: 'https://behavior.example.com',
+      ...behaviorReleasePin,
+    });
+
+    expect(config.BEHAVIOR_VISION_ARTIFACT_SHA256).toBe(
+      behaviorReleasePin.BEHAVIOR_VISION_ARTIFACT_SHA256
+    );
+  });
+
+  it('rejects malformed Behavior Vision artifact hashes', () => {
+    expect(() =>
+      validateEnvironment({
+        ...base,
+        ...behaviorReleasePin,
+        BEHAVIOR_VISION_ARTIFACT_SHA256: 'not-a-sha256',
+      })
+    ).toThrow(/SHA-256/i);
+  });
+
   it('requires stronger non-development secrets in production', () => {
     expect(() =>
       validateEnvironment({
@@ -59,6 +100,18 @@ describe('validateEnvironment', () => {
         JWT_SECRET: 'dev-this-is-long-but-still-not-production-safe',
       })
     ).toThrow(/production/i);
+  });
+
+  it('requires an authenticated model service in production', () => {
+    expect(() =>
+      validateEnvironment({
+        ...base,
+        NODE_ENV: 'production',
+        JWT_SECRET: '8f3f89a744824fd99ee61797d67dc1023f6f7717762c4ab8',
+        BEHAVIOR_VISION_SERVICE_URL: 'https://behavior.example.com',
+        ...behaviorReleasePin,
+      })
+    ).toThrow(/BEHAVIOR_VISION_SERVICE_TOKEN/i);
   });
 
   it('accepts a sufficiently strong production secret', () => {

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -54,6 +54,14 @@ const envSchema = z.object({
   BEHAVIOR_VISION_SERVICE_URL: z.string().url().optional(),
   BEHAVIOR_VISION_SERVICE_TOKEN: z.string().min(16).optional(),
   BEHAVIOR_VISION_TIMEOUT_MS: z.coerce.number().int().min(5000).max(90000).default(45000),
+  BEHAVIOR_VISION_RELEASE_ID: z.string().trim().min(1).max(128).optional(),
+  BEHAVIOR_VISION_MODEL_VERSION: z.string().trim().min(1).max(128).optional(),
+  BEHAVIOR_VISION_FEATURE_VERSION: z.string().trim().min(1).max(128).optional(),
+  BEHAVIOR_VISION_ARTIFACT_SHA256: z
+    .string()
+    .trim()
+    .regex(/^[A-Fa-f0-9]{64}$/, 'BEHAVIOR_VISION_ARTIFACT_SHA256 must be a 64-hex SHA-256')
+    .optional(),
 });
 
 function connectorKeyIsValid(encoded: string | undefined) {
@@ -79,6 +87,27 @@ export function validateEnvironment(config: Record<string, unknown>) {
 
   if (env.OPS_METRICS_TOKEN && env.OPS_METRICS_TOKEN.length < 32) {
     throw new Error('OPS_METRICS_TOKEN must be at least 32 characters when configured');
+  }
+
+  const behaviorReleasePin = [
+    env.BEHAVIOR_VISION_RELEASE_ID,
+    env.BEHAVIOR_VISION_MODEL_VERSION,
+    env.BEHAVIOR_VISION_FEATURE_VERSION,
+    env.BEHAVIOR_VISION_ARTIFACT_SHA256,
+  ];
+  const hasAnyBehaviorReleasePin = behaviorReleasePin.some(Boolean);
+  const hasCompleteBehaviorReleasePin = behaviorReleasePin.every(Boolean);
+
+  if (hasAnyBehaviorReleasePin && !hasCompleteBehaviorReleasePin) {
+    throw new Error(
+      'Behavior Vision release pin must include release ID, model version, feature version, and artifact SHA-256 together'
+    );
+  }
+
+  if (env.BEHAVIOR_VISION_SERVICE_URL && !hasCompleteBehaviorReleasePin) {
+    throw new Error(
+      'A complete Behavior Vision release pin is required when BEHAVIOR_VISION_SERVICE_URL is configured'
+    );
   }
 
   if (env.NODE_ENV === 'production') {

--- a/apps/web/e2e/behavior-moments-shadow.spec.ts
+++ b/apps/web/e2e/behavior-moments-shadow.spec.ts
@@ -54,7 +54,7 @@ async function seedSession(page: Page) {
   });
 }
 
-test('Shadow Lab renders reviewable evidence without requesting compatibility authority', async ({
+test('Shadow Lab renders active-release evidence without requesting compatibility authority', async ({
   page,
 }) => {
   await seedSession(page);
@@ -74,19 +74,27 @@ test('Shadow Lab renders reviewable evidence without requesting compatibility au
         canMakeSafetyDecision: false,
         promotionEnabled: false,
         promotionRequiresSeparateQualifiedRelease: true,
+        requiresQualifiedModelRelease: true,
+        learningScope: 'active-qualified-release-only',
       },
       evaluation: {
         observations: 24,
+        qualifiedObservations: 22,
+        activeReleaseObservations: 20,
+        inactiveQualifiedObservations: 2,
+        unqualifiedObservations: 2,
         usableObservations: 20,
         ownerReviewedObservations: 12,
         ownerConfirmedObservations: 11,
         ownerRejectedObservations: 1,
         ownerUnreviewedObservations: 8,
         confirmationRate: 11 / 12,
-        usableRate: 20 / 24,
+        usableRate: 1,
         contextsSeen: 4,
         pairedSessions: 6,
         personalizationConfidence: 0.72,
+        activeReleaseId: 'behavior-shadow-2026-08-27',
+        qualifiedReleaseIds: ['behavior-shadow-2026-07-01', 'behavior-shadow-2026-08-27'],
         modelVersions: ['behavior-shadow-model-1'],
         evidenceReady: true,
         readinessGates: {
@@ -117,6 +125,11 @@ test('Shadow Lab renders reviewable evidence without requesting compatibility au
 
   await expect(page.getByRole('heading', { name: 'Shadow Lab' })).toBeVisible();
   await expect(page.getByText('zero authority')).toBeVisible();
+  await expect(page.getByText('Active qualified release only')).toBeVisible();
+  await expect(
+    page.getByText(/2 older qualified and 2 legacy unqualified observations/i)
+  ).toBeVisible();
+  await expect(page.getByText(/Active release: behavior-shadow-2026-08-27/)).toBeVisible();
   await expect(page.getByText('Evidence gates met')).toBeVisible();
   await expect(page.getByText('0:04.2–0:06.8')).toBeVisible();
   await expect(page.getByText('oriented toward dog · forward movement')).toBeVisible();

--- a/apps/web/src/app/coach/observe/shadow/page.tsx
+++ b/apps/web/src/app/coach/observe/shadow/page.tsx
@@ -154,7 +154,7 @@ export default function BehaviorShadowPage() {
                 <p className="text-xs text-muted-foreground">Usable evidence</p>
                 <p className="mt-1 text-2xl font-bold">{evaluation?.usableObservations ?? 0}</p>
                 <p className="mt-1 text-xs text-muted-foreground">
-                  {percent(evaluation?.usableRate ?? 0)} of observations
+                  {percent(evaluation?.usableRate ?? 0)} of active-release observations
                 </p>
               </div>
               <div className="rounded-2xl border border-border/60 bg-card p-4">
@@ -176,6 +176,49 @@ export default function BehaviorShadowPage() {
                 <p className="mt-1 text-2xl font-bold">{evaluation?.pairedSessions ?? 0}</p>
                 <p className="mt-1 text-xs text-muted-foreground">baseline + change/recovery</p>
               </div>
+            </section>
+
+            <section className="rounded-3xl border border-border/60 bg-card/70 p-5">
+              <div className="flex gap-3">
+                <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+                <div className="min-w-0 flex-1">
+                  <p className="eyebrow">Model evidence authority</p>
+                  <h2 className="mt-2 font-semibold">Active qualified release only</h2>
+                  <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                    Personal baselines and research-readiness gates use only observations from the
+                    exact model release active today. Older qualified releases remain visible for
+                    audit, but are not mixed into the current measurement scale.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-4 grid grid-cols-3 gap-2">
+                <div className="rounded-xl bg-muted/35 px-3 py-3">
+                  <p className="text-[11px] text-muted-foreground">Active release</p>
+                  <p className="mt-1 text-lg font-bold">
+                    {evaluation?.activeReleaseObservations ?? 0}
+                  </p>
+                </div>
+                <div className="rounded-xl bg-muted/35 px-3 py-3">
+                  <p className="text-[11px] text-muted-foreground">Older qualified</p>
+                  <p className="mt-1 text-lg font-bold">
+                    {evaluation?.inactiveQualifiedObservations ?? 0}
+                  </p>
+                </div>
+                <div className="rounded-xl bg-muted/35 px-3 py-3">
+                  <p className="text-[11px] text-muted-foreground">Legacy unknown</p>
+                  <p className="mt-1 text-lg font-bold">
+                    {evaluation?.unqualifiedObservations ?? 0}
+                  </p>
+                </div>
+              </div>
+              <p className="mt-3 text-xs leading-relaxed text-muted-foreground">
+                {evaluation?.inactiveQualifiedObservations ?? 0} older qualified and{' '}
+                {evaluation?.unqualifiedObservations ?? 0} legacy unqualified observations are
+                excluded from current learning.
+              </p>
+              <p className="mt-2 break-words text-xs text-muted-foreground">
+                Active release: {evaluation?.activeReleaseId ?? 'none configured'}
+              </p>
             </section>
 
             <section className="rounded-3xl border border-border/60 bg-card/70 p-5">
@@ -214,8 +257,8 @@ export default function BehaviorShadowPage() {
                 ))}
               </div>
               <p className="mt-4 text-xs leading-relaxed text-muted-foreground">
-                Passing every gate only makes the evidence substantial enough to evaluate. It does
-                not switch on production authority.
+                Passing every gate only makes the active-release evidence substantial enough to
+                evaluate. It does not switch on production authority.
               </p>
             </section>
 
@@ -230,8 +273,8 @@ export default function BehaviorShadowPage() {
               </p>
               {snapshot.data.moments.length === 0 ? (
                 <p className="mt-4 rounded-xl bg-muted/40 p-4 text-sm text-muted-foreground">
-                  No timestamped video evidence yet. New model runs can populate moments when the
-                  model returns timed evidence.
+                  No timestamped active-release video evidence yet. New model runs can populate
+                  moments when the model returns timed evidence.
                 </p>
               ) : (
                 <div className="mt-4 space-y-3">

--- a/apps/web/src/lib/api/behavior-vision.ts
+++ b/apps/web/src/lib/api/behavior-vision.ts
@@ -38,10 +38,23 @@ export type HandlerAction =
   | 'end-interaction'
   | 'other';
 
+export type BehaviorVisionReleaseQualification = {
+  qualificationVersion: string;
+  qualified: true;
+  releaseId: string;
+  modelVersion: string;
+  featureVersion: string;
+  artifactSha256: string;
+  responseContract: string;
+};
+
 export type BehaviorVisionAnalysis = {
   schemaVersion: string;
   modelVersion: string;
   featureVersion: string;
+  releaseId?: string;
+  artifactSha256?: string;
+  releaseQualification?: BehaviorVisionReleaseQualification;
   mediaQuality: {
     usable: boolean;
     confidence: number;
@@ -130,6 +143,8 @@ export type BehaviorVisionResult = {
     pathway: string;
     schemaVersion: string;
     modelConfigured: boolean;
+    modelReleaseQualified: boolean;
+    activeReleaseId: string | null;
     savedToTimeline: boolean;
   };
   privacy: {
@@ -149,9 +164,15 @@ export type BehaviorShadowSnapshot = {
     canMakeSafetyDecision: false;
     promotionEnabled: false;
     promotionRequiresSeparateQualifiedRelease: true;
+    requiresQualifiedModelRelease: true;
+    learningScope: 'active-qualified-release-only';
   };
   evaluation: {
     observations: number;
+    qualifiedObservations: number;
+    activeReleaseObservations: number;
+    inactiveQualifiedObservations: number;
+    unqualifiedObservations: number;
     usableObservations: number;
     ownerReviewedObservations: number;
     ownerConfirmedObservations: number;
@@ -162,6 +183,8 @@ export type BehaviorShadowSnapshot = {
     contextsSeen: number;
     pairedSessions: number;
     personalizationConfidence: number;
+    activeReleaseId: string | null;
+    qualifiedReleaseIds: string[];
     modelVersions: string[];
     evidenceReady: boolean;
     readinessGates: {

--- a/docs/DOGOS_BEHAVIOR_VISION_RELEASE_AUTHORITY.md
+++ b/docs/DOGOS_BEHAVIOR_VISION_RELEASE_AUTHORITY.md
@@ -1,0 +1,158 @@
+# dogOS Behavior Vision Release Authority
+
+## Purpose
+
+Behavior Vision is shadow evidence, not autonomous behavior or safety authority. This contract adds a second boundary: model-derived evidence may influence a dog's longitudinal Behavior Vision baseline only when Woof can identify the exact qualified model release that produced it.
+
+A plausible JSON response is not sufficient evidence of model identity.
+
+## API active release pin
+
+When `BEHAVIOR_VISION_SERVICE_URL` is configured, the API also requires a complete deployment pin:
+
+- `BEHAVIOR_VISION_RELEASE_ID`
+- `BEHAVIOR_VISION_MODEL_VERSION`
+- `BEHAVIOR_VISION_FEATURE_VERSION`
+- `BEHAVIOR_VISION_ARTIFACT_SHA256`
+
+The artifact value is a 64-hex SHA-256 digest of the deployed model artifact or immutable model bundle. Woof does not hard-code a pretend production artifact into source control. The deployment must pin the artifact it actually serves.
+
+Production additionally requires `BEHAVIOR_VISION_SERVICE_TOKEN`.
+
+## Worker-owned release identity
+
+The specialized Behavior Vision worker independently owns the identity of the release it is actually serving:
+
+- `WOOF_BEHAVIOR_RELEASE_ID`
+- `WOOF_BEHAVIOR_MODEL_VERSION`
+- `WOOF_BEHAVIOR_FEATURE_VERSION`
+- `WOOF_BEHAVIOR_ARTIFACT_SHA256`
+
+A partially configured worker release fails closed. The worker does not derive its release identity from request metadata.
+
+`/health` exposes non-secret release metadata and reports the worker unhealthy when release identity is missing or malformed. Credentials are never included in health output.
+
+The pipeline's per-request adapter-composition diagnostic remains separate from release identity. Which adapters happened to contribute to one clip is not allowed to redefine the immutable deployed model release.
+
+## Bilateral request contract
+
+The API sends its `expectedRelease` with every analysis request, including the observation response-contract version.
+
+The worker parses that expectation, independently loads its own release identity, and rejects the request when the two differ. Only then does it run the video pipeline. The worker serializes its own release identity into the response rather than echoing request values.
+
+The specialized service returns:
+
+- the canonical observation schema version;
+- release ID;
+- model version;
+- feature version;
+- artifact SHA-256.
+
+These response values are still claims from the service, not authority by themselves.
+
+## API-owned qualification
+
+`BehaviorVisionModelService` compares the returned identity against the API deployment pin. Qualification fails closed when any field differs or when the artifact digest is malformed.
+
+Only after all fields match does the API inject `releaseQualification` into the normalized analysis. Upstream `releaseQualification` content is ignored and overwritten. A model service cannot certify itself merely by placing `qualified: true` in JSON.
+
+Qualification version:
+
+`woof-behavior-release-qualification-v1`
+
+The qualification records:
+
+- release ID;
+- model version;
+- feature version;
+- artifact SHA-256;
+- observation response contract;
+- API-owned qualified state.
+
+## Persistence
+
+The existing privacy contract is unchanged:
+
+- raw images/video remain transient;
+- raw media is not written to Woof object storage by Behavior Vision;
+- the timeline persists derived observations and an irreversible media fingerprint;
+- qualified model metadata is stored with the derived observation.
+
+A mismatched model response is rejected before the observation can be persisted.
+
+## Active-release-only longitudinal learning
+
+An observation being valid under a previous release does not prove that its numeric dimensions are directly comparable with a newly deployed release. Therefore longitudinal learning is scoped to the API's **currently active qualified release**.
+
+Only exact matches on qualification version, release ID, model version, feature version, artifact SHA-256, and response contract may contribute to:
+
+- the prior individual profile sent into a new model request;
+- individualized dimension baselines;
+- paired intervention-effect estimates;
+- personalization confidence;
+- Shadow readiness gates;
+- current reviewable Behavior Moments.
+
+Older qualified releases remain in the timeline as auditable history but receive zero current learning weight. A future cross-release calibration bridge must be separately evaluated and explicit; release mixing is never inferred automatically.
+
+If the model service is not configured, there is no active qualified release, so prior model observations do not silently continue driving the current profile.
+
+## Legacy observations
+
+Older observations may not contain `releaseQualification`. They remain available as historical timeline records, but they are unqualified model evidence and also receive zero current learning weight.
+
+Owner confirmation does not retroactively qualify an unknown model artifact. Human feedback can strengthen or reject a measurement from the active qualified release, but it cannot prove which software produced an old one.
+
+## Shadow readiness
+
+Behavior Shadow separates stored history into three buckets:
+
+1. observations from the active qualified release;
+2. observations from older qualified releases;
+3. legacy/unqualified observations.
+
+Only bucket 1 contributes to usable evidence, owner-review rates, paired sessions, personalization confidence, readiness, and current Behavior Moments.
+
+The evaluation reports total history, all qualified history, active-release observations, inactive qualified observations, legacy unqualified observations, the active release ID, and the qualified release IDs represented in history.
+
+The original zero-authority policy remains literal:
+
+- cannot influence Compatibility;
+- cannot mutate canonical pet state;
+- cannot make safety decisions;
+- promotion remains disabled;
+- any promotion requires a separate qualified release.
+
+## Why a SHA-256 is not called a signature
+
+The artifact digest gives a cryptographic identity for the pinned artifact. It does not prove publisher identity by itself and is not described as a digital signature.
+
+Trust comes from the combination of:
+
+1. API deployment-owned release pin;
+2. worker deployment-owned release identity;
+3. authenticated specialized-service boundary in production;
+4. bilateral expectation/worker comparison;
+5. exact response/API-pin comparison;
+6. API-owned qualification after comparison;
+7. active-release-only longitudinal learning;
+8. release-specific evaluation and future promotion gates.
+
+If signed artifact manifests are introduced later, they should strengthen this contract rather than replace exact artifact pinning.
+
+## Qualification
+
+`dogOS Behavior Moments Shadow CI` enforces this boundary by checking:
+
+- zero downstream authority remains literal;
+- canonical pet mutation remains forbidden;
+- Compatibility cannot import Behavior Vision authority;
+- individual profiles require qualified evidence;
+- active-release-only learning remains explicit;
+- the API model request carries `expectedRelease`;
+- environment validation keeps the API artifact pin;
+- the worker owns and compares its own release environment identity;
+- exact release/mismatch/missing-pin/malformed-metadata model tests;
+- older-qualified and legacy-unqualified profile/readiness tests;
+- Python worker compilation and release contract tests;
+- existing Behavior Vision, Web transport, browser, API build, and Web build contracts.

--- a/ml/behavior_vision/contracts.py
+++ b/ml/behavior_vision/contracts.py
@@ -6,11 +6,13 @@ lightweight CI without downloading any vision checkpoints.
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
+import re
 from typing import Any, Literal
 
 SCHEMA_VERSION = "woof-behavior-observation-v1"
 FEATURE_VERSION = "behavior-evidence-fusion-v1"
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 
 DIMENSIONS = {
     "arousal",
@@ -46,6 +48,58 @@ def clamp01(value: float) -> float:
     except (TypeError, ValueError) as exc:
         raise ContractError(f"expected numeric probability/value, got {value!r}") from exc
     return max(0.0, min(1.0, numeric))
+
+
+@dataclass(frozen=True)
+class ReleaseIdentity:
+    release_id: str
+    model_version: str
+    feature_version: str
+    artifact_sha256: str
+    response_contract: str = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("releaseId", self.release_id),
+            ("modelVersion", self.model_version),
+            ("featureVersion", self.feature_version),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise ContractError(f"{name} must be a non-empty string")
+        if not isinstance(self.artifact_sha256, str):
+            raise ContractError("artifactSha256 must be a string")
+        normalized_sha = self.artifact_sha256.strip().lower()
+        if not SHA256_RE.fullmatch(normalized_sha):
+            raise ContractError("artifactSha256 must be a 64-hex SHA-256")
+        if not isinstance(self.response_contract, str):
+            raise ContractError("responseContract must be a string")
+        if self.response_contract != SCHEMA_VERSION:
+            raise ContractError("responseContract does not match Behavior Vision contract")
+        object.__setattr__(self, "release_id", self.release_id.strip())
+        object.__setattr__(self, "model_version", self.model_version.strip())
+        object.__setattr__(self, "feature_version", self.feature_version.strip())
+        object.__setattr__(self, "artifact_sha256", normalized_sha)
+
+    @classmethod
+    def from_api(cls, value: object) -> "ReleaseIdentity":
+        if not isinstance(value, dict):
+            raise ContractError("expectedRelease must be an object")
+        return cls(
+            release_id=value.get("releaseId", ""),
+            model_version=value.get("modelVersion", ""),
+            feature_version=value.get("featureVersion", ""),
+            artifact_sha256=value.get("artifactSha256", ""),
+            response_contract=value.get("responseContract", ""),
+        )
+
+    def to_api(self) -> dict[str, str]:
+        return {
+            "releaseId": self.release_id,
+            "modelVersion": self.model_version,
+            "featureVersion": self.feature_version,
+            "artifactSha256": self.artifact_sha256,
+            "responseContract": self.response_contract,
+        }
 
 
 @dataclass(frozen=True)
@@ -204,8 +258,8 @@ class CanonicalAnalysis:
     feature_version: str = FEATURE_VERSION
     schema_version: str = SCHEMA_VERSION
 
-    def to_api(self) -> dict[str, Any]:
-        return {
+    def to_api(self, release_identity: ReleaseIdentity | None = None) -> dict[str, Any]:
+        payload: dict[str, Any] = {
             "schemaVersion": self.schema_version,
             "modelVersion": self.model_version,
             "featureVersion": self.feature_version,
@@ -216,6 +270,16 @@ class CanonicalAnalysis:
             "observableSummary": self.observable_summary,
             "uncertainty": self.uncertainty,
         }
+        if release_identity is not None:
+            payload.update(
+                {
+                    "releaseId": release_identity.release_id,
+                    "modelVersion": release_identity.model_version,
+                    "featureVersion": release_identity.feature_version,
+                    "artifactSha256": release_identity.artifact_sha256,
+                }
+            )
+        return payload
 
 
 @dataclass(frozen=True)
@@ -225,6 +289,7 @@ class RequestMetadata:
     question: str | None = None
     prior_profile_summary: dict[str, Any] | None = None
     policy: dict[str, Any] = field(default_factory=dict)
+    expected_release: ReleaseIdentity | None = None
 
     @classmethod
     def from_json(cls, payload: dict[str, Any]) -> "RequestMetadata":
@@ -251,6 +316,12 @@ class RequestMetadata:
         prior = payload.get("priorProfileSummary")
         if prior is not None and not isinstance(prior, dict):
             raise ContractError("priorProfileSummary must be an object or null")
+        expected_release_raw = payload.get("expectedRelease")
+        expected_release = (
+            ReleaseIdentity.from_api(expected_release_raw)
+            if expected_release_raw is not None
+            else None
+        )
 
         return cls(
             pet=pet,
@@ -258,4 +329,5 @@ class RequestMetadata:
             question=question,
             prior_profile_summary=prior,
             policy=policy,
+            expected_release=expected_release,
         )

--- a/ml/behavior_vision/release.py
+++ b/ml/behavior_vision/release.py
@@ -1,0 +1,49 @@
+"""Deployment-owned release identity for the Behavior Vision worker.
+
+The API sends the release it expects. The worker independently loads the release it actually serves
+from its own environment and rejects disagreement. Request metadata is never treated as release
+authority.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+from .contracts import ContractError, ReleaseIdentity
+
+RELEASE_ENV = {
+    "release_id": "WOOF_BEHAVIOR_RELEASE_ID",
+    "model_version": "WOOF_BEHAVIOR_MODEL_VERSION",
+    "feature_version": "WOOF_BEHAVIOR_FEATURE_VERSION",
+    "artifact_sha256": "WOOF_BEHAVIOR_ARTIFACT_SHA256",
+}
+
+
+def load_release_identity(
+    environ: Mapping[str, str] | None = None,
+) -> ReleaseIdentity | None:
+    env = os.environ if environ is None else environ
+    values = {field: (env.get(name) or "").strip() for field, name in RELEASE_ENV.items()}
+    configured = [bool(value) for value in values.values()]
+    if not any(configured):
+        return None
+    if not all(configured):
+        missing = [RELEASE_ENV[field] for field, value in values.items() if not value]
+        raise ContractError(
+            "Behavior Vision worker release identity is incomplete; missing " + ", ".join(missing)
+        )
+    return ReleaseIdentity(**values)
+
+
+def require_matching_release(
+    expected: ReleaseIdentity | None,
+    actual: ReleaseIdentity | None,
+) -> ReleaseIdentity:
+    if actual is None:
+        raise ContractError("Behavior Vision worker has no configured release identity")
+    if expected is None:
+        raise ContractError("Behavior Vision request is missing expectedRelease")
+    if expected != actual:
+        raise ContractError("Behavior Vision expectedRelease does not match the deployed worker")
+    return actual

--- a/ml/behavior_vision/serve.py
+++ b/ml/behavior_vision/serve.py
@@ -2,7 +2,8 @@
 
 Run separately from the main compatibility service because video dependencies and latency profiles are
 very different. Raw uploads are held only in request memory by this worker. Production deployments
-should put the worker on a private network and configure WOOF_BEHAVIOR_SERVICE_TOKEN.
+should put the worker on a private network and configure WOOF_BEHAVIOR_SERVICE_TOKEN plus an exact
+worker-owned release identity.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ from fastapi import FastAPI, File, Form, Header, HTTPException, UploadFile
 from .adapters import MediaInput
 from .contracts import ContractError, RequestMetadata
 from .pipeline import BehaviorVisionPipeline
+from .release import load_release_identity, require_matching_release
 
 MAX_MEDIA_BYTES = 50 * 1024 * 1024
 ALLOWED_MEDIA_TYPES = {
@@ -48,12 +50,31 @@ def _authorize(authorization: str | None) -> None:
         raise HTTPException(status_code=403, detail="invalid behavior service bearer token")
 
 
+def _worker_release_or_http_error():
+    try:
+        release = load_release_identity()
+    except ContractError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    if release is None:
+        raise HTTPException(status_code=503, detail="Behavior Vision worker release is not configured")
+    return release
+
+
 @app.get("/health")
 def health() -> dict[str, object]:
+    try:
+        release = load_release_identity()
+        release_error = None
+    except ContractError as exc:
+        release = None
+        release_error = str(exc)
     return {
-        "ok": True,
+        "ok": release is not None and release_error is None,
         "service": "woof-behavior-vision",
         "enabledAdapters": [getattr(adapter, "adapter_id", "unknown") for adapter in pipeline.adapters],
+        "releaseConfigured": release is not None,
+        "release": release.to_api() if release is not None else None,
+        "releaseError": release_error,
         "authoritativeEmotionInference": False,
         "automaticGreetingRecommendation": False,
     }
@@ -66,6 +87,7 @@ async def analyze(
     authorization: Annotated[str | None, Header()] = None,
 ) -> dict[str, object]:
     _authorize(authorization)
+    worker_release = _worker_release_or_http_error()
 
     if media.content_type not in ALLOWED_MEDIA_TYPES:
         raise HTTPException(status_code=415, detail="unsupported behavior media type")
@@ -79,6 +101,10 @@ async def analyze(
 
     try:
         request_metadata = RequestMetadata.from_json(raw_metadata)
+        qualified_release = require_matching_release(
+            request_metadata.expected_release,
+            worker_release,
+        )
     except ContractError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -96,4 +122,4 @@ async def analyze(
         ),
         request_metadata,
     )
-    return analysis.to_api()
+    return analysis.to_api(qualified_release)

--- a/ml/behavior_vision/test_release.py
+++ b/ml/behavior_vision/test_release.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import unittest
+
+from ml.behavior_vision.contracts import (
+    CanonicalAnalysis,
+    ContractError,
+    Hypothesis,
+    MediaQuality,
+    ReleaseIdentity,
+    RequestMetadata,
+    SCHEMA_VERSION,
+)
+from ml.behavior_vision.release import load_release_identity, require_matching_release
+
+SHA = "a" * 64
+
+
+def release(**overrides: str) -> ReleaseIdentity:
+    values = {
+        "release_id": "behavior-shadow-2026-08-27",
+        "model_version": "shadow-model-1",
+        "feature_version": "features-1",
+        "artifact_sha256": SHA,
+    }
+    values.update(overrides)
+    return ReleaseIdentity(**values)
+
+
+class BehaviorVisionReleaseTest(unittest.TestCase):
+    def test_worker_loads_complete_release_from_its_own_environment(self) -> None:
+        identity = load_release_identity(
+            {
+                "WOOF_BEHAVIOR_RELEASE_ID": "behavior-shadow-2026-08-27",
+                "WOOF_BEHAVIOR_MODEL_VERSION": "shadow-model-1",
+                "WOOF_BEHAVIOR_FEATURE_VERSION": "features-1",
+                "WOOF_BEHAVIOR_ARTIFACT_SHA256": SHA.upper(),
+            }
+        )
+        self.assertEqual(identity, release())
+
+    def test_worker_rejects_partial_release_configuration(self) -> None:
+        with self.assertRaises(ContractError):
+            load_release_identity(
+                {
+                    "WOOF_BEHAVIOR_RELEASE_ID": "behavior-shadow-2026-08-27",
+                    "WOOF_BEHAVIOR_MODEL_VERSION": "shadow-model-1",
+                }
+            )
+
+    def test_worker_requires_request_and_deployment_release_to_match(self) -> None:
+        actual = release()
+        self.assertEqual(require_matching_release(release(), actual), actual)
+
+        with self.assertRaises(ContractError):
+            require_matching_release(
+                release(artifact_sha256="b" * 64),
+                actual,
+            )
+        with self.assertRaises(ContractError):
+            require_matching_release(None, actual)
+        with self.assertRaises(ContractError):
+            require_matching_release(actual, None)
+
+    def test_release_identity_rejects_malformed_artifact_hash(self) -> None:
+        with self.assertRaises(ContractError):
+            release(artifact_sha256="not-a-sha")
+
+    def test_request_parser_rejects_non_string_release_metadata_cleanly(self) -> None:
+        with self.assertRaises(ContractError):
+            RequestMetadata.from_json(
+                {
+                    "schemaVersion": SCHEMA_VERSION,
+                    "pet": {"name": "Nova", "species": "DOG"},
+                    "context": {"context": "street"},
+                    "policy": {
+                        "objectiveObservationOnly": True,
+                        "noDefinitiveEmotionInference": True,
+                        "noAutomaticGreetingRecommendation": True,
+                    },
+                    "expectedRelease": {
+                        "releaseId": "behavior-shadow-2026-08-27",
+                        "modelVersion": "shadow-model-1",
+                        "featureVersion": "features-1",
+                        "artifactSha256": 12345,
+                        "responseContract": SCHEMA_VERSION,
+                    },
+                }
+            )
+
+    def test_http_serialization_uses_worker_release_not_adapter_diagnostic_version(self) -> None:
+        analysis = CanonicalAnalysis(
+            model_version="fake-pose@1+fake-motion@2",
+            feature_version="behavior-evidence-fusion-v1",
+            media_quality=MediaQuality(usable=False, confidence=0),
+            evidence=(),
+            dimensions=(),
+            hypotheses=(
+                Hypothesis(
+                    id="insufficient-evidence",
+                    confidence=1,
+                    statement="Not enough reliable evidence.",
+                ),
+            ),
+            observable_summary="No reliable observation.",
+            uncertainty="Abstained.",
+        )
+
+        payload = analysis.to_api(release())
+
+        self.assertEqual(payload["schemaVersion"], SCHEMA_VERSION)
+        self.assertEqual(payload["releaseId"], "behavior-shadow-2026-08-27")
+        self.assertEqual(payload["modelVersion"], "shadow-model-1")
+        self.assertEqual(payload["featureVersion"], "features-1")
+        self.assertEqual(payload["artifactSha256"], SHA)
+        self.assertNotEqual(payload["modelVersion"], analysis.model_version)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This release closes the model-release authority gap in Behavior Vision while preserving its existing shadow-only product role.

## Bilateral release identity

The API now requires an exact active Behavior Vision release pin whenever the specialized worker is configured:

- release ID
- model version
- feature version
- artifact SHA-256

The worker independently owns the release it is actually serving through its own `WOOF_BEHAVIOR_*` deployment identity. The API sends `expectedRelease`; the worker rejects a mismatch before inference and returns its own identity rather than echoing request values.

## API-owned qualification

The API validates schema, release ID, model version, feature version and artifact SHA-256 against the deployment pin before accepting model output. Only after an exact match does Woof inject `woof-behavior-release-qualification-v1`.

An upstream service cannot self-certify by returning `qualified: true`; any such claim is ignored/overwritten. The artifact digest is cryptographic artifact identity, not a digital signature.

## Active-release-only longitudinal learning

Only observations matching the currently active qualified release can affect:

- the prior individual profile sent into a new inference
- individualized dimension baselines
- paired handler-intervention effects
- personalization confidence
- Shadow readiness
- current reviewable Behavior Moments

Older qualified releases remain auditable timeline history but contribute zero current learning weight. Legacy observations without release qualification also remain visible but contribute zero learning weight. Owner confirmation cannot retroactively attest unknown software.

If the model service is disabled, there is no active release and historical model evidence cannot silently keep driving the current profile.

## Zero authority remains literal

Behavior Vision still cannot influence Compatibility, mutate canonical pet state, make safety decisions, auto-promote itself, or infer direct dog-to-dog greeting from social orientation. Promotion still requires a separate qualified release.

## Privacy + Shadow Lab

Raw images/video remain transient. The timeline stores derived evidence, an irreversible media fingerprint, and qualified release provenance.

Shadow Lab separates active qualified release observations, older qualified observations, and legacy/unqualified observations. Only active-release evidence fills readiness gates and current moments.

## Worker governance

The in-repo worker now requires its own complete release identity, rejects API/worker identity drift, reports non-secret release health metadata, keeps adapter-composition diagnostics separate from immutable release identity, and has standard-library release-contract tests.

Architecture contract: `docs/DOGOS_BEHAVIOR_VISION_RELEASE_AUTHORITY.md`.

No database migration is required.

## Final qualification

Final candidate: `908cc6bb76d01821ddbaa21809f35b8c928d6ae8`

The branch is one commit directly parented on production `141666cd442b789952d9dc3cf48b99e15b6bdd40`, with 21 scoped files and no temporary formatter workflows.

All ten workflow families completed successfully on that exact SHA:

- dogOS Behavior Moments Shadow CI #36
- CI #641, including static quality, backend tests, frontend unit/browser/accessibility/visual contracts, and API/Web production builds
- dogOS Production Runtime CI #45, including production image build and HTTP boot verification
- Adventure System CI #548
- CI Action Runtime Qualification #162
- dogOS Observability + Device Contracts CI #48
- dogOS Connectors CI #106
- dogOS Autopilot CI #146
- dogOS Concierge CI #85
- dogOS Our Story CI #120

The dedicated Behavior lane passed formatting, zero-warning lint, literal zero-authority/release checks, API/Web type-check, adversarial API release tests, active-release profile/shadow tests, Python worker compilation and bilateral release tests, Web transport, the Shadow Lab Playwright journey, and API/Web builds.

No review threads are open. `main` remained at `141666cd442b789952d9dc3cf48b99e15b6bdd40` through final qualification.