### PR TITLE
Harden deployment credential and notification authority

### DIFF
--- a/.github/workflows/ci-action-runtime-ci.yml
+++ b/.github/workflows/ci-action-runtime-ci.yml
@@ -103,21 +103,23 @@ jobs:
           production = Path('.github/workflows/deploy-production.yml').read_text()
           staging = Path('.github/workflows/deploy-staging.yml').read_text()
 
-          secret_ref = lambda name: f'{name}: $' + '{{ secrets.' + name + ' }}'
+          def secret_mapping(env_name: str, secret_name: str | None = None) -> str:
+              secret_name = secret_name or env_name
+              return f'{env_name}: $' + '{{ secrets.' + secret_name + ' }}'
 
           required_production = [
-              secret_ref('FLY_API_TOKEN'),
-              secret_ref('VERCEL_TOKEN'),
-              secret_ref('VERCEL_ORG_ID'),
-              secret_ref('VERCEL_PROJECT_ID'),
+              secret_mapping('FLY_API_TOKEN'),
+              secret_mapping('VERCEL_TOKEN'),
+              secret_mapping('VERCEL_ORG_ID'),
+              secret_mapping('VERCEL_PROJECT_ID'),
               'Validate production API deployment credentials',
               'Validate production Web deployment credentials',
           ]
           required_staging = [
-              secret_ref('FLY_API_TOKEN'),
-              secret_ref('VERCEL_TOKEN'),
-              secret_ref('VERCEL_ORG_ID'),
-              secret_ref('VERCEL_PROJECT_ID'),
+              secret_mapping('FLY_API_TOKEN'),
+              secret_mapping('VERCEL_TOKEN'),
+              secret_mapping('VERCEL_ORG_ID'),
+              secret_mapping('VERCEL_PROJECT_ID'),
               'Validate staging API deployment credentials',
               'Validate staging Web deployment credentials',
           ]
@@ -142,8 +144,7 @@ jobs:
               )
 
           notification_markers = [
-              secret_ref('SLACK_WEBHOOK'),
-              'SLACK_WEBHOOK_URL',
+              secret_mapping('SLACK_WEBHOOK_URL', 'SLACK_WEBHOOK'),
               'continue-on-error: true',
               'skipping optional deployment notification',
           ]

--- a/.github/workflows/ci-action-runtime-ci.yml
+++ b/.github/workflows/ci-action-runtime-ci.yml
@@ -95,6 +95,68 @@ jobs:
               raise SystemExit(f'missing required maintained action families: {missing}')
           PY
 
+      - name: Enforce explicit deployment credential and notification contracts
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          production = Path('.github/workflows/deploy-production.yml').read_text()
+          staging = Path('.github/workflows/deploy-staging.yml').read_text()
+
+          secret_ref = lambda name: f'{name}: $' + '{{ secrets.' + name + ' }}'
+
+          required_production = [
+              secret_ref('FLY_API_TOKEN'),
+              secret_ref('VERCEL_TOKEN'),
+              secret_ref('VERCEL_ORG_ID'),
+              secret_ref('VERCEL_PROJECT_ID'),
+              'Validate production API deployment credentials',
+              'Validate production Web deployment credentials',
+          ]
+          required_staging = [
+              secret_ref('FLY_API_TOKEN'),
+              secret_ref('VERCEL_TOKEN'),
+              secret_ref('VERCEL_ORG_ID'),
+              secret_ref('VERCEL_PROJECT_ID'),
+              'Validate staging API deployment credentials',
+              'Validate staging Web deployment credentials',
+          ]
+
+          missing = [
+              f'production:{marker}'
+              for marker in required_production
+              if marker not in production
+          ] + [
+              f'staging:{marker}'
+              for marker in required_staging
+              if marker not in staging
+          ]
+          if missing:
+              raise SystemExit('deployment credential contract drift:\n' + '\n'.join(missing))
+
+          forbidden = '8398a7/action-slack'
+          if forbidden in production or forbidden in staging:
+              raise SystemExit(
+                  'deployment workflows must not use the legacy action-slack integration; '
+                  'notifications are optional and must not own deployment success'
+              )
+
+          notification_markers = [
+              secret_ref('SLACK_WEBHOOK'),
+              'SLACK_WEBHOOK_URL',
+              'continue-on-error: true',
+              'skipping optional deployment notification',
+          ]
+          notification_missing = [
+              marker for marker in notification_markers if marker not in production
+          ]
+          if notification_missing:
+              raise SystemExit(
+                  'production notification contract drift:\n'
+                  + '\n'.join(notification_missing)
+              )
+          PY
+
       - name: Exercise pinned Fly.io setup action
         uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # 1.5
         with:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -5,13 +5,30 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   deploy-api-production:
     name: Deploy API to Production
     runs-on: ubuntu-latest
     environment: production
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
     steps:
       - uses: actions/checkout@v7
