### PR TITLE
Fix: Retire legacy event gamification points from dogOS reward authority (closes #68)

### DIFF
--- a/.github/workflows/dogos-events-reward-authority-ci.yml
+++ b/.github/workflows/dogos-events-reward-authority-ci.yml
@@ -1,0 +1,49 @@
+name: dogOS Events Reward Authority CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/events/**'
+      - 'docs/DOGOS_EVENTS_REWARD_AUTHORITY.md'
+      - '.github/workflows/dogos-events-reward-authority-ci.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-events-reward-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  qualify:
+    name: Community events must not award legacy points
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Enforce events reward-authority source contract
+        run: |
+          if grep -REn "awardPoints|pointsAwarded|GamificationService" apps/api/src/events; then
+            echo 'Community Events must not award or advertise legacy points.' >&2
+            exit 1
+          fi
+
+      - name: Run events reward-authority tests
+        run: pnpm --filter @woof/api exec jest src/events/events.reward-authority.spec.ts --runInBand

--- a/apps/api/src/events/events.module.ts
+++ b/apps/api/src/events/events.module.ts
@@ -1,10 +1,8 @@
 import { Module } from '@nestjs/common';
 import { EventsService } from './events.service';
 import { EventsController } from './events.controller';
-import { GamificationModule } from '../gamification/gamification.module';
 
 @Module({
-  imports: [GamificationModule],
   providers: [EventsService],
   controllers: [EventsController],
   exports: [EventsService],

--- a/apps/api/src/events/events.reward-authority.spec.ts
+++ b/apps/api/src/events/events.reward-authority.spec.ts
@@ -1,0 +1,133 @@
+import { BadRequestException } from '@nestjs/common';
+import { EventsService } from './events.service';
+
+describe('EventsService reward authority', () => {
+  const eventId = 'event-1';
+  const userId = 'user-1';
+
+  function buildService() {
+    const prisma = {
+      eventRSVP: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+      eventFeedback: {
+        findUnique: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+      },
+      pointTransaction: {
+        create: jest.fn(),
+      },
+      user: {
+        update: jest.fn(),
+      },
+    };
+    const service = new EventsService(prisma as never);
+    return { service, prisma };
+  }
+
+  it('checks in without mutating legacy points or advertising rewards', async () => {
+    const { service, prisma } = buildService();
+    const checkedInAt = new Date('2026-08-28T12:00:00.000Z');
+
+    prisma.eventRSVP.findUnique.mockResolvedValue({
+      eventId,
+      userId,
+      checkedInAt: null,
+    });
+    prisma.eventRSVP.update.mockResolvedValue({
+      eventId,
+      userId,
+      checkedInAt,
+    });
+
+    const result = await service.checkIn(eventId, userId);
+
+    expect(result.message).not.toMatch(/points/i);
+    expect(result).not.toHaveProperty('pointsAwarded');
+    expect(prisma.pointTransaction.create).not.toHaveBeenCalled();
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate check-ins without attempting a reward write', async () => {
+    const { service, prisma } = buildService();
+
+    prisma.eventRSVP.findUnique.mockResolvedValue({
+      eventId,
+      userId,
+      checkedInAt: new Date('2026-08-28T11:00:00.000Z'),
+    });
+
+    await expect(service.checkIn(eventId, userId)).rejects.toBeInstanceOf(BadRequestException);
+    expect(prisma.eventRSVP.update).not.toHaveBeenCalled();
+    expect(prisma.pointTransaction.create).not.toHaveBeenCalled();
+  });
+
+  it('records first feedback without legacy point awards', async () => {
+    const { service, prisma } = buildService();
+    const feedback = {
+      eventId,
+      userId,
+      vibeScore: 4,
+      petDensity: 'just_right',
+      surfaceType: 'grass',
+      crowding: 'moderate',
+      noiseLevel: 'quiet',
+      tags: ['friendly'],
+      notes: 'Great turnout',
+    };
+
+    prisma.eventRSVP.findUnique.mockResolvedValue({ eventId, userId });
+    prisma.eventFeedback.findUnique.mockResolvedValue(null);
+    prisma.eventFeedback.create.mockResolvedValue(feedback);
+
+    const result = await service.submitFeedback(eventId, userId, {
+      vibeScore: 4,
+      petDensity: 'just_right',
+      surfaceType: 'grass',
+      crowding: 'moderate',
+      noiseLevel: 'quiet',
+      tags: ['friendly'],
+      notes: 'Great turnout',
+    });
+
+    expect(result.message).not.toMatch(/points/i);
+    expect(result).not.toHaveProperty('pointsAwarded');
+    expect(prisma.pointTransaction.create).not.toHaveBeenCalled();
+    expect(prisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it('updates existing feedback without legacy point awards', async () => {
+    const { service, prisma } = buildService();
+    const existing = {
+      eventId,
+      userId,
+      vibeScore: 3,
+      petDensity: 'just_right',
+      surfaceType: 'grass',
+      crowding: 'moderate',
+      noiseLevel: 'quiet',
+      tags: [],
+      notes: null,
+    };
+
+    prisma.eventRSVP.findUnique.mockResolvedValue({ eventId, userId });
+    prisma.eventFeedback.findUnique.mockResolvedValue(existing);
+    prisma.eventFeedback.update.mockResolvedValue({
+      ...existing,
+      vibeScore: 5,
+      notes: 'Even better on the second visit',
+    });
+
+    const result = await service.submitFeedback(eventId, userId, {
+      vibeScore: 5,
+      notes: 'Even better on the second visit',
+    });
+
+    expect(result.message).toBe('Feedback updated successfully.');
+    expect(result).not.toHaveProperty('pointsAwarded');
+    expect(prisma.eventFeedback.create).not.toHaveBeenCalled();
+    expect(prisma.pointTransaction.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/events/events.service.ts
+++ b/apps/api/src/events/events.service.ts
@@ -1,17 +1,14 @@
 import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { Prisma } from '@woof/database';
 import { PrismaService } from '../prisma/prisma.service';
-import { GamificationService } from '../gamification/gamification.service';
 import { CreateEventDto } from './dto/create-event.dto';
 import { UpdateEventDto } from './dto/update-event.dto';
 import { CreateRSVPDto, EventFeedbackDto } from './dto/rsvp-event.dto';
 
+// Community events acknowledge participation without issuing legacy totalPoints.
 @Injectable()
 export class EventsService {
-  constructor(
-    private prisma: PrismaService,
-    private gamificationService: GamificationService,
-  ) {}
+  constructor(private prisma: PrismaService) {}
 
   async create(hostUserId: string, dto: CreateEventDto) {
     return this.prisma.communityEvent.create({
@@ -223,17 +220,9 @@ export class EventsService {
       },
     });
 
-    await this.gamificationService.awardPoints({
-      userId,
-      points: 5,
-      reason: 'event_attended',
-      relatedEntityId: eventId,
-    });
-
     return {
       ...updatedRSVP,
-      pointsAwarded: 5,
-      message: 'Checked in successfully! You earned 5 points.',
+      message: 'Checked in successfully. Thanks for joining the community event.',
     };
   }
 
@@ -298,20 +287,10 @@ export class EventsService {
       isNewFeedback = true;
     }
 
-    if (isNewFeedback) {
-      await this.gamificationService.awardPoints({
-        userId,
-        points: 3,
-        reason: 'event_feedback',
-        relatedEntityId: eventId,
-      });
-    }
-
     return {
       ...feedback,
-      pointsAwarded: isNewFeedback ? 3 : 0,
       message: isNewFeedback
-        ? 'Feedback submitted! You earned 3 points.'
+        ? 'Feedback submitted. Thanks for helping the community learn about this event.'
         : 'Feedback updated successfully.',
     };
   }

--- a/docs/DOGOS_EVENTS_REWARD_AUTHORITY.md
+++ b/docs/DOGOS_EVENTS_REWARD_AUTHORITY.md
@@ -1,0 +1,25 @@
+# dogOS Community Events reward authority
+
+Community event attendance and venue feedback are **acknowledgement-only** surfaces.
+
+## Active authority
+
+- `EventsService.checkIn` records `eventRSVP.checkedInAt` and returns a participation acknowledgement.
+- `EventsService.submitFeedback` creates or updates `eventFeedback` rows for community signal quality.
+- Duplicate check-ins are rejected before any write; feedback updates are idempotent per `(eventId, userId)`.
+
+## Retired coupling
+
+Community Events must **not** call `GamificationService.awardPoints`, mutate `users.totalPoints`, or return `pointsAwarded` / "You earned points" copy.
+
+Legacy gamification remains **read-only** through `GET /gamification/me/summary` for historical profile compatibility. Adventure/Bond rewards continue through `CareEventsService` and the Adventure system.
+
+## Remaining legacy writers (historical read path)
+
+| Surface | Role |
+| --- | --- |
+| `GET /gamification/me/summary` | Read-only legacy totals, badges, streaks |
+| `CareEventsService` / Adventure | Canonical Bond XP authority (not community events) |
+| `GamificationService.awardPoints` | Retained for compatibility only; no live community callers |
+
+New event or social code must not reintroduce universal point awards. CI enforces `awardPoints` absence under `apps/api/src/events`.


### PR DESCRIPTION
## Summary
Resolves #68 by decoupling community event check-in and feedback from the retired universal points economy.

### Changes
- Removed `GamificationService.awardPoints` from `EventsService` check-in and feedback paths.
- Dropped `pointsAwarded` and "You earned points" response semantics; replaced with participation acknowledgements.
- Documented remaining legacy reward surfaces in `docs/DOGOS_EVENTS_REWARD_AUTHORITY.md`.
- Added `events.reward-authority.spec.ts` covering idempotent check-in/feedback without point mutation.
- Added `dogos-events-reward-authority-ci.yml` grep + test gate blocking `awardPoints` reintroduction in `apps/api/src/events`.

Fixes #68

### Payout Settlement:
- **Settlement Wallet**: `0xbf10d7ef874044c5a48074c049b5d23b57087537` (USDC/EVM)
- **Base/Farcaster**: `0xbA8f7CC2455Ec39B05FC493C3Ab1cAc77fAAf988`