### PR TITLE
Make Adventure interaction history immutable

### DIFF
--- a/.github/workflows/dogos-adventure-history-ci.yml
+++ b/.github/workflows/dogos-adventure-history-ci.yml
@@ -1,0 +1,178 @@
+name: dogOS Adventure History Integrity CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/database/prisma/migrations/**quest_interactions**/**'
+      - '.github/workflows/dogos-adventure-history-ci.yml'
+      - 'docs/DOGOS_ADVENTURE_HISTORY_INTEGRITY.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-adventure-history-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  qualify:
+    name: Immutable Adventure interaction history
+    runs-on: ubuntu-24.04
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+      SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_shadow
+      PGPASSWORD: postgres
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from committed lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply canonical migrations
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Create isolated interaction fixture
+        run: |
+          psql -h localhost -U postgres -d woof_test -v ON_ERROR_STOP=1 <<'SQL'
+          INSERT INTO users (id, handle, email, created_at, updated_at)
+          VALUES ('history-user', 'history_user', 'history@example.test', NOW(), NOW());
+
+          INSERT INTO pets (id, owner_id, name, species, created_at, updated_at)
+          VALUES ('history-pet', 'history-user', 'History Dog', 'DOG', NOW(), NOW());
+
+          INSERT INTO quest_interactions (
+            id, user_id, pet_id, quest_id, interaction, pathway, context, created_at
+          ) VALUES (
+            'history-interaction',
+            'history-user',
+            'history-pet',
+            'history-quest',
+            'SELECTED',
+            'LEARN',
+            '{"decisionReceiptId":"receipt-v1","rank":1}'::jsonb,
+            '2026-08-27T18:00:00Z'::timestamptz
+          );
+          SQL
+
+      - name: Prove exact retry converges without rewriting time
+        run: |
+          psql -h localhost -U postgres -d woof_test -v ON_ERROR_STOP=1 <<'SQL'
+          INSERT INTO quest_interactions (
+            id, user_id, pet_id, quest_id, interaction, pathway, context, created_at
+          ) VALUES (
+            'different-insert-id-is-ignored-on-conflict',
+            'history-user',
+            'history-pet',
+            'history-quest',
+            'SELECTED',
+            'LEARN',
+            '{"decisionReceiptId":"receipt-v1","rank":1}'::jsonb,
+            NOW()
+          )
+          ON CONFLICT (user_id, pet_id, quest_id, interaction)
+          DO UPDATE SET
+            pathway = EXCLUDED.pathway,
+            context = EXCLUDED.context,
+            created_at = EXCLUDED.created_at;
+
+          DO $$
+          DECLARE
+            row_count integer;
+            preserved_at timestamptz;
+          BEGIN
+            SELECT COUNT(*), MIN(created_at)
+            INTO row_count, preserved_at
+            FROM quest_interactions
+            WHERE user_id = 'history-user'
+              AND pet_id = 'history-pet'
+              AND quest_id = 'history-quest'
+              AND interaction = 'SELECTED';
+
+            IF row_count <> 1 THEN
+              RAISE EXCEPTION 'exact retry did not converge: % rows', row_count;
+            END IF;
+            IF preserved_at <> '2026-08-27T18:00:00Z'::timestamptz THEN
+              RAISE EXCEPTION 'exact retry rewrote created_at: %', preserved_at;
+            END IF;
+          END $$;
+          SQL
+
+      - name: Prove divergent retry fails closed
+        run: |
+          if psql -h localhost -U postgres -d woof_test -v ON_ERROR_STOP=1 <<'SQL'
+          INSERT INTO quest_interactions (
+            id, user_id, pet_id, quest_id, interaction, pathway, context, created_at
+          ) VALUES (
+            'divergent-interaction',
+            'history-user',
+            'history-pet',
+            'history-quest',
+            'SELECTED',
+            'LEARN',
+            '{"decisionReceiptId":"receipt-v1","rank":2}'::jsonb,
+            NOW()
+          )
+          ON CONFLICT (user_id, pet_id, quest_id, interaction)
+          DO UPDATE SET
+            pathway = EXCLUDED.pathway,
+            context = EXCLUDED.context,
+            created_at = EXCLUDED.created_at;
+          SQL
+          then
+            echo 'Divergent retry unexpectedly rewrote history.' >&2
+            exit 1
+          fi
+
+      - name: Prove direct historical mutation fails
+        run: |
+          if psql -h localhost -U postgres -d woof_test -v ON_ERROR_STOP=1 \
+            -c "UPDATE quest_interactions SET pathway = 'BOND' WHERE id = 'history-interaction';"
+          then
+            echo 'Direct historical mutation unexpectedly succeeded.' >&2
+            exit 1
+          fi
+
+      - name: Prove privacy/cascade deletion remains possible
+        run: |
+          psql -h localhost -U postgres -d woof_test -v ON_ERROR_STOP=1 \
+            -c "DELETE FROM users WHERE id = 'history-user';"
+          remaining="$(psql -h localhost -U postgres -d woof_test -Atc \
+            "SELECT COUNT(*) FROM quest_interactions WHERE user_id = 'history-user';")"
+          test "${remaining}" = '0'
+
+      - name: Check migration contract and formatting
+        run: |
+          grep -F "RETURN OLD;" packages/database/prisma/migrations/20260827181500_make_quest_interactions_immutable/migration.sql
+          grep -F "ERRCODE = '23514'" packages/database/prisma/migrations/20260827181500_make_quest_interactions_immutable/migration.sql
+          pnpm exec prettier --check \
+            .github/workflows/dogos-adventure-history-ci.yml \
+            docs/DOGOS_ADVENTURE_HISTORY_INTEGRITY.md