+
+      - name: Validate production API deployment credentials
+        run: |
+          if [[ -z "${FLY_API_TOKEN}" ]]; then
+            echo "::error title=Missing production secret::FLY_API_TOKEN is not configured for the production environment. Add a Fly deploy token before rerunning this workflow."
+            exit 1
+          fi
 
       - name: Install pinned Fly.io CLI
         uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # 1.5
@@ -24,8 +41,6 @@ jobs:
           --remote-only
           --app woof-api-prod
           --config apps/api/fly.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Verify API liveness and readiness
         run: |
@@ -34,43 +49,81 @@ jobs:
           curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 \
             https://woof-api-prod.fly.dev/api/v1/ops/health/ready
 
-      - name: Notify deployment
-        uses: 8398a7/action-slack@v3
-        if: always()
-        with:
-          status: ${{ job.status }}
-          text: 'Production API deployment completed'
-          webhook_url: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Notify production API deployment when configured
+        if: ${{ always() }}
+        continue-on-error: true
+        env:
+          DEPLOYMENT_STATUS: ${{ job.status }}
+        run: |
+          if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
+            echo "SLACK_WEBHOOK is not configured; skipping optional deployment notification."
+            exit 0
+          fi
+
+          payload=$(printf '{"text":"Woof production API deployment: %s (%s @ %.12s)"}' \
+            "${DEPLOYMENT_STATUS}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}")
+          curl --fail --silent --show-error \
+            -H 'Content-Type: application/json' \
+            --data "${payload}" \
+            "${SLACK_WEBHOOK_URL}"
 
   deploy-web-production:
     name: Deploy Web to Production
     runs-on: ubuntu-latest
     environment: production
     needs: deploy-api-production
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
     steps:
       - uses: actions/checkout@v7
+
+      - name: Validate production Web deployment credentials
+        run: |
+          missing=0
+          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error title=Missing production secret::${name} is not configured for the production environment."
+              missing=1
+            fi
+          done
+          if [[ "${missing}" -ne 0 ]]; then
+            exit 1
+          fi
 
       - name: Install pinned Vercel CLI
         run: npm install --global vercel@58.4.4
 
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=production --token="${VERCEL_TOKEN}"
         working-directory: apps/web
 
       - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --prod --token="${VERCEL_TOKEN}"
         working-directory: apps/web
         env:
           NEXT_PUBLIC_API_URL: https://woof-api-prod.fly.dev/api/v1
 
       - name: Deploy to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --prod --token="${VERCEL_TOKEN}"
         working-directory: apps/web
 
