### PR TITLE
Make UI lint toolchain deterministic

### DIFF
--- a/.github/workflows/ui-lint-toolchain-ci.yml
+++ b/.github/workflows/ui-lint-toolchain-ci.yml
@@ -1,0 +1,64 @@
+name: UI Lint Toolchain Qualification
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/ui/**'
+      - 'packages/config/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/ui-lint-toolchain-ci.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ui-lint-toolchain-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  ESLINT_VERSION: 'v8.57.1'
+
+jobs:
+  qualify:
+    name: Lockfile-owned UI lint executor
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from committed lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Prove UI lint delegates to the config-owned executor
+        run: |
+          node - <<'NODE'
+          const pkg = require('./packages/ui/package.json');
+          const expected = 'pnpm --dir ../config exec eslint "../ui/src/**/*.{ts,tsx}" --max-warnings=0';
+          if (pkg.scripts?.lint !== expected) {
+            throw new Error(`Unexpected @woof/ui lint command: ${pkg.scripts?.lint}`);
+          }
+          NODE
+
+      - name: Verify exact lockfile-owned ESLint version
+        run: |
+          resolved="$(pnpm --dir packages/config exec eslint --version)"
+          test "${resolved}" = "${ESLINT_VERSION}"
+          echo "@woof/ui lint executor: ${resolved}"
+
+      - name: Run UI lint through its package contract
+        run: pnpm --filter @woof/ui lint
+
+      - name: Verify UI package metadata formatting
+        run: pnpm exec prettier --check packages/ui/package.json .github/workflows/ui-lint-toolchain-ci.yml

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,7 +11,7 @@
     "./components": "./src/components/index.ts"
   },
   "scripts": {
-    "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0",
+    "lint": "pnpm --dir ../config exec eslint \"../ui/src/**/*.{ts,tsx}\" --max-warnings=0",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
Closes #39.

`@woof/ui` previously ran a bare `eslint` command without declaring or otherwise owning the executable. On clean GitHub-hosted runners this could resolve an ambient ESLint 9 binary even though Woof's shared config owns ESLint 8.57.1 in the committed lockfile.

This PR removes that ambient dependency without duplicating toolchain packages or changing the lockfile.

## Change

`@woof/ui` now delegates lint execution to the existing `@woof/config` workspace:

`pnpm --dir ../config exec eslint "../ui/src/**/*.{ts,tsx}" --max-warnings=0`

The linted source and zero-warning policy are unchanged. The only authority change is where the executable/plugins come from.

## Dedicated qualification

Adds `UI Lint Toolchain Qualification` on Ubuntu 24.04. After a frozen-lockfile install it proves:

- the UI package still uses the explicit config-owned lint command
- the resolved executable is exactly ESLint `v8.57.1`
- the actual `@woof/ui` lint script passes
- changed package/workflow metadata is Prettier-clean

Root CI remains responsible for the broader monorepo lint/type/test/build surface.