--- a/docs/DOGOS_ADVENTURE_HISTORY_INTEGRITY.md
+++ b/docs/DOGOS_ADVENTURE_HISTORY_INTEGRITY.md
@@ -1,0 +1,55 @@
+# dogOS Adventure History Integrity
+
+Adventure ranking can only become trainable if its historical evidence cannot silently change after an interaction occurs.
+
+## Problem
+
+`QuestInteraction` is an event-like record keyed by:
+
+`user + pet + quest + interaction`
+
+The application intentionally uses `INSERT ... ON CONFLICT DO UPDATE` so network retries converge instead of producing duplicate rows. Before this contract, that retry path also meant a later request could replace `pathway`, replace `context`, and refresh `created_at` for an interaction that had already happened.
+
+That is unacceptable as a substrate for counterfactual recommendation evaluation. Historical evidence must not acquire a different rank, receipt identity, pathway, or timestamp after downstream outcomes are known.
+
+## Database authority
+
+The database now owns the immutability boundary with a `BEFORE UPDATE` trigger on `quest_interactions`.
+
+An attempted update has only two outcomes:
+
+1. **Exact semantic retry.** Identity, pathway, and context match the stored row. PostgreSQL returns the existing row unchanged, preserving the original `id` and `created_at`.
+2. **Divergent retry or mutation.** Any historical field differs. PostgreSQL rejects the update with SQLSTATE `23514`.
+
+The trigger intentionally allows deletion. Account/pet cascade deletion and privacy workflows must remain able to remove the user's historical data.
+
+## Why the boundary lives in PostgreSQL
+
+Application-only checks are insufficient because:
+
+- multiple API processes can race,
+- a future maintenance script could bypass one service method,
+- `ON CONFLICT DO UPDATE` is itself executed atomically by PostgreSQL,
+- the history contract should survive refactors of Adventure service code.
+
+The database therefore provides the final fail-closed boundary while the application keeps its existing idempotent insert interface.
+
+## What this does not solve
+
+This release is a prerequisite for the broader counterfactual decision/outcome ledger in issue #43. It does **not** yet persist the complete quest deck, candidate eligibility/reason codes, deterministic scores, rank order, feature-schema identity, exploration budget, or selection propensity.
+
+The correct next layer is an immutable server-generated deck receipt created before any selection/outcome. Existing `QuestInteraction` rows can then reference that receipt without being able to rewrite it later.
+
+## Qualification
+
+`dogOS Adventure History Integrity CI` starts PostgreSQL, applies the complete canonical migration history, and proves:
+
+- an initial interaction can be recorded,
+- an exact conflict retry converges to one row,
+- the original timestamp is preserved,
+- a divergent retry fails closed,
+- a direct historical mutation fails,
+- user cascade deletion still removes the interaction,
+- the migration retains its `RETURN OLD` no-op path and explicit integrity-error contract.
+
+This is intentionally a database integration contract rather than a source-text-only assertion.

