### PR TITLE
Compatibility: require uncertainty-aware model promotion

### DIFF
--- a/.github/workflows/dogos-compatibility-promotion-ci.yml
+++ b/.github/workflows/dogos-compatibility-promotion-ci.yml
@@ -1,0 +1,65 @@
+name: dogOS Compatibility Promotion CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'ml/evaluation/uncertainty.py'
+      - 'ml/evaluation/test_uncertainty.py'
+      - 'ml/evaluation/promotion_gate.py'
+      - 'ml/evaluation/test_promotion_gate.py'
+      - 'ml/evaluation/attest_promotion.py'
+      - 'ml/evaluation/test_release_attestation.py'
+      - 'docs/ML_PROMOTION_UNCERTAINTY.md'
+      - '.github/workflows/dogos-compatibility-promotion-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'ml/evaluation/uncertainty.py'
+      - 'ml/evaluation/test_uncertainty.py'
+      - 'ml/evaluation/promotion_gate.py'
+      - 'ml/evaluation/test_promotion_gate.py'
+      - 'ml/evaluation/attest_promotion.py'
+      - 'ml/evaluation/test_release_attestation.py'
+      - 'docs/ML_PROMOTION_UNCERTAINTY.md'
+      - '.github/workflows/dogos-compatibility-promotion-ci.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: compatibility-promotion-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  promotion-authority:
+    name: Cluster uncertainty + release authority
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Report Python runtime
+        run: python --version
+
+      - name: Compile promotion authority modules
+        run: >-
+          python -m compileall -q
+          ml/common
+          ml/evaluation/uncertainty.py
+          ml/evaluation/promotion_gate.py
+          ml/evaluation/attest_promotion.py
+
+      - name: Run cluster uncertainty contracts
+        run: python -m unittest ml.evaluation.test_uncertainty
+
+      - name: Run statistical promotion authority contracts
+        run: python -m unittest ml.evaluation.test_promotion_gate
+
+      - name: Run signed release authority contracts
+        run: python -m unittest ml.evaluation.test_release_attestation
+
+      - name: Verify standard-library evaluator CLIs load
+        run: |
+          python -m ml.evaluation.uncertainty --help >/dev/null
+          python -m ml.evaluation.promotion_gate --help >/dev/null
+          python -m ml.evaluation.attest_promotion --help >/dev/null

--- a/docs/ML_PROMOTION_UNCERTAINTY.md
+++ b/docs/ML_PROMOTION_UNCERTAINTY.md
@@ -1,0 +1,186 @@
+# Compatibility Promotion Uncertainty Authority
+
+Woof does not promote a learned Compatibility model because one held-out score happens to look better than the deterministic baseline.
+
+The authoritative question is stronger:
+
+> Is the candidate's improvement practically meaningful, stable under relationship-level resampling, calibrated under uncertainty, robust to cold-start cohorts, and operationally safe enough to earn production authority?
+
+This document defines the v2 statistical promotion contract.
+
+## 1. Why point estimates are insufficient
+
+A Brier improvement of `0.006` can mean very different things:
+
+- a stable improvement repeated across many independent owner/pet relationships;
+- a handful of unusually favorable outcomes;
+- repeated observations from the same relationship that make the nominal row count look larger than the effective evidence base;
+- a candidate whose average improves while a cold-start cohort can plausibly regress beyond the product tolerance.
+
+The old promotion gate checked point estimates and minimum row counts. Those remain useful, but they are no longer sufficient for authoritative promotion.
+
+## 2. Paired evidence
+
+Baseline and learned scores are evaluated on the same outcome rows.
+
+For each outcome `i`, define the paired Brier improvement:
+
+`(baseline_i - label_i)^2 - (learned_i - label_i)^2`
+
+Positive values favor the learned candidate.
+
+The bootstrap always resamples the baseline and learned loss for an outcome together. Independent model resampling is prohibited because it would discard the strongest available experimental control: both scorers saw the same held-out event.
+
+## 3. Relationship-cluster bootstrap
+
+Rows are not assumed independent.
+
+The leakage-resistant evaluation dataset already owns canonical relationship identifiers:
+
+- `pair_key`: unordered pet pair;
+- `owner_pair_key`: unordered owner pair.
+
+Canonical training prediction files already carry `outcome_id`. The uncertainty evaluator joins predictions back to the exact evaluation split by `outcome_id`, so relationship identity remains evaluation metadata rather than a serving feature.
+
+For authoritative evidence, the split is also the source of truth for the held-out label. The prediction label must agree with the split label for every joined `outcome_id`; missing outcomes, duplicate prediction outcomes, or label disagreement fail closed. A prediction file cannot self-declare its own cluster identities and still qualify for promotion.
+
+Authoritative cluster policy:
+
+| Slice | Bootstrap cluster |
+| --- | --- |
+| future temporal test | `owner_pair_key` |
+| cold-pair test | `pair_key` |
+| cold-owner test | `owner_pair_key` |
+| safety cohort, when supplied | `owner_pair_key` |
+
+A bootstrap draw samples relationship clusters with replacement and includes every outcome belonging to each sampled cluster.
+
+This intentionally gives repeated observations from one relationship less statistical authority than the same number of observations spread across many relationships.
+
+## 4. Future-test promotion rule
+
+The temporal holdout must still satisfy all point-estimate policies, including minimum rows, Brier improvement, ECE, and AUC non-regression.
+
+In addition, the paired cluster bootstrap must satisfy:
+
+- at least the configured minimum number of relationship clusters;
+- at least the configured bootstrap resample count;
+- at least the configured confidence level;
+- the lower confidence bound for Brier improvement must be at least the practical promotion threshold;
+- the upper confidence bound for learned ECE must be at or below the calibration threshold.
+
+The default confidence level is 95%.
+
+The gate therefore does not ask merely whether the candidate probably beats zero improvement. It asks whether the uncertainty-adjusted lower bound still clears Woof's minimum *practical* improvement.
+
+## 5. Cold-start and safety rule
+
+Cold-pair, cold-owner, and optional safety cohorts retain the existing bounded-regression policy.
+
+For each cohort, the bootstrap computes:
+
+`learned Brier - baseline Brier`
+
+The upper confidence bound must remain at or below the configured maximum tolerated regression.
+
+This means a cohort cannot pass merely because its average is acceptable while its uncertainty still admits a materially harmful regression.
+
+AUC non-regression remains a separate point-estimate guard because its role is discrimination, while the bootstrap gate is currently focused on paired probability-quality loss and calibration.
+
+## 6. Evidence provenance
+
+Every authoritative uncertainty slice records:
+
+- prediction file path and SHA-256;
+- evaluation split / cluster-source path and SHA-256;
+- join key (`outcome_id`);
+- explicit confirmation that the prediction label agreed with the split label;
+- baseline and learned score columns;
+- the policy-approved cluster column for that slice;
+- row count;
+- cluster count;
+- bootstrap method;
+- deterministic seed;
+- bootstrap resample count;
+- confidence level;
+- point estimates;
+- interval bounds.
+
+The top-level uncertainty policy must explicitly state that paired rows are used, relationship clusters are resampled, cluster identity comes from evaluation splits, and split-label agreement is required.
+
+`promotion_gate.py` independently verifies that uncertainty point estimates reconcile with the aggregate calibration reports. It also rejects missing split hashes, self-declared cluster policy, the wrong cluster dimension, an invalid join key, missing label verification, or score-column drift. A reassuring uncertainty report generated from different or weaker evidence therefore fails closed.
+
+## 7. Statistical receipt v2
+
+Authoritative Compatibility promotion now requires:
+
+`woof-model-promotion-receipt-v2`
+
+The receipt includes an `uncertaintyEvidence` block and an `authoritativeEligible` field.
+
+A receipt can say `promote` only when:
+
+1. aggregate future/cold/safety policy passes;
+2. required split-backed uncertainty evidence passes;
+3. required shadow telemetry passes;
+4. the evaluation was run in authoritative mode.
+
+Research flags may explicitly omit uncertainty or service telemetry, but such a successful run is labeled:
+
+`research_only`
+
+It can never emit `promote`.
+
+## 8. Signed release authority
+
+`attest_promotion.py` refuses to sign a promoted release unless the statistical receipt:
+
+- uses v2 schema;
+- says `passed: true`;
+- says `decision: promote`;
+- says `authoritativeEligible: true`;
+- requires uncertainty;
+- reports the uncertainty gate passed;
+- identifies `woof-compatibility-uncertainty-v1`;
+- preserves the paired, split-backed cluster and label-verification policy;
+- contains valid prediction and split SHA-256 provenance for future, cold-pair, and cold-owner slices;
+- uses `outcome_id` as the evidence join key;
+- uses the policy-approved cluster dimension for each slice.
+
+If a safety slice participates in the statistical decision, the signer requires the same provenance for its uncertainty evidence.
+
+A legacy v1 point-estimate receipt, research-only receipt, or fabricated v2-looking receipt without the required provenance cannot be used to bypass the new statistical authority.
+
+The signed release receipt remains bound to the exact model, calibration artifact, feature contract, training manifest, and statistical receipt hash.
+
+Because the statistical receipt carries the hashed uncertainty evidence sources, this creates an authority chain from held-out predictions and evaluation splits through statistical promotion to the signed model release.
+
+## 9. Defaults are policy, not scientific constants
+
+Current defaults are conservative beta release policy:
+
+- future rows: 500;
+- cold rows: 75;
+- future relationship clusters: 25;
+- cold relationship clusters: 10;
+- bootstrap resamples: 2,000 minimum;
+- confidence level: 95% minimum;
+- future Brier improvement lower bound: at least 0.005;
+- learned ECE upper bound: at most 0.08;
+- cold/safety Brier-regression upper bound: at most 0.01.
+
+These values may evolve as Woof accumulates real beta evidence. Policy changes must be explicit and preserved in the statistical receipt; they must never be silently tuned until a candidate passes.
+
+## 10. What this does not prove
+
+Passing v2 promotion does not prove that a model improves real-world relationships.
+
+It provides stronger E2-E4 evidence that the model:
+
+- improves held-out probability quality beyond a practical floor;
+- is not relying on an obviously lucky relationship sample;
+- remains bounded under important cold-start cohorts;
+- is calibrated within the current product tolerance;
+- meets operational shadow constraints.
+
+A controlled online outcome experiment is still required before claiming real product lift. The ML evidence ladder in `docs/ML_SYSTEM.md` remains authoritative on that distinction.