-      - name: Notify deployment
-        uses: 8398a7/action-slack@v3
-        if: always()
-        with:
-          status: ${{ job.status }}
-          text: 'Production Web deployment completed'
-          webhook_url: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Notify production Web deployment when configured
+        if: ${{ always() }}
+        continue-on-error: true
+        env:
+          DEPLOYMENT_STATUS: ${{ job.status }}
+        run: |
+          if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
+            echo "SLACK_WEBHOOK is not configured; skipping optional deployment notification."
+            exit 0
+          fi
+
+          payload=$(printf '{"text":"Woof production Web deployment: %s (%s @ %.12s)"}' \
+            "${DEPLOYMENT_STATUS}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}")
+          curl --fail --silent --show-error \
+            -H 'Content-Type: application/json' \
+            --data "${payload}" \
+            "${SLACK_WEBHOOK_URL}"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,13 +4,29 @@ on:
   push:
     branches: [develop]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
 jobs:
   deploy-api-staging:
     name: Deploy API to Staging
     runs-on: ubuntu-latest
     environment: staging
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
     steps:
       - uses: actions/checkout@v7
+
+      - name: Validate staging API deployment credentials
+        run: |
+          if [[ -z "${FLY_API_TOKEN}" ]]; then
+            echo "::error title=Missing staging secret::FLY_API_TOKEN is not configured for the staging environment. Add a Fly deploy token before rerunning this workflow."
+            exit 1
+          fi
 
       - name: Install pinned Fly.io CLI
         uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # 1.5
@@ -23,8 +39,6 @@ jobs:
           --remote-only
           --app woof-api-staging
           --config apps/api/fly.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Verify API liveness and readiness
         run: |
@@ -38,22 +52,39 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     needs: deploy-api-staging
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v7
+
+      - name: Validate staging Web deployment credentials
+        run: |
+          missing=0
+          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error title=Missing staging secret::${name} is not configured for the staging environment."
+              missing=1
+            fi
+          done
+          if [[ "${missing}" -ne 0 ]]; then
+            exit 1
+          fi
 
       - name: Install pinned Vercel CLI
         run: npm install --global vercel@58.4.4
 
       - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=preview --token="${VERCEL_TOKEN}"
         working-directory: apps/web
 
       - name: Build Project Artifacts
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --token="${VERCEL_TOKEN}"
         working-directory: apps/web
         env:
           NEXT_PUBLIC_API_URL: https://woof-api-staging.fly.dev/api/v1
 
       - name: Deploy to Vercel
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --token="${VERCEL_TOKEN}"
         working-directory: apps/web

--- a/docs/CI_ACTION_RUNTIME.md
+++ b/docs/CI_ACTION_RUNTIME.md
@@ -15,9 +15,11 @@ These maintained action lines use the current GitHub Actions Node 24 execution g
 
 The repository does not use removed `actions/setup-node` inputs such as `always-auth`, and it does not depend on an `actions/download-artifact@v4` workflow contract.
 
+The Fly CLI setup action is additionally pinned to immutable upstream commit `fc53c09e1bc3be6f54706524e3b82c4f462f77be`, while the installed `flyctl` binary remains pinned to `0.4.76`. Deployment workflows must not float this action independently of the qualification lane.
+
 ## Product toolchain remains unchanged
 
-This release does **not** migrate the application runtime.
+This contract does **not** migrate the application runtime.
 
 Woof continues to build and test with:
 
@@ -26,7 +28,23 @@ Woof continues to build and test with:
 
 `actions/setup-node@v7` installs that exact project Node version. `pnpm/action-setup@v6` installs that exact pnpm version.
 
-The release also leaves Fly CLI, Vercel CLI, Docker image Node, database migrations, dependency lockfiles, and deployment behavior unchanged.
+## Deployment credential authority
+
+Staging and production deployment workflows fail before deployment work when their required deployment identity is absent.
+
+The API deployment requires:
+
+- `FLY_API_TOKEN`
+
+The Web deployment requires:
+
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
+
+Those values belong in the corresponding GitHub environment or repository secret store. The workflow does not invent fallback credentials, run an interactive login, or silently create/link a Vercel project when release identity is unknown.
+
+Production Slack notification is optional. `SLACK_WEBHOOK` may be omitted without changing deployment success. The notification path uses a small `curl` webhook request and is `continue-on-error`; an unavailable notification sink cannot turn a successful API/Web release into a failed deployment. The legacy `8398a7/action-slack` integration is forbidden because its old input/runtime contract both drifted from the workflow and obscured the actual deployment result.
 
 ## Executable drift guard
 
