### PR TITLE
Hotfix deployment Fly action pin

### DIFF
--- a/.github/workflows/ci-action-runtime-ci.yml
+++ b/.github/workflows/ci-action-runtime-ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install from committed lockfile
         run: pnpm install --frozen-lockfile
 
-      - name: Enforce maintained action majors across every workflow
+      - name: Enforce maintained and pinned action refs across every workflow
         run: |
           python - <<'PY'
           from pathlib import Path
@@ -55,6 +55,7 @@ jobs:
               'actions/setup-node': 'v7',
               'pnpm/action-setup': 'v6',
               'actions/upload-artifact': 'v7',
+              'superfly/flyctl-actions/setup-flyctl': 'fc53c09e1bc3be6f54706524e3b82c4f462f77be',
           }
 
           workflows = sorted(Path('.github/workflows').glob('*.yml'))
@@ -83,11 +84,24 @@ jobs:
           if violations:
               raise SystemExit('\n'.join(violations))
 
-          required = ['actions/checkout', 'actions/setup-node', 'pnpm/action-setup']
+          required = [
+              'actions/checkout',
+              'actions/setup-node',
+              'pnpm/action-setup',
+              'superfly/flyctl-actions/setup-flyctl',
+          ]
           missing = [action for action in required if seen[action] == 0]
           if missing:
               raise SystemExit(f'missing required maintained action families: {missing}')
           PY
+
+      - name: Exercise pinned Fly.io setup action
+        uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # 1.5
+        with:
+          version: 0.4.76
+
+      - name: Verify pinned Fly.io CLI
+        run: flyctl version | grep -F '0.4.76'
 
       - name: Parse and format-check the complete workflow inventory
         run: pnpm exec prettier --check .github/workflows docs/CI_ACTION_RUNTIME.md
@@ -97,6 +111,7 @@ jobs:
           {
             echo "node=$(node --version)"
             echo "pnpm=$(pnpm --version)"
+            echo "flyctl=$(flyctl version | head -n 1)"
             echo "workflows=$(find .github/workflows -maxdepth 1 -type f -name '*.yml' | wc -l | tr -d ' ')"
           } > /tmp/ci-action-runtime-proof.txt
           cat /tmp/ci-action-runtime-proof.txt

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install pinned Fly.io CLI
-        uses: superfly/flyctl-actions/setup-flyctl@v1.5
+        uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # 1.5
         with:
           version: 0.4.76
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install pinned Fly.io CLI
-        uses: superfly/flyctl-actions/setup-flyctl@v1.5
+        uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # 1.5
         with:
           version: 0.4.76
 

--- a/.github/workflows/dogos-production-runtime-ci.yml
+++ b/.github/workflows/dogos-production-runtime-ci.yml
@@ -274,7 +274,7 @@ jobs:
           ]:
               workflow = Path(workflow_path).read_text()
               required = [
-                  'setup-flyctl@v1.5',
+                  'setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be',
                   'version: 0.4.76',
                   'apps/api/fly.toml',
                   '/api/v1/ops/health/live',
@@ -284,7 +284,12 @@ jobs:
               missing = [token for token in required if token not in workflow]
               if missing:
                   raise SystemExit(f'{workflow_path} missing deterministic deploy invariant: {missing}')
-              for forbidden in ['setup-flyctl@master', 'vercel@latest', 'sleep 10']:
+              for forbidden in [
+                  'setup-flyctl@v1.5',
+                  'setup-flyctl@master',
+                  'vercel@latest',
+                  'sleep 10',
+              ]:
                   if forbidden in workflow:
                       raise SystemExit(f'{workflow_path} contains forbidden deploy pattern: {forbidden}')
           PY


### PR DESCRIPTION
This hotfix repairs the production deployment incident exposed immediately after #57 merged.

## Incident

`Deploy to Production` #45 failed during GitHub Actions job setup before checkout, build, migration, or deployment because the workflow referenced:

`superfly/flyctl-actions/setup-flyctl@v1.5`

The upstream action publishes release `1.5` at immutable commit:

`fc53c09e1bc3be6f54706524e3b82c4f462f77be`

There is no `v1.5` ref. The same invalid action reference was present in staging.

## Fix

- pin production Fly setup to `superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be`
- pin staging to the same immutable upstream commit
- retain the explicit `flyctl` CLI version `0.4.76`
- make CI Action Runtime Qualification enforce the Fly action SHA across workflows
- make that lane execute the exact pinned action and verify `flyctl 0.4.76`
- align dogOS Production Runtime CI with the immutable Fly authority
- explicitly forbid the broken `setup-flyctl@v1.5` and floating `setup-flyctl@master` patterns

No application code, model behavior, database schema, or product UX changes are included.

## Release history

The implementation was semantically qualified on construction head `6aef64c2af4cb060854f791bc4dfaf7b617b491b`, then clean-restacked using the exact qualified tree.

Final release candidate:

`3ad0ac81aec676f17cafed30afa007e6388a27e0`

Production parent:

`86731fca23688efbac19a2c4023ee40df8a20bd3`

The final diff is one commit touching only four workflow files.

## Exact-head qualification

All applicable workflow families were rerun from zero after the restack and completed successfully on `3ad0ac81aec676f17cafed30afa007e6388a27e0`:

- CI Action Runtime Qualification #175: success
  - exact maintained/pinned action refs enforced
  - immutable Fly action resolved and executed
  - `flyctl 0.4.76` verified
  - workflow inventory parsed/formatted
- dogOS Production Runtime CI #48: success
  - deployment contract accepted the immutable Fly pin
  - API type/tests/build passed
  - production Docker image built and passed image contracts
  - production image booted successfully
  - liveness/readiness/request-correlation/docs HTTP contracts passed
- root CI #656: success
  - static formatting/lint/type/ML policy passed
  - backend unit + API tests passed
  - frontend unit + Chromium browser/accessibility/visual contracts passed
  - API + Web production builds passed

After merge, the push-triggered `Deploy to Production` workflow must still be inspected through the real Fly deploy, API health probes, and Vercel production deployment before the incident is considered closed.