### PR TITLE
Align Woof public narrative with the current dogOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Woof 🐾
 
-### A full-stack pet social coordination system for turning online compatibility into safer, repeatable real-world dog friendships.
+**A relationship-first pet companion that helps people choose one useful thing to do with their dog, learn from how it went, and make the next shared moment easier.**
 
 [![Next.js](https://img.shields.io/badge/Next.js-15.3-000000?logo=nextdotjs)](apps/web)
 [![NestJS](https://img.shields.io/badge/NestJS-10-E0234E?logo=nestjs)](apps/api)
@@ -8,312 +8,251 @@
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-pgvector-4169E1?logo=postgresql)](packages/database)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript)](package.json)
 
-> **Portfolio case study.** Woof is intentionally broader than a CRUD social app. It explores product design, social graph modeling, geospatial coordination, trust and safety, activity telemetry, realtime systems, experimentation, and ML-assisted matching in one coherent product surface.
+Woof began as a pet socialization and compatibility project. The current codebase has evolved into a broader **dogOS** experiment: a hardware-agnostic longitudinal context layer for everyday dog life.
 
-## The product thesis
+The product is deliberately not a diagnosis engine, an engagement-maximizing feed, or a universal pet score. Its central question is simpler:
 
-Dog owners do not really need another feed. They need help answering a harder question:
+> **What would be a good thing for this dog and person to do together right now, why, and what should Woof learn from the outcome?**
 
-**Who nearby is a genuinely good fit for my dog, when should we meet, where should we go, and did the match actually work in the real world?**
+This repository is an active engineering and product research project. It contains production-oriented infrastructure and strongly qualified subsystems, but it should not be interpreted as a clinically validated veterinary product or a claim of broad public-production readiness.
 
-Woof is designed around that loop:
+---
+
+## Product thesis
+
+Woof is built around one relationship loop:
+
+```text
+notice -> choose -> do together -> read the response -> adapt -> remember -> make next time easier
+```
+
+A screen earns its place when it helps the owner:
+
+- choose a useful shared action,
+- notice what the dog is communicating,
+- handle, reinforce, or pace an activity more clearly,
+- adapt difficulty or context,
+- preserve evidence that should improve a later decision.
+
+The dog and human are both part of the system. Their outcomes can disagree, and Woof keeps those signals separate instead of collapsing them into one opaque score.
 
 ```mermaid
 flowchart LR
-  A[Pet + owner context] --> B[Compatibility ranking]
-  B --> C[Discovery]
-  C --> D[Conversation]
-  D --> E[Meetup proposal]
-  E --> F[IRL activity]
-  F --> G[Outcome feedback]
-  G --> H[Relationship graph]
+  A[Pair context] --> B[Today recommendation]
+  B --> C[Adventure / Coach]
+  C --> D[Dog + owner outcome]
+  D --> E[Adaptive profile + evidence]
+  E --> F[Learning receipt / Story]
+  F --> B
+  G[Daily Signals] --> H[Individual baseline]
   H --> B
+  H -. bounded context .-> I[Health Lens / Concierge]
 ```
 
-The interesting engineering problem is not recommendation in isolation. It is building a system that can **learn from real-world social outcomes while remaining useful before the ML is perfect**.
+The guiding product principles live in [`docs/RELATIONSHIP_FIRST_PRODUCT_PRINCIPLES.md`](docs/RELATIONSHIP_FIRST_PRODUCT_PRINCIPLES.md).
 
 ---
 
-## What this project demonstrates
+## What is on `main` today
 
-Woof is a monorepo containing a web product, native mobile client, API, relational and graph-oriented data model, realtime messaging, automation workflows, observability hooks, and an experimental ML service.
+Woof uses explicit maturity boundaries. **Implemented** means the canonical path exists. **Qualified** means dedicated tests/CI enforce the stated contract. **Shadow** means a capability may produce evidence but has intentionally limited authority. **Planned** means the roadmap exists but the release is not complete.
 
-| Area | What is implemented | Why it matters |
+| Capability | State | Current role |
 | --- | --- | --- |