@@ -34,13 +52,17 @@ The release also leaves Fly CLI, Vercel CLI, Docker image Node, database migrati
 
 1. uses the maintained checkout, pnpm, setup-node, and artifact-upload actions itself;
 2. proves the project runtime resolves to Node `20.20.2` and pnpm `8.15.1`;
-3. scans every workflow and rejects an unapproved major for the four standardized action families;
-4. runs Prettier over the complete workflow inventory so malformed YAML cannot pass silently;
-5. performs a frozen lockfile install; and
-6. uploads a one-day qualification artifact so `actions/upload-artifact@v7` is exercised on a successful path.
+3. scans every workflow and rejects an unapproved major for the standardized action families or an unapproved Fly setup ref;
+4. checks staging and production for explicit Fly/Vercel credential preflight contracts;
+5. rejects the legacy Slack action and verifies notification failure cannot own production release success;
+6. runs Prettier over the complete workflow inventory so malformed YAML cannot pass silently;
+7. performs a frozen lockfile install; and
+8. uploads a one-day qualification artifact so `actions/upload-artifact@v7` is exercised on a successful path.
 
-A future action-major change should be an explicit, qualified infrastructure release rather than silent version drift.
+A future action-major, deployment-identity, or notification-contract change should be an explicit, qualified infrastructure release rather than silent version drift.
 
 ## Release qualification
 
 Changing shared workflow infrastructure has a wide ownership surface. A release is qualified only when every workflow actually triggered by the PR completes successfully on one frozen exact head SHA. Earlier diagnostic heads do not count.
+
+Passing CI proves the deployment workflow is structurally executable. It does **not** prove external deployment credentials exist in a GitHub environment. A real push/dispatch deployment remains the final integration proof, including Fly deployment, API liveness/readiness, and the Vercel production release.


### PR DESCRIPTION
The post-#58 production deployment still failed on `main` after Fly setup succeeded. The exact run showed `FLY_API_TOKEN` resolving empty, so `flyctl deploy` exited before deployment. The same job then produced a second, unrelated failure because the legacy Slack action was configured with an unsupported `webhook_url` input and expected a different secret contract.

This PR turns that incident into an explicit deployment boundary instead of another one-off patch.

## Required deployment identity

Production and staging now fail before deployment work when required credentials are absent:

- API: `FLY_API_TOKEN`
- Web: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`

Vercel organization/project identity is explicit so CI cannot silently depend on ambient CLI linking or accidentally create/link the wrong project.

## Notification isolation

Production Slack notification is optional and can no longer make a successful deployment fail.

- removes `8398a7/action-slack@v3`
- uses a minimal webhook `curl` only when `SLACK_WEBHOOK` is configured
- `continue-on-error: true`
- missing Slack configuration is a clean skip

## Deployment concurrency

Staging and production have explicit non-cancelling deployment concurrency groups, preventing a newer push from aborting an in-flight migration/release half way through.

## Permanent CI contract

`CI Action Runtime Qualification` now verifies:

- immutable Fly setup pin remains present
- production/staging keep explicit required secret refs and preflight steps
- legacy Slack action cannot reappear
- optional notification semantics remain non-authoritative
- complete workflow inventory still passes Prettier

The contract is documented in `docs/CI_ACTION_RUNTIME.md`.

## External configuration still required

This code cannot manufacture deployment credentials. Before a production rerun can succeed, the GitHub `production` environment (or repository secret store) must contain a valid `FLY_API_TOKEN`; the Web job additionally requires the three Vercel values above. `SLACK_WEBHOOK` remains optional.

This PR does not change application code, database schema, model behavior, or product UX.