--- a/packages/database/prisma/migrations/20260827181500_make_quest_interactions_immutable/migration.sql
+++ b/packages/database/prisma/migrations/20260827181500_make_quest_interactions_immutable/migration.sql
@@ -1,0 +1,37 @@
+-- QuestInteraction is historical evidence. Exact retries may converge on the
+-- existing row, but a later request must never rewrite the pathway, context,
+-- identity, or original timestamp of an already-recorded interaction.
+--
+-- The application currently uses `INSERT ... ON CONFLICT DO UPDATE` for retry
+-- convergence. This BEFORE UPDATE trigger therefore distinguishes a semantic
+-- no-op retry from divergent history:
+--   * exact semantic duplicate -> preserve OLD row, including created_at
+--   * any changed historical field -> fail closed
+--
+-- Deletes remain allowed so ordinary account/pet cascade deletion and privacy
+-- workflows are not blocked by the immutability contract.
+
+CREATE OR REPLACE FUNCTION enforce_quest_interaction_immutability()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.id IS NOT DISTINCT FROM OLD.id
+     AND NEW.user_id IS NOT DISTINCT FROM OLD.user_id
+     AND NEW.pet_id IS NOT DISTINCT FROM OLD.pet_id
+     AND NEW.quest_id IS NOT DISTINCT FROM OLD.quest_id
+     AND NEW.interaction IS NOT DISTINCT FROM OLD.interaction
+     AND NEW.pathway IS NOT DISTINCT FROM OLD.pathway
+     AND NEW.context IS NOT DISTINCT FROM OLD.context THEN
+    RETURN OLD;
+  END IF;
+
+  RAISE EXCEPTION 'quest_interactions are immutable; divergent retry rejected'
+    USING ERRCODE = '23514';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS quest_interactions_immutable ON quest_interactions;
+
+CREATE TRIGGER quest_interactions_immutable
+BEFORE UPDATE ON quest_interactions
+FOR EACH ROW
+EXECUTE FUNCTION enforce_quest_interaction_immutability();


### PR DESCRIPTION
Prerequisite for #43. This does **not** close the full counterfactual decision-ledger roadmap.

## Problem found during the Adventure audit

`QuestInteraction` behaves like historical evidence, but `CareEventsService.recordQuestInteraction()` currently converges duplicates with:

`INSERT ... ON CONFLICT DO UPDATE`

The update replaces `pathway`, replaces `context`, and refreshes `created_at` for an already-existing `(user, pet, quest, interaction)` row. That means a later retry can rewrite the history that future ranking/evaluation code would train on.

## Database-owned immutability

Adds a PostgreSQL `BEFORE UPDATE` trigger for `quest_interactions`.

- exact semantic retry: returns `OLD`, preserving original `id` and `created_at`
- divergent pathway/context/identity: fails closed with SQLSTATE `23514`
- delete remains allowed so account/pet cascade deletion and privacy workflows continue to work

This keeps the existing application retry interface intact while moving the final history-integrity boundary beneath every API process and maintenance caller.

## Dedicated qualification

Adds `dogOS Adventure History Integrity CI` on PostgreSQL 15/pgvector. It applies the complete canonical migration history and proves:

- initial interaction insert succeeds
- exact `ON CONFLICT DO UPDATE` retry converges to one row
- original `created_at` survives the retry
- divergent retry fails
- direct mutation fails
- user cascade deletion still removes the interaction

The rationale and scope are documented in `docs/DOGOS_ADVENTURE_HISTORY_INTEGRITY.md`.

## What remains for #43

The next release still needs an immutable server-generated **deck decision receipt** created before outcome, including the candidate set, eligibility/reason codes, deterministic scores, final rank, policy/feature versions, exploration mode/budget, and propensity when exploration exists. Outcomes should then reference the exact receipt/candidate rather than teaching from mutable UI state.