-| Product UX | Feed, discovery, pet profiles, events, activity tracking, messaging, services, gamification | Demonstrates a complete multi-surface consumer product rather than isolated screens |
-| Web | Next.js App Router, React Query, Zustand, Tailwind, Radix primitives, PWA support | Modern server/client architecture with reusable accessible UI |
-| Mobile | Expo / React Native client with native navigation, location, maps, camera and notifications | Shows platform-aware product thinking beyond responsive web |
-| Backend | NestJS modular API, JWT auth, Socket.IO, validation, rate limiting, storage integrations | Separates domain concerns and supports synchronous and realtime workloads |
-| Data | PostgreSQL + Prisma + pgvector, pet relationship edges, activities, events, feedback and goals | Models transactional state plus future learning signals |
-| Matching | Deterministic compatibility baseline plus an experimental Python ML service | Core behavior stays stable during cold start or model-service failure |
-| Experimentation | A/B testing and outcome-oriented analytics concepts | Ranking changes can be judged on behavior rather than offline metrics alone |
-| Operations | Docker, CI, Sentry hooks and deployment configuration | Treats reliability and deployment as product concerns |
+| First Adventure onboarding | Implemented + qualified | Creates the account/pet first, then asks only a few optional high-value personalization questions. Sparse profiles never block first use. |
+| Today | Implemented + qualified | Action-first home surface with one primary shared recommendation and subordinate alternatives/supporting context. |
+| Adventure | Implemented + qualified | Shared activities, outcomes, safe opt-outs, Bond XP, pathway context, and bounded recommendation adaptation. |
+| Adaptive Profile | Implemented + qualified | Pair-scoped evidence with provenance, uncertainty, corrections, skip/not-sure semantics, and deterministic progressive-question policy. |
+| Adventure learning v2 | Implemented + qualified | Learns bounded recommendation-fit signals from canonical outcomes while keeping reward authority and temporary owner load separate. |
+| Daily Signals + individual baseline substrate | Implemented + qualified backend | Canonical private check-ins, evidence projection, and deterministic longitudinal baseline policy. The richer Today capture/correction UX remains roadmap work. |
+| Coach | Implemented v1 | Reward-based practice flow. A deeper individualized skill graph and relationship-mastery model remain planned. |
+| Health Lens | Implemented + safety hardened | Conservative photo/context screening and handoff support with deterministic emergency boundaries and explicit model provenance. Not a diagnostic product. |
+| Behavior Vision | Shadow only | Derived behavior evidence with active-release attestation. It has zero Compatibility, safety, or canonical pet-state authority. |
+| Compatibility + Discovery | Implemented | Social matching remains a supporting capability with deterministic fallback and tightly governed learned-model promotion. |
+| Realtime messaging | Implemented + heavily qualified | Runtime payload validation, relationship authorization, bounded abuse control, finite session leases, persisted revocation, and private delivery rules. |
+| Session authority | Implemented + qualified | Persisted server-owned login sessions support immediate logout/logout-all revocation across protected HTTP and new realtime work. |
+| Deployment | Configured + qualified structurally | Fly API and Vercel Web workflows use explicit health/readiness gates. External deployment credentials remain environment-owned configuration. |
 
-### Maturity labels
-
-To keep the project technically honest, I use explicit maturity language:
-
-- **Implemented**: code is present in the canonical product path.
-- **Integrated**: multiple subsystems are connected through that path.
-- **Experimental**: research/prototype code exists but should not be interpreted as production evidence.
-- **Planned**: architectural direction only.
-
-The GNN, temporal, similarity and ensemble work under [`ml/`](ml/) is intentionally presented as **experimental ML research** until it clears the same integration, calibration and outcome gates as the deterministic baseline.
+The project intentionally resists making every experimental model authoritative simply because it can produce a score.
 
 ---
 
-## Product experience
+## The authority model
 
-### 1. Discover compatible dogs, not just nearby users
+A recurring design rule in Woof is that **different facts have different owners**.
 
-A match is modeled as a relationship between pets, with owner context layered around it. The current baseline can use persisted profile attributes and exposes **score provenance, confidence, factor breakdown and human-readable reasons** instead of an unexplained percentage.
+### Recommendation authority is not reward authority
 
-### 2. Move from recommendation to coordination
+Bond XP is a game mechanic. It is not a recommendation label.
 
-Discovery connects to conversation, events and meetup proposals. The product is designed to reduce the gap between “this looks promising” and “we actually met at the park.”
+Adventure learning distinguishes:
 
-### 3. Capture the signal most social products throw away
+- what activity/pathway Woof recommended,
+- where the reward policy placed XP,
+- how the dog appeared to experience the activity,
+- how burdensome the activity felt to the human,
+- whether stopping was the correct welfare-respecting choice.
 
-The strongest compatibility label is not a swipe. It is what happened after the dogs met:
+A dog loving an activity while the owner says it was a lot today can therefore produce two simultaneous truths: durable positive dog-fit evidence and temporary lower-effort context.
 