--- a/ml/evaluation/attest_promotion.py
+++ b/ml/evaluation/attest_promotion.py
@@ -19,6 +19,25 @@ from ml.common.attestation import (
     sign_receipt,
 )
 
+STATISTICAL_RECEIPT_SCHEMA = "woof-model-promotion-receipt-v2"
+UNCERTAINTY_REPORT_SCHEMA = "woof-compatibility-uncertainty-v1"
+EXPECTED_CLUSTER_COLUMNS = {
+    "futureTest": "owner_pair_key",
+    "coldPair": "pair_key",
+    "coldOwner": "owner_pair_key",
+    "safety": "owner_pair_key",
+}
+
+
+def _sha256_hex(value: Any) -> bool:
+    if not isinstance(value, str) or len(value) != 64:
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return True
+
 
 def _artifact_consistency_failures(
     manifest: dict[str, Any],
@@ -50,6 +69,74 @@ def _artifact_consistency_failures(
     return failures
 
 
+def _uncertainty_slice_authority_failures(
+    uncertainty: dict[str, Any], slice_name: str
+) -> list[str]:
+    failures: list[str] = []
+    block = uncertainty.get(slice_name)
+    if not isinstance(block, dict) or block.get("available") is not True:
+        return [f"{slice_name}_uncertainty_authority_missing"]
+
+    source = block.get("source")
+    if not isinstance(source, dict):
+        return [f"{slice_name}_uncertainty_source_missing"]
+
+    if not _sha256_hex(source.get("predictionSha256")):
+        failures.append(f"{slice_name}_prediction_hash_missing")
+    if not _sha256_hex(source.get("clusterSourceSha256")):
+        failures.append(f"{slice_name}_cluster_source_hash_missing")
+    if source.get("clusterJoinKey") != "outcome_id":
+        failures.append(f"{slice_name}_cluster_join_key_invalid")
+    if source.get("clusterLabelVerified") is not True:
+        failures.append(f"{slice_name}_cluster_label_verification_missing")
+    if source.get("clusterColumn") != EXPECTED_CLUSTER_COLUMNS[slice_name]:
+        failures.append(f"{slice_name}_cluster_column_invalid")
+    return failures
+
+
+def _statistical_authority_failures(statistical: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if statistical.get("schemaVersion") != STATISTICAL_RECEIPT_SCHEMA:
+        failures.append("statistical_receipt_schema_not_authoritative")
+    if statistical.get("passed") is not True or statistical.get("decision") != "promote":
+        failures.append("statistical_gate_not_passed")
+    if statistical.get("authoritativeEligible") is not True:
+        failures.append("statistical_receipt_not_authoritative")
+
+    uncertainty = statistical.get("uncertaintyEvidence")
+    if not isinstance(uncertainty, dict):
+        failures.append("uncertainty_authority_missing")
+        return failures
+
+    if uncertainty.get("required") is not True:
+        failures.append("uncertainty_not_required_by_statistical_gate")
+    if uncertainty.get("passed") is not True:
+        failures.append("uncertainty_gate_not_passed")
+    if uncertainty.get("schemaVersion") != UNCERTAINTY_REPORT_SCHEMA:
+        failures.append("uncertainty_schema_not_authoritative")
+
+    policy = uncertainty.get("policy")
+    if not isinstance(policy, dict):
+        failures.append("uncertainty_policy_missing")
+    else:
+        if policy.get("pairedRows") is not True:
+            failures.append("uncertainty_paired_rows_policy_missing")
+        if policy.get("relationshipClusterBootstrap") is not True:
+            failures.append("uncertainty_cluster_bootstrap_policy_missing")
+        if policy.get("clusterIdentityFromEvaluationSplits") is not True:
+            failures.append("uncertainty_split_cluster_authority_missing")
+        if policy.get("splitLabelAgreementRequired") is not True:
+            failures.append("uncertainty_split_label_authority_missing")
+
+    for slice_name in ("futureTest", "coldPair", "coldOwner"):
+        failures.extend(_uncertainty_slice_authority_failures(uncertainty, slice_name))
+
+    safety = statistical.get("safety")
+    if isinstance(safety, dict) and safety.get("available") is True:
+        failures.extend(_uncertainty_slice_authority_failures(uncertainty, "safety"))
+    return failures
+
+
 def attest_promotion(
     *,
     statistical_receipt_path: Path,
@@ -70,9 +157,7 @@ def attest_promotion(
         feature_contract_path,
     )
 
-    failures: list[str] = []
-    if statistical.get("passed") is not True or statistical.get("decision") != "promote":
-        failures.append("statistical_gate_not_passed")
+    failures = _statistical_authority_failures(statistical)
     failures.extend(_artifact_consistency_failures(manifest, contract, hashes))
 
     calibration = manifest.get("calibration")
@@ -92,6 +177,10 @@ def attest_promotion(
     release_status = "promoted" if not deduplicated else "shadow"
     decision = "promote" if not deduplicated else "hold_shadow"
     statistical_hash = sha256_file(statistical_receipt_path)
+
+    uncertainty = statistical.get("uncertaintyEvidence")
+    uncertainty_schema = uncertainty.get("schemaVersion") if isinstance(uncertainty, dict) else None
+    uncertainty_policy = uncertainty.get("policy") if isinstance(uncertainty, dict) else None
 
     attestation_seed = {
         "identity": identity,
@@ -114,6 +203,9 @@ def attest_promotion(
             "statisticalReceiptSchema": statistical.get("schemaVersion"),
             "statisticalDecision": statistical.get("decision"),
             "statisticalGeneratedAt": statistical.get("generatedAt"),
+            "statisticalAuthoritativeEligible": statistical.get("authoritativeEligible"),
+            "uncertaintyReportSchema": uncertainty_schema,
+            "uncertaintyPolicy": uncertainty_policy,
         },
         "failures": deduplicated,
     }

--- a/ml/evaluation/promotion_gate.py
+++ b/ml/evaluation/promotion_gate.py
@@ -1,8 +1,9 @@
 """Evidence gate for promoting a learned Woof compatibility scorer.
 
-The gate consumes calibration reports produced by ``evaluate_calibration.py``
-and optional shadow-service telemetry. It emits a machine-readable release
-receipt and exits non-zero when an authoritative promotion is not supported.
+The gate consumes aggregate calibration reports, cluster-aware uncertainty
+evidence produced by ``uncertainty.py``, and optional shadow-service telemetry.
+It emits a machine-readable receipt and exits non-zero when authoritative
+promotion is not supported.
 
 Default thresholds are conservative beta policy defaults, not universal
 scientific constants. Override them explicitly and preserve the resulting
@@ -19,15 +20,28 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+PROMOTION_SCHEMA = "woof-model-promotion-receipt-v2"
+UNCERTAINTY_SCHEMA = "woof-compatibility-uncertainty-v1"
+EXPECTED_CLUSTER_COLUMNS = {
+    "future_test": "owner_pair_key",
+    "cold_pair": "pair_key",
+    "cold_owner": "owner_pair_key",
+    "safety": "owner_pair_key",
+}
+
 
 @dataclass(frozen=True)
 class Thresholds:
     min_test_rows: int = 500
     min_cold_rows: int = 75
+    min_test_clusters: int = 25
+    min_cold_clusters: int = 10
     min_brier_improvement: float = 0.005
     max_ece: float = 0.08
     max_cold_brier_regression: float = 0.01
     max_auc_regression: float = 0.01
+    min_bootstrap_resamples: int = 2000
+    min_confidence_level: float = 0.95
     min_shadow_attempts: int = 200
     max_fallback_rate: float = 0.05
     max_p95_latency_ms: float = 1200.0
@@ -51,6 +65,16 @@ def finite_number(value: Any) -> float | None:
     return None
 
 
+def _sha256_hex(value: Any) -> bool:
+    if not isinstance(value, str) or len(value) != 64:
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return True
+
+
 def model_metrics(report: dict[str, Any], column: str) -> dict[str, Any]:
     models = report.get("models")
     if not isinstance(models, dict) or not isinstance(models.get(column), dict):
@@ -60,11 +84,7 @@ def model_metrics(report: dict[str, Any], column: str) -> dict[str, Any]:
 
 def telemetry_values(telemetry: dict[str, Any] | None) -> dict[str, Any]:
     if telemetry is None:
-        return {
-            "attempts": None,
-            "fallbackRate": None,
-            "p95LatencyMs": None,
-        }
+        return {"attempts": None, "fallbackRate": None, "p95LatencyMs": None}
 
     attempts_block = telemetry.get("attempts", {})
     latency_block = telemetry.get("latencyMs", {})
@@ -77,7 +97,6 @@ def telemetry_values(telemetry: dict[str, Any] | None) -> dict[str, Any]:
     fallback_rate = None
     if attempts is not None and attempts > 0 and fallbacks is not None:
         fallback_rate = fallbacks / attempts
-
     if fallback_rate is None:
         fallback_rate = finite_number(telemetry.get("fallbackRate"))
 
@@ -117,12 +136,12 @@ def compare_slice(
         failures.append(f"{name}_rows_below_minimum")
 
     brier_delta = None
-    if baseline_brier is not None and learned_brier is not None:
+    if baseline_brier is None or learned_brier is None:
+        failures.append(f"{name}_brier_missing")
+    else:
         brier_delta = learned_brier - baseline_brier
         if brier_delta > thresholds.max_cold_brier_regression:
             failures.append(f"{name}_brier_regression")
-    else:
-        failures.append(f"{name}_brier_missing")
 
     auc_delta = None
     if baseline_auc is not None and learned_auc is not None:
@@ -147,6 +166,152 @@ def compare_slice(
     )
 
 
+def _same_metric(left: Any, right: Any, tolerance: float = 1e-9) -> bool:
+    left_number = finite_number(left)
+    right_number = finite_number(right)
+    if left_number is None or right_number is None:
+        return False
+    return abs(left_number - right_number) <= tolerance
+
+
+def _interval_bound(block: Any, bound: str) -> float | None:
+    if not isinstance(block, dict):
+        return None
+    return finite_number(block.get(bound))
+
+
+def _uncertainty_policy_failures(
+    uncertainty_report: dict[str, Any], thresholds: Thresholds
+) -> list[str]:
+    policy = uncertainty_report.get("policy")
+    if not isinstance(policy, dict):
+        return ["uncertainty_policy_missing"]
+
+    failures: list[str] = []
+    if policy.get("pairedRows") is not True:
+        failures.append("uncertainty_paired_rows_policy_missing")
+    if policy.get("relationshipClusterBootstrap") is not True:
+        failures.append("uncertainty_cluster_bootstrap_policy_missing")
+    if policy.get("clusterIdentityFromEvaluationSplits") is not True:
+        failures.append("uncertainty_split_cluster_authority_missing")
+    if policy.get("splitLabelAgreementRequired") is not True:
+        failures.append("uncertainty_split_label_authority_missing")
+
+    resamples = finite_number(policy.get("resamples"))
+    if resamples is None or resamples < thresholds.min_bootstrap_resamples:
+        failures.append("uncertainty_policy_resamples_below_minimum")
+    confidence = finite_number(policy.get("confidenceLevel"))
+    if confidence is None or confidence < thresholds.min_confidence_level:
+        failures.append("uncertainty_policy_confidence_below_minimum")
+    return failures
+
+
+def validate_uncertainty_slice(
+    *,
+    name: str,
+    uncertainty: dict[str, Any] | None,
+    aggregate: dict[str, Any],
+    thresholds: Thresholds,
+    baseline_column: str,
+    learned_column: str,
+    future_test: bool,
+) -> tuple[dict[str, Any], list[str]]:
+    if uncertainty is None or uncertainty.get("available") is not True:
+        return {"name": name, "available": False}, [f"{name}_uncertainty_missing"]
+
+    failures: list[str] = []
+    source = uncertainty.get("source")
+    point = uncertainty.get("point")
+    bootstrap = uncertainty.get("bootstrap")
+    if not isinstance(source, dict):
+        failures.append(f"{name}_uncertainty_source_missing")
+        source = {}
+    if not isinstance(point, dict):
+        failures.append(f"{name}_uncertainty_point_missing")
+        point = {}
+    if not isinstance(bootstrap, dict):
+        failures.append(f"{name}_uncertainty_bootstrap_missing")
+        bootstrap = {}
+
+    if not _sha256_hex(source.get("predictionSha256")):
+        failures.append(f"{name}_prediction_hash_missing")
+    if not _sha256_hex(source.get("clusterSourceSha256")):
+        failures.append(f"{name}_cluster_source_hash_missing")
+    if source.get("clusterJoinKey") != "outcome_id":
+        failures.append(f"{name}_cluster_join_key_invalid")
+    if source.get("clusterLabelVerified") is not True:
+        failures.append(f"{name}_cluster_label_verification_missing")
+    if source.get("clusterColumn") != EXPECTED_CLUSTER_COLUMNS[name]:
+        failures.append(f"{name}_cluster_column_invalid")
+    if source.get("baselineColumn") != baseline_column:
+        failures.append(f"{name}_baseline_column_mismatch")
+    if source.get("learnedColumn") != learned_column:
+        failures.append(f"{name}_learned_column_mismatch")
+
+    if bootstrap.get("method") != "paired_cluster_percentile_bootstrap":
+        failures.append(f"{name}_bootstrap_method_invalid")
+
+    resamples = finite_number(bootstrap.get("resamples"))
+    if resamples is None or resamples < thresholds.min_bootstrap_resamples:
+        failures.append(f"{name}_bootstrap_resamples_below_minimum")
+
+    confidence = finite_number(bootstrap.get("confidenceLevel"))
+    if confidence is None or confidence < thresholds.min_confidence_level:
+        failures.append(f"{name}_confidence_level_below_minimum")
+
+    cluster_count = finite_number(bootstrap.get("clusterCount"))
+    minimum_clusters = (
+        thresholds.min_test_clusters if future_test else thresholds.min_cold_clusters
+    )
+    if cluster_count is None or cluster_count < minimum_clusters:
+        failures.append(f"{name}_clusters_below_minimum")
+
+    row_count = finite_number(bootstrap.get("rowCount"))
+    aggregate_rows = finite_number(aggregate.get("rows"))
+    if row_count is None or aggregate_rows is None or int(row_count) != int(aggregate_rows):
+        failures.append(f"{name}_uncertainty_row_count_mismatch")
+
+    if not _same_metric(point.get("baselineBrier"), aggregate.get("baselineBrier")):
+        failures.append(f"{name}_baseline_brier_evidence_mismatch")
+    if not _same_metric(point.get("learnedBrier"), aggregate.get("learnedBrier")):
+        failures.append(f"{name}_learned_brier_evidence_mismatch")
+
+    if future_test:
+        if not _same_metric(point.get("learnedEce10"), aggregate.get("learnedEce10")):
+            failures.append("future_test_ece_evidence_mismatch")
+        improvement_lower = _interval_bound(bootstrap.get("brierImprovement"), "lower")
+        if improvement_lower is None:
+            failures.append("future_test_brier_improvement_lower_missing")
+        elif improvement_lower < thresholds.min_brier_improvement:
+            failures.append("future_test_brier_improvement_lower_below_minimum")
+
+        ece_upper = _interval_bound(bootstrap.get("learnedEce10"), "upper")
+        if ece_upper is None:
+            failures.append("future_test_ece_upper_missing")
+        elif ece_upper > thresholds.max_ece:
+            failures.append("future_test_ece_upper_above_maximum")
+    else:
+        regression_upper = _interval_bound(
+            bootstrap.get("learnedMinusBaselineBrier"), "upper"
+        )
+        if regression_upper is None:
+            failures.append(f"{name}_brier_regression_upper_missing")
+        elif regression_upper > thresholds.max_cold_brier_regression:
+            failures.append(f"{name}_brier_regression_upper_above_maximum")
+
+    return (
+        {
+            "name": name,
+            "available": True,
+            "source": source,
+            "point": point,
+            "bootstrap": bootstrap,
+            "passed": not failures,
+        },
+        failures,
+    )
+
+
 def evaluate_gate(
     report: dict[str, Any],
     baseline_column: str,
@@ -155,7 +320,9 @@ def evaluate_gate(
     cold_pair_report: dict[str, Any] | None = None,
     cold_owner_report: dict[str, Any] | None = None,
     safety_report: dict[str, Any] | None = None,
+    uncertainty_report: dict[str, Any] | None = None,
     telemetry: dict[str, Any] | None = None,
+    require_uncertainty: bool = True,
     require_telemetry: bool = True,
     require_safety_slice: bool = False,
 ) -> dict[str, Any]:
@@ -192,37 +359,133 @@ def evaluate_gate(
         if auc_delta < -thresholds.max_auc_regression:
             failures.append("test_auc_regression")
 
+    future_test = {
+        "rows": rows,
+        "baselineBrier": baseline_brier,
+        "learnedBrier": learned_brier,
+        "brierImprovement": brier_improvement,
+        "learnedEce10": learned_ece,
+        "baselineRocAuc": baseline_auc,
+        "learnedRocAuc": learned_auc,
+        "learnedMinusBaselineRocAuc": auc_delta,
+    }
+
     cold_pair, cold_pair_failures = compare_slice(
-        "cold_pair",
-        cold_pair_report,
-        baseline_column,
-        learned_column,
-        thresholds,
+        "cold_pair", cold_pair_report, baseline_column, learned_column, thresholds
     )
     cold_owner, cold_owner_failures = compare_slice(
-        "cold_owner",
-        cold_owner_report,
-        baseline_column,
-        learned_column,
-        thresholds,
+        "cold_owner", cold_owner_report, baseline_column, learned_column, thresholds
     )
     failures.extend(cold_pair_failures)
     failures.extend(cold_owner_failures)
 
-    safety: dict[str, Any]
     if safety_report is not None:
         safety, safety_failures = compare_slice(
-            "safety",
-            safety_report,
-            baseline_column,
-            learned_column,
-            thresholds,
+            "safety", safety_report, baseline_column, learned_column, thresholds
         )
         failures.extend(safety_failures)
     else:
         safety = {"name": "safety", "available": False}
         if require_safety_slice:
             failures.append("safety_report_missing")
+
+    uncertainty_failures: list[str] = []
+    uncertainty_evidence: dict[str, Any] = {
+        "required": require_uncertainty,
+        "available": uncertainty_report is not None,
+        "schemaVersion": (
+            uncertainty_report.get("schemaVersion")
+            if isinstance(uncertainty_report, dict)
+            else None
+        ),
+    }
+
+    if uncertainty_report is None:
+        if require_uncertainty:
+            uncertainty_failures.append("uncertainty_report_missing")
+    elif uncertainty_report.get("schemaVersion") != UNCERTAINTY_SCHEMA:
+        uncertainty_failures.append("uncertainty_schema_invalid")
+    else:
+        uncertainty_failures.extend(
+            _uncertainty_policy_failures(uncertainty_report, thresholds)
+        )
+        policy = uncertainty_report.get("policy")
+        uncertainty_evidence["policy"] = policy
+
+        future_uncertainty, future_uncertainty_failures = validate_uncertainty_slice(
+            name="future_test",
+            uncertainty=(
+                uncertainty_report.get("futureTest")
+                if isinstance(uncertainty_report.get("futureTest"), dict)
+                else None
+            ),
+            aggregate=future_test,
+            thresholds=thresholds,
+            baseline_column=baseline_column,
+            learned_column=learned_column,
+            future_test=True,
+        )
+        cold_pair_uncertainty, cold_pair_uncertainty_failures = validate_uncertainty_slice(
+            name="cold_pair",
+            uncertainty=(
+                uncertainty_report.get("coldPair")
+                if isinstance(uncertainty_report.get("coldPair"), dict)
+                else None
+            ),
+            aggregate=cold_pair,
+            thresholds=thresholds,
+            baseline_column=baseline_column,
+            learned_column=learned_column,
+            future_test=False,
+        )
+        cold_owner_uncertainty, cold_owner_uncertainty_failures = validate_uncertainty_slice(
+            name="cold_owner",
+            uncertainty=(
+                uncertainty_report.get("coldOwner")
+                if isinstance(uncertainty_report.get("coldOwner"), dict)
+                else None
+            ),
+            aggregate=cold_owner,
+            thresholds=thresholds,
+            baseline_column=baseline_column,
+            learned_column=learned_column,
+            future_test=False,
+        )
+        uncertainty_failures.extend(future_uncertainty_failures)
+        uncertainty_failures.extend(cold_pair_uncertainty_failures)
+        uncertainty_failures.extend(cold_owner_uncertainty_failures)
+
+        safety_uncertainty: dict[str, Any] = {"name": "safety", "available": False}
+        if safety_report is not None:
+            safety_uncertainty, safety_uncertainty_failures = validate_uncertainty_slice(
+                name="safety",
+                uncertainty=(
+                    uncertainty_report.get("safety")
+                    if isinstance(uncertainty_report.get("safety"), dict)
+                    else None
+                ),
+                aggregate=safety,
+                thresholds=thresholds,
+                baseline_column=baseline_column,
+                learned_column=learned_column,
+                future_test=False,
+            )
+            uncertainty_failures.extend(safety_uncertainty_failures)
+        elif require_safety_slice:
+            uncertainty_failures.append("safety_uncertainty_missing")
+
+        uncertainty_evidence.update(
+            {
+                "futureTest": future_uncertainty,
+                "coldPair": cold_pair_uncertainty,
+                "coldOwner": cold_owner_uncertainty,
+                "safety": safety_uncertainty,
+            }
+        )
+
+    uncertainty_evidence["passed"] = not uncertainty_failures
+    uncertainty_evidence["failures"] = list(dict.fromkeys(uncertainty_failures))
+    failures.extend(uncertainty_failures)
 
     shadow = telemetry_values(telemetry)
     if require_telemetry:
@@ -242,27 +505,28 @@ def evaluate_gate(
             failures.append("p95_latency_above_maximum")
 
     deduplicated_failures = list(dict.fromkeys(failures))
+    authoritative_eligible = require_uncertainty and require_telemetry
+    if deduplicated_failures:
+        decision = "hold_shadow"
+    elif authoritative_eligible:
+        decision = "promote"
+    else:
+        decision = "research_only"
+
     return {
-        "schemaVersion": "woof-model-promotion-receipt-v1",
+        "schemaVersion": PROMOTION_SCHEMA,
         "generatedAt": datetime.now(timezone.utc).isoformat(),
-        "decision": "promote" if not deduplicated_failures else "hold_shadow",
+        "decision": decision,
         "passed": not deduplicated_failures,
+        "authoritativeEligible": authoritative_eligible,
         "baselineColumn": baseline_column,
         "learnedColumn": learned_column,
         "thresholds": asdict(thresholds),
-        "futureTest": {
-            "rows": rows,
-            "baselineBrier": baseline_brier,
-            "learnedBrier": learned_brier,
-            "brierImprovement": brier_improvement,
-            "learnedEce10": learned_ece,
-            "baselineRocAuc": baseline_auc,
-            "learnedRocAuc": learned_auc,
-            "learnedMinusBaselineRocAuc": auc_delta,
-        },
+        "futureTest": future_test,
         "coldPair": cold_pair,
         "coldOwner": cold_owner,
         "safety": safety,
+        "uncertaintyEvidence": uncertainty_evidence,
         "shadowTelemetry": shadow,
         "failures": deduplicated_failures,
     }
@@ -274,23 +538,33 @@ def main() -> None:
     parser.add_argument("--cold-pair-report", type=Path)
     parser.add_argument("--cold-owner-report", type=Path)
     parser.add_argument("--safety-report", type=Path)
+    parser.add_argument("--uncertainty-report", type=Path)
     parser.add_argument("--telemetry", type=Path)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--baseline-column", default="baseline_score")
     parser.add_argument("--learned-column", default="learned_score")
     parser.add_argument("--min-test-rows", type=int, default=500)
     parser.add_argument("--min-cold-rows", type=int, default=75)
+    parser.add_argument("--min-test-clusters", type=int, default=25)
+    parser.add_argument("--min-cold-clusters", type=int, default=10)
     parser.add_argument("--min-brier-improvement", type=float, default=0.005)
     parser.add_argument("--max-ece", type=float, default=0.08)
     parser.add_argument("--max-cold-brier-regression", type=float, default=0.01)
     parser.add_argument("--max-auc-regression", type=float, default=0.01)
+    parser.add_argument("--min-bootstrap-resamples", type=int, default=2000)
+    parser.add_argument("--min-confidence-level", type=float, default=0.95)
     parser.add_argument("--min-shadow-attempts", type=int, default=200)
     parser.add_argument("--max-fallback-rate", type=float, default=0.05)
     parser.add_argument("--max-p95-latency-ms", type=float, default=1200.0)
     parser.add_argument(
+        "--allow-missing-uncertainty",
+        action="store_true",
+        help="Offline research only. The resulting receipt can never authorize promotion.",
+    )
+    parser.add_argument(
         "--allow-missing-telemetry",
         action="store_true",
-        help="For offline research only. Authoritative release review should require telemetry.",
+        help="Offline research only. The resulting receipt can never authorize promotion.",
     )
     parser.add_argument("--require-safety-slice", action="store_true")
     parser.add_argument(
@@ -303,10 +577,14 @@ def main() -> None:
     thresholds = Thresholds(
         min_test_rows=args.min_test_rows,
         min_cold_rows=args.min_cold_rows,
+        min_test_clusters=args.min_test_clusters,
+        min_cold_clusters=args.min_cold_clusters,
         min_brier_improvement=args.min_brier_improvement,
         max_ece=args.max_ece,
         max_cold_brier_regression=args.max_cold_brier_regression,
         max_auc_regression=args.max_auc_regression,
+        min_bootstrap_resamples=args.min_bootstrap_resamples,
+        min_confidence_level=args.min_confidence_level,
         min_shadow_attempts=args.min_shadow_attempts,
         max_fallback_rate=args.max_fallback_rate,
         max_p95_latency_ms=args.max_p95_latency_ms,
@@ -319,7 +597,9 @@ def main() -> None:
         cold_pair_report=load_json(args.cold_pair_report),
         cold_owner_report=load_json(args.cold_owner_report),
         safety_report=load_json(args.safety_report),
+        uncertainty_report=load_json(args.uncertainty_report),
         telemetry=load_json(args.telemetry),
+        require_uncertainty=not args.allow_missing_uncertainty,
         require_telemetry=not args.allow_missing_telemetry,
         require_safety_slice=args.require_safety_slice,
     )
@@ -328,7 +608,7 @@ def main() -> None:
     args.output.write_text(json.dumps(receipt, indent=2), encoding="utf-8")
     print(json.dumps(receipt, indent=2))
 
-    if not receipt["passed"] and not args.non_blocking:
+    if receipt["decision"] == "hold_shadow" and not args.non_blocking:
         raise SystemExit(2)
 
 

--- a/ml/evaluation/test_promotion_gate.py
+++ b/ml/evaluation/test_promotion_gate.py
@@ -25,68 +25,214 @@ def report(rows: int = 800, baseline_brier: float = 0.20, learned_brier: float =
     }
 
 
+def uncertainty_slice(
+    aggregate,
+    *,
+    name: str,
+    cluster_column: str,
+    clusters: int,
+    improvement_lower: float = 0.01,
+    regression_upper: float = 0.005,
+    ece_upper: float = 0.06,
+):
+    baseline = aggregate["models"]["baseline_score"]
+    learned = aggregate["models"]["learned_score"]
+    improvement = baseline["brier"] - learned["brier"]
+    return {
+        "name": name,
+        "available": True,
+        "source": {
+            "predictionSha256": "a" * 64,
+            "clusterSourceSha256": "b" * 64,
+            "clusterJoinKey": "outcome_id",
+            "clusterLabelVerified": True,
+            "clusterColumn": cluster_column,
+            "baselineColumn": "baseline_score",
+            "learnedColumn": "learned_score",
+        },
+        "point": {
+            "baselineBrier": baseline["brier"],
+            "learnedBrier": learned["brier"],
+            "brierImprovement": improvement,
+            "learnedMinusBaselineBrier": -improvement,
+            "learnedEce10": learned["ece10"],
+        },
+        "bootstrap": {
+            "method": "paired_cluster_percentile_bootstrap",
+            "seed": 17,
+            "resamples": 4000,
+            "confidenceLevel": 0.95,
+            "clusterCount": clusters,
+            "rowCount": baseline["rows"],
+            "brierImprovement": {
+                "lower": improvement_lower,
+                "upper": improvement + 0.01,
+            },
+            "learnedMinusBaselineBrier": {
+                "lower": -improvement - 0.01,
+                "upper": regression_upper,
+            },
+            "learnedEce10": {"lower": 0.03, "upper": ece_upper},
+        },
+    }
+
+
+def uncertainty_report(main, cold_pair, cold_owner):
+    return {
+        "schemaVersion": "woof-compatibility-uncertainty-v1",
+        "policy": {
+            "pairedRows": True,
+            "relationshipClusterBootstrap": True,
+            "clusterIdentityFromEvaluationSplits": True,
+            "splitLabelAgreementRequired": True,
+            "resamples": 4000,
+            "confidenceLevel": 0.95,
+            "seed": 17,
+        },
+        "futureTest": uncertainty_slice(
+            main,
+            name="future_test",
+            cluster_column="owner_pair_key",
+            clusters=45,
+            improvement_lower=0.008,
+        ),
+        "coldPair": uncertainty_slice(
+            cold_pair,
+            name="cold_pair",
+            cluster_column="pair_key",
+            clusters=18,
+            regression_upper=0.006,
+        ),
+        "coldOwner": uncertainty_slice(
+            cold_owner,
+            name="cold_owner",
+            cluster_column="owner_pair_key",
+            clusters=14,
+            regression_upper=0.006,
+        ),
+        "safety": {"name": "safety", "available": False},
+    }
+
+
+def telemetry(fallbacks: int = 8):
+    return {
+        "attempts": {"total": 500, "fallbacks": fallbacks},
+        "latencyMs": {"p95": 430},
+    }
+
+
 class PromotionGateTests(unittest.TestCase):
-    def test_promotes_only_when_future_cold_and_operational_gates_pass(self):
-        receipt = evaluate_gate(
-            report(),
+    def setUp(self):
+        self.main = report()
+        self.cold_pair = report(rows=180, baseline_brier=0.22, learned_brier=0.215)
+        self.cold_owner = report(rows=120, baseline_brier=0.23, learned_brier=0.225)
+
+    def evaluate(self, **overrides):
+        arguments = {
+            "cold_pair_report": self.cold_pair,
+            "cold_owner_report": self.cold_owner,
+            "uncertainty_report": uncertainty_report(
+                self.main,
+                self.cold_pair,
+                self.cold_owner,
+            ),
+            "telemetry": telemetry(),
+        }
+        arguments.update(overrides)
+        return evaluate_gate(
+            self.main,
             "baseline_score",
             "learned_score",
             Thresholds(),
-            cold_pair_report=report(rows=180, baseline_brier=0.22, learned_brier=0.215),
-            cold_owner_report=report(rows=120, baseline_brier=0.23, learned_brier=0.225),
-            telemetry={
-                "attempts": {"total": 500, "fallbacks": 8},
-                "latencyMs": {"p95": 430},
-            },
+            **arguments,
         )
+
+    def test_promotes_only_when_point_uncertainty_and_operational_gates_pass(self):
+        receipt = self.evaluate()
         self.assertTrue(receipt["passed"])
+        self.assertTrue(receipt["authoritativeEligible"])
+        self.assertEqual(receipt["schemaVersion"], "woof-model-promotion-receipt-v2")
         self.assertEqual(receipt["decision"], "promote")
+        self.assertTrue(receipt["uncertaintyEvidence"]["passed"])
         self.assertEqual(receipt["failures"], [])
 
-    def test_holds_shadow_when_fallback_rate_is_too_high(self):
-        receipt = evaluate_gate(
-            report(),
-            "baseline_score",
-            "learned_score",
-            Thresholds(),
-            cold_pair_report=report(rows=180),
-            cold_owner_report=report(rows=120),
-            telemetry={
-                "attempts": {"total": 500, "fallbacks": 60},
-                "latencyMs": {"p95": 430},
-            },
+    def test_holds_shadow_when_point_improves_but_bootstrap_lower_bound_is_weak(self):
+        uncertainty = uncertainty_report(self.main, self.cold_pair, self.cold_owner)
+        uncertainty["futureTest"]["bootstrap"]["brierImprovement"]["lower"] = 0.001
+        receipt = self.evaluate(uncertainty_report=uncertainty)
+        self.assertFalse(receipt["passed"])
+        self.assertIn(
+            "future_test_brier_improvement_lower_below_minimum",
+            receipt["failures"],
         )
+
+    def test_holds_shadow_when_cold_owner_uncertainty_crosses_regression_limit(self):
+        uncertainty = uncertainty_report(self.main, self.cold_pair, self.cold_owner)
+        uncertainty["coldOwner"]["bootstrap"]["learnedMinusBaselineBrier"]["upper"] = 0.02
+        receipt = self.evaluate(uncertainty_report=uncertainty)
+        self.assertFalse(receipt["passed"])
+        self.assertIn(
+            "cold_owner_brier_regression_upper_above_maximum",
+            receipt["failures"],
+        )
+
+    def test_holds_shadow_when_uncertainty_evidence_does_not_match_aggregate_report(self):
+        uncertainty = uncertainty_report(self.main, self.cold_pair, self.cold_owner)
+        uncertainty["futureTest"]["point"]["learnedBrier"] = 0.12
+        receipt = self.evaluate(uncertainty_report=uncertainty)
+        self.assertFalse(receipt["passed"])
+        self.assertIn("future_test_learned_brier_evidence_mismatch", receipt["failures"])
+
+    def test_holds_shadow_when_split_cluster_provenance_is_missing(self):
+        uncertainty = uncertainty_report(self.main, self.cold_pair, self.cold_owner)
+        del uncertainty["futureTest"]["source"]["clusterSourceSha256"]
+        receipt = self.evaluate(uncertainty_report=uncertainty)
+        self.assertFalse(receipt["passed"])
+        self.assertIn("future_test_cluster_source_hash_missing", receipt["failures"])
+
+    def test_holds_shadow_when_uncertainty_policy_allows_self_declared_clusters(self):
+        uncertainty = uncertainty_report(self.main, self.cold_pair, self.cold_owner)
+        uncertainty["policy"]["clusterIdentityFromEvaluationSplits"] = False
+        receipt = self.evaluate(uncertainty_report=uncertainty)
+        self.assertFalse(receipt["passed"])
+        self.assertIn("uncertainty_split_cluster_authority_missing", receipt["failures"])
+
+    def test_holds_shadow_when_uncertainty_report_is_missing(self):
+        receipt = self.evaluate(uncertainty_report=None)
+        self.assertFalse(receipt["passed"])
+        self.assertEqual(receipt["decision"], "hold_shadow")
+        self.assertIn("uncertainty_report_missing", receipt["failures"])
+
+    def test_holds_shadow_when_fallback_rate_is_too_high(self):
+        receipt = self.evaluate(telemetry=telemetry(fallbacks=60))
         self.assertFalse(receipt["passed"])
         self.assertEqual(receipt["decision"], "hold_shadow")
         self.assertIn("fallback_rate_above_maximum", receipt["failures"])
 
-    def test_holds_shadow_on_cold_owner_regression_even_if_average_improves(self):
-        receipt = evaluate_gate(
-            report(),
-            "baseline_score",
-            "learned_score",
-            Thresholds(),
-            cold_pair_report=report(rows=180),
-            cold_owner_report=report(rows=120, baseline_brier=0.20, learned_brier=0.23),
-            telemetry={
-                "attempts": {"total": 500, "fallbacks": 2},
-                "latencyMs": {"p95": 300},
-            },
+    def test_holds_shadow_on_point_cold_owner_regression_even_if_average_future_improves(self):
+        bad_cold_owner = report(rows=120, baseline_brier=0.20, learned_brier=0.23)
+        uncertainty = uncertainty_report(self.main, self.cold_pair, bad_cold_owner)
+        receipt = self.evaluate(
+            cold_owner_report=bad_cold_owner,
+            uncertainty_report=uncertainty,
         )
         self.assertFalse(receipt["passed"])
         self.assertIn("cold_owner_brier_regression", receipt["failures"])
 
-    def test_offline_research_can_explicitly_skip_service_telemetry(self):
+    def test_offline_research_bypass_cannot_emit_promotion_decision(self):
         receipt = evaluate_gate(
-            report(),
+            self.main,
             "baseline_score",
             "learned_score",
             Thresholds(),
-            cold_pair_report=report(rows=180),
-            cold_owner_report=report(rows=120),
+            cold_pair_report=self.cold_pair,
+            cold_owner_report=self.cold_owner,
+            require_uncertainty=False,
             require_telemetry=False,
         )
         self.assertTrue(receipt["passed"])
+        self.assertFalse(receipt["authoritativeEligible"])
+        self.assertEqual(receipt["decision"], "research_only")
 
 
 if __name__ == "__main__":

--- a/ml/evaluation/test_release_attestation.py
+++ b/ml/evaluation/test_release_attestation.py
@@ -9,8 +9,30 @@ from ml.common.attestation import sha256_file, verify_release_receipt
 from ml.evaluation.attest_promotion import attest_promotion
 
 
+def uncertainty_slice(cluster_column: str) -> dict:
+    return {
+        "available": True,
+        "source": {
+            "predictionSha256": "a" * 64,
+            "clusterSourceSha256": "b" * 64,
+            "clusterJoinKey": "outcome_id",
+            "clusterLabelVerified": True,
+            "clusterColumn": cluster_column,
+        },
+    }
+
+
 class ReleaseAttestationTests(unittest.TestCase):
-    def _candidate(self, root: Path, statistical_passed: bool = True):
+    def _candidate(
+        self,
+        root: Path,
+        *,
+        statistical_passed: bool = True,
+        statistical_schema: str = "woof-model-promotion-receipt-v2",
+        authoritative: bool = True,
+        uncertainty_passed: bool = True,
+        mutate_statistical=None,
+    ):
         model = root / "compatibility_model.joblib"
         calibration = root / "calibration.joblib"
         contract = root / "feature_contract.json"
@@ -47,36 +69,71 @@ class ReleaseAttestationTests(unittest.TestCase):
             ),
             encoding="utf-8",
         )
-        statistical.write_text(
-            json.dumps(
-                {
-                    "schemaVersion": "woof-model-promotion-receipt-v1",
-                    "generatedAt": "2026-08-20T00:00:00+00:00",
-                    "decision": "promote" if statistical_passed else "hold_shadow",
-                    "passed": statistical_passed,
-                }
+        payload = {
+            "schemaVersion": statistical_schema,
+            "generatedAt": "2026-08-27T00:00:00+00:00",
+            "decision": (
+                "promote"
+                if statistical_passed and authoritative
+                else "hold_shadow" if not statistical_passed else "research_only"
             ),
-            encoding="utf-8",
-        )
+            "passed": statistical_passed,
+            "authoritativeEligible": authoritative,
+            "safety": {"name": "safety", "available": False},
+            "uncertaintyEvidence": {
+                "required": True,
+                "passed": uncertainty_passed,
+                "schemaVersion": "woof-compatibility-uncertainty-v1",
+                "policy": {
+                    "pairedRows": True,
+                    "relationshipClusterBootstrap": True,
+                    "clusterIdentityFromEvaluationSplits": True,
+                    "splitLabelAgreementRequired": True,
+                    "confidenceLevel": 0.95,
+                    "resamples": 4000,
+                },
+                "futureTest": uncertainty_slice("owner_pair_key"),
+                "coldPair": uncertainty_slice("pair_key"),
+                "coldOwner": uncertainty_slice("owner_pair_key"),
+                "safety": {"name": "safety", "available": False},
+            },
+        }
+        if mutate_statistical is not None:
+            mutate_statistical(payload)
+        statistical.write_text(json.dumps(payload), encoding="utf-8")
         return model, calibration, manifest, contract, statistical
+
+    def _attest(self, root: Path, **candidate_kwargs):
+        model, calibration, manifest, contract, statistical = self._candidate(
+            root, **candidate_kwargs
+        )
+        receipt = attest_promotion(
+            statistical_receipt_path=statistical,
+            model_path=model,
+            calibration_path=calibration,
+            training_manifest_path=manifest,
+            feature_contract_path=contract,
+            signing_key="test-release-secret",
+            key_id="test-key-v1",
+        )
+        return receipt, model, calibration, manifest, contract
 
     def test_signed_receipt_is_bound_to_exact_candidate_artifacts(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            model, calibration, manifest, contract, statistical = self._candidate(root)
-            receipt = attest_promotion(
-                statistical_receipt_path=statistical,
-                model_path=model,
-                calibration_path=calibration,
-                training_manifest_path=manifest,
-                feature_contract_path=contract,
-                signing_key="test-release-secret",
-                key_id="test-key-v1",
-            )
+            receipt, model, calibration, manifest, contract = self._attest(root)
 
             self.assertTrue(receipt["passed"])
             self.assertEqual(receipt["decision"], "promote")
             self.assertEqual(receipt["releaseStatus"], "promoted")
+            self.assertEqual(
+                receipt["evidence"]["statisticalReceiptSchema"],
+                "woof-model-promotion-receipt-v2",
+            )
+            self.assertEqual(
+                receipt["evidence"]["uncertaintyReportSchema"],
+                "woof-compatibility-uncertainty-v1",
+            )
             valid, failures = verify_release_receipt(
                 receipt,
                 key="test-release-secret",
@@ -88,19 +145,69 @@ class ReleaseAttestationTests(unittest.TestCase):
             self.assertTrue(valid)
             self.assertEqual(failures, [])
 
+    def test_legacy_point_estimate_receipt_cannot_authorize_release(self):
+        with tempfile.TemporaryDirectory() as directory:
+            receipt, *_ = self._attest(
+                Path(directory),
+                statistical_schema="woof-model-promotion-receipt-v1",
+            )
+            self.assertFalse(receipt["passed"])
+            self.assertEqual(receipt["releaseStatus"], "shadow")
+            self.assertIn(
+                "statistical_receipt_schema_not_authoritative",
+                receipt["failures"],
+            )
+
+    def test_research_only_receipt_cannot_authorize_release(self):
+        with tempfile.TemporaryDirectory() as directory:
+            receipt, *_ = self._attest(Path(directory), authoritative=False)
+            self.assertFalse(receipt["passed"])
+            self.assertIn("statistical_gate_not_passed", receipt["failures"])
+            self.assertIn("statistical_receipt_not_authoritative", receipt["failures"])
+
+    def test_failed_uncertainty_gate_cannot_authorize_release(self):
+        with tempfile.TemporaryDirectory() as directory:
+            receipt, *_ = self._attest(Path(directory), uncertainty_passed=False)
+            self.assertFalse(receipt["passed"])
+            self.assertIn("uncertainty_gate_not_passed", receipt["failures"])
+
+    def test_missing_split_provenance_cannot_authorize_release(self):
+        with tempfile.TemporaryDirectory() as directory:
+            def mutate(payload):
+                del payload["uncertaintyEvidence"]["futureTest"]["source"][
+                    "clusterSourceSha256"
+                ]
+
+            receipt, *_ = self._attest(Path(directory), mutate_statistical=mutate)
+            self.assertFalse(receipt["passed"])
+            self.assertIn("futureTest_cluster_source_hash_missing", receipt["failures"])
+
+    def test_self_declared_cluster_policy_cannot_authorize_release(self):
+        with tempfile.TemporaryDirectory() as directory:
+            def mutate(payload):
+                payload["uncertaintyEvidence"]["policy"][
+                    "clusterIdentityFromEvaluationSplits"
+                ] = False
+
+            receipt, *_ = self._attest(Path(directory), mutate_statistical=mutate)
+            self.assertFalse(receipt["passed"])
+            self.assertIn("uncertainty_split_cluster_authority_missing", receipt["failures"])
+
+    def test_wrong_cluster_dimension_cannot_authorize_release(self):
+        with tempfile.TemporaryDirectory() as directory:
+            def mutate(payload):
+                payload["uncertaintyEvidence"]["coldPair"]["source"][
+                    "clusterColumn"
+                ] = "owner_pair_key"
+
+            receipt, *_ = self._attest(Path(directory), mutate_statistical=mutate)
+            self.assertFalse(receipt["passed"])
+            self.assertIn("coldPair_cluster_column_invalid", receipt["failures"])
+
     def test_artifact_swap_invalidates_an_otherwise_valid_receipt(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            model, calibration, manifest, contract, statistical = self._candidate(root)
-            receipt = attest_promotion(
-                statistical_receipt_path=statistical,
-                model_path=model,
-                calibration_path=calibration,
-                training_manifest_path=manifest,
-                feature_contract_path=contract,
-                signing_key="test-release-secret",
-                key_id="test-key-v1",
-            )
+            receipt, model, calibration, manifest, contract = self._attest(root)
             model.write_bytes(b"swapped-model")
 
             valid, failures = verify_release_receipt(
@@ -117,16 +224,7 @@ class ReleaseAttestationTests(unittest.TestCase):
     def test_wrong_signing_key_invalidates_release(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            model, calibration, manifest, contract, statistical = self._candidate(root)
-            receipt = attest_promotion(
-                statistical_receipt_path=statistical,
-                model_path=model,
-                calibration_path=calibration,
-                training_manifest_path=manifest,
-                feature_contract_path=contract,
-                signing_key="test-release-secret",
-                key_id="test-key-v1",
-            )
+            receipt, model, calibration, manifest, contract = self._attest(root)
             valid, failures = verify_release_receipt(
                 receipt,
                 key="different-secret",
@@ -140,19 +238,7 @@ class ReleaseAttestationTests(unittest.TestCase):
 
     def test_failed_statistical_gate_can_only_produce_shadow_receipt(self):
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            model, calibration, manifest, contract, statistical = self._candidate(
-                root, statistical_passed=False
-            )
-            receipt = attest_promotion(
-                statistical_receipt_path=statistical,
-                model_path=model,
-                calibration_path=calibration,
-                training_manifest_path=manifest,
-                feature_contract_path=contract,
-                signing_key="test-release-secret",
-                key_id="test-key-v1",
-            )
+            receipt, *_ = self._attest(Path(directory), statistical_passed=False)
             self.assertFalse(receipt["passed"])
             self.assertEqual(receipt["releaseStatus"], "shadow")
             self.assertIn("statistical_gate_not_passed", receipt["failures"])

--- a/ml/evaluation/test_uncertainty.py
+++ b/ml/evaluation/test_uncertainty.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import csv
+import tempfile
+import unittest
+from pathlib import Path
+
+from ml.evaluation.uncertainty import (
+    PredictionRow,
+    build_report,
+    cluster_bootstrap,
+    load_predictions,
+    point_estimates,
+)
+
+
+class CompatibilityUncertaintyTests(unittest.TestCase):
+    def test_cluster_bootstrap_is_deterministic_and_paired(self):
+        rows = []
+        for cluster_index in range(8):
+            cluster = f"owner-{cluster_index}"
+            for label in (0, 1, 0, 1):
+                baseline = 0.58 if label else 0.42
+                learned = 0.82 if label else 0.18
+                rows.append(PredictionRow(label, baseline, learned, cluster))
+
+        first = cluster_bootstrap(
+            rows,
+            resamples=500,
+            confidence_level=0.95,
+            seed=7,
+        )
+        second = cluster_bootstrap(
+            rows,
+            resamples=500,
+            confidence_level=0.95,
+            seed=7,
+        )
+
+        self.assertEqual(first, second)
+        self.assertEqual(first["method"], "paired_cluster_percentile_bootstrap")
+        self.assertEqual(first["clusterCount"], 8)
+        self.assertGreater(first["brierImprovement"]["lower"], 0.0)
+        self.assertLess(first["learnedMinusBaselineBrier"]["upper"], 0.0)
+
+    def test_point_estimate_uses_same_rows_for_baseline_and_learned(self):
+        rows = [
+            PredictionRow(1, 0.55, 0.90, "a"),
+            PredictionRow(0, 0.45, 0.10, "b"),
+        ]
+        estimates = point_estimates(rows)
+        self.assertAlmostEqual(estimates["baselineBrier"], 0.2025)
+        self.assertAlmostEqual(estimates["learnedBrier"], 0.01)
+        self.assertAlmostEqual(estimates["brierImprovement"], 0.1925)
+
+    def test_prediction_loader_rejects_missing_cluster_identity(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "predictions.csv"
+            path.write_text(
+                "label,baseline_score,learned_score\n1,0.5,0.8\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "owner_pair_key"):
+                load_predictions(path, cluster_column="owner_pair_key")
+
+    def test_prediction_loader_joins_cluster_identity_from_split_by_outcome_id(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            predictions = root / "predictions.csv"
+            clusters = root / "split.csv"
+            predictions.write_text(
+                "outcome_id,label,baseline_score,learned_score\n"
+                "o1,1,0.55,0.85\n"
+                "o2,0,0.45,0.15\n",
+                encoding="utf-8",
+            )
+            clusters.write_text(
+                "outcome_id,label,owner_pair_key\n"
+                "o1,1,owner-a::owner-b\n"
+                "o2,0,owner-c::owner-d\n",
+                encoding="utf-8",
+            )
+
+            rows = load_predictions(
+                predictions,
+                cluster_column="owner_pair_key",
+                cluster_source=clusters,
+            )
+            self.assertEqual([row.cluster for row in rows], ["owner-a::owner-b", "owner-c::owner-d"])
+
+    def test_prediction_loader_fails_closed_when_split_label_disagrees(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            predictions = root / "predictions.csv"
+            clusters = root / "split.csv"
+            predictions.write_text(
+                "outcome_id,label,baseline_score,learned_score\no1,1,0.55,0.85\n",
+                encoding="utf-8",
+            )
+            clusters.write_text(
+                "outcome_id,label,owner_pair_key\no1,0,owner-a::owner-b\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "disagrees"):
+                load_predictions(
+                    predictions,
+                    cluster_column="owner_pair_key",
+                    cluster_source=clusters,
+                )
+
+    def test_prediction_loader_fails_closed_when_prediction_is_absent_from_split(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            predictions = root / "predictions.csv"
+            clusters = root / "split.csv"
+            predictions.write_text(
+                "outcome_id,label,baseline_score,learned_score\nmissing,1,0.55,0.85\n",
+                encoding="utf-8",
+            )
+            clusters.write_text(
+                "outcome_id,label,pair_key\no1,1,pet-a::pet-b\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "absent"):
+                load_predictions(
+                    predictions,
+                    cluster_column="pair_key",
+                    cluster_source=clusters,
+                )
+
+    def test_report_binds_prediction_and_split_hashes_to_cluster_policy(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+
+            def write_prediction(name: str) -> Path:
+                path = root / f"{name}-predictions.csv"
+                with path.open("w", encoding="utf-8", newline="") as handle:
+                    writer = csv.DictWriter(
+                        handle,
+                        fieldnames=[
+                            "outcome_id",
+                            "label",
+                            "baseline_score",
+                            "learned_score",
+                        ],
+                    )
+                    writer.writeheader()
+                    for cluster_index in range(4):
+                        for row_index, label in enumerate((0, 1)):
+                            writer.writerow(
+                                {
+                                    "outcome_id": f"{name}-{cluster_index}-{row_index}",
+                                    "label": label,
+                                    "baseline_score": 0.4 if label == 0 else 0.6,
+                                    "learned_score": 0.15 if label == 0 else 0.85,
+                                }
+                            )
+                return path
+
+            def write_split(name: str) -> Path:
+                path = root / f"{name}-split.csv"
+                with path.open("w", encoding="utf-8", newline="") as handle:
+                    writer = csv.DictWriter(
+                        handle,
+                        fieldnames=["outcome_id", "label", "pair_key", "owner_pair_key"],
+                    )
+                    writer.writeheader()
+                    for cluster_index in range(4):
+                        for row_index, label in enumerate((0, 1)):
+                            writer.writerow(
+                                {
+                                    "outcome_id": f"{name}-{cluster_index}-{row_index}",
+                                    "label": label,
+                                    "pair_key": f"pet-pair-{cluster_index}",
+                                    "owner_pair_key": f"owner-pair-{cluster_index}",
+                                }
+                            )
+                return path
+
+            future = write_prediction("future")
+            future_split = write_split("future")
+            cold_pair = write_prediction("cold-pair")
+            cold_pair_split = write_split("cold-pair")
+            cold_owner = write_prediction("cold-owner")
+            cold_owner_split = write_split("cold-owner")
+            report = build_report(
+                future_path=future,
+                future_cluster_source=future_split,
+                cold_pair_path=cold_pair,
+                cold_pair_cluster_source=cold_pair_split,
+                cold_owner_path=cold_owner,
+                cold_owner_cluster_source=cold_owner_split,
+                resamples=300,
+                seed=99,
+            )
+
+            self.assertEqual(report["schemaVersion"], "woof-compatibility-uncertainty-v1")
+            self.assertTrue(report["policy"]["clusterIdentityFromEvaluationSplits"])
+            self.assertTrue(report["policy"]["splitLabelAgreementRequired"])
+            self.assertEqual(
+                report["futureTest"]["source"]["clusterColumn"],
+                "owner_pair_key",
+            )
+            self.assertEqual(report["coldPair"]["source"]["clusterColumn"], "pair_key")
+            self.assertEqual(
+                report["coldOwner"]["source"]["clusterColumn"],
+                "owner_pair_key",
+            )
+            self.assertEqual(len(report["futureTest"]["source"]["predictionSha256"]), 64)
+            self.assertEqual(len(report["futureTest"]["source"]["clusterSourceSha256"]), 64)
+            self.assertEqual(report["futureTest"]["source"]["clusterJoinKey"], "outcome_id")
+            self.assertTrue(report["futureTest"]["source"]["clusterLabelVerified"])
+            self.assertFalse(report["safety"]["available"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ml/evaluation/uncertainty.py
+++ b/ml/evaluation/uncertainty.py
@@ -1,0 +1,447 @@
+"""Cluster-aware uncertainty evidence for Woof compatibility promotion.
+
+This module consumes paired prediction CSVs emitted by canonical compatibility
+training and the leakage-resistant split files that own relationship identity.
+It bootstraps relationship clusters rather than pretending repeated outcomes
+from the same pair are independent observations.
+
+The resulting report is evidence, not authority. ``promotion_gate.py`` decides
+whether its bounds satisfy the current release policy, and artifact attestation
+then binds that statistical decision to exact model artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import random
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+SCHEMA_VERSION = "woof-compatibility-uncertainty-v1"
+
+
+@dataclass(frozen=True)
+class PredictionRow:
+    label: int
+    baseline: float
+    learned: float
+    cluster: str
+
+
+@dataclass(frozen=True)
+class ClusterIdentity:
+    cluster: str
+    label: int
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _probability(value: str, *, column: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{column} must contain numeric probabilities") from exc
+    if not math.isfinite(result) or not 0.0 <= result <= 1.0:
+        raise ValueError(f"{column} must contain finite probabilities in [0, 1]")
+    return min(max(result, 1e-6), 1.0 - 1e-6)
+
+
+def _label(value: str) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("label must contain binary integers") from exc
+    if result not in (0, 1):
+        raise ValueError("label must contain only 0 or 1")
+    return result
+
+
+def load_cluster_map(path: Path, *, cluster_column: str) -> dict[str, ClusterIdentity]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        required = {"outcome_id", "label", cluster_column}
+        missing = sorted(required.difference(reader.fieldnames or []))
+        if missing:
+            raise ValueError(f"{path} is missing required columns: {missing}")
+
+        result: dict[str, ClusterIdentity] = {}
+        for index, raw in enumerate(reader, start=2):
+            outcome_id = str(raw.get("outcome_id", "")).strip()
+            cluster = str(raw.get(cluster_column, "")).strip()
+            label = _label(str(raw.get("label", "")))
+            if not outcome_id:
+                raise ValueError(f"{path}:{index} has an empty outcome_id")
+            if not cluster:
+                raise ValueError(f"{path}:{index} has an empty {cluster_column}")
+            identity = ClusterIdentity(cluster=cluster, label=label)
+            existing = result.get(outcome_id)
+            if existing is not None and existing != identity:
+                raise ValueError(
+                    f"{path}:{index} maps outcome {outcome_id!r} to conflicting evidence"
+                )
+            result[outcome_id] = identity
+    if not result:
+        raise ValueError(f"{path} contains no cluster identities")
+    return result
+
+
+def load_predictions(
+    path: Path,
+    *,
+    cluster_column: str,
+    cluster_source: Path | None = None,
+    baseline_column: str = "baseline_score",
+    learned_column: str = "learned_score",
+) -> list[PredictionRow]:
+    cluster_map = (
+        load_cluster_map(cluster_source, cluster_column=cluster_column)
+        if cluster_source is not None
+        else None
+    )
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        fields = set(reader.fieldnames or [])
+        required = {"label", baseline_column, learned_column}
+        if cluster_map is None:
+            required.add(cluster_column)
+        else:
+            required.add("outcome_id")
+        missing = sorted(required.difference(fields))
+        if missing:
+            raise ValueError(f"{path} is missing required columns: {missing}")
+
+        rows: list[PredictionRow] = []
+        seen_outcomes: set[str] = set()
+        for index, raw in enumerate(reader, start=2):
+            label = _label(str(raw.get("label", "")))
+            if cluster_map is None:
+                cluster = str(raw.get(cluster_column, "")).strip()
+            else:
+                outcome_id = str(raw.get("outcome_id", "")).strip()
+                if not outcome_id:
+                    raise ValueError(f"{path}:{index} has an empty outcome_id")
+                if outcome_id in seen_outcomes:
+                    raise ValueError(f"{path}:{index} duplicates outcome {outcome_id!r}")
+                seen_outcomes.add(outcome_id)
+                identity = cluster_map.get(outcome_id)
+                if identity is None:
+                    raise ValueError(
+                        f"{path}:{index} outcome {outcome_id!r} is absent from {cluster_source}"
+                    )
+                if identity.label != label:
+                    raise ValueError(
+                        f"{path}:{index} label for outcome {outcome_id!r} disagrees with {cluster_source}"
+                    )
+                cluster = identity.cluster
+            if not cluster:
+                raise ValueError(f"{path}:{index} has no {cluster_column} identity")
+            rows.append(
+                PredictionRow(
+                    label=label,
+                    baseline=_probability(
+                        str(raw.get(baseline_column, "")), column=baseline_column
+                    ),
+                    learned=_probability(
+                        str(raw.get(learned_column, "")), column=learned_column
+                    ),
+                    cluster=cluster,
+                )
+            )
+    if not rows:
+        raise ValueError(f"{path} contains no evaluable prediction rows")
+    return rows
+
+
+def brier(labels_and_scores: Iterable[tuple[int, float]]) -> float:
+    values = [(score - label) ** 2 for label, score in labels_and_scores]
+    if not values:
+        raise ValueError("Brier score requires at least one row")
+    return sum(values) / len(values)
+
+
+def expected_calibration_error(rows: Sequence[PredictionRow], bins: int = 10) -> float:
+    if not rows:
+        raise ValueError("ECE requires at least one row")
+    total = len(rows)
+    result = 0.0
+    for index in range(bins):
+        left = index / bins
+        right = (index + 1) / bins
+        bucket = [
+            row
+            for row in rows
+            if row.learned >= left
+            and (row.learned <= right if index == bins - 1 else row.learned < right)
+        ]
+        if not bucket:
+            continue
+        mean_score = sum(row.learned for row in bucket) / len(bucket)
+        positive_rate = sum(row.label for row in bucket) / len(bucket)
+        result += (len(bucket) / total) * abs(mean_score - positive_rate)
+    return result
+
+
+def point_estimates(rows: Sequence[PredictionRow]) -> dict[str, float]:
+    baseline_brier = brier((row.label, row.baseline) for row in rows)
+    learned_brier = brier((row.label, row.learned) for row in rows)
+    improvement = baseline_brier - learned_brier
+    return {
+        "baselineBrier": baseline_brier,
+        "learnedBrier": learned_brier,
+        "brierImprovement": improvement,
+        "learnedMinusBaselineBrier": -improvement,
+        "learnedEce10": expected_calibration_error(rows),
+    }
+
+
+def percentile(values: Sequence[float], probability: float) -> float:
+    if not values:
+        raise ValueError("percentile requires at least one value")
+    if not 0.0 <= probability <= 1.0:
+        raise ValueError("probability must be in [0, 1]")
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = probability * (len(ordered) - 1)
+    lower = int(math.floor(position))
+    upper = int(math.ceil(position))
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+
+
+def cluster_bootstrap(
+    rows: Sequence[PredictionRow],
+    *,
+    resamples: int,
+    confidence_level: float,
+    seed: int,
+) -> dict[str, object]:
+    if resamples < 200:
+        raise ValueError("resamples must be at least 200")
+    if not 0.80 <= confidence_level < 1.0:
+        raise ValueError("confidence_level must be in [0.80, 1.0)")
+
+    grouped: dict[str, list[PredictionRow]] = {}
+    for row in rows:
+        grouped.setdefault(row.cluster, []).append(row)
+    clusters = sorted(grouped)
+    if len(clusters) < 2:
+        raise ValueError("cluster bootstrap requires at least two distinct clusters")
+
+    rng = random.Random(seed)
+    improvements: list[float] = []
+    regressions: list[float] = []
+    learned_eces: list[float] = []
+    for _ in range(resamples):
+        sampled: list[PredictionRow] = []
+        for _cluster_index in range(len(clusters)):
+            sampled.extend(grouped[clusters[rng.randrange(len(clusters))]])
+        estimates = point_estimates(sampled)
+        improvements.append(estimates["brierImprovement"])
+        regressions.append(estimates["learnedMinusBaselineBrier"])
+        learned_eces.append(estimates["learnedEce10"])
+
+    alpha = 1.0 - confidence_level
+    lower_probability = alpha / 2.0
+    upper_probability = 1.0 - lower_probability
+    return {
+        "method": "paired_cluster_percentile_bootstrap",
+        "seed": seed,
+        "resamples": resamples,
+        "confidenceLevel": confidence_level,
+        "clusterCount": len(clusters),
+        "rowCount": len(rows),
+        "brierImprovement": {
+            "lower": percentile(improvements, lower_probability),
+            "upper": percentile(improvements, upper_probability),
+        },
+        "learnedMinusBaselineBrier": {
+            "lower": percentile(regressions, lower_probability),
+            "upper": percentile(regressions, upper_probability),
+        },
+        "learnedEce10": {
+            "lower": percentile(learned_eces, lower_probability),
+            "upper": percentile(learned_eces, upper_probability),
+        },
+    }
+
+
+def evaluate_prediction_file(
+    path: Path,
+    *,
+    name: str,
+    cluster_column: str,
+    cluster_source: Path | None,
+    resamples: int,
+    confidence_level: float,
+    seed: int,
+    baseline_column: str = "baseline_score",
+    learned_column: str = "learned_score",
+) -> dict[str, object]:
+    rows = load_predictions(
+        path,
+        cluster_column=cluster_column,
+        cluster_source=cluster_source,
+        baseline_column=baseline_column,
+        learned_column=learned_column,
+    )
+    source: dict[str, object] = {
+        "predictionPath": str(path),
+        "predictionSha256": sha256_file(path),
+        "clusterColumn": cluster_column,
+        "baselineColumn": baseline_column,
+        "learnedColumn": learned_column,
+    }
+    if cluster_source is not None:
+        source["clusterSourcePath"] = str(cluster_source)
+        source["clusterSourceSha256"] = sha256_file(cluster_source)
+        source["clusterJoinKey"] = "outcome_id"
+        source["clusterLabelVerified"] = True
+    return {
+        "name": name,
+        "available": True,
+        "source": source,
+        "point": point_estimates(rows),
+        "bootstrap": cluster_bootstrap(
+            rows,
+            resamples=resamples,
+            confidence_level=confidence_level,
+            seed=seed,
+        ),
+    }
+
+
+def build_report(
+    *,
+    future_path: Path,
+    cold_pair_path: Path,
+    cold_owner_path: Path,
+    future_cluster_source: Path | None = None,
+    cold_pair_cluster_source: Path | None = None,
+    cold_owner_cluster_source: Path | None = None,
+    safety_path: Path | None = None,
+    safety_cluster_source: Path | None = None,
+    resamples: int = 4000,
+    confidence_level: float = 0.95,
+    seed: int = 20260827,
+) -> dict[str, object]:
+    required_cluster_sources = (
+        future_cluster_source,
+        cold_pair_cluster_source,
+        cold_owner_cluster_source,
+    )
+    cluster_identity_from_splits = all(source is not None for source in required_cluster_sources)
+    if safety_path is not None:
+        cluster_identity_from_splits = (
+            cluster_identity_from_splits and safety_cluster_source is not None
+        )
+
+    report: dict[str, object] = {
+        "schemaVersion": SCHEMA_VERSION,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "policy": {
+            "pairedRows": True,
+            "relationshipClusterBootstrap": True,
+            "clusterIdentityFromEvaluationSplits": cluster_identity_from_splits,
+            "splitLabelAgreementRequired": cluster_identity_from_splits,
+            "resamples": resamples,
+            "confidenceLevel": confidence_level,
+            "seed": seed,
+        },
+        "futureTest": evaluate_prediction_file(
+            future_path,
+            name="future_test",
+            cluster_column="owner_pair_key",
+            cluster_source=future_cluster_source,
+            resamples=resamples,
+            confidence_level=confidence_level,
+            seed=seed,
+        ),
+        "coldPair": evaluate_prediction_file(
+            cold_pair_path,
+            name="cold_pair",
+            cluster_column="pair_key",
+            cluster_source=cold_pair_cluster_source,
+            resamples=resamples,
+            confidence_level=confidence_level,
+            seed=seed + 1,
+        ),
+        "coldOwner": evaluate_prediction_file(
+            cold_owner_path,
+            name="cold_owner",
+            cluster_column="owner_pair_key",
+            cluster_source=cold_owner_cluster_source,
+            resamples=resamples,
+            confidence_level=confidence_level,
+            seed=seed + 2,
+        ),
+    }
+    report["safety"] = (
+        evaluate_prediction_file(
+            safety_path,
+            name="safety",
+            cluster_column="owner_pair_key",
+            cluster_source=safety_cluster_source,
+            resamples=resamples,
+            confidence_level=confidence_level,
+            seed=seed + 3,
+        )
+        if safety_path is not None
+        else {"name": "safety", "available": False}
+    )
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--future-predictions", type=Path, required=True)
+    parser.add_argument("--future-clusters", type=Path)
+    parser.add_argument("--cold-pair-predictions", type=Path, required=True)
+    parser.add_argument("--cold-pair-clusters", type=Path)
+    parser.add_argument("--cold-owner-predictions", type=Path, required=True)
+    parser.add_argument("--cold-owner-clusters", type=Path)
+    parser.add_argument("--safety-predictions", type=Path)
+    parser.add_argument("--safety-clusters", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--resamples", type=int, default=4000)
+    parser.add_argument("--confidence-level", type=float, default=0.95)
+    parser.add_argument("--seed", type=int, default=20260827)
+    args = parser.parse_args()
+
+    if args.safety_clusters is not None and args.safety_predictions is None:
+        raise SystemExit("--safety-clusters requires --safety-predictions")
+
+    report = build_report(
+        future_path=args.future_predictions,
+        future_cluster_source=args.future_clusters,
+        cold_pair_path=args.cold_pair_predictions,
+        cold_pair_cluster_source=args.cold_pair_clusters,
+        cold_owner_path=args.cold_owner_predictions,
+        cold_owner_cluster_source=args.cold_owner_clusters,
+        safety_path=args.safety_predictions,
+        safety_cluster_source=args.safety_clusters,
+        resamples=args.resamples,
+        confidence_level=args.confidence_level,
+        seed=args.seed,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This release hardens Compatibility model promotion so point-estimate wins cannot directly earn production authority.

## Cluster-aware uncertainty

A new standard-library evaluator consumes paired baseline/learned prediction artifacts and relationship identity from the leakage-resistant evaluation splits. It joins by `outcome_id`, verifies held-out labels agree with the split, hashes both evidence sources, and applies deterministic paired cluster bootstrap resampling.

Cluster policy:

- future temporal test: `owner_pair_key`
- cold-pair test: `pair_key`
- cold-owner test: `owner_pair_key`
- safety cohort, when supplied: `owner_pair_key`

This avoids treating repeated outcomes from one relationship as independent evidence and prevents prediction artifacts from self-declaring their own authoritative cluster identities.

## Uncertainty promotion policy

Authoritative promotion now requires minimum held-out rows and relationship clusters, minimum bootstrap depth and confidence level, confidence-bound Brier/ECE/cold-start safety thresholds, exact split-backed provenance, expected cluster dimensions, and the existing AUC/telemetry/latency/fallback guards.

## Promotion receipt v2 + signed release authority

The statistical receipt is upgraded to `woof-model-promotion-receipt-v2` with `authoritativeEligible` and uncertainty evidence. Research-only runs may omit uncertainty or shadow telemetry but can emit only `research_only`, never `promote`. The release attestor refuses legacy v1, research-only, non-authoritative, failed-uncertainty, missing split-provenance, wrong-cluster-dimension, or wrong-schema evidence.

Architecture contract: `docs/ML_PROMOTION_UNCERTAINTY.md`.

No database migration or product-serving behavior changes are included.

## Exact-head release qualification

Final release candidate: `ae6b2226299c38f48744f5c87d1ff7948639c5af`

The branch was clean-restacked to one commit directly on production base `af297e0fa0816ca5de1a537dbbe2e87b0384582f` and qualified from zero:

- dogOS Compatibility Promotion CI #10: success
- CI Action Runtime Qualification #172: success
- CI #652: success, including static quality, ML policy, backend/API, frontend/browser/accessibility/visual, and API/Web production builds

PR #57 merged with expected-head guard as merge SHA `86731fca23688efbac19a2c4023ee40df8a20bd3`.

## Post-merge deployment incident

The push-triggered production deployment did not reach application deployment. `Deploy to Production` #45 failed during job setup because `.github/workflows/deploy-production.yml` referenced `superfly/flyctl-actions/setup-flyctl@v1.5`, but the upstream repository publishes the release ref as `1.5` (commit `fc53c09e1bc3be6f54706524e3b82c4f462f77be`) and has no `v1.5` ref. The same invalid ref exists in staging. This is being repaired as a separate deployment-infrastructure hotfix from the merged production boundary rather than rewriting this qualified release.