-- Did both owners attend?
-- Did the dogs play successfully?
-- Was a slow introduction needed?
-- Did the pair meet again?
-- Did either owner mark the relationship as avoid?
-- Did the meetup lead to more joint activity?
+See [`docs/DOGOS_ADVENTURE_LEARNING_V2.md`](docs/DOGOS_ADVENTURE_LEARNING_V2.md).
 
-Those outcomes can become relationship edges, ranking labels and trust signals.
+### Model output is not release authority
 
-### 4. Build habits around shared activity
+Learned systems follow an `off -> shadow -> promoted` ladder with deterministic fallback. Promotion is tied to versioned evidence and exact release identity rather than a model declaring itself trustworthy.
 
-Walks, runs, hikes, play sessions, goals, streaks and events make Woof useful even when a user is not actively searching for a new friend. This creates a healthier retention loop than endless feed consumption.
+Compatibility promotion includes leakage-resistant evaluation, calibration/safety gates, cluster-aware uncertainty, artifact identity, and signed promotion receipts. Behavior Vision independently verifies the release the worker is actually serving before its evidence can contribute to current longitudinal learning.
 
----
+### Baseline context is not medical authority
 
-## Frontend and design system
+Woof can learn an individual dog's recent pattern without turning that pattern into a disease probability or universal wellness score. Missing evidence remains missing; stale evidence remains stale; disagreement reduces authority.
 
-The web experience is designed as a **mobile-first companion product** with a desktop-capable shell rather than a pile of unrelated demo pages.
-
-Portfolio hardening focused the visual system around a calm deep-neutral foundation, warm amber action color, teal compatibility/success signal, stronger information hierarchy, and fewer competing navigation destinations.
-
-Design principles:
-
-1. **Calm over noisy.** Social, location and compatibility information is already dense; the interface should reduce visual competition.
-2. **Explain the recommendation.** Compatibility surfaces reasons, confidence and uncertainty where possible.
-3. **Action near context.** Message, meetup and activity actions sit close to the pet or event that motivated them.
-4. **Accessible by default.** Visible focus, semantic controls, minimum touch targets, skip navigation and reduced-motion behavior are requirements.
-5. **One product identity.** Earlier code mixed “PetPath” and “Woof”; the canonical application now standardizes on **Woof**.
-6. **Useful failure states.** Feed and recommendation failures degrade locally instead of turning the entire product into a dead end.
-7. **Mobile navigation is scarce real estate.** The primary bar is intentionally reduced to Home, Discover, Create, Inbox and Profile; secondary destinations stay contextual.
-
-The home experience now begins with user intent: **find a match, plan a meetup, log activity, or review progress**. The feed becomes one useful surface rather than the whole product.
+Health Lens retains its own deterministic emergency boundary and cannot be made less urgent by a model or baseline summary.
 
 ---
 
-## Architecture
+## First Adventure
 
-```mermaid
-flowchart TB
-  subgraph Clients
-    WEB[Next.js Web / PWA]
-    MOBILE[Expo React Native]
-  end
+The canonical onboarding path is intentionally small:
 
-  subgraph Application
-    API[NestJS API]
-    WS[Socket.IO realtime]
-    JOBS[Scheduled + automation jobs]
-  end
+1. create the human account,
+2. create the authorized pet/household pair,
+3. optionally answer a few questions that can materially improve the first recommendation,
+4. enter the real Today/Adventure loop.
 
-  subgraph Intelligence
-    BASE[Deterministic compatibility baseline]
-    MLSVC[FastAPI ML service]
-    MODELS[GNN / temporal / ensemble experiments]
-  end
+Account and pet creation have separate replay identities so uncertain/lost HTTP responses can be retried without silently creating duplicates. Browser recovery state is only a hint; the server re-authorizes the pair before resuming.
 
-  subgraph Data
-    PG[(PostgreSQL)]
-    VECTOR[(pgvector)]
-    OBJECT[(S3 / R2)]
-  end
+See [`docs/FIRST_ADVENTURE_RELEASE.md`](docs/FIRST_ADVENTURE_RELEASE.md).
 
-  WEB --> API
-  MOBILE --> API
-  WEB <--> WS
-  MOBILE <--> WS
-  API --> PG
-  API --> VECTOR
-  API --> OBJECT
-  API --> BASE
-  API -. experimental .-> MLSVC
-  MLSVC --> MODELS
-  JOBS --> API
-```
+---
 
-### Canonical repository map
+## Today and Adventure
+
+Today is designed around one decision rather than a dashboard wall:
+
+- **What should we do?**
+- **Why does it fit now?**
+- **How should I approach it?**
+- **What happened afterward?**
+
+Alternatives remain available but visually subordinate. Concierge and game progress support the recommendation rather than competing for top-level attention.
+
+Adventure outcomes distinguish dog experience, owner experience, and safe opt-outs. Temporary hard days can make future suggestions gentler without being converted into permanent dog traits.
+
+---
+
+## Longitudinal intelligence
+
+The dogOS intelligence layer separates canonical occurrence truth from a derived read model.
+
+Current foundations include:
+
+- private Daily Signals check-ins,
+- household/timezone-aware local-day identity,
+- replay-safe evidence projection,
+- explicit evidence provenance,
+- correction/supersession semantics,
+- deterministic per-dimension baseline policy,
+- sparse / learning / established / stale states,
+- bounded recent and baseline windows,
+- explicit uncertainty and source disagreement.
+
+The next user-facing work is not “invent a smarter health score.” It is to make these foundations useful through calm capture, correction, explanation, and bounded cross-product context.
+
+Relevant contracts:
+
+- [`docs/DOGOS_INTELLIGENCE_BASELINE_POLICY_V1.md`](docs/DOGOS_INTELLIGENCE_BASELINE_POLICY_V1.md)
+- [`docs/DOGOS_INTELLIGENCE_EVIDENCE_PROJECTION_V1.md`](docs/DOGOS_INTELLIGENCE_EVIDENCE_PROJECTION_V1.md)
+- [`docs/DOGOS_INTELLIGENCE_DAILY_SIGNALS_CAPTURE_V1.md`](docs/DOGOS_INTELLIGENCE_DAILY_SIGNALS_CAPTURE_V1.md)
+
+---
+
+## Health Lens
+
+Health Lens is a privacy-conscious screening/documentation surface, not automated veterinary diagnosis.
+
+Its architecture keeps several boundaries explicit:
+
+- deterministic emergency/red-flag screening runs before model analysis,
+- model output can escalate but cannot downgrade emergency authority,
+- unsafe treatment directives are rejected server-side,
+- raw image bytes are transient rather than stored in the ordinary social-media path,
+- derived assessments carry model/provider/policy provenance when a model was used,
+- model-unavailable paths fail conservatively rather than fabricating image findings.
+
+The long-term goal is better observation and professional handoff, not replacing veterinary care.
+
+---
+
+## Behavior Vision
+
+Behavior Vision is deliberately **shadow evidence**.
+
+The specialized worker and API must agree on the exact active release identity before observations can contribute to the current profile. Older qualified releases remain auditable history but no longer influence active longitudinal learning after a new release becomes authoritative.
+
+Behavior Vision cannot currently:
+
+- drive Compatibility,
+- mutate canonical pet state,
+- make safety decisions,
+- self-promote,
+- convert social orientation into a dog-to-dog greeting claim.
+
+This is intentional. The system is designed so a promising model can be useful before it is trusted with product authority.
+
+---
+
+## Social compatibility is now a supporting loop
+
+Woof still contains the social graph, compatibility, discovery, conversation, meetup, and outcome ideas that the project started with.
+
+The difference is hierarchy. Finding another dog is one possible shared-life capability, not the product's entire identity.
+
+Compatibility remains interesting because real-world outcomes can become relationship evidence. But the product should still be useful on a day when the owner has no interest in finding a new dog friend.
+
+---
+
+## Repository architecture
 
 ```text
 woof/
 ├── apps/
-│   ├── web/             # Next.js 15 web/PWA client
-│   ├── mobile/          # Expo React Native client
-│   └── api/             # NestJS application API
+│   ├── api/             # NestJS API, domain services, realtime, dogOS policies
+│   ├── web/             # Next.js web/PWA product
+│   └── mobile/          # Expo / React Native client
 ├── packages/
-│   ├── database/        # Prisma schema + PostgreSQL/pgvector access
-│   ├── ui/              # Shared UI primitives
-│   └── config/          # Shared tooling configuration
-├── ml/                  # Experimental training + FastAPI inference work
-├── n8n/                 # Automation workflows
-├── infra/               # Deployment/infrastructure configuration
-├── docs/                # Canonical architecture, product and ML documentation
-└── legacy/              # Preserved pre-monorepo prototypes, not active entry points
+│   ├── database/        # Prisma + PostgreSQL/pgvector
+│   ├── ui/              # shared UI primitives
+│   └── config/          # shared TypeScript/ESLint configuration
+├── ml/                  # model training/evaluation + specialized workers
+├── docs/                # executable architecture/product/release contracts
+├── infra/               # infrastructure configuration
+├── n8n/                 # automation workflows
+└── legacy/              # preserved early prototypes, not canonical runtime
 ```
 
-Historical milestone reports are preserved under [`docs/archive/`](docs/archive/) rather than competing with the current project entry point.
-
-For the deeper walkthrough, see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+At runtime, PostgreSQL remains the source of transactional/authorization truth. Derived intelligence projections and learned-model outputs do not replace canonical state ownership.
 
 ---
 
-## Matching architecture: useful before “AI”, extensible after it
+## Engineering posture
 
-A portfolio-quality ML product should not require a model server just to behave coherently.
+This repository has become intentionally strict about the difference between **a feature existing** and **a feature earning authority**.
 
-### Layer 0: deterministic product baseline
+Current quality practices include:
 
-The canonical API now computes a repeatable compatibility estimate instead of the historical random placeholder. The baseline:
+- committed `pnpm-lock.yaml`,
+- frozen-lockfile CI installs,
+- zero-warning lint lanes,
+- whole-monorepo TypeScript checks,
+- unit and PostgreSQL integration contracts,
+- Playwright browser/accessibility/visual contracts,
+- production API and Web builds,
+- production Docker boot/HTTP/Socket.IO proofs on high-risk backend surfaces,
+- immutable/pinned critical CI action contracts,
+- explicit policy/release receipts for sensitive deterministic and learned systems.
 
-- rejects self-matches,
-- uses only available persisted pet signals,
-- weights breed lightly rather than treating it as destiny,
-- recalculates legacy edge recommendations deterministically,
-- returns `source`, `confidence`, `factors`, and `explanation`,
-- provides a stable control for future model evaluation.
-
-This matters for debugging, regression testing, cold start, graceful degradation and honest ML comparison.
-
-### Layer 1: learned representations
-
-The database includes vector support so learned representations can be attached to pet/product entities without replacing transactional state.
-
-### Layer 2: experimental graph and temporal models
-
-The [`ml/`](ml/) package explores graph attention, graph similarity, temporal modeling, diffusion and ensembles. These are research artifacts until they clear an explicit promotion gate.
-
-### Layer 3: outcome calibration
-
-The real objective is not “high offline similarity.” It is better real-world outcomes: accepted matches, completed meetups, positive post-meetup feedback, repeat interactions and safe long-term graph formation.
-
-See [`docs/ML_SYSTEM.md`](docs/ML_SYSTEM.md) for evidence levels E0 through E5, split strategy, metrics, serving requirements and promotion gates.
-
----
-
-## Data model and learning flywheel
-
-The schema stores both **entities** and **relationships**.
-
-Core entities include users, pets, activities, meetups, events, services, posts and conversations. `PetEdge` represents the evolving relationship between two pets and can carry compatibility, interaction and status information.
-
-```text
-profile features
-    ↓
-candidate generation
-    ↓
-compatibility ranking
-    ↓
-message / meetup
-    ↓
-attendance + activity + feedback
-    ↓
-relationship edge update
-    ↓
-future ranking / experimentation
-```
-
-The central idea is that **the product itself becomes an instrumentation system for better future matching**.
-
----
-
-## Full-scale engineering considerations
-
-The codebase is intentionally designed around the questions a real local social network eventually faces.
-
-### Geospatial scale
-
-Nearby discovery should eventually use indexed geospatial search, constrained candidate generation, locality-aware caches and deliberately reduced public location precision.
-
-### Social graph scale
-
-Relationship edges grow much faster than users. The system should never materialize every possible pet pair. Confirmed/observed edges plus approximate candidate generation are more tractable.
-
-### Realtime messaging
-
-Socket connections are stateful. A scaled topology needs shared pub/sub, reconnect catch-up, authorization on room joins, idempotent persistence and backpressure-aware fanout.
-
-### ML serving
-
-Inference is separated from the main API so model dependencies can evolve independently. Production promotion should require latency, calibration, fallback behavior and measured outcome lift, not an impressive model class name.
-
-### Trust and safety
-
-Pet meetups involve real people and locations. A serious deployment needs blocking/reporting, verification policy, moderation queues, rate controls, suspicious-account signals, location-sharing boundaries and safety guidance.
-
-### Privacy
-
-Home coordinates, routes and schedules are unusually sensitive. Precise private location, coarse discovery location and public meetup location should be distinct data products with different retention and permission rules.
-
-### Observability
-
-Reliability telemetry, product analytics and model telemetry should remain separate. Important measures include request latency, realtime health, push failure, model fallback rate, ranking latency, meetup funnel conversion, calibration and safety events.
-
-### Reliability
-
-Subsystem failure should remain local: ML failure falls back to deterministic scoring; push failure should not invalidate a meetup; media failure should not corrupt relational state; realtime failure should not erase message history.
-
-### Experimentation
-
-A ranking change is successful only if it improves downstream behavior without damaging safety, calibration, diversity or fairness. Click lift alone is not enough.
-
----
-
-## Security posture
-
-Implemented foundations include JWT authentication, request validation, Helmet, origin controls, rate limiting, upload constraints and monitoring hooks.
-
-Before treating Woof as an internet-facing production service, I would still require:
-
-- threat modeling for location and meetup flows,
-- secrets rotation and environment validation,
-- dependency and container scanning,
-- explicit authorization tests for every user-owned resource,
-- abuse/reporting workflows,
-- backup and restore drills,
-- audit logging for sensitive actions,
-- privacy/export/deletion workflows,
-- deployed security-header verification.
-
-See [`SECURITY.md`](SECURITY.md). This README deliberately avoids calling the repository “production ready” simply because production-oriented components exist.
-
----
-
-## Engineering quality
-
-The repository now has explicit local and CI gates for formatting, linting, TypeScript checking, unit tests, browser smoke tests and production builds.
-
-A known reproducibility gap remains: **there is not yet a committed `pnpm-lock.yaml`**. CI therefore installs with `--no-frozen-lockfile` rather than pretending a lockfile exists. Adding and validating the lockfile is a prerequisite before claiming reproducible builds.
-
-Browser authentication smoke tests mock the invalid-login network response so they do not secretly depend on a live API. The seeded full-stack login remains an explicit integration test.
-
-```bash
-pnpm format:check
-pnpm lint
-pnpm type-check
-pnpm test
-pnpm build
-```
-
-Contributor conventions live in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+A green generic build is not treated as sufficient evidence for a security, ML, health, or concurrency release. Those areas have dedicated qualification lanes that encode their specific authority boundaries.
 
 ---
 
@@ -322,15 +261,19 @@ Contributor conventions live in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 ### Prerequisites
 
 - Node.js 20+
-- pnpm 8.15+
+- pnpm 8.15.1+
 - Docker / Docker Compose
-- Python only if running the experimental ML service
+- Python only for ML/specialized-worker development
 
-### Start the core product
+### Install
 
 ```bash
-pnpm install
+pnpm install --frozen-lockfile
+```
 
+### Start local dependencies and applications
+
+```bash
 docker compose up -d
 
 cp apps/api/.env.example apps/api/.env
@@ -344,70 +287,145 @@ pnpm --filter @woof/api dev
 pnpm --filter @woof/web dev
 ```
 
-Default local endpoints:
+Typical local endpoints:
 
 | Surface | URL |
 | --- | --- |
 | Web | `http://localhost:3000` |
 | API | `http://localhost:4000` |
 | Swagger | `http://localhost:4000/docs` |
-| ML service, optional | `http://localhost:8001` |
+| Optional ML service | `http://localhost:8001` |
+
+### Repository verification
+
+```bash
+pnpm format:check
+pnpm lint
+pnpm type-check
+pnpm test
+pnpm build
+```
+
+Or run the aggregate contract:
+
+```bash
+pnpm verify
+```
+
+---
+
+## Deployment
+
+The repository contains separate staging and production workflows for:
+
+- Fly.io API deployment,
+- API liveness/readiness verification,
+- Vercel Web build/deployment.
+
+Deployment credentials are external authority, not repository defaults. A deploy environment must provide the required Fly/Vercel secrets; the workflows should fail clearly rather than inventing interactive/fallback identities.
+
+See [`DEPLOYMENT_GUIDE.md`](DEPLOYMENT_GUIDE.md) and [`docs/CI_ACTION_RUNTIME.md`](docs/CI_ACTION_RUNTIME.md).
+
+---
+
+## What should be built next
+
+The codebase no longer needs more feature count for its own sake. The highest-leverage work is to connect the strong backend contracts into a small number of visible, measurable product loops.
+
+### 1. Counterfactual Adventure decision/outcome ledger
+
+Persist the candidate set, eligibility, ranking policy/version, reason codes, eventual choice, and outcome for every recommendation decision. This is the prerequisite for honest offline replay, future propensity logging, and learned personalization that can be evaluated rather than merely trained.
+
+Roadmap: [#43](https://github.com/sidhulyalkar/woof/issues/43)
+
+### 2. Coach skill graph + relationship mastery
+
+Turn Coach from a useful v1 lesson flow into an individualized curriculum that separately tracks dog skill/comfort, owner handling fluency, pair communication/recovery, and context generalization.
+
+Roadmap: [#44](https://github.com/sidhulyalkar/woof/issues/44)
+
+### 3. Make longitudinal intelligence visible
+
+Finish the calm Daily Signals / correction / explanation loop and feed only bounded, uncertainty-preserving context into downstream surfaces.
+
+Roadmaps: [#34](https://github.com/sidhulyalkar/woof/issues/34), [#35](https://github.com/sidhulyalkar/woof/issues/35)
+
+### 4. Make game progression mean something
+
+Build chapters, discoveries, mastery, and memory around real shared experiences rather than adding more point counters or streak pressure.
+
+Roadmap: [#45](https://github.com/sidhulyalkar/woof/issues/45)
+
+### 5. Earn learned ranking with data
+
+Only after the decision/outcome substrate exists should the personalized ranker/contextual-bandit program move beyond shadow/offline evaluation.
+
+Roadmap: [#46](https://github.com/sidhulyalkar/woof/issues/46)
+
+### 6. Pilot the loop
+
+The biggest remaining evidence gap is human, not architectural. A small owner pilot with trainer/veterinary feedback should measure time-to-first-useful-action, recommendation usefulness, correction rate, safe declines, owner burden, and whether professional handoff context is actually helpful.
+
+Retention is useful as an outcome, not the optimization target.
+
+---
+
+## Design principles worth preserving
+
+1. **Individual normal beats universal score.**
+2. **Dog outcome and human outcome are separate signals.**
+3. **A safe stop can be a successful decision.**
+4. **Missing evidence is not reassurance.**
+5. **Reward mechanics are not ML labels.**
+6. **Models earn authority through evidence and exact release identity.**
+7. **The owner should spend more attention on the dog than on Woof.**
+8. **One useful next action beats a wall of clever features.**
+9. **Professional handoff is a product success, not a failure of automation.**
+10. **More complexity must beat a simpler baseline before it earns promotion.**
 
 ---
 
 ## Canonical documentation
 
-- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — system boundaries, data flow, failure modes and scale
-- [`docs/PRODUCT_CASE_STUDY.md`](docs/PRODUCT_CASE_STUDY.md) — product strategy, UX decisions and metrics
-- [`docs/ML_SYSTEM.md`](docs/ML_SYSTEM.md) — baseline, experimental models, evidence levels and promotion gates
-- [`docs/api-spec.md`](docs/api-spec.md) — API reference
-- [`docs/data-models.md`](docs/data-models.md) — data model overview
-- [`DEPLOYMENT_GUIDE.md`](DEPLOYMENT_GUIDE.md) — deployment notes
-- [`docs/archive/`](docs/archive/) — historical development reports, preserved but non-canonical
-- [`legacy/`](legacy/) — early mock prototypes, preserved but non-canonical
+The repository contains many release-specific contracts because high-risk features are expected to explain what they own and what they explicitly do not own.
+
+Start with:
+
+- [`docs/RELATIONSHIP_FIRST_PRODUCT_PRINCIPLES.md`](docs/RELATIONSHIP_FIRST_PRODUCT_PRINCIPLES.md)
+- [`docs/FIRST_ADVENTURE_RELEASE.md`](docs/FIRST_ADVENTURE_RELEASE.md)
+- [`docs/DOGOS_ADVENTURE_LEARNING_V2.md`](docs/DOGOS_ADVENTURE_LEARNING_V2.md)
+- [`docs/DOGOS_SESSION_AUTHORITY.md`](docs/DOGOS_SESSION_AUTHORITY.md)
+- [`docs/DOGOS_INTELLIGENCE_BASELINE_POLICY_V1.md`](docs/DOGOS_INTELLIGENCE_BASELINE_POLICY_V1.md)
+- [`docs/DOGOS_BEHAVIOR_VISION_RELEASE_AUTHORITY.md`](docs/DOGOS_BEHAVIOR_VISION_RELEASE_AUTHORITY.md)
+- [`docs/HEALTH_LENS.md`](docs/HEALTH_LENS.md)
+- [`docs/CI_ACTION_RUNTIME.md`](docs/CI_ACTION_RUNTIME.md)
+- [Integrated dogOS roadmap #30](https://github.com/sidhulyalkar/woof/issues/30)
+- [Adaptive Adventure roadmap #41](https://github.com/sidhulyalkar/woof/issues/41)
+
+Historical reports and prototypes remain useful context, but they should not be read as the current product contract.
 
 ---
 
-## What I would build next
+## Why this project is interesting
 
-The next phase is intentionally about **validation and integration**, not feature count:
+Woof looks friendly on the surface, but the hard problem underneath is authority.
 
-1. Generate, commit and validate a reproducible pnpm lockfile.
-2. Run the repaired CI workflow on the full change set and fix any latent failures it exposes.
-3. Connect the advanced ML service to the same compatibility response contract as the deterministic baseline.
-4. Build leakage-resistant evaluation datasets from seeded and eventually real post-meetup outcomes.
-5. Add model fallback telemetry, score provenance persistence and calibration dashboards.
-6. Add precise trust/safety and privacy controls around location and IRL coordination.
-7. Add automated accessibility and visual-regression checks to the frontend pipeline.
-8. Deploy a public synthetic-data demo with no sensitive location flows.
-9. Measure discovery → conversation → meetup → repeat-meetup conversion rather than optimizing feed engagement alone.
+Who owns the truth when:
 
----
+- a model disagrees with a deterministic safety screen,
+- the dog enjoys an activity but the human finds it exhausting,
+- XP rewards a welfare-respecting stop,
+- a browser retries a request after the server may already have committed it,
+- a realtime token is valid cryptographically but its server session has been revoked,
+- a new model version starts serving after months of older longitudinal evidence,
+- an owner corrects something the system previously inferred?
 
-## Why Woof belongs in my portfolio
+The codebase is increasingly organized around making those answers explicit, testable, and reversible.
 
-Woof is less interesting as “a social app for dog owners” than as a systems problem disguised as a friendly consumer product.
-
-It forced decisions across:
-
-- interaction and visual design,
-- mobile/web product architecture,
-- API contracts,
-- relational and graph-like data modeling,
-- realtime systems,
-- geospatial privacy,
-- deterministic baselines and research ML,
-- experimentation,
-- trust and safety,
-- observability,
-- graceful degradation,
-- CI and deployment,
-- scale planning.
-
-The result demonstrates how I approach a product from **user experience through infrastructure and learning systems**, while being explicit about what is implemented, what is integrated, what is experimental, and what evidence is still required.
+The next challenge is equally important: making all that machinery disappear into a product that feels simple enough to use while standing next to your dog.
 
 ---
 
 ## License
 
-MIT © Sidharth Hulyalkar
+MIT

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "woof-monorepo",
   "version": "1.0.0",
   "private": true,
-  "description": "Woof - pet social coordination, activity, and compatibility platform",
+  "description": "Woof - relationship-first dogOS companion for shared activities, longitudinal context, and trustworthy personalization",
   "author": "Sidharth Hulyalkar",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
The public entry point has fallen far behind `main`.

The existing README still frames Woof primarily as a dog social-matching system, describes a navigation/product hierarchy that has since been replaced, says there is no committed pnpm lockfile, and proposes work that has already shipped through the dogOS / Adaptive Adventure releases.

This PR makes the repository tell the truth about the system that is actually present.

## New public thesis

Woof is presented as a relationship-first, hardware-agnostic pet context layer centered on:

`notice -> choose -> do together -> read the response -> adapt -> remember -> make next time easier`

Social compatibility remains a real capability, but no longer masquerades as the entire product.

## Current-state inventory

The README now distinguishes implemented, qualified, shadow, and planned capabilities and documents the current role of:

- First Adventure
- Today
- Adventure + Adaptive Profile
- reward-independent Adventure learning
- Daily Signals / individual baseline substrate
- Coach
- Health Lens
- Behavior Vision
- Compatibility / Discovery
- realtime + persisted session authority
- deployment

## Authority model

The public architecture now explains several decisions that make the modern codebase distinctive:

- recommendation evidence != game reward
- model output != model-release authority
- individual baseline context != medical authority
- shadow behavior evidence cannot silently become canonical pet truth

## Engineering truth

Removes the obsolete claim that there is no committed lockfile. The README now documents frozen-lockfile installs and the modern dedicated qualification posture.

## Roadmap truth

The next-work section now prioritizes:

1. counterfactual Adventure decision/outcome receipts (#43)
2. Coach skill graph / relationship mastery (#44)
3. visible Daily Signals + bounded longitudinal context (#34/#35)
4. meaningful game progression (#45)
5. learned ranking only after the evaluation substrate exists (#46)
6. an actual owner/advisor pilot

The root package description is updated to match this product identity. No runtime behavior or schema changes are included.