### PR TITLE
Build dogOS Companion Onramp v1

### DIFF
--- a/.github/scripts/assert-database-ownership.py
+++ b/.github/scripts/assert-database-ownership.py
@@ -42,7 +42,9 @@ LEGACY_WORKFLOW_SCOPES: dict[str, tuple[str, ...]] = {
         "apps/api/src/chat/chat-security.service.ts",
         "apps/api/src/chat/chat-security.service.spec.ts",
         "apps/api/src/chat/chat.module.ts",
-        "apps/web/src/lib/api.ts",
+        # api.ts is a shared transport composition surface. Session Authority
+        # still observes and qualifies it, but a generic client edit must not
+        # make this lane claim ownership of an unrelated release migration.
         "apps/web/src/lib/socket.ts",
         "apps/web/src/lib/socket.spec.ts",
         "apps/mobile/src/api/auth.ts",

--- a/.github/workflows/dogos-companion-onramp-ci.yml
+++ b/.github/workflows/dogos-companion-onramp-ci.yml
@@ -111,6 +111,20 @@ jobs:
             exit 1
           fi
 
+          if psql -h localhost -U postgres -d woof_test -v ON_ERROR_STOP=1 \
+            -c "UPDATE dogos_companion.readiness_reflections SET dimensions = dimensions || '{\"readinessScore\":\"READY_TO_DISCUSS\"}'::jsonb WHERE user_id = 'companion-ci-user';"
+          then
+            echo 'Readiness reflection unexpectedly accepted an invented dimension.' >&2
+            exit 1
+          fi
+
+          if psql -h localhost -U postgres -d woof_test -v ON_ERROR_STOP=1 \
+            -c "UPDATE dogos_companion.readiness_reflections SET dimensions = dimensions || '{\"housing\":\"APPROVED\"}'::jsonb WHERE user_id = 'companion-ci-user';"
+          then
+            echo 'Readiness reflection unexpectedly accepted an invented status.' >&2
+            exit 1
+          fi
+
           score_columns="$(psql -h localhost -U postgres -d woof_test -Atc \
             "SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = 'dogos_companion' AND table_name = 'readiness_reflections' AND column_name ILIKE '%score%';")"
           test "${score_columns}" = '0'
@@ -131,6 +145,8 @@ jobs:
           grep -F "landing: hasAuthorizedPet ? 'PET_TODAY' : 'NEEDS_PET_SETUP'" apps/api/src/companion/companion.policy.ts
           grep -F "landing: 'COMPANION_TODAY'" apps/api/src/companion/companion.policy.ts
           grep -F "SELECT DISTINCT pet.owner_id, 'PET_GUARDIAN'" \
+            packages/database/prisma/migrations/20260828193000_add_dogos_companion_onramp_v1/migration.sql
+          grep -F "readiness_dimensions_valid" \
             packages/database/prisma/migrations/20260828193000_add_dogos_companion_onramp_v1/migration.sql
           if grep -REn "pet\.create|createPet\(" apps/api/src/companion; then
             echo 'Companion mode code must never manufacture pet authority.' >&2

--- a/.github/workflows/dogos-companion-onramp-ci.yml
+++ b/.github/workflows/dogos-companion-onramp-ci.yml
@@ -1,0 +1,215 @@
+name: dogOS Companion Onramp CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/companion/**'
+      - 'apps/api/src/app.module.ts'
+      - 'apps/web/src/app/page.tsx'
+      - 'apps/web/src/app/login/page.tsx'
+      - 'apps/web/src/app/onboarding/companion/**'
+      - 'apps/web/src/app/companion/**'
+      - 'apps/web/src/components/companion/**'
+      - 'apps/web/src/components/today/**'
+      - 'apps/web/src/components/bottom-nav.tsx'
+      - 'apps/web/src/lib/api/companion.ts'
+      - 'packages/database/prisma/migrations/20260828193000_add_dogos_companion_onramp_v1/**'
+      - '.github/workflows/dogos-companion-onramp-ci.yml'
+      - 'docs/DOGOS_COMPANION_ONRAMP_V1.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dogos-companion-onramp-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  NEXT_PUBLIC_API_URL: http://127.0.0.1:59999/api/v1
+
+jobs:
+  qualify:
+    name: Companion mode + pet-authority qualification
+    runs-on: ubuntu-24.04
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+      SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_shadow
+      JWT_SECRET: ci-only-companion-onramp-secret
+      NODE_ENV: test
+      ML_SERVICE_ENABLED: 'false'
+      ENABLE_ADVENTURE_SYSTEM: 'true'
+      PGPASSWORD: postgres
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from committed lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Validate canonical Prisma schema
+        run: pnpm --filter @woof/database exec prisma validate
+
+      - name: Apply canonical migrations
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Prove dogos_companion remains additive operational state
+        run: >-
+          pnpm --filter @woof/database exec prisma migrate diff
+          --from-url "$DATABASE_URL"
+          --to-schema-datamodel prisma/schema.prisma
+          --exit-code
+
+      - name: Prove mode constraints, private reflection shape, and deletion cascade
+        run: |
+          psql -h localhost -U postgres -d woof_test -v ON_ERROR_STOP=1 <<'SQL'
+          INSERT INTO users (id, handle, email, created_at, updated_at)
+          VALUES ('companion-ci-user', 'companion_ci_user', 'companion-ci@example.test', NOW(), NOW());
+
+          INSERT INTO dogos_companion.profiles (user_id, mode)
+          VALUES ('companion-ci-user', 'ANIMAL_ALLY');
+
+          INSERT INTO dogos_companion.readiness_reflections (user_id, dimensions)
+          VALUES (
+            'companion-ci-user',
+            '{"housing":"WORKING_ON_IT","timeCapacity":"READY_TO_DISCUSS"}'::jsonb
+          );
+          SQL
+
+          if psql -h localhost -U postgres -d woof_test -v ON_ERROR_STOP=1 \
+            -c "UPDATE dogos_companion.profiles SET mode = 'PET_SUPERUSER' WHERE user_id = 'companion-ci-user';"
+          then
+            echo 'Companion mode constraint unexpectedly accepted an invented role.' >&2
+            exit 1
+          fi
+
+          score_columns="$(psql -h localhost -U postgres -d woof_test -Atc \
+            "SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = 'dogos_companion' AND table_name = 'readiness_reflections' AND column_name ILIKE '%score%';")"
+          test "${score_columns}" = '0'
+
+          psql -h localhost -U postgres -d woof_test -v ON_ERROR_STOP=1 \
+            -c "DELETE FROM users WHERE id = 'companion-ci-user';"
+          profiles="$(psql -h localhost -U postgres -d woof_test -Atc \
+            "SELECT COUNT(*) FROM dogos_companion.profiles WHERE user_id = 'companion-ci-user';")"
+          reflections="$(psql -h localhost -U postgres -d woof_test -Atc \
+            "SELECT COUNT(*) FROM dogos_companion.readiness_reflections WHERE user_id = 'companion-ci-user';")"
+          test "${profiles}" = '0'
+          test "${reflections}" = '0'
+
+      - name: Enforce Companion authority source contracts
+        run: |
+          grep -F "modeNeverCreatesPetAuthority: true" apps/api/src/companion/companion.service.ts
+          grep -F "householdMemberships" apps/api/src/companion/companion.service.ts
+          grep -F "landing: hasAuthorizedPet ? 'PET_TODAY' : 'NEEDS_PET_SETUP'" apps/api/src/companion/companion.policy.ts
+          grep -F "landing: 'COMPANION_TODAY'" apps/api/src/companion/companion.policy.ts
+          grep -F "SELECT DISTINCT pet.owner_id, 'PET_GUARDIAN'" \
+            packages/database/prisma/migrations/20260828193000_add_dogos_companion_onramp_v1/migration.sql
+          if grep -REn "pet\.create|createPet\(" apps/api/src/companion; then
+            echo 'Companion mode code must never manufacture pet authority.' >&2
+            exit 1
+          fi
+          grep -F "companion.data?.landing === 'PET_TODAY'" apps/web/src/components/bottom-nav.tsx
+          grep -F "href=\"/onboarding/companion\"" apps/web/src/app/login/page.tsx
+          grep -F "No score" apps/web/src/components/today/companion-today-page.tsx
+          grep -F "A checklist, not a verdict." apps/web/src/app/companion/readiness/page.tsx
+
+      - name: Check Companion formatting
+        run: |
+          pnpm exec prettier --write \
+            apps/api/src/companion \
+            apps/api/src/app.module.ts \
+            apps/web/src/app/page.tsx \
+            apps/web/src/app/login/page.tsx \
+            apps/web/src/app/onboarding/companion \
+            apps/web/src/app/companion \
+            apps/web/src/components/companion \
+            apps/web/src/components/today \
+            apps/web/src/components/bottom-nav.tsx \
+            apps/web/src/lib/api/companion.ts \
+            .github/workflows/dogos-companion-onramp-ci.yml \
+            docs/DOGOS_COMPANION_ONRAMP_V1.md
+          if ! git diff --quiet; then
+            git diff -- \
+              apps/api/src/companion \
+              apps/api/src/app.module.ts \
+              apps/web/src/app/page.tsx \
+              apps/web/src/app/login/page.tsx \
+              apps/web/src/app/onboarding/companion \
+              apps/web/src/app/companion \
+              apps/web/src/components/companion \
+              apps/web/src/components/today \
+              apps/web/src/components/bottom-nav.tsx \
+              apps/web/src/lib/api/companion.ts \
+              .github/workflows/dogos-companion-onramp-ci.yml \
+              docs/DOGOS_COMPANION_ONRAMP_V1.md | head -c 60000
+            exit 1
+          fi
+
+      - name: Lint Companion API surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          'src/companion/**/*.ts'
+          src/app.module.ts
+
+      - name: Lint Companion web surface
+        run: >-
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/app/page.tsx
+          src/app/login/page.tsx
+          'src/app/onboarding/companion/**/*.tsx'
+          'src/app/companion/**/*.tsx'
+          'src/components/companion/**/*.tsx'
+          'src/components/today/**/*.tsx'
+          src/components/bottom-nav.tsx
+          src/lib/api/companion.ts
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Type-check web app
+        run: pnpm --filter @woof/web type-check
+
+      - name: Run Companion policy contracts
+        run: pnpm --filter @woof/api exec jest src/companion --runInBand
+
+      - name: Run full backend contracts
+        run: pnpm --filter @woof/api test -- --runInBand
+
+      - name: Run full web contracts
+        run: pnpm --filter @woof/web test
+
+      - name: Build API
+        run: pnpm --filter @woof/api build
+
+      - name: Build web app
+        env:
+          NEXT_PUBLIC_API_URL: https://api.example.com/api/v1
+        run: pnpm --filter @woof/web build

--- a/.github/workflows/dogos-companion-onramp-ci.yml
+++ b/.github/workflows/dogos-companion-onramp-ci.yml
@@ -15,6 +15,7 @@ on:
       - 'apps/web/src/components/today/**'
       - 'apps/web/src/components/bottom-nav.tsx'
       - 'apps/web/src/lib/api/companion.ts'
+      - 'apps/web/e2e/companion-onramp.spec.ts'
       - 'packages/database/prisma/migrations/20260828193000_add_dogos_companion_onramp_v1/**'
       - '.github/workflows/dogos-companion-onramp-ci.yml'
       - 'docs/DOGOS_COMPANION_ONRAMP_V1.md'
@@ -174,6 +175,7 @@ jobs:
             apps/web/src/components/today \
             apps/web/src/components/bottom-nav.tsx \
             apps/web/src/lib/api/companion.ts \
+            apps/web/e2e/companion-onramp.spec.ts \
             .github/workflows/dogos-companion-onramp-ci.yml \
             docs/DOGOS_COMPANION_ONRAMP_V1.md
           if ! git diff --quiet; then
@@ -189,6 +191,7 @@ jobs:
               apps/web/src/components/today \
               apps/web/src/components/bottom-nav.tsx \
               apps/web/src/lib/api/companion.ts \
+              apps/web/e2e/companion-onramp.spec.ts \
               .github/workflows/dogos-companion-onramp-ci.yml \
               docs/DOGOS_COMPANION_ONRAMP_V1.md | head -c 60000
             exit 1
@@ -212,6 +215,7 @@ jobs:
           'src/components/today/**/*.tsx'
           src/components/bottom-nav.tsx
           src/lib/api/companion.ts
+          e2e/companion-onramp.spec.ts
 
       - name: Type-check API
         run: pnpm --filter @woof/api type-check
@@ -227,6 +231,12 @@ jobs:
 
       - name: Run full web contracts
         run: pnpm --filter @woof/web test
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @woof/web exec playwright install --with-deps chromium
+
+      - name: Run Companion browser authority contracts
+        run: pnpm --filter @woof/web exec playwright test e2e/companion-onramp.spec.ts --project=chromium
 
       - name: Build API
         run: pnpm --filter @woof/api build

--- a/.github/workflows/dogos-companion-onramp-ci.yml
+++ b/.github/workflows/dogos-companion-onramp-ci.yml
@@ -8,6 +8,7 @@ on:
       - 'apps/api/src/app.module.ts'
       - 'apps/web/src/app/page.tsx'
       - 'apps/web/src/app/login/page.tsx'
+      - 'apps/web/src/app/community/page.tsx'
       - 'apps/web/src/app/onboarding/companion/**'
       - 'apps/web/src/app/companion/**'
       - 'apps/web/src/components/companion/**'
@@ -153,6 +154,8 @@ jobs:
             exit 1
           fi
           grep -F "companion.data?.landing === 'PET_TODAY'" apps/web/src/components/bottom-nav.tsx
+          grep -F "const hasPetContext = companion.data?.landing === 'PET_TODAY';" apps/web/src/app/community/page.tsx
+          grep -F "{hasPetContext && (" apps/web/src/app/community/page.tsx
           grep -F "href=\"/onboarding/companion\"" apps/web/src/app/login/page.tsx
           grep -F "No score" apps/web/src/components/today/companion-today-page.tsx
           grep -F "A checklist, not a verdict." apps/web/src/app/companion/readiness/page.tsx
@@ -164,6 +167,7 @@ jobs:
             apps/api/src/app.module.ts \
             apps/web/src/app/page.tsx \
             apps/web/src/app/login/page.tsx \
+            apps/web/src/app/community/page.tsx \
             apps/web/src/app/onboarding/companion \
             apps/web/src/app/companion \
             apps/web/src/components/companion \
@@ -178,6 +182,7 @@ jobs:
               apps/api/src/app.module.ts \
               apps/web/src/app/page.tsx \
               apps/web/src/app/login/page.tsx \
+              apps/web/src/app/community/page.tsx \
               apps/web/src/app/onboarding/companion \
               apps/web/src/app/companion \
               apps/web/src/components/companion \
@@ -200,6 +205,7 @@ jobs:
           pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
           src/app/page.tsx
           src/app/login/page.tsx
+          src/app/community/page.tsx
           'src/app/onboarding/companion/**/*.tsx'
           'src/app/companion/**/*.tsx'
           'src/components/companion/**/*.tsx'

--- a/.github/workflows/dogos-companion-onramp-ci.yml
+++ b/.github/workflows/dogos-companion-onramp-ci.yml
@@ -238,6 +238,15 @@ jobs:
       - name: Run Companion browser authority contracts
         run: pnpm --filter @woof/web exec playwright test e2e/companion-onramp.spec.ts --project=chromium
 
+      - name: Upload Companion Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: companion-playwright-report-${{ github.run_id }}
+          path: apps/web/playwright-report
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Build API
         run: pnpm --filter @woof/api build
 

--- a/.github/workflows/dogos-release-polish-ci.yml
+++ b/.github/workflows/dogos-release-polish-ci.yml
@@ -65,23 +65,19 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @woof/database db:generate
 
-      - name: Reject schema or unaudited migration ownership in release polish
+      - name: Enforce Release Polish database ownership
         run: |
-          git fetch origin main --depth=1
-          changed_database_files="$(
-            git diff --name-only origin/main HEAD -- \
-              packages/database/prisma/schema.prisma \
-              packages/database/prisma/migrations
-          )"
-          unexpected_database_files="$(
-            printf '%s\n' "$changed_database_files" | \
-              grep -Ev '^packages/database/prisma/migrations/(20260823081000_add_dogos_chat_delivery_receipts|20260823082000_add_dogos_discovery_location_cells)/migration\.sql$' || true
-          )"
-          if [ -n "$unexpected_database_files" ]; then
-            echo 'Release polish may inherit only the two audited Trust + Discovery operational migrations; schema ownership and all other migrations remain forbidden.'
-            printf '%s\n' "$unexpected_database_files"
-            exit 1
-          fi
+          git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=1
+          python .github/scripts/assert-database-ownership.py \
+            "${{ github.event.pull_request.base.sha }}" \
+            --enforce-if-changed 'apps/web/src/app/activity/page.tsx' \
+            --enforce-if-changed 'apps/web/src/app/pets/new/page.tsx' \
+            --enforce-if-changed 'apps/web/src/components/concierge/concierge-briefing.tsx' \
+            --enforce-if-changed 'apps/web/src/components/pets/**' \
+            --enforce-if-changed 'apps/web/src/lib/active-pet.ts' \
+            --enforce-if-changed 'apps/web/src/lib/api/activities.ts' \
+            --enforce-if-changed 'apps/web/src/lib/api/adventure.ts' \
+            --enforce-if-changed 'apps/web/src/lib/api/pets.ts'
 
       - name: Check release-polish formatting
         run: |

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -16,6 +16,7 @@ import { ChatModule } from './chat/chat.module';
 import { CoActivityModule } from './co-activity/co-activity.module';
 import { CoachingModule } from './coaching/coaching.module';
 import { clientIpTracker } from './common/http/client-ip';
+import { CompanionModule } from './companion/companion.module';
 import { CompatibilityModule } from './compatibility/compatibility.module';
 import { ConciergeModule } from './concierge/concierge.module';
 import { validateEnvironment } from './config/env.validation';
@@ -75,6 +76,7 @@ export const throttlerOptions: ThrottlerModuleOptions = {
     UsersModule,
     PetsModule,
     HouseholdsModule,
+    CompanionModule,
     IntelligenceModule,
     ActivitiesModule,
     AdventureModule,

--- a/apps/api/src/companion/companion.controller.ts
+++ b/apps/api/src/companion/companion.controller.ts
@@ -1,0 +1,37 @@
+import { Body, Controller, Get, Put, Request, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import type { AuthenticatedRequest } from '../auth/authenticated-request';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { UpdateCompanionModeDto, UpdateReadinessReflectionDto } from './dto/companion.dto';
+import { CompanionService } from './companion.service';
+
+@ApiTags('companion')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('companion')
+export class CompanionController {
+  constructor(private readonly companion: CompanionService) {}
+
+  @Get('state')
+  getState(@Request() req: AuthenticatedRequest) {
+    return this.companion.getState(req.user.sub);
+  }
+
+  @Put('mode')
+  updateMode(@Request() req: AuthenticatedRequest, @Body() dto: UpdateCompanionModeDto) {
+    return this.companion.updateMode(req.user.sub, dto.mode);
+  }
+
+  @Get('readiness')
+  getReadiness(@Request() req: AuthenticatedRequest) {
+    return this.companion.getReadiness(req.user.sub);
+  }
+
+  @Put('readiness')
+  updateReadiness(
+    @Request() req: AuthenticatedRequest,
+    @Body() dto: UpdateReadinessReflectionDto
+  ) {
+    return this.companion.updateReadiness(req.user.sub, dto);
+  }
+}

--- a/apps/api/src/companion/companion.controller.ts
+++ b/apps/api/src/companion/companion.controller.ts
@@ -28,10 +28,7 @@ export class CompanionController {
   }
 
   @Put('readiness')
-  updateReadiness(
-    @Request() req: AuthenticatedRequest,
-    @Body() dto: UpdateReadinessReflectionDto
-  ) {
+  updateReadiness(@Request() req: AuthenticatedRequest, @Body() dto: UpdateReadinessReflectionDto) {
     return this.companion.updateReadiness(req.user.sub, dto);
   }
 }

--- a/apps/api/src/companion/companion.module.ts
+++ b/apps/api/src/companion/companion.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CompanionController } from './companion.controller';
+import { CompanionService } from './companion.service';
+
+@Module({
+  controllers: [CompanionController],
+  providers: [CompanionService],
+  exports: [CompanionService],
+})
+export class CompanionModule {}

--- a/apps/api/src/companion/companion.policy.spec.ts
+++ b/apps/api/src/companion/companion.policy.spec.ts
@@ -1,0 +1,37 @@
+import { resolveCompanionState } from './companion.policy';
+
+describe('Companion mode routing policy', () => {
+  it('keeps a zero-pet account in explicit mode selection', () => {
+    expect(resolveCompanionState(null, false)).toEqual({
+      mode: null,
+      modeSource: 'UNSET',
+      hasAuthorizedPet: false,
+      landing: 'NEEDS_MODE',
+    });
+  });
+
+  it('preserves existing authorized-pet access without inventing a persisted identity mode', () => {
+    expect(resolveCompanionState(null, true)).toEqual({
+      mode: null,
+      modeSource: 'PET_AUTHORITY_COMPAT',
+      hasAuthorizedPet: true,
+      landing: 'PET_TODAY',
+    });
+  });
+
+  it('requires real pet authority before Pet Guardian reaches pet Today', () => {
+    expect(resolveCompanionState('PET_GUARDIAN', false).landing).toBe('NEEDS_PET_SETUP');
+    expect(resolveCompanionState('PET_GUARDIAN', true).landing).toBe('PET_TODAY');
+  });
+
+  it('lets Animal Ally and Foster Caregiver use Companion Today without a pet', () => {
+    expect(resolveCompanionState('ANIMAL_ALLY', false).landing).toBe('COMPANION_TODAY');
+    expect(resolveCompanionState('FOSTER_CAREGIVER', false).landing).toBe('COMPANION_TODAY');
+  });
+
+  it('does not let a presentation mode revoke existing pet relationship authority', () => {
+    const state = resolveCompanionState('ANIMAL_ALLY', true);
+    expect(state.hasAuthorizedPet).toBe(true);
+    expect(state.landing).toBe('COMPANION_TODAY');
+  });
+});

--- a/apps/api/src/companion/companion.policy.ts
+++ b/apps/api/src/companion/companion.policy.ts
@@ -1,0 +1,53 @@
+export const COMPANION_MODES = ['PET_GUARDIAN', 'ANIMAL_ALLY', 'FOSTER_CAREGIVER'] as const;
+
+export type CompanionMode = (typeof COMPANION_MODES)[number];
+export type CompanionLanding =
+  | 'NEEDS_MODE'
+  | 'NEEDS_PET_SETUP'
+  | 'PET_TODAY'
+  | 'COMPANION_TODAY';
+
+export type CompanionState = {
+  mode: CompanionMode | null;
+  modeSource: 'PERSISTED' | 'PET_AUTHORITY_COMPAT' | 'UNSET';
+  hasAuthorizedPet: boolean;
+  landing: CompanionLanding;
+};
+
+export function resolveCompanionState(
+  mode: CompanionMode | null,
+  hasAuthorizedPet: boolean
+): CompanionState {
+  if (!mode) {
+    if (hasAuthorizedPet) {
+      return {
+        mode: 'PET_GUARDIAN',
+        modeSource: 'PET_AUTHORITY_COMPAT',
+        hasAuthorizedPet,
+        landing: 'PET_TODAY',
+      };
+    }
+    return {
+      mode: null,
+      modeSource: 'UNSET',
+      hasAuthorizedPet,
+      landing: 'NEEDS_MODE',
+    };
+  }
+
+  if (mode === 'PET_GUARDIAN') {
+    return {
+      mode,
+      modeSource: 'PERSISTED',
+      hasAuthorizedPet,
+      landing: hasAuthorizedPet ? 'PET_TODAY' : 'NEEDS_PET_SETUP',
+    };
+  }
+
+  return {
+    mode,
+    modeSource: 'PERSISTED',
+    hasAuthorizedPet,
+    landing: 'COMPANION_TODAY',
+  };
+}

--- a/apps/api/src/companion/companion.policy.ts
+++ b/apps/api/src/companion/companion.policy.ts
@@ -12,11 +12,7 @@ export const READINESS_DIMENSIONS = [
 export type CompanionMode = (typeof COMPANION_MODES)[number];
 export type ReadinessStatus = (typeof READINESS_STATUSES)[number];
 export type ReadinessDimension = (typeof READINESS_DIMENSIONS)[number];
-export type CompanionLanding =
-  | 'NEEDS_MODE'
-  | 'NEEDS_PET_SETUP'
-  | 'PET_TODAY'
-  | 'COMPANION_TODAY';
+export type CompanionLanding = 'NEEDS_MODE' | 'NEEDS_PET_SETUP' | 'PET_TODAY' | 'COMPANION_TODAY';
 
 export type CompanionState = {
   mode: CompanionMode | null;

--- a/apps/api/src/companion/companion.policy.ts
+++ b/apps/api/src/companion/companion.policy.ts
@@ -1,6 +1,17 @@
 export const COMPANION_MODES = ['PET_GUARDIAN', 'ANIMAL_ALLY', 'FOSTER_CAREGIVER'] as const;
+export const READINESS_STATUSES = ['NOT_SURE', 'WORKING_ON_IT', 'READY_TO_DISCUSS'] as const;
+export const READINESS_DIMENSIONS = [
+  'housing',
+  'householdAlignment',
+  'timeCapacity',
+  'financialPlan',
+  'supportPlan',
+  'carePlan',
+] as const;
 
 export type CompanionMode = (typeof COMPANION_MODES)[number];
+export type ReadinessStatus = (typeof READINESS_STATUSES)[number];
+export type ReadinessDimension = (typeof READINESS_DIMENSIONS)[number];
 export type CompanionLanding =
   | 'NEEDS_MODE'
   | 'NEEDS_PET_SETUP'
@@ -21,7 +32,7 @@ export function resolveCompanionState(
   if (!mode) {
     if (hasAuthorizedPet) {
       return {
-        mode: 'PET_GUARDIAN',
+        mode: null,
         modeSource: 'PET_AUTHORITY_COMPAT',
         hasAuthorizedPet,
         landing: 'PET_TODAY',

--- a/apps/api/src/companion/companion.service.ts
+++ b/apps/api/src/companion/companion.service.ts
@@ -1,0 +1,144 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+import type { UpdateReadinessReflectionDto } from './dto/companion.dto';
+import {
+  READINESS_DIMENSIONS,
+  resolveCompanionState,
+  type CompanionMode,
+  type ReadinessDimension,
+  type ReadinessStatus,
+} from './companion.policy';
+
+type ModeRow = {
+  mode: string | null;
+};
+
+type ReadinessRow = {
+  dimensions: unknown;
+  updatedAt: Date;
+};
+
+@Injectable()
+export class CompanionService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getState(userId: string) {
+    const [mode, hasAuthorizedPet] = await Promise.all([
+      this.getPersistedMode(userId),
+      this.hasAuthorizedPet(userId),
+    ]);
+    const state = resolveCompanionState(mode, hasAuthorizedPet);
+
+    return {
+      ...state,
+      authority: {
+        modeControlsPresentation: true,
+        petAccessComesFromRelationships: true,
+        modeNeverCreatesPetAuthority: true,
+      },
+    };
+  }
+
+  async updateMode(userId: string, mode: CompanionMode) {
+    await this.prisma.$executeRaw(Prisma.sql`
+      INSERT INTO dogos_companion.profiles (user_id, mode, updated_at)
+      VALUES (${userId}, ${mode}, NOW())
+      ON CONFLICT (user_id)
+      DO UPDATE SET mode = EXCLUDED.mode, updated_at = NOW()
+    `);
+    return this.getState(userId);
+  }
+
+  async getReadiness(userId: string) {
+    const rows = await this.prisma.$queryRaw<ReadinessRow[]>(Prisma.sql`
+      SELECT dimensions, updated_at AS "updatedAt"
+      FROM dogos_companion.readiness_reflections
+      WHERE user_id = ${userId}
+      LIMIT 1
+    `);
+    const row = rows[0];
+    const dimensions = this.readinessDimensions(row?.dimensions);
+
+    return {
+      dimensions,
+      updatedAt: row?.updatedAt.toISOString() ?? null,
+      statuses: ['NOT_SURE', 'WORKING_ON_IT', 'READY_TO_DISCUSS'] as const,
+      disclaimer:
+        'This is a private reflection, not an adoption, foster, financial, housing, or welfare assessment. Woof does not combine these answers into a readiness score.',
+    };
+  }
+
+  async updateReadiness(userId: string, dto: UpdateReadinessReflectionDto) {
+    const patch = Object.fromEntries(
+      Object.entries(dto).filter(([, value]) => value !== undefined)
+    ) as Partial<Record<ReadinessDimension, ReadinessStatus>>;
+
+    if (Object.keys(patch).length > 0) {
+      await this.prisma.$executeRaw(Prisma.sql`
+        INSERT INTO dogos_companion.readiness_reflections (user_id, dimensions, updated_at)
+        VALUES (${userId}, ${JSON.stringify(patch)}::jsonb, NOW())
+        ON CONFLICT (user_id)
+        DO UPDATE SET
+          dimensions = dogos_companion.readiness_reflections.dimensions || EXCLUDED.dimensions,
+          updated_at = NOW()
+      `);
+    }
+
+    return this.getReadiness(userId);
+  }
+
+  private async getPersistedMode(userId: string): Promise<CompanionMode | null> {
+    const rows = await this.prisma.$queryRaw<ModeRow[]>(Prisma.sql`
+      SELECT mode
+      FROM dogos_companion.profiles
+      WHERE user_id = ${userId}
+      LIMIT 1
+    `);
+    const mode = rows[0]?.mode ?? null;
+    return mode === 'PET_GUARDIAN' || mode === 'ANIMAL_ALLY' || mode === 'FOSTER_CAREGIVER'
+      ? mode
+      : null;
+  }
+
+  private async hasAuthorizedPet(userId: string): Promise<boolean> {
+    const count = await this.prisma.pet.count({
+      where: {
+        OR: [
+          { ownerId: userId },
+          {
+            householdMemberships: {
+              some: {
+                status: 'ACTIVE',
+                household: {
+                  members: {
+                    some: {
+                      userId,
+                      status: 'ACTIVE',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    return count > 0;
+  }
+
+  private readinessDimensions(value: unknown) {
+    const record = value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+
+    return Object.fromEntries(
+      READINESS_DIMENSIONS.map((dimension) => {
+        const status = record[dimension];
+        const valid =
+          status === 'NOT_SURE' || status === 'WORKING_ON_IT' || status === 'READY_TO_DISCUSS';
+        return [dimension, valid ? status : null];
+      })
+    ) as Record<ReadinessDimension, ReadinessStatus | null>;
+  }
+}

--- a/apps/api/src/companion/companion.service.ts
+++ b/apps/api/src/companion/companion.service.ts
@@ -128,9 +128,10 @@ export class CompanionService {
   }
 
   private readinessDimensions(value: unknown) {
-    const record = value && typeof value === 'object' && !Array.isArray(value)
-      ? (value as Record<string, unknown>)
-      : {};
+    const record =
+      value && typeof value === 'object' && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : {};
 
     return Object.fromEntries(
       READINESS_DIMENSIONS.map((dimension) => {

--- a/apps/api/src/companion/dto/companion.dto.ts
+++ b/apps/api/src/companion/dto/companion.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsOptional } from 'class-validator';
+import {
+  COMPANION_MODES,
+  READINESS_STATUSES,
+  type CompanionMode,
+  type ReadinessStatus,
+} from '../companion.policy';
+
+export class UpdateCompanionModeDto {
+  @ApiProperty({ enum: COMPANION_MODES })
+  @IsIn(COMPANION_MODES)
+  mode!: CompanionMode;
+}
+
+export class UpdateReadinessReflectionDto {
+  @ApiPropertyOptional({ enum: READINESS_STATUSES })
+  @IsOptional()
+  @IsIn(READINESS_STATUSES)
+  housing?: ReadinessStatus;
+
+  @ApiPropertyOptional({ enum: READINESS_STATUSES })
+  @IsOptional()
+  @IsIn(READINESS_STATUSES)
+  householdAlignment?: ReadinessStatus;
+
+  @ApiPropertyOptional({ enum: READINESS_STATUSES })
+  @IsOptional()
+  @IsIn(READINESS_STATUSES)
+  timeCapacity?: ReadinessStatus;
+
+  @ApiPropertyOptional({ enum: READINESS_STATUSES })
+  @IsOptional()
+  @IsIn(READINESS_STATUSES)
+  financialPlan?: ReadinessStatus;
+
+  @ApiPropertyOptional({ enum: READINESS_STATUSES })
+  @IsOptional()
+  @IsIn(READINESS_STATUSES)
+  supportPlan?: ReadinessStatus;
+
+  @ApiPropertyOptional({ enum: READINESS_STATUSES })
+  @IsOptional()
+  @IsIn(READINESS_STATUSES)
+  carePlan?: ReadinessStatus;
+}

--- a/apps/web/e2e/companion-onramp.spec.ts
+++ b/apps/web/e2e/companion-onramp.spec.ts
@@ -23,23 +23,34 @@ async function fulfillJson(route: Route, body: unknown, status = 200) {
   });
 }
 
-async function authenticate(page: Page) {
-  await page.route('**/auth/me', (route) =>
-    fulfillJson(route, {
-      id: 'ally-user',
-      email: 'ally@example.com',
-      handle: 'animal-ally',
-      pets: [],
-    })
-  );
+const browserUser = {
+  id: 'ally-user',
+  email: 'ally@example.com',
+  handle: 'animal-ally',
+  pets: [],
+};
 
-  // Seed browser auth from a real same-origin public page. addInitScript is
-  // intentionally avoided because Woof's CSP must remain free to reject
-  // un-nonced inline scripts, including brittle test-only injection.
+async function authenticate(page: Page) {
+  const token = 'companion-browser-token';
+
+  // Seed the same persisted auth representation Woof itself writes. A raw
+  // authToken alone forces AuthGuard to race through /auth/me before the
+  // feature test can begin, which makes browser authority tests nondeterministic.
+  // Using a real same-origin page keeps CSP fully enforced.
   await page.goto('/login');
-  await page.evaluate(() => {
-    window.localStorage.setItem('authToken', 'companion-browser-token');
-  });
+  await page.evaluate(
+    ({ token, user }) => {
+      window.localStorage.setItem('authToken', token);
+      window.localStorage.setItem(
+        'woof-auth-storage',
+        JSON.stringify({
+          state: { user, token, isAuthenticated: true },
+          version: 0,
+        })
+      );
+    },
+    { token, user: browserUser }
+  );
 }
 
 const allyState = {

--- a/apps/web/e2e/companion-onramp.spec.ts
+++ b/apps/web/e2e/companion-onramp.spec.ts
@@ -32,7 +32,12 @@ async function authenticate(page: Page) {
       pets: [],
     })
   );
-  await page.addInitScript(() => {
+
+  // Seed browser auth from a real same-origin public page. addInitScript is
+  // intentionally avoided because Woof's CSP must remain free to reject
+  // un-nonced inline scripts, including brittle test-only injection.
+  await page.goto('/login');
+  await page.evaluate(() => {
     window.localStorage.setItem('authToken', 'companion-browser-token');
   });
 }
@@ -107,14 +112,14 @@ test.describe('dogOS Companion Onramp', () => {
       page.getByRole('heading', {
         name: 'Learn useful dog-human skills before you need a pet profile.',
       })
-    ).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Arcade' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Community' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Readiness' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Compass' })).toHaveCount(0);
-    await expect(page.getByRole('link', { name: 'Story' })).toHaveCount(0);
-    await expect(page.getByRole('link', { name: 'Auto' })).toHaveCount(0);
-    await expect(page.getByRole('link', { name: 'Coach' })).toHaveCount(0);
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('link', { name: 'Arcade', exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Community', exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Readiness', exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Compass', exact: true })).toHaveCount(0);
+    await expect(page.getByRole('link', { name: 'Story', exact: true })).toHaveCount(0);
+    await expect(page.getByRole('link', { name: 'Auto', exact: true })).toHaveCount(0);
+    await expect(page.getByRole('link', { name: 'Coach', exact: true })).toHaveCount(0);
 
     await page.goto('/community');
     await expect(page.getByRole('link', { name: /Skill Arcade/i })).toBeVisible();
@@ -133,11 +138,13 @@ test.describe('dogOS Companion Onramp', () => {
 
     await page.goto('/');
 
-    await expect(page.getByRole('heading', { name: 'We could not resolve your Woof mode' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Arcade' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Community' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Readiness' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Compass' })).toHaveCount(0);
+    await expect(
+      page.getByRole('heading', { name: 'We could not resolve your Woof mode' })
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('link', { name: 'Arcade', exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Community', exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Readiness', exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Compass', exact: true })).toHaveCount(0);
     await expect(page.locator('[data-today-primary-quest]')).toHaveCount(0);
   });
 
@@ -159,9 +166,11 @@ test.describe('dogOS Companion Onramp', () => {
 
     await page.goto('/');
 
-    await expect(page.getByRole('heading', { name: 'Add the dog you actually care for.' })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Add the dog you actually care for.' })
+    ).toBeVisible({ timeout: 10_000 });
     await expect(page.getByRole('link', { name: 'Add a dog' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Compass' })).toHaveCount(0);
+    await expect(page.getByRole('link', { name: 'Compass', exact: true })).toHaveCount(0);
     await expect(page.locator('[data-today-primary-quest]')).toHaveCount(0);
   });
 });

--- a/apps/web/e2e/companion-onramp.spec.ts
+++ b/apps/web/e2e/companion-onramp.spec.ts
@@ -33,6 +33,11 @@ const browserUser = {
 async function authenticate(page: Page) {
   const token = 'companion-browser-token';
 
+  // Persisted Zustand hydration and AuthGuard's canonical /auth/me fallback are
+  // both valid startup paths. Keep them pointed at the same user so a dev-server
+  // full reload cannot turn feature qualification into an authentication race.
+  await page.route('**/auth/me', (route) => fulfillJson(route, browserUser));
+
   // Seed the same persisted auth representation Woof itself writes. A raw
   // authToken alone forces AuthGuard to race through /auth/me before the
   // feature test can begin, which makes browser authority tests nondeterministic.

--- a/apps/web/e2e/companion-onramp.spec.ts
+++ b/apps/web/e2e/companion-onramp.spec.ts
@@ -112,6 +112,21 @@ async function mockPetlessSocial(page: Page) {
 }
 
 test.describe('dogOS Companion Onramp', () => {
+  test('authenticated returns resume at role choice instead of recreating account details', async ({
+    page,
+  }) => {
+    await authenticate(page);
+    await page.goto('/onboarding/companion');
+
+    await expect(
+      page.getByRole('heading', { name: 'You do not need a pet to start learning.' })
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Step 2 of 2')).toBeVisible();
+    await expect(page.getByLabel('Email')).toHaveCount(0);
+    await expect(page.getByLabel('Password')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Return to Woof' })).toBeVisible();
+  });
+
   test('Animal Ally gets a useful petless Today and no pet-only navigation', async ({ page }) => {
     await authenticate(page);
     await page.route('**/companion/state', (route) => fulfillJson(route, allyState));

--- a/apps/web/e2e/companion-onramp.spec.ts
+++ b/apps/web/e2e/companion-onramp.spec.ts
@@ -1,0 +1,167 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+function corsHeaders(route: Route) {
+  const requestHeaders = route.request().headers();
+  return {
+    'access-control-allow-origin': requestHeaders.origin ?? 'http://localhost:3000',
+    'access-control-allow-methods': 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+    'access-control-allow-headers':
+      requestHeaders['access-control-request-headers'] ?? 'authorization,content-type',
+    vary: 'Origin',
+  };
+}
+
+async function fulfillJson(route: Route, body: unknown, status = 200) {
+  if (route.request().method() === 'OPTIONS') {
+    await route.fulfill({ status: 204, headers: corsHeaders(route), body: '' });
+    return;
+  }
+  await route.fulfill({
+    status,
+    headers: { ...corsHeaders(route), 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function authenticate(page: Page) {
+  await page.route('**/auth/me', (route) =>
+    fulfillJson(route, {
+      id: 'ally-user',
+      email: 'ally@example.com',
+      handle: 'animal-ally',
+      pets: [],
+    })
+  );
+  await page.addInitScript(() => {
+    window.localStorage.setItem('authToken', 'companion-browser-token');
+  });
+}
+
+const allyState = {
+  mode: 'ANIMAL_ALLY',
+  modeSource: 'PERSISTED',
+  hasAuthorizedPet: false,
+  landing: 'COMPANION_TODAY',
+  authority: {
+    modeControlsPresentation: true,
+    petAccessComesFromRelationships: true,
+    modeNeverCreatesPetAuthority: true,
+  },
+};
+
+async function mockPetlessSocial(page: Page) {
+  await page.route('**/social-adventure/me', (route) =>
+    fulfillJson(route, {
+      preferences: { globalLeaderboardOptIn: false },
+      season: {
+        key: 'week:2026-08-24',
+        startsAt: '2026-08-24T00:00:00.000Z',
+        endsAt: '2026-08-31T00:00:00.000Z',
+      },
+      score: 50,
+      maxScore: 375,
+      components: {
+        humanSkill: {
+          score: 50,
+          maxScore: 200,
+          completedChallenges: ['MAKE_IT_EASIER'],
+        },
+        adventureVariety: { score: 0, maxScore: 175, pathways: [] },
+      },
+      humanSkillBestScores: { MAKE_IT_EASIER: 100 },
+      policyVersion: 'social-adventure-score-v1',
+      principles: ['human-skill-over-pet-performance'],
+    })
+  );
+  await page.route('**/social-adventure/leaderboard/global**', (route) =>
+    fulfillJson(route, {
+      scope: 'GLOBAL',
+      season: {
+        key: 'week:2026-08-24',
+        startsAt: '2026-08-24T00:00:00.000Z',
+        endsAt: '2026-08-31T00:00:00.000Z',
+      },
+      entries: [],
+      me: { score: 50, maxScore: 375, rank: null, public: false },
+      policyVersion: 'social-adventure-score-v1',
+      disclaimer: 'Human learning and bounded Adventure variety only.',
+    })
+  );
+  await page.route('**/social-adventure/feed**', (route) =>
+    fulfillJson(route, { posts: [], privacy: 'Public shares plus your own private shares.' })
+  );
+  await page.route('**/social-adventure/share-candidates**', (route) =>
+    fulfillJson(route, { candidates: [], privacy: 'Nothing is posted automatically.' })
+  );
+}
+
+test.describe('dogOS Companion Onramp', () => {
+  test('Animal Ally gets a useful petless Today and no pet-only navigation', async ({ page }) => {
+    await authenticate(page);
+    await page.route('**/companion/state', (route) => fulfillJson(route, allyState));
+    await mockPetlessSocial(page);
+
+    await page.goto('/');
+
+    await expect(
+      page.getByRole('heading', {
+        name: 'Learn useful dog-human skills before you need a pet profile.',
+      })
+    ).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Arcade' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Community' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Readiness' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Compass' })).toHaveCount(0);
+    await expect(page.getByRole('link', { name: 'Story' })).toHaveCount(0);
+    await expect(page.getByRole('link', { name: 'Auto' })).toHaveCount(0);
+    await expect(page.getByRole('link', { name: 'Coach' })).toHaveCount(0);
+
+    await page.goto('/community');
+    await expect(page.getByRole('link', { name: /Skill Arcade/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Local Packs/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Cooperative Pack quests/i })).toHaveCount(0);
+    await expect(page.getByText('Human learning league')).toBeVisible();
+  });
+
+  test('unavailable Companion authority fails closed instead of guessing guardian access', async ({
+    page,
+  }) => {
+    await authenticate(page);
+    await page.route('**/companion/state', (route) =>
+      fulfillJson(route, { message: 'Companion state unavailable' }, 503)
+    );
+
+    await page.goto('/');
+
+    await expect(page.getByRole('heading', { name: 'We could not resolve your Woof mode' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Arcade' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Community' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Readiness' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Compass' })).toHaveCount(0);
+    await expect(page.locator('[data-today-primary-quest]')).toHaveCount(0);
+  });
+
+  test('Pet Guardian mode without real pet authority stays in pet setup', async ({ page }) => {
+    await authenticate(page);
+    await page.route('**/companion/state', (route) =>
+      fulfillJson(route, {
+        mode: 'PET_GUARDIAN',
+        modeSource: 'PERSISTED',
+        hasAuthorizedPet: false,
+        landing: 'NEEDS_PET_SETUP',
+        authority: {
+          modeControlsPresentation: true,
+          petAccessComesFromRelationships: true,
+          modeNeverCreatesPetAuthority: true,
+        },
+      })
+    );
+
+    await page.goto('/');
+
+    await expect(page.getByRole('heading', { name: 'Add the dog you actually care for.' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Add a dog' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Compass' })).toHaveCount(0);
+    await expect(page.locator('[data-today-primary-quest]')).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/release-polish.spec.ts
+++ b/apps/web/e2e/release-polish.spec.ts
@@ -37,6 +37,22 @@ async function authenticate(page: Page) {
   });
 }
 
+async function authorizePetToday(page: Page) {
+  await page.route('**/companion/state', (route) =>
+    fulfillJson(route, {
+      mode: 'PET_GUARDIAN',
+      modeSource: 'PERSISTED',
+      hasAuthorizedPet: true,
+      landing: 'PET_TODAY',
+      authority: {
+        modeControlsPresentation: true,
+        petAccessComesFromRelationships: true,
+        modeNeverCreatesPetAuthority: true,
+      },
+    })
+  );
+}
+
 const pets = [
   {
     id: 'pet-1',
@@ -143,6 +159,7 @@ test.describe('dogOS release polish', () => {
     page,
   }) => {
     await authenticate(page);
+    await authorizePetToday(page);
     await page.route('**/pets/me**', (route) =>
       fulfillJson(route, { pets, total: 2, skip: 0, take: 100 })
     );
@@ -195,6 +212,7 @@ test.describe('dogOS release polish', () => {
     page,
   }) => {
     await authenticate(page);
+    await authorizePetToday(page);
     await page.route('**/pets/me**', (route) =>
       fulfillJson(route, { pets, total: 2, skip: 0, take: 100 })
     );
@@ -263,6 +281,19 @@ test.describe('dogOS release polish', () => {
     await authenticate(page);
     let createdBody: Record<string, unknown> | null = null;
     let created = false;
+    await page.route('**/companion/state', (route) =>
+      fulfillJson(route, {
+        mode: 'PET_GUARDIAN',
+        modeSource: 'PERSISTED',
+        hasAuthorizedPet: created,
+        landing: created ? 'PET_TODAY' : 'NEEDS_PET_SETUP',
+        authority: {
+          modeControlsPresentation: true,
+          petAccessComesFromRelationships: true,
+          modeNeverCreatesPetAuthority: true,
+        },
+      })
+    );
     await page.route('**/pets', async (route) => {
       if (route.request().method() === 'OPTIONS') return fulfillJson(route, {});
       createdBody = route.request().postDataJSON() as Record<string, unknown>;

--- a/apps/web/e2e/trust-discovery.spec.ts
+++ b/apps/web/e2e/trust-discovery.spec.ts
@@ -47,8 +47,10 @@ async function authenticate(page: Page) {
   await page.context().grantPermissions(['geolocation'], { origin: 'http://localhost:3000' });
   await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194, accuracy: 100 });
 
-  // Persist the real client auth shape before the protected navigation so
-  // AuthGuard does not race feature rendering through a redundant /auth/me hop.
+  // Persist the real client auth shape before protected navigation so AuthGuard
+  // does not race through session hydration. Discovery still performs its own
+  // canonical profile refresh below, because current pet membership is part of
+  // that feature's freshness contract rather than authentication bootstrap.
   await page.goto('/login');
   await page.evaluate(
     ({ token, user }) => {
@@ -63,6 +65,7 @@ async function authenticate(page: Page) {
     },
     { token, user }
   );
+  await page.route('**/auth/me', (route) => fulfillJson(route, user));
 }
 
 const recommendation = {

--- a/apps/web/e2e/trust-discovery.spec.ts
+++ b/apps/web/e2e/trust-discovery.spec.ts
@@ -23,33 +23,6 @@ async function fulfillJson(route: Route, body: unknown, status = 200) {
   });
 }
 
-async function authenticate(page: Page) {
-  await page.addInitScript(() => {
-    window.localStorage.setItem('authToken', 'trust-browser-token');
-    Object.defineProperty(navigator, 'geolocation', {
-      configurable: true,
-      value: {
-        getCurrentPosition(success: PositionCallback) {
-          success({
-            coords: {
-              latitude: 37.7749,
-              longitude: -122.4194,
-              accuracy: 100,
-              altitude: null,
-              altitudeAccuracy: null,
-              heading: null,
-              speed: null,
-              toJSON: () => ({}),
-            },
-            timestamp: Date.now(),
-            toJSON: () => ({}),
-          } as GeolocationPosition);
-        },
-      },
-    });
-  });
-}
-
 const user = {
   id: 'user-1',
   email: 'owner@example.com',
@@ -64,6 +37,33 @@ const user = {
     },
   ],
 };
+
+async function authenticate(page: Page) {
+  const token = 'trust-browser-token';
+
+  // Model geolocation through Playwright's browser context rather than replacing
+  // navigator.geolocation with an injected inline script. This keeps the test
+  // compatible with the same CSP that protects the production app.
+  await page.context().grantPermissions(['geolocation'], { origin: 'http://localhost:3000' });
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194, accuracy: 100 });
+
+  // Persist the real client auth shape before the protected navigation so
+  // AuthGuard does not race feature rendering through a redundant /auth/me hop.
+  await page.goto('/login');
+  await page.evaluate(
+    ({ token, user }) => {
+      window.localStorage.setItem('authToken', token);
+      window.localStorage.setItem(
+        'woof-auth-storage',
+        JSON.stringify({
+          state: { user, token, isAuthenticated: true },
+          version: 0,
+        })
+      );
+    },
+    { token, user }
+  );
+}
 
 const recommendation = {
   id: 'candidate-pet-2',
@@ -100,7 +100,6 @@ test('explicit rough-location discovery leads to an empty canonical conversation
   let locationEnabled = false;
   let conversationCreated = false;
 
-  await page.route('**/auth/me', (route) => fulfillJson(route, user));
   await page.route('**/compatibility/recommendations/pet-1**', (route) =>
     fulfillJson(route, { recommendations: [recommendation] })
   );

--- a/apps/web/src/app/community/page.tsx
+++ b/apps/web/src/app/community/page.tsx
@@ -18,6 +18,7 @@ import { BottomNav } from '@/components/bottom-nav';
 import { ShareableMoments } from '@/components/social-adventure/shareable-moments';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
+import { companionApi } from '@/lib/api/companion';
 import { socialAdventureApi, type SocialAdventureReaction } from '@/lib/api/social-adventure';
 
 const reactionCopy: Record<SocialAdventureReaction, string> = {
@@ -30,6 +31,12 @@ const reactionCopy: Record<SocialAdventureReaction, string> = {
 
 export default function CommunityPage() {
   const queryClient = useQueryClient();
+  const companion = useQuery({
+    queryKey: ['companion', 'state'],
+    queryFn: companionApi.state,
+    retry: false,
+    staleTime: 60_000,
+  });
   const me = useQuery({
     queryKey: ['social-adventure', 'me'],
     queryFn: socialAdventureApi.getMine,
@@ -73,6 +80,7 @@ export default function CommunityPage() {
   });
 
   const loading = me.isLoading || leaderboard.isLoading || feed.isLoading;
+  const hasPetContext = companion.data?.landing === 'PET_TODAY';
 
   return (
     <div className="min-h-screen pb-24">
@@ -122,7 +130,7 @@ export default function CommunityPage() {
                   </p>
                 </div>
                 <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-bold text-primary">
-                  Human + pair league
+                  {hasPetContext ? 'Human + pair league' : 'Human learning league'}
                 </span>
               </div>
               <Progress className="mt-3 h-2" value={(me.data.score / me.data.maxScore) * 100} />
@@ -156,12 +164,14 @@ export default function CommunityPage() {
                 Local Packs
               </Link>
             </Button>
-            <Button variant="outline" asChild className="col-span-2 bg-transparent">
-              <Link href="/pack">
-                <HeartHandshake className="mr-2 h-4 w-4" aria-hidden="true" />
-                Cooperative Pack quests
-              </Link>
-            </Button>
+            {hasPetContext && (
+              <Button variant="outline" asChild className="col-span-2 bg-transparent">
+                <Link href="/pack">
+                  <HeartHandshake className="mr-2 h-4 w-4" aria-hidden="true" />
+                  Cooperative Pack quests
+                </Link>
+              </Button>
+            )}
           </div>
         </section>
 

--- a/apps/web/src/app/companion/readiness/page.tsx
+++ b/apps/web/src/app/companion/readiness/page.tsx
@@ -5,23 +5,46 @@ import { BookOpenCheck, Loader2, ShieldCheck } from 'lucide-react';
 import Link from 'next/link';
 import { BottomNav } from '@/components/bottom-nav';
 import { Button } from '@/components/ui/button';
-import {
-  companionApi,
-  type ReadinessDimension,
-  type ReadinessStatus,
-} from '@/lib/api/companion';
+import { companionApi, type ReadinessDimension, type ReadinessStatus } from '@/lib/api/companion';
 
 const dimensions: Array<{
   key: ReadinessDimension;
   label: string;
   description: string;
 }> = [
-  { key: 'housing', label: 'Housing', description: 'Would the living situation realistically support the animal and applicable rules?' },
-  { key: 'householdAlignment', label: 'Household alignment', description: 'Are the people sharing the home aligned on responsibilities and boundaries?' },
-  { key: 'timeCapacity', label: 'Time capacity', description: 'Is there room for daily care, decompression, training, transport, and interruptions?' },
-  { key: 'financialPlan', label: 'Financial plan', description: 'Is there a realistic plan for routine costs and unexpected care?' },
-  { key: 'supportPlan', label: 'Support plan', description: 'Who can help with care, transport, travel, emergencies, or difficult weeks?' },
-  { key: 'carePlan', label: 'Care plan', description: 'Are veterinary care, supplies, management, and transition needs understood enough to discuss?' },
+  {
+    key: 'housing',
+    label: 'Housing',
+    description:
+      'Would the living situation realistically support the animal and applicable rules?',
+  },
+  {
+    key: 'householdAlignment',
+    label: 'Household alignment',
+    description: 'Are the people sharing the home aligned on responsibilities and boundaries?',
+  },
+  {
+    key: 'timeCapacity',
+    label: 'Time capacity',
+    description:
+      'Is there room for daily care, decompression, training, transport, and interruptions?',
+  },
+  {
+    key: 'financialPlan',
+    label: 'Financial plan',
+    description: 'Is there a realistic plan for routine costs and unexpected care?',
+  },
+  {
+    key: 'supportPlan',
+    label: 'Support plan',
+    description: 'Who can help with care, transport, travel, emergencies, or difficult weeks?',
+  },
+  {
+    key: 'carePlan',
+    label: 'Care plan',
+    description:
+      'Are veterinary care, supplies, management, and transition needs understood enough to discuss?',
+  },
 ];
 
 const statuses: Array<{ value: ReadinessStatus; label: string }> = [
@@ -51,7 +74,9 @@ export default function CompanionReadinessPage() {
         <div className="mx-auto flex h-16 max-w-xl items-center gap-3 px-4">
           <BookOpenCheck className="h-5 w-5 text-primary" aria-hidden="true" />
           <div>
-            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Companion mode</p>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Companion mode
+            </p>
             <h1 className="text-lg font-bold tracking-tight">Readiness reflection</h1>
           </div>
         </div>
@@ -64,7 +89,9 @@ export default function CompanionReadinessPage() {
             <div>
               <h2 className="font-bold">A checklist, not a verdict.</h2>
               <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-                These answers are private self-reflection. Woof does not combine them into an adoption or foster score, publish them, or replace a shelter, rescue, landlord, veterinarian, trainer, or financial decision-maker.
+                These answers are private self-reflection. Woof does not combine them into an
+                adoption or foster score, publish them, or replace a shelter, rescue, landlord,
+                veterinarian, trainer, or financial decision-maker.
               </p>
             </div>
           </div>
@@ -80,7 +107,9 @@ export default function CompanionReadinessPage() {
         ) : readiness.isError || !readiness.data ? (
           <section className="surface-soft mt-5 rounded-2xl p-5 text-center">
             <p className="font-semibold">Your reflection is unavailable right now.</p>
-            <Button className="mt-4" onClick={() => void readiness.refetch()}>Try again</Button>
+            <Button className="mt-4" onClick={() => void readiness.refetch()}>
+              Try again
+            </Button>
           </section>
         ) : (
           <div className="mt-5 space-y-3">
@@ -89,7 +118,9 @@ export default function CompanionReadinessPage() {
               return (
                 <section key={dimension.key} className="surface-soft rounded-2xl p-5">
                   <h2 className="font-bold">{dimension.label}</h2>
-                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{dimension.description}</p>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                    {dimension.description}
+                  </p>
                   <div className="mt-4 flex flex-wrap gap-2">
                     {statuses.map((status) => (
                       <Button
@@ -112,7 +143,9 @@ export default function CompanionReadinessPage() {
         )}
 
         <p className="mt-5 text-xs leading-relaxed text-muted-foreground">
-          A “Ready to discuss” selection means only that you feel prepared to talk about that dimension. Placement and foster decisions stay with the organizations and people responsible for them.
+          A “Ready to discuss” selection means only that you feel prepared to talk about that
+          dimension. Placement and foster decisions stay with the organizations and people
+          responsible for them.
         </p>
       </main>
 

--- a/apps/web/src/app/companion/readiness/page.tsx
+++ b/apps/web/src/app/companion/readiness/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { BookOpenCheck, Loader2, ShieldCheck } from 'lucide-react';
+import Link from 'next/link';
+import { BottomNav } from '@/components/bottom-nav';
+import { Button } from '@/components/ui/button';
+import {
+  companionApi,
+  type ReadinessDimension,
+  type ReadinessStatus,
+} from '@/lib/api/companion';
+
+const dimensions: Array<{
+  key: ReadinessDimension;
+  label: string;
+  description: string;
+}> = [
+  { key: 'housing', label: 'Housing', description: 'Would the living situation realistically support the animal and applicable rules?' },
+  { key: 'householdAlignment', label: 'Household alignment', description: 'Are the people sharing the home aligned on responsibilities and boundaries?' },
+  { key: 'timeCapacity', label: 'Time capacity', description: 'Is there room for daily care, decompression, training, transport, and interruptions?' },
+  { key: 'financialPlan', label: 'Financial plan', description: 'Is there a realistic plan for routine costs and unexpected care?' },
+  { key: 'supportPlan', label: 'Support plan', description: 'Who can help with care, transport, travel, emergencies, or difficult weeks?' },
+  { key: 'carePlan', label: 'Care plan', description: 'Are veterinary care, supplies, management, and transition needs understood enough to discuss?' },
+];
+
+const statuses: Array<{ value: ReadinessStatus; label: string }> = [
+  { value: 'NOT_SURE', label: 'Not sure yet' },
+  { value: 'WORKING_ON_IT', label: 'Working on it' },
+  { value: 'READY_TO_DISCUSS', label: 'Ready to discuss' },
+];
+
+export default function CompanionReadinessPage() {
+  const queryClient = useQueryClient();
+  const readiness = useQuery({
+    queryKey: ['companion', 'readiness'],
+    queryFn: companionApi.readiness,
+    retry: false,
+  });
+  const update = useMutation({
+    mutationFn: ({ key, value }: { key: ReadinessDimension; value: ReadinessStatus }) =>
+      companionApi.updateReadiness({ [key]: value }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['companion', 'readiness'] });
+    },
+  });
+
+  return (
+    <div className="min-h-screen pb-24">
+      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/88 backdrop-blur-2xl">
+        <div className="mx-auto flex h-16 max-w-xl items-center gap-3 px-4">
+          <BookOpenCheck className="h-5 w-5 text-primary" aria-hidden="true" />
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Companion mode</p>
+            <h1 className="text-lg font-bold tracking-tight">Readiness reflection</h1>
+          </div>
+        </div>
+      </header>
+
+      <main id="main-content" className="mx-auto max-w-xl px-4 pb-8 pt-5">
+        <section className="rounded-3xl border border-primary/20 bg-primary/[0.05] p-5">
+          <div className="flex items-start gap-3">
+            <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+            <div>
+              <h2 className="font-bold">A checklist, not a verdict.</h2>
+              <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                These answers are private self-reflection. Woof does not combine them into an adoption or foster score, publish them, or replace a shelter, rescue, landlord, veterinarian, trainer, or financial decision-maker.
+              </p>
+            </div>
+          </div>
+          <Button asChild variant="outline" className="mt-4 bg-transparent">
+            <Link href="/">← Back to Today</Link>
+          </Button>
+        </section>
+
+        {readiness.isLoading ? (
+          <div className="flex min-h-48 items-center justify-center" role="status">
+            <Loader2 className="h-6 w-6 animate-spin text-primary" aria-hidden="true" />
+          </div>
+        ) : readiness.isError || !readiness.data ? (
+          <section className="surface-soft mt-5 rounded-2xl p-5 text-center">
+            <p className="font-semibold">Your reflection is unavailable right now.</p>
+            <Button className="mt-4" onClick={() => void readiness.refetch()}>Try again</Button>
+          </section>
+        ) : (
+          <div className="mt-5 space-y-3">
+            {dimensions.map((dimension) => {
+              const current = readiness.data.dimensions[dimension.key];
+              return (
+                <section key={dimension.key} className="surface-soft rounded-2xl p-5">
+                  <h2 className="font-bold">{dimension.label}</h2>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{dimension.description}</p>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {statuses.map((status) => (
+                      <Button
+                        key={status.value}
+                        type="button"
+                        size="sm"
+                        variant={current === status.value ? 'default' : 'outline'}
+                        className={current === status.value ? undefined : 'bg-transparent'}
+                        disabled={update.isPending}
+                        onClick={() => update.mutate({ key: dimension.key, value: status.value })}
+                      >
+                        {status.label}
+                      </Button>
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        )}
+
+        <p className="mt-5 text-xs leading-relaxed text-muted-foreground">
+          A “Ready to discuss” selection means only that you feel prepared to talk about that dimension. Placement and foster decisions stay with the organizations and people responsible for them.
+        </p>
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -12,9 +12,9 @@ import { Label } from '@/components/ui/label';
 import { authApi } from '@/lib/api';
 
 const productSignals = [
-  'Explainable compatibility, not mystery scores',
-  'Designed around real-world meetup outcomes',
-  'Location and trust treated as product boundaries',
+  'Relationship-first dogOS when you have an authorized pet',
+  'Human-skill practice and community without inventing a pet',
+  'Location, health, and placement authority treated as product boundaries',
 ];
 
 export default function LoginPage() {
@@ -51,11 +51,7 @@ export default function LoginPage() {
           aria-hidden="true"
         />
         <div className="relative">
-          <Link
-            href="/login"
-            className="inline-flex min-h-11 items-center gap-3 rounded-xl"
-            aria-label="Woof sign in"
-          >
+          <Link href="/login" className="inline-flex min-h-11 items-center gap-3 rounded-xl" aria-label="Woof sign in">
             <span className="brand-mark flex h-11 w-11 items-center justify-center rounded-2xl">
               <PawPrint className="h-6 w-6 text-primary-foreground" aria-hidden="true" />
             </span>
@@ -64,13 +60,12 @@ export default function LoginPage() {
         </div>
 
         <div className="relative max-w-xl">
-          <p className="eyebrow">A social network that closes the loop</p>
+          <p className="eyebrow">dogOS starts with the relationship you actually have</p>
           <h2 className="mt-4 text-4xl font-bold leading-tight tracking-tight xl:text-5xl">
-            Better dog friendships start with better context.
+            Learn with a dog, for a future dog, or as someone helping dogs.
           </h2>
           <p className="mt-5 max-w-lg text-base leading-7 text-muted-foreground">
-            Discover compatible dogs, coordinate a safe meetup, and learn from what actually
-            happened offline instead of optimizing another endless feed.
+            Woof can open the full pet relationship loop when you have real pet authority, or stay useful through human-skill practice, community, and private readiness reflection when you do not.
           </p>
 
           <div className="mt-8 space-y-3">
@@ -87,21 +82,18 @@ export default function LoginPage() {
 
         <div className="relative flex items-center gap-2 text-xs text-muted-foreground">
           <ShieldCheck className="h-4 w-4 text-secondary" aria-hidden="true" />
-          Precise location should stay contextual and permissioned.
+          A mode changes presentation. It never grants access to a pet.
         </div>
       </aside>
 
-      <main
-        id="main-content"
-        className="flex min-h-screen items-center justify-center px-4 py-10 sm:px-6 lg:px-10"
-      >
+      <main id="main-content" className="flex min-h-screen items-center justify-center px-4 py-10 sm:px-6 lg:px-10">
         <div className="w-full max-w-md">
           <div className="mb-8 flex items-center gap-3 lg:hidden">
             <span className="brand-mark flex h-10 w-10 items-center justify-center rounded-xl">
               <PawPrint className="h-5 w-5 text-primary-foreground" aria-hidden="true" />
             </span>
             <div>
-              <p className="eyebrow">Your local pack</p>
+              <p className="eyebrow">Relationship-first dogOS</p>
               <p className="font-bold">Woof</p>
             </div>
           </div>
@@ -114,7 +106,7 @@ export default function LoginPage() {
               <div>
                 <h1 className="text-3xl font-bold tracking-tight">Welcome back</h1>
                 <CardDescription className="mt-2 leading-relaxed">
-                  Sign in to continue learning what helps your pet thrive with you.
+                  Sign in to continue from the dog, caregiver, or learning context that actually applies to you.
                 </CardDescription>
               </div>
             </CardHeader>
@@ -122,42 +114,17 @@ export default function LoginPage() {
               <form onSubmit={handleSubmit} className="space-y-4">
                 <div className="space-y-2">
                   <Label htmlFor="email">Email</Label>
-                  <Input
-                    id="email"
-                    type="email"
-                    autoComplete="email"
-                    placeholder="you@example.com"
-                    value={email}
-                    onChange={(event) => setEmail(event.target.value)}
-                    required
-                    disabled={isLoading}
-                  />
+                  <Input id="email" type="email" autoComplete="email" placeholder="you@example.com" value={email} onChange={(event) => setEmail(event.target.value)} required disabled={isLoading} />
                 </div>
-
                 <div className="space-y-2">
                   <Label htmlFor="password">Password</Label>
-                  <Input
-                    id="password"
-                    type="password"
-                    autoComplete="current-password"
-                    placeholder="••••••••"
-                    value={password}
-                    onChange={(event) => setPassword(event.target.value)}
-                    required
-                    disabled={isLoading}
-                  />
+                  <Input id="password" type="password" autoComplete="current-password" placeholder="••••••••" value={password} onChange={(event) => setPassword(event.target.value)} required disabled={isLoading} />
                 </div>
-
                 {error && (
-                  <div
-                    role="alert"
-                    aria-live="polite"
-                    className="rounded-xl border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive"
-                  >
+                  <div role="alert" aria-live="polite" className="rounded-xl border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">
                     {error}
                   </div>
                 )}
-
                 <Button type="submit" size="lg" className="w-full" disabled={isLoading}>
                   {isLoading ? (
                     <>
@@ -172,19 +139,15 @@ export default function LoginPage() {
 
               <p className="mt-6 text-center text-sm text-muted-foreground">
                 New to Woof?{' '}
-                <Link
-                  href="/onboarding"
-                  className="inline-flex min-h-8 items-center rounded-md px-1 font-semibold text-primary hover:text-primary/80"
-                >
-                  Create your profile
+                <Link href="/onboarding/companion" className="inline-flex min-h-8 items-center rounded-md px-1 font-semibold text-primary hover:text-primary/80">
+                  Choose how to start
                 </Link>
               </p>
             </CardContent>
           </Card>
 
           <p className="mt-5 text-center text-xs leading-relaxed text-muted-foreground">
-            Woof is a beta research product. Public demos use synthetic data and avoid sensitive
-            real-world location history.
+            Woof is a beta research product. Public demos use synthetic data and avoid sensitive real-world location history.
           </p>
         </div>
       </main>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -51,7 +51,11 @@ export default function LoginPage() {
           aria-hidden="true"
         />
         <div className="relative">
-          <Link href="/login" className="inline-flex min-h-11 items-center gap-3 rounded-xl" aria-label="Woof sign in">
+          <Link
+            href="/login"
+            className="inline-flex min-h-11 items-center gap-3 rounded-xl"
+            aria-label="Woof sign in"
+          >
             <span className="brand-mark flex h-11 w-11 items-center justify-center rounded-2xl">
               <PawPrint className="h-6 w-6 text-primary-foreground" aria-hidden="true" />
             </span>
@@ -65,7 +69,9 @@ export default function LoginPage() {
             Learn with a dog, for a future dog, or as someone helping dogs.
           </h2>
           <p className="mt-5 max-w-lg text-base leading-7 text-muted-foreground">
-            Woof can open the full pet relationship loop when you have real pet authority, or stay useful through human-skill practice, community, and private readiness reflection when you do not.
+            Woof can open the full pet relationship loop when you have real pet authority, or stay
+            useful through human-skill practice, community, and private readiness reflection when
+            you do not.
           </p>
 
           <div className="mt-8 space-y-3">
@@ -81,12 +87,15 @@ export default function LoginPage() {
         </div>
 
         <div className="relative flex items-center gap-2 text-xs text-muted-foreground">
-          <ShieldCheck className="h-4 w-4 text-secondary" aria-hidden="true" />
-          A mode changes presentation. It never grants access to a pet.
+          <ShieldCheck className="h-4 w-4 text-secondary" aria-hidden="true" />A mode changes
+          presentation. It never grants access to a pet.
         </div>
       </aside>
 
-      <main id="main-content" className="flex min-h-screen items-center justify-center px-4 py-10 sm:px-6 lg:px-10">
+      <main
+        id="main-content"
+        className="flex min-h-screen items-center justify-center px-4 py-10 sm:px-6 lg:px-10"
+      >
         <div className="w-full max-w-md">
           <div className="mb-8 flex items-center gap-3 lg:hidden">
             <span className="brand-mark flex h-10 w-10 items-center justify-center rounded-xl">
@@ -106,7 +115,8 @@ export default function LoginPage() {
               <div>
                 <h1 className="text-3xl font-bold tracking-tight">Welcome back</h1>
                 <CardDescription className="mt-2 leading-relaxed">
-                  Sign in to continue from the dog, caregiver, or learning context that actually applies to you.
+                  Sign in to continue from the dog, caregiver, or learning context that actually
+                  applies to you.
                 </CardDescription>
               </div>
             </CardHeader>
@@ -114,14 +124,36 @@ export default function LoginPage() {
               <form onSubmit={handleSubmit} className="space-y-4">
                 <div className="space-y-2">
                   <Label htmlFor="email">Email</Label>
-                  <Input id="email" type="email" autoComplete="email" placeholder="you@example.com" value={email} onChange={(event) => setEmail(event.target.value)} required disabled={isLoading} />
+                  <Input
+                    id="email"
+                    type="email"
+                    autoComplete="email"
+                    placeholder="you@example.com"
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                    required
+                    disabled={isLoading}
+                  />
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="password">Password</Label>
-                  <Input id="password" type="password" autoComplete="current-password" placeholder="••••••••" value={password} onChange={(event) => setPassword(event.target.value)} required disabled={isLoading} />
+                  <Input
+                    id="password"
+                    type="password"
+                    autoComplete="current-password"
+                    placeholder="••••••••"
+                    value={password}
+                    onChange={(event) => setPassword(event.target.value)}
+                    required
+                    disabled={isLoading}
+                  />
                 </div>
                 {error && (
-                  <div role="alert" aria-live="polite" className="rounded-xl border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">
+                  <div
+                    role="alert"
+                    aria-live="polite"
+                    className="rounded-xl border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive"
+                  >
                     {error}
                   </div>
                 )}
@@ -139,7 +171,10 @@ export default function LoginPage() {
 
               <p className="mt-6 text-center text-sm text-muted-foreground">
                 New to Woof?{' '}
-                <Link href="/onboarding/companion" className="inline-flex min-h-8 items-center rounded-md px-1 font-semibold text-primary hover:text-primary/80">
+                <Link
+                  href="/onboarding/companion"
+                  className="inline-flex min-h-8 items-center rounded-md px-1 font-semibold text-primary hover:text-primary/80"
+                >
                   Choose how to start
                 </Link>
               </p>
@@ -147,7 +182,8 @@ export default function LoginPage() {
           </Card>
 
           <p className="mt-5 text-center text-xs leading-relaxed text-muted-foreground">
-            Woof is a beta research product. Public demos use synthetic data and avoid sensitive real-world location history.
+            Woof is a beta research product. Public demos use synthetic data and avoid sensitive
+            real-world location history.
           </p>
         </div>
       </main>

--- a/apps/web/src/app/onboarding/companion/page.tsx
+++ b/apps/web/src/app/onboarding/companion/page.tsx
@@ -3,7 +3,7 @@
 import { isAxiosError } from 'axios';
 import { ChevronLeft, Loader2, PawPrint } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { CompanionModeChooser } from '@/components/companion/companion-mode-chooser';
 import { OwnerInfoStep, type OwnerInfoData } from '@/components/onboarding/owner-info-step';
 import { Button } from '@/components/ui/button';
@@ -30,6 +30,17 @@ export default function CompanionOnboardingPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
   const registrationKeyRef = useRef<string | null>(null);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  // Registration can succeed before mode persistence does. The auth store is
+  // durable, so a returning user should resume at the role choice rather than
+  // being asked to recreate account details that already exist canonically.
+  useEffect(() => {
+    if (isAuthenticated && step === 1) {
+      setError('');
+      setStep(2);
+    }
+  }, [isAuthenticated, step]);
 
   const getRegistrationKey = () => {
     if (registrationKeyRef.current) return registrationKeyRef.current;
@@ -84,6 +95,12 @@ export default function CompanionOnboardingPage() {
   };
 
   const progress = step === 1 ? 50 : 100;
+  const backLabel =
+    step === 2
+      ? isAuthenticated
+        ? 'Return to Woof'
+        : 'Back to account details'
+      : 'Return to sign in';
 
   return (
     <div className="min-h-screen">
@@ -93,8 +110,14 @@ export default function CompanionOnboardingPage() {
             variant="ghost"
             size="icon"
             disabled={isLoading}
-            onClick={() => (step === 2 ? setStep(1) : router.push('/login'))}
-            aria-label={step === 2 ? 'Back to account details' : 'Return to sign in'}
+            onClick={() => {
+              if (step === 2 && !isAuthenticated) {
+                setStep(1);
+                return;
+              }
+              router.push(isAuthenticated ? '/' : '/login');
+            }}
+            aria-label={backLabel}
           >
             <ChevronLeft className="h-5 w-5" aria-hidden="true" />
           </Button>

--- a/apps/web/src/app/onboarding/companion/page.tsx
+++ b/apps/web/src/app/onboarding/companion/page.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { isAxiosError } from 'axios';
+import { ChevronLeft, Loader2, PawPrint } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useRef, useState } from 'react';
+import { CompanionModeChooser } from '@/components/companion/companion-mode-chooser';
+import { OwnerInfoStep, type OwnerInfoData } from '@/components/onboarding/owner-info-step';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { authApi } from '@/lib/api';
+import { companionApi, type CompanionMode } from '@/lib/api/companion';
+import { useAuthStore } from '@/lib/stores/auth-store';
+
+type ApiErrorBody = { message?: string | string[] };
+const REGISTRATION_KEY_STORAGE = 'woof:companion-onramp:registration-key';
+
+function apiErrorMessage(error: unknown, fallback: string) {
+  const responseMessage = isAxiosError<ApiErrorBody>(error)
+    ? error.response?.data?.message
+    : undefined;
+  if (Array.isArray(responseMessage)) return responseMessage.join(' ');
+  return responseMessage || fallback;
+}
+
+export default function CompanionOnboardingPage() {
+  const router = useRouter();
+  const [step, setStep] = useState(1);
+  const [ownerData, setOwnerData] = useState<OwnerInfoData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+  const registrationKeyRef = useRef<string | null>(null);
+
+  const getRegistrationKey = () => {
+    if (registrationKeyRef.current) return registrationKeyRef.current;
+    const stored = window.sessionStorage.getItem(REGISTRATION_KEY_STORAGE);
+    if (stored) {
+      registrationKeyRef.current = stored;
+      return stored;
+    }
+    const next = crypto.randomUUID();
+    window.sessionStorage.setItem(REGISTRATION_KEY_STORAGE, next);
+    registrationKeyRef.current = next;
+    return next;
+  };
+
+  const clearRegistrationKey = () => {
+    window.sessionStorage.removeItem(REGISTRATION_KEY_STORAGE);
+    registrationKeyRef.current = null;
+  };
+
+  const selectMode = async (mode: CompanionMode) => {
+    if (!ownerData && !useAuthStore.getState().isAuthenticated) return;
+    setIsLoading(true);
+    setError('');
+
+    try {
+      if (!useAuthStore.getState().isAuthenticated) {
+        if (!ownerData?.password) throw new Error('Your account password is missing.');
+        const registrationRequest = {
+          handle: ownerData.handle,
+          email: ownerData.email,
+          password: ownerData.password,
+          bio: ownerData.bio || undefined,
+          registrationKey: getRegistrationKey(),
+        };
+        await authApi.register(registrationRequest);
+        clearRegistrationKey();
+        setOwnerData((current) => (current ? { ...current, password: '' } : current));
+      }
+
+      await companionApi.updateMode(mode);
+      router.replace(mode === 'PET_GUARDIAN' ? '/onboarding' : '/');
+    } catch (caught) {
+      setError(
+        apiErrorMessage(
+          caught,
+          'We could not finish your account mode. Your pet and relationship state were not changed.'
+        )
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const progress = step === 1 ? 50 : 100;
+
+  return (
+    <div className="min-h-screen">
+      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/88 backdrop-blur-2xl">
+        <div className="mx-auto flex max-w-lg items-center gap-4 px-4 py-4">
+          <Button
+            variant="ghost"
+            size="icon"
+            disabled={isLoading}
+            onClick={() => (step === 2 ? setStep(1) : router.push('/login'))}
+            aria-label={step === 2 ? 'Back to account details' : 'Return to sign in'}
+          >
+            <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+          </Button>
+          <div className="flex-1">
+            <div className="mb-2 flex items-center justify-between gap-4">
+              <span className="text-sm font-semibold">Step {step} of 2</span>
+              <span className="text-xs text-muted-foreground">{progress}%</span>
+            </div>
+            <Progress
+              value={progress}
+              className="h-2"
+              aria-label={`Onboarding ${progress}% complete`}
+            />
+          </div>
+          <span className="brand-mark flex h-9 w-9 shrink-0 items-center justify-center rounded-xl">
+            <PawPrint className="h-5 w-5 text-primary-foreground" aria-hidden="true" />
+          </span>
+        </div>
+      </header>
+
+      <main id="main-content" className="mx-auto max-w-lg px-4 py-8">
+        {step === 1 ? (
+          <OwnerInfoStep
+            initialData={ownerData}
+            onComplete={(data) => {
+              setOwnerData(data);
+              setError('');
+              setStep(2);
+            }}
+          />
+        ) : (
+          <section>
+            <p className="eyebrow">Choose your starting role</p>
+            <h1 className="mt-2 text-3xl font-bold tracking-tight">
+              You do not need a pet to start learning.
+            </h1>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              This choice controls the experience you see. It never creates pet access. Pet-specific
+              dogOS opens only after a real owned or authorized household relationship exists.
+            </p>
+            <div className="mt-6">
+              <CompanionModeChooser
+                disabled={isLoading}
+                onSelect={(mode) => void selectMode(mode)}
+              />
+            </div>
+            {isLoading && (
+              <p
+                className="mt-4 flex items-center gap-2 text-sm text-muted-foreground"
+                role="status"
+              >
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                Saving your starting role…
+              </p>
+            )}
+          </section>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            className="mt-5 rounded-xl border border-destructive/20 bg-destructive/10 p-4 text-sm text-destructive"
+          >
+            {error}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -27,7 +27,11 @@ export default function HomePage() {
 
   if (state.isLoading) {
     return (
-      <main id="main-content" className="flex min-h-screen items-center justify-center" role="status">
+      <main
+        id="main-content"
+        className="flex min-h-screen items-center justify-center"
+        role="status"
+      >
         <div className="text-center">
           <Loader2 className="mx-auto h-7 w-7 animate-spin text-primary" aria-hidden="true" />
           <p className="mt-3 text-sm text-muted-foreground">Opening the right Woof for you…</p>
@@ -71,7 +75,9 @@ export default function HomePage() {
         <main id="main-content" className="mx-auto max-w-xl px-4 py-10">
           <section className="rounded-3xl border border-primary/20 bg-gradient-to-br from-primary/[0.1] via-card/95 to-secondary/[0.06] p-6">
             <p className="eyebrow">Pet Guardian</p>
-            <h1 className="mt-2 text-3xl font-bold tracking-tight">Add the dog you actually care for.</h1>
+            <h1 className="mt-2 text-3xl font-bold tracking-tight">
+              Add the dog you actually care for.
+            </h1>
             <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
               Choosing Pet Guardian never creates pet authority by itself. Add a real pet, or join a
               household through an authorized relationship, before pet-specific Today opens.

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,596 +1,126 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import {
-  Brain,
-  Check,
-  Footprints,
-  Heart,
-  HeartHandshake,
-  Loader2,
-  MoonStar,
-  PawPrint,
-  ShieldCheck,
-  Sparkles,
-  TreePine,
-  X,
-} from 'lucide-react';
+import { Loader2, PawPrint } from 'lucide-react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
 import { BottomNav } from '@/components/bottom-nav';
-import { ConciergeBriefing } from '@/components/concierge/concierge-briefing';
-import { PetSwitcher } from '@/components/pets/pet-switcher';
+import { CompanionModeChooser } from '@/components/companion/companion-mode-chooser';
+import CompanionTodayPage from '@/components/today/companion-today-page';
+import GuardianTodayPage from '@/components/today/guardian-today-page';
 import { Button } from '@/components/ui/button';
-import { Progress } from '@/components/ui/progress';
-import { adventureApi, type AdventureQuest, type WellbeingPathway } from '@/lib/api/adventure';
-
-const pathwayIcons: Record<WellbeingPathway, typeof PawPrint> = {
-  MOVE: Footprints,
-  EXPLORE: TreePine,
-  ENRICH: Sparkles,
-  LEARN: Brain,
-  CONNECT: HeartHandshake,
-  CARE: ShieldCheck,
-  RECOVER: MoonStar,
-  BOND: Heart,
-};
-
-const dogChoices = [
-  { value: 'loved_it' as const, emoji: '😄', label: 'Loved it' },
-  { value: 'comfortable' as const, emoji: '😌', label: 'Comfortable' },
-  { value: 'not_their_thing' as const, emoji: '😕', label: 'Not their thing' },
-];
-
-const ownerChoices = [
-  { value: 'great' as const, emoji: '✨', label: 'Great' },
-  { value: 'fine' as const, emoji: '🙂', label: 'Fine' },
-  { value: 'a_lot_today' as const, emoji: '😮‍💨', label: 'A lot today' },
-];
-
-type CompletionReceipt = {
-  message: string;
-  rewardCopy: string;
-  rewardExplanation: string;
-  duplicate: boolean;
-};
-
-function QuestActions({
-  quest,
-  startingQuestId,
-  onStart,
-  onComplete,
-  onSafeStop,
-  prominent = false,
-}: {
-  quest: AdventureQuest;
-  startingQuestId: string | null;
-  onStart: (quest: AdventureQuest) => void;
-  onComplete: (quest: AdventureQuest) => void;
-  onSafeStop: (quest: AdventureQuest) => void;
-  prominent?: boolean;
-}) {
-  return (
-    <div className={prominent ? 'mt-5 space-y-2' : 'mt-3 flex flex-wrap gap-2'}>
-      <Button
-        size={prominent ? 'lg' : 'sm'}
-        className={prominent ? 'w-full sm:w-auto' : undefined}
-        disabled={startingQuestId !== null}
-        onClick={() => onStart(quest)}
-      >
-        {startingQuestId === quest.id && (
-          <Loader2 className="mr-1.5 h-4 w-4 animate-spin" aria-hidden="true" />
-        )}
-        {quest.actionLabel}
-      </Button>
-      <div className={prominent ? 'flex flex-wrap gap-2' : 'contents'}>
-        <Button
-          variant="outline"
-          size="sm"
-          className="bg-transparent"
-          onClick={() => onComplete(quest)}
-        >
-          <Check className="mr-1.5 h-4 w-4" aria-hidden="true" />
-          Close the loop
-        </Button>
-        {quest.safeStopEligible && (
-          <Button variant="ghost" size="sm" onClick={() => onSafeStop(quest)}>
-            I listened and stopped
-          </Button>
-        )}
-      </div>
-    </div>
-  );
-}
+import { companionApi, type CompanionMode } from '@/lib/api/companion';
 
 export default function HomePage() {
   const queryClient = useQueryClient();
-  const router = useRouter();
-  const [closingQuest, setClosingQuest] = useState<AdventureQuest | null>(null);
-  const [startingQuestId, setStartingQuestId] = useState<string | null>(null);
-  const [dogExperience, setDogExperience] = useState<
-    'loved_it' | 'comfortable' | 'not_their_thing' | null
-  >(null);
-  const [safeOptOut, setSafeOptOut] = useState(false);
-  const [completionReceipt, setCompletionReceipt] = useState<CompletionReceipt | null>(null);
-
-  const { data, isLoading, error } = useQuery({
-    queryKey: ['adventure', 'me'],
-    queryFn: () => adventureApi.getMine(),
+  const state = useQuery({
+    queryKey: ['companion', 'state'],
+    queryFn: companionApi.state,
     retry: false,
   });
 
-  const completeMutation = useMutation({
-    mutationFn: ({
-      quest,
-      ownerExperience,
-    }: {
-      quest: AdventureQuest;
-      ownerExperience: 'great' | 'fine' | 'a_lot_today';
-    }) => {
-      if (!data || !dogExperience) throw new Error('Outcome is incomplete');
-      return adventureApi.completeQuest(quest.id, {
-        petId: data.pet.id,
-        dogExperience,
-        ownerExperience,
-        safeOptOut,
-      });
-    },
-    onSuccess: async (result) => {
-      const rewardCopy = result.reward.duplicate
-        ? 'Already saved · no additional Bond XP'
-        : result.reward.bondXp > 0
-          ? `+${result.reward.bondXp} Bond XP`
-          : 'No Bond XP this time';
-      setCompletionReceipt({
-        message: result.message,
-        rewardCopy,
-        rewardExplanation: result.reward.explanation,
-        duplicate: result.reward.duplicate,
-      });
-      await queryClient.invalidateQueries({ queryKey: ['adventure', 'me'] });
+  const modeMutation = useMutation({
+    mutationFn: (mode: CompanionMode) => companionApi.updateMode(mode),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['companion'] });
     },
   });
 
-  const startQuest = async (quest: AdventureQuest) => {
-    if (!data || startingQuestId) return;
-
-    setStartingQuestId(quest.id);
-    try {
-      await adventureApi.selectQuest(quest.id, data.pet.id);
-    } finally {
-      // Selection persistence improves continuity, but a transient analytics/network
-      // failure must never trap the user on Today instead of letting them do the activity.
-      setStartingQuestId(null);
-      router.push(quest.href);
-    }
-  };
-
-  const closeOutcome = () => {
-    setClosingQuest(null);
-    setDogExperience(null);
-    setSafeOptOut(false);
-    setCompletionReceipt(null);
-    completeMutation.reset();
-  };
-
-  const openCompletion = (quest: AdventureQuest, optOut = false) => {
-    setClosingQuest(quest);
-    setCompletionReceipt(null);
-    setSafeOptOut(optOut);
-    setDogExperience(optOut ? 'not_their_thing' : null);
-  };
-
-  const bestQuest = data?.quests[0] ?? null;
-  const alternatives = data?.quests.slice(1) ?? [];
-
-  return (
-    <div className="min-h-screen pb-24">
-      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/88 backdrop-blur-2xl">
-        <div className="mx-auto flex h-16 max-w-xl items-center px-4">
-          <Link href="/" className="flex items-center gap-3" aria-label="Woof Today">
-            <span className="brand-mark flex h-9 w-9 items-center justify-center rounded-xl">
-              <PawPrint className="h-5 w-5 text-primary-foreground" aria-hidden="true" />
-            </span>
-            <span>
-              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                Dog + human
-              </span>
-              <span className="block text-lg font-bold tracking-tight">Today</span>
-            </span>
-          </Link>
+  if (state.isLoading) {
+    return (
+      <main id="main-content" className="flex min-h-screen items-center justify-center" role="status">
+        <div className="text-center">
+          <Loader2 className="mx-auto h-7 w-7 animate-spin text-primary" aria-hidden="true" />
+          <p className="mt-3 text-sm text-muted-foreground">Opening the right Woof for you…</p>
         </div>
-      </header>
+      </main>
+    );
+  }
 
-      <main id="main-content" className="mx-auto max-w-xl px-4 pb-8 pt-5">
-        {isLoading ? (
-          <div className="flex min-h-[60vh] items-center justify-center" role="status">
-            <div className="text-center">
-              <Loader2 className="mx-auto h-7 w-7 animate-spin text-primary" aria-hidden="true" />
-              <p className="mt-3 text-sm text-muted-foreground">
-                Finding one good thing to do together…
-              </p>
-            </div>
-          </div>
-        ) : error || !data ? (
+  if (state.isError || !state.data) {
+    return (
+      <div className="min-h-screen pb-24">
+        <main id="main-content" className="mx-auto max-w-xl px-4 py-16">
           <section className="surface-soft rounded-3xl p-6 text-center">
             <PawPrint className="mx-auto h-8 w-8 text-primary" aria-hidden="true" />
-            <h1 className="mt-3 text-xl font-bold">Adventure mode is unavailable</h1>
+            <h1 className="mt-3 text-xl font-bold">We could not resolve your Woof mode</h1>
             <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-              Adventure may be paused or temporarily unavailable. Your existing Coach, Health,
-              Library, and social tools are still available.
+              Pet-only surfaces stay closed when account mode cannot be verified. Retry when the
+              connection is available.
             </p>
-            <Button
-              className="mt-5"
-              onClick={() => queryClient.invalidateQueries({ queryKey: ['adventure'] })}
-            >
+            <Button className="mt-5" onClick={() => void state.refetch()}>
               Try again
             </Button>
           </section>
-        ) : (
-          <>
-            <PetSwitcher currentPetId={data.pet.id} label="Today is for" withDivider={false} />
+        </main>
+        <BottomNav />
+      </div>
+    );
+  }
 
-            {bestQuest ? (
-              <section
-                data-today-primary-quest
-                className="mt-4 rounded-3xl border border-primary/25 bg-gradient-to-br from-primary/[0.12] via-card/95 to-secondary/[0.06] p-5 shadow-sm sm:p-6"
-                aria-labelledby="today-primary-quest-heading"
-              >
-                <div className="flex items-start gap-4">
-                  <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-sm">
-                    {(() => {
-                      const Icon = pathwayIcons[bestQuest.primaryPathway];
-                      return <Icon className="h-6 w-6" aria-hidden="true" />;
-                    })()}
-                  </span>
-                  <div className="min-w-0 flex-1">
-                    <p className="eyebrow">A good place to start with {data.pet.name}</p>
-                    <h1
-                      id="today-primary-quest-heading"
-                      className="mt-1 text-3xl font-bold tracking-tight text-balance"
-                    >
-                      {bestQuest.title}
-                    </h1>
-                  </div>
-                </div>
+  if (state.data.landing === 'PET_TODAY') {
+    return <GuardianTodayPage />;
+  }
 
-                <p className="mt-4 text-base leading-relaxed text-foreground/90">
-                  {bestQuest.description}
-                </p>
+  if (state.data.landing === 'COMPANION_TODAY') {
+    return <CompanionTodayPage state={state.data} />;
+  }
 
-                <div className="mt-4 rounded-2xl border border-border/70 bg-background/55 p-4">
-                  <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-                    Why this one today
-                  </p>
-                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-                    {bestQuest.why}
-                  </p>
-                </div>
-
-                <QuestActions
-                  quest={bestQuest}
-                  startingQuestId={startingQuestId}
-                  onStart={(quest) => void startQuest(quest)}
-                  onComplete={(quest) => openCompletion(quest)}
-                  onSafeStop={(quest) => openCompletion(quest, true)}
-                  prominent
-                />
-
-                <p className="mt-4 text-xs leading-relaxed text-muted-foreground">
-                  Woof recommends, you choose. Changing your mind, making it easier, or stopping
-                  when
-                  {` ${data.pet.name}`} is done can all be the right outcome.
-                </p>
-              </section>
-            ) : (
-              <section className="mt-4 surface-soft rounded-3xl p-6 text-center">
-                <PawPrint className="mx-auto h-7 w-7 text-primary" aria-hidden="true" />
-                <h1 className="mt-3 text-xl font-bold">Nothing needs pushing today</h1>
-                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                  Woof does not have a useful quest to recommend right now. Rest or your usual
-                  routine is a valid choice.
-                </p>
-              </section>
-            )}
-
-            {alternatives.length > 0 && (
-              <details
-                data-today-alternatives
-                className="mt-4 rounded-2xl border border-border/70 bg-card/65 px-4 py-3"
-              >
-                <summary className="cursor-pointer text-sm font-semibold">
-                  Want a different kind of day?{' '}
-                  <span className="font-normal text-muted-foreground">
-                    {alternatives.length} other {alternatives.length === 1 ? 'option' : 'options'}
-                  </span>
-                </summary>
-                <div className="mt-3 space-y-3 border-t border-border/60 pt-3">
-                  {alternatives.map((quest) => {
-                    const Icon = pathwayIcons[quest.primaryPathway];
-                    return (
-                      <article key={quest.id} className="rounded-2xl bg-background/50 p-4">
-                        <div className="flex items-start gap-3">
-                          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
-                            <Icon className="h-4 w-4" aria-hidden="true" />
-                          </span>
-                          <div className="min-w-0 flex-1">
-                            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                              {quest.variant === 'wildcard' ? 'Something different' : 'Alternative'}{' '}
-                              · {quest.primaryPathway.toLowerCase()}
-                            </p>
-                            <h2 className="mt-1 font-bold tracking-tight">{quest.title}</h2>
-                            <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-                              {quest.description}
-                            </p>
-                            <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-                              {quest.why}
-                            </p>
-                            <QuestActions
-                              quest={quest}
-                              startingQuestId={startingQuestId}
-                              onStart={(candidate) => void startQuest(candidate)}
-                              onComplete={(candidate) => openCompletion(candidate)}
-                              onSafeStop={(candidate) => openCompletion(candidate, true)}
-                            />
-                          </div>
-                        </div>
-                      </article>
-                    );
-                  })}
-                </div>
-              </details>
-            )}
-
-            {data.learningSummary.length > 0 && (
-              <section
-                data-today-learning
-                className="mt-6 rounded-3xl border border-secondary/20 bg-secondary/[0.05] p-5"
-              >
-                <p className="eyebrow">What Woof is learning</p>
-                <ul className="mt-3 space-y-2 text-sm leading-relaxed text-muted-foreground">
-                  {data.learningSummary.slice(0, 3).map((line) => (
-                    <li key={line} className="flex gap-2">
-                      <Sparkles
-                        className="mt-0.5 h-4 w-4 shrink-0 text-primary"
-                        aria-hidden="true"
-                      />
-                      <span>{line}</span>
-                    </li>
-                  ))}
-                </ul>
-              </section>
-            )}
-
-            <details
-              data-today-concierge
-              className="mt-6 rounded-2xl border border-border/70 bg-card/50 px-4 py-3"
-            >
-              <summary className="cursor-pointer text-sm font-semibold">
-                More context for today{' '}
-                <span className="font-normal text-muted-foreground">from Concierge</span>
-              </summary>
-              <div className="mt-4 border-t border-border/60 pt-4">
-                <ConciergeBriefing showPetSwitcher={false} />
-              </div>
-            </details>
-
-            <section data-today-progress className="mt-7" aria-labelledby="recent-rhythm-heading">
-              <div className="flex items-end justify-between gap-3">
-                <div>
-                  <p className="eyebrow">Recent rhythm</p>
-                  <h2 id="recent-rhythm-heading" className="mt-1 text-lg font-bold tracking-tight">
-                    Context, not today&apos;s assignment
-                  </h2>
-                </div>
-                <Link href="/compass" className="text-sm font-semibold text-primary">
-                  Full compass →
-                </Link>
-              </div>
-
-              <div className="mt-3 grid grid-cols-2 gap-3">
-                <div className="surface-soft rounded-2xl p-4">
-                  <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                    Bond XP
-                  </p>
-                  <p className="mt-1 text-xl font-bold text-primary">{data.bondXp}</p>
-                  <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
-                    Game progress, not a wellbeing score.
-                  </p>
-                </div>
-                <div className="surface-soft rounded-2xl p-4">
-                  <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                    {data.rhythm.label}
-                  </p>
-                  <p className="mt-1 text-xl font-bold text-primary">
-                    {data.rhythm.activeWeeks}/{data.rhythm.windowWeeks}
-                  </p>
-                  <Progress
-                    className="mt-2 h-1.5"
-                    value={(data.rhythm.activeWeeks / data.rhythm.windowWeeks) * 100}
-                  />
-                </div>
-              </div>
-
-              {data.compass.length > 0 && (
-                <details className="mt-3 rounded-2xl border border-border/70 bg-background/40 px-4 py-3">
-                  <summary className="cursor-pointer text-sm font-semibold">
-                    See recent Pawprint Compass opportunities
-                  </summary>
-                  <div className="mt-3 grid grid-cols-2 gap-3 border-t border-border/60 pt-3">
-                    {data.compass.slice(0, 4).map((item) => {
-                      const Icon = pathwayIcons[item.pathway];
-                      return (
-                        <div key={item.pathway} className="surface-soft rounded-2xl p-4">
-                          <div className="flex items-center justify-between gap-2">
-                            <span className="flex items-center gap-2 text-sm font-semibold">
-                              <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
-                              {item.label}
-                            </span>
-                            <span className="text-xs font-bold text-primary">
-                              {item.recentDays}d
-                            </span>
-                          </div>
-                          <Progress className="mt-3 h-1.5" value={item.coverage} />
-                          <p className="mt-2 text-[11px] text-muted-foreground">
-                            Recent opportunity coverage · 28-day window
-                          </p>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </details>
-              )}
-            </section>
-
-            <p className="mt-5 text-center text-xs leading-relaxed text-muted-foreground">
-              {data.disclaimer}
+  if (state.data.landing === 'NEEDS_PET_SETUP') {
+    return (
+      <div className="min-h-screen pb-24">
+        <main id="main-content" className="mx-auto max-w-xl px-4 py-10">
+          <section className="rounded-3xl border border-primary/20 bg-gradient-to-br from-primary/[0.1] via-card/95 to-secondary/[0.06] p-6">
+            <p className="eyebrow">Pet Guardian</p>
+            <h1 className="mt-2 text-3xl font-bold tracking-tight">Add the dog you actually care for.</h1>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              Choosing Pet Guardian never creates pet authority by itself. Add a real pet, or join a
+              household through an authorized relationship, before pet-specific Today opens.
             </p>
-          </>
-        )}
-      </main>
+            <Button asChild className="mt-5">
+              <Link href="/onboarding">Add a dog</Link>
+            </Button>
+          </section>
 
-      {closingQuest && data && (
-        <div
-          className="fixed inset-0 z-[70] flex items-end justify-center bg-background/70 p-3 backdrop-blur-sm sm:items-center"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Quest outcome"
-        >
-          <div className="w-full max-w-md rounded-3xl border border-border bg-card p-5 shadow-2xl">
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <p className="eyebrow">Five-second learning loop</p>
-                <h2 className="mt-1 text-xl font-bold">{closingQuest.title}</h2>
-              </div>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={closeOutcome}
-                aria-label="Close outcome flow"
-              >
-                <X className="h-5 w-5" aria-hidden="true" />
-              </Button>
+          <section className="mt-6">
+            <p className="eyebrow">Different role?</p>
+            <h2 className="mt-1 text-xl font-bold">Use Woof without inventing a pet.</h2>
+            <div className="mt-3">
+              <CompanionModeChooser
+                compact
+                disabled={modeMutation.isPending}
+                onSelect={(mode) => modeMutation.mutate(mode)}
+              />
             </div>
+          </section>
+        </main>
+        <BottomNav />
+      </div>
+    );
+  }
 
-            {completionReceipt ? (
-              <div className="mt-5 rounded-2xl bg-primary/10 p-5">
-                <div className="flex items-start gap-3">
-                  <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-primary text-primary-foreground">
-                    <PawPrint className="h-5 w-5" aria-hidden="true" />
-                  </div>
-                  <div className="min-w-0">
-                    <p className="eyebrow">What Woof learned</p>
-                    <p className="mt-1 font-semibold leading-relaxed">
-                      {completionReceipt.message}
-                    </p>
-                    <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-                      {completionReceipt.duplicate
-                        ? 'This outcome was already in your shared history, so Woof did not count it twice.'
-                        : `This outcome is now part of ${data.pet.name}'s recent shared pattern and can influence future quest ranking.`}
-                    </p>
-                  </div>
-                </div>
-
-                <div className="mt-4 rounded-xl border border-border/70 bg-background/55 p-3">
-                  <div className="flex items-center justify-between gap-3">
-                    <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                      Game progress
-                    </p>
-                    <span className="text-xs font-bold text-primary">
-                      {completionReceipt.rewardCopy}
-                    </span>
-                  </div>
-                  <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
-                    {completionReceipt.rewardExplanation}
-                  </p>
-                </div>
-
-                <div className="mt-4 flex flex-wrap gap-2">
-                  <Button onClick={closeOutcome}>Done</Button>
-                  <Button variant="outline" asChild className="bg-transparent">
-                    <Link href="/library">Add a memory</Link>
-                  </Button>
-                </div>
-              </div>
-            ) : (
-              <>
-                {safeOptOut ? (
-                  <div className="mt-5 rounded-2xl border border-primary/20 bg-primary/[0.05] p-4">
-                    <p className="font-semibold text-primary">You listened.</p>
-                    <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-                      Woof will treat giving space or ending the interaction as successful dog
-                      literacy.
-                    </p>
-                  </div>
-                ) : !dogExperience ? (
-                  <div className="mt-5">
-                    <p className="text-sm font-semibold">How was it for {data.pet.name}?</p>
-                    <div className="mt-3 grid grid-cols-3 gap-2">
-                      {dogChoices.map((choice) => (
-                        <button
-                          key={choice.value}
-                          type="button"
-                          onClick={() => setDogExperience(choice.value)}
-                          className="rounded-2xl border border-border bg-background/55 p-3 text-center transition-colors hover:border-primary/40 hover:bg-primary/[0.05]"
-                        >
-                          <span className="block text-2xl" aria-hidden="true">
-                            {choice.emoji}
-                          </span>
-                          <span className="mt-1 block text-xs font-semibold">{choice.label}</span>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                ) : null}
-
-                {(dogExperience || safeOptOut) && (
-                  <div className="mt-5">
-                    <p className="text-sm font-semibold">How was it for you?</p>
-                    <div className="mt-3 grid grid-cols-3 gap-2">
-                      {ownerChoices.map((choice) => (
-                        <button
-                          key={choice.value}
-                          type="button"
-                          disabled={completeMutation.isPending}
-                          onClick={() =>
-                            completeMutation.mutate({
-                              quest: closingQuest,
-                              ownerExperience: choice.value,
-                            })
-                          }
-                          className="rounded-2xl border border-border bg-background/55 p-3 text-center transition-colors hover:border-primary/40 hover:bg-primary/[0.05] disabled:opacity-50"
-                        >
-                          <span className="block text-2xl" aria-hidden="true">
-                            {choice.emoji}
-                          </span>
-                          <span className="mt-1 block text-xs font-semibold">{choice.label}</span>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {completeMutation.isPending && (
-                  <div
-                    className="mt-4 flex items-center justify-center gap-2 text-sm text-muted-foreground"
-                    role="status"
-                  >
-                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-                    Learning from the outcome…
-                  </div>
-                )}
-                {completeMutation.isError && (
-                  <p className="mt-4 text-center text-sm text-destructive">
-                    That outcome could not be saved. Nothing was lost from your existing history.
-                  </p>
-                )}
-              </>
-            )}
+  return (
+    <div className="min-h-screen pb-24">
+      <main id="main-content" className="mx-auto max-w-xl px-4 py-10">
+        <section>
+          <p className="eyebrow">Welcome to Woof</p>
+          <h1 className="mt-2 text-3xl font-bold tracking-tight">How do you want to use dogOS?</h1>
+          <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+            Pick the role that fits today. This controls the experience you see, not which pets you
+            are authorized to access. You can change it later.
+          </p>
+          <div className="mt-6">
+            <CompanionModeChooser
+              disabled={modeMutation.isPending}
+              onSelect={(mode) => modeMutation.mutate(mode)}
+            />
           </div>
-        </div>
-      )}
-
+          {modeMutation.isError && (
+            <p className="mt-4 text-sm text-destructive" role="alert">
+              Your mode could not be saved. No pet or relationship state was changed.
+            </p>
+          )}
+        </section>
+      </main>
       <BottomNav />
     </div>
   );

--- a/apps/web/src/components/bottom-nav.tsx
+++ b/apps/web/src/components/bottom-nav.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { Brain, Compass, Map, PawPrint, Sparkles, Users } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { Brain, ClipboardCheck, Compass, Gamepad2, Map, PawPrint, Sparkles, Users } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { companionApi } from '@/lib/api/companion';
 import { cn } from '@/lib/utils';
 
-const navItems = [
+const petNavItems = [
   { href: '/', icon: PawPrint, label: 'Today' },
   { href: '/compass', icon: Compass, label: 'Compass' },
   { href: '/journey', icon: Map, label: 'Story', isSpecial: true },
@@ -14,8 +16,25 @@ const navItems = [
   { href: '/community', icon: Users, label: 'Community' },
 ];
 
+const companionNavItems = [
+  { href: '/', icon: PawPrint, label: 'Today' },
+  { href: '/arcade', icon: Gamepad2, label: 'Arcade' },
+  { href: '/community', icon: Users, label: 'Community' },
+  { href: '/companion/readiness', icon: ClipboardCheck, label: 'Readiness' },
+];
+
 export function BottomNav() {
   const pathname = usePathname();
+  const companion = useQuery({
+    queryKey: ['companion', 'state'],
+    queryFn: companionApi.state,
+    retry: false,
+    staleTime: 60_000,
+  });
+
+  // Fail closed for pet-only navigation. Until account state is positively
+  // resolved as PET_TODAY, only surfaces that are valid without a pet appear.
+  const navItems = companion.data?.landing === 'PET_TODAY' ? petNavItems : companionNavItems;
 
   return (
     <nav
@@ -27,7 +46,7 @@ export function BottomNav() {
           const isActive = item.href === '/' ? pathname === '/' : pathname.startsWith(item.href);
           const Icon = item.icon;
 
-          if (item.isSpecial) {
+          if ('isSpecial' in item && item.isSpecial) {
             return (
               <Link
                 key={item.href}
@@ -39,10 +58,7 @@ export function BottomNav() {
                   isActive ? 'border-primary/50 ring-4 ring-primary/10' : 'border-primary/20'
                 )}
               >
-                <Icon
-                  className="h-6 w-6 transition-transform group-hover:scale-105"
-                  aria-hidden="true"
-                />
+                <Icon className="h-6 w-6 transition-transform group-hover:scale-105" aria-hidden="true" />
                 <span className="sr-only">{item.label}</span>
               </Link>
             );
@@ -66,9 +82,7 @@ export function BottomNav() {
                 aria-hidden="true"
               />
               <Icon className="h-5 w-5" aria-hidden="true" />
-              <span className="text-[10px] font-semibold tracking-wide sm:text-[11px]">
-                {item.label}
-              </span>
+              <span className="text-[10px] font-semibold tracking-wide sm:text-[11px]">{item.label}</span>
             </Link>
           );
         })}

--- a/apps/web/src/components/bottom-nav.tsx
+++ b/apps/web/src/components/bottom-nav.tsx
@@ -39,6 +39,10 @@ export function BottomNav() {
     queryFn: companionApi.state,
     retry: false,
     staleTime: 60_000,
+    // Navigation observes account authority but does not own its resolution.
+    // In particular, mounting the fail-closed nav after a state error must not
+    // refetch the same failed query and bounce the root router back to loading.
+    refetchOnMount: false,
   });
 
   // Fail closed for pet-only navigation. Until account state is positively

--- a/apps/web/src/components/bottom-nav.tsx
+++ b/apps/web/src/components/bottom-nav.tsx
@@ -40,9 +40,11 @@ export function BottomNav() {
     retry: false,
     staleTime: 60_000,
     // Navigation observes account authority but does not own its resolution.
-    // In particular, mounting the fail-closed nav after a state error must not
-    // refetch the same failed query and bounce the root router back to loading.
+    // Failed no-data queries use retryOnMount rather than refetchOnMount, so
+    // both controls must remain off here. The owning surface exposes explicit
+    // retry UX instead of letting a navigation observer revive authority work.
     refetchOnMount: false,
+    retryOnMount: false,
   });
 
   // Fail closed for pet-only navigation. Until account state is positively

--- a/apps/web/src/components/bottom-nav.tsx
+++ b/apps/web/src/components/bottom-nav.tsx
@@ -1,7 +1,16 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { Brain, ClipboardCheck, Compass, Gamepad2, Map, PawPrint, Sparkles, Users } from 'lucide-react';
+import {
+  Brain,
+  ClipboardCheck,
+  Compass,
+  Gamepad2,
+  Map,
+  PawPrint,
+  Sparkles,
+  Users,
+} from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { companionApi } from '@/lib/api/companion';
@@ -58,7 +67,10 @@ export function BottomNav() {
                   isActive ? 'border-primary/50 ring-4 ring-primary/10' : 'border-primary/20'
                 )}
               >
-                <Icon className="h-6 w-6 transition-transform group-hover:scale-105" aria-hidden="true" />
+                <Icon
+                  className="h-6 w-6 transition-transform group-hover:scale-105"
+                  aria-hidden="true"
+                />
                 <span className="sr-only">{item.label}</span>
               </Link>
             );
@@ -82,7 +94,9 @@ export function BottomNav() {
                 aria-hidden="true"
               />
               <Icon className="h-5 w-5" aria-hidden="true" />
-              <span className="text-[10px] font-semibold tracking-wide sm:text-[11px]">{item.label}</span>
+              <span className="text-[10px] font-semibold tracking-wide sm:text-[11px]">
+                {item.label}
+              </span>
             </Link>
           );
         })}

--- a/apps/web/src/components/companion/companion-mode-chooser.tsx
+++ b/apps/web/src/components/companion/companion-mode-chooser.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { HeartHandshake, Home, PawPrint } from 'lucide-react';
+import type { CompanionMode } from '@/lib/api/companion';
+
+const options: Array<{
+  mode: CompanionMode;
+  title: string;
+  description: string;
+  icon: typeof PawPrint;
+}> = [
+  {
+    mode: 'PET_GUARDIAN',
+    title: 'I live with a dog',
+    description: 'Use pet-specific Today, Story, Coach, Adventure, and relationship learning.',
+    icon: PawPrint,
+  },
+  {
+    mode: 'ANIMAL_ALLY',
+    title: 'I want to learn and help',
+    description: 'Practice human skills, join the community, and prepare without inventing a pet profile.',
+    icon: HeartHandshake,
+  },
+  {
+    mode: 'FOSTER_CAREGIVER',
+    title: 'I foster or plan to foster',
+    description: 'Build caregiver skills and practical readiness while pet authority stays relationship-specific.',
+    icon: Home,
+  },
+];
+
+export function CompanionModeChooser({
+  onSelect,
+  disabled = false,
+  compact = false,
+}: {
+  onSelect: (mode: CompanionMode) => void;
+  disabled?: boolean;
+  compact?: boolean;
+}) {
+  return (
+    <div className={compact ? 'grid gap-2' : 'grid gap-3'}>
+      {options.map((option) => {
+        const Icon = option.icon;
+        return (
+          <button
+            key={option.mode}
+            type="button"
+            disabled={disabled}
+            onClick={() => onSelect(option.mode)}
+            className="group rounded-2xl border border-border/70 bg-card/70 p-4 text-left transition hover:border-primary/35 hover:bg-primary/[0.04] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <div className="flex items-start gap-3">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                <Icon className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <div>
+                <p className="font-bold tracking-tight">{option.title}</p>
+                <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                  {option.description}
+                </p>
+              </div>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/companion/companion-mode-chooser.tsx
+++ b/apps/web/src/components/companion/companion-mode-chooser.tsx
@@ -18,13 +18,15 @@ const options: Array<{
   {
     mode: 'ANIMAL_ALLY',
     title: 'I want to learn and help',
-    description: 'Practice human skills, join the community, and prepare without inventing a pet profile.',
+    description:
+      'Practice human skills, join the community, and prepare without inventing a pet profile.',
     icon: HeartHandshake,
   },
   {
     mode: 'FOSTER_CAREGIVER',
     title: 'I foster or plan to foster',
-    description: 'Build caregiver skills and practical readiness while pet authority stays relationship-specific.',
+    description:
+      'Build caregiver skills and practical readiness while pet authority stays relationship-specific.',
     icon: Home,
   },
 ];

--- a/apps/web/src/components/today/companion-today-page.tsx
+++ b/apps/web/src/components/today/companion-today-page.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { BookOpenCheck, Gamepad2, HeartHandshake, Home, PawPrint, Users } from 'lucide-react';
+import Link from 'next/link';
+import { BottomNav } from '@/components/bottom-nav';
+import { Button } from '@/components/ui/button';
+import { companionApi, type CompanionState } from '@/lib/api/companion';
+import { socialAdventureApi } from '@/lib/api/social-adventure';
+
+const modeCopy = {
+  ANIMAL_ALLY: {
+    eyebrow: 'Animal Ally',
+    title: 'Learn useful dog-human skills before you need a pet profile.',
+    body: 'Practice observation and handling judgment, join the community, and build practical readiness without creating fictional dog data.',
+    icon: HeartHandshake,
+  },
+  FOSTER_CAREGIVER: {
+    eyebrow: 'Foster Caregiver',
+    title: 'Prepare for temporary care without pretending every dog is the same.',
+    body: 'Build human skill and practical readiness first. Individual foster-dog assumptions should begin only after an authorized relationship exists.',
+    icon: Home,
+  },
+} as const;
+
+export default function CompanionTodayPage({ state }: { state: CompanionState }) {
+  const queryClient = useQueryClient();
+  const social = useQuery({
+    queryKey: ['social-adventure', 'me'],
+    queryFn: socialAdventureApi.getMine,
+    retry: false,
+  });
+  const modeMutation = useMutation({
+    mutationFn: companionApi.updateMode,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['companion'] });
+    },
+  });
+
+  const mode = state.mode === 'FOSTER_CAREGIVER' ? 'FOSTER_CAREGIVER' : 'ANIMAL_ALLY';
+  const copy = modeCopy[mode];
+  const Icon = copy.icon;
+  const completedSkills = social.data?.components.humanSkill.completedChallenges.length ?? 0;
+
+  return (
+    <div className="min-h-screen pb-24">
+      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/88 backdrop-blur-2xl">
+        <div className="mx-auto flex h-16 max-w-xl items-center gap-3 px-4">
+          <span className="brand-mark flex h-9 w-9 items-center justify-center rounded-xl">
+            <PawPrint className="h-5 w-5 text-primary-foreground" aria-hidden="true" />
+          </span>
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Companion mode
+            </p>
+            <h1 className="text-lg font-bold tracking-tight">Today</h1>
+          </div>
+        </div>
+      </header>
+
+      <main id="main-content" className="mx-auto max-w-xl px-4 pb-8 pt-5">
+        <section className="rounded-3xl border border-primary/20 bg-gradient-to-br from-primary/[0.1] via-card/95 to-secondary/[0.06] p-6">
+          <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+            <Icon className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <p className="eyebrow mt-4">{copy.eyebrow}</p>
+          <h2 className="mt-1 text-3xl font-bold tracking-tight text-balance">{copy.title}</h2>
+          <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{copy.body}</p>
+        </section>
+
+        <section className="mt-6 grid gap-3 sm:grid-cols-2">
+          <Link href="/arcade" className="surface-soft rounded-2xl p-5 transition hover:ring-2 hover:ring-primary/20">
+            <Gamepad2 className="h-5 w-5 text-primary" aria-hidden="true" />
+            <h2 className="mt-3 font-bold">Skillcraft Arcade</h2>
+            <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+              Practice marker timing, making setups easier, catching useful behavior, and positive association timing.
+            </p>
+            <p className="mt-3 text-xs font-semibold text-primary">{completedSkills}/4 games explored this week →</p>
+          </Link>
+
+          <Link href="/community" className="surface-soft rounded-2xl p-5 transition hover:ring-2 hover:ring-primary/20">
+            <Users className="h-5 w-5 text-primary" aria-hidden="true" />
+            <h2 className="mt-3 font-bold">Community</h2>
+            <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+              Join Packs and learn from shared good reads without competing on pet performance.
+            </p>
+            <p className="mt-3 text-xs font-semibold text-primary">Open Community →</p>
+          </Link>
+
+          <Link href="/companion/readiness" className="surface-soft rounded-2xl p-5 transition hover:ring-2 hover:ring-primary/20 sm:col-span-2">
+            <BookOpenCheck className="h-5 w-5 text-primary" aria-hidden="true" />
+            <h2 className="mt-3 font-bold">Private readiness reflection</h2>
+            <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+              Think through housing, time, finances, household alignment, support, and care planning. No score and no automatic sharing.
+            </p>
+            <p className="mt-3 text-xs font-semibold text-primary">Reflect on readiness →</p>
+          </Link>
+        </section>
+
+        <section className="mt-6 rounded-3xl border border-border/70 bg-card/60 p-5">
+          <p className="eyebrow">Real-world opportunities</p>
+          <h2 className="mt-1 text-lg font-bold">Partner authority before placement prompts.</h2>
+          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+            Woof does not fabricate shelter inventory or scrape a dog into your profile. Foster, volunteer, and adoption opportunities will appear only from authorized partner sources with their own eligibility and placement authority.
+          </p>
+        </section>
+
+        <section className="mt-6 rounded-3xl border border-border/70 bg-card/50 p-5">
+          <h2 className="font-bold">Your role can change.</h2>
+          <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+            If you now live with a dog, switch to Pet Guardian. Woof will still require a real pet or authorized household relationship before opening pet-specific surfaces.
+          </p>
+          <Button
+            variant="outline"
+            className="mt-4 bg-transparent"
+            disabled={modeMutation.isPending}
+            onClick={() => modeMutation.mutate('PET_GUARDIAN')}
+          >
+            I have a dog now
+          </Button>
+        </section>
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+}

--- a/apps/web/src/components/today/companion-today-page.tsx
+++ b/apps/web/src/components/today/companion-today-page.tsx
@@ -69,16 +69,25 @@ export default function CompanionTodayPage({ state }: { state: CompanionState })
         </section>
 
         <section className="mt-6 grid gap-3 sm:grid-cols-2">
-          <Link href="/arcade" className="surface-soft rounded-2xl p-5 transition hover:ring-2 hover:ring-primary/20">
+          <Link
+            href="/arcade"
+            className="surface-soft rounded-2xl p-5 transition hover:ring-2 hover:ring-primary/20"
+          >
             <Gamepad2 className="h-5 w-5 text-primary" aria-hidden="true" />
             <h2 className="mt-3 font-bold">Skillcraft Arcade</h2>
             <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-              Practice marker timing, making setups easier, catching useful behavior, and positive association timing.
+              Practice marker timing, making setups easier, catching useful behavior, and positive
+              association timing.
             </p>
-            <p className="mt-3 text-xs font-semibold text-primary">{completedSkills}/4 games explored this week →</p>
+            <p className="mt-3 text-xs font-semibold text-primary">
+              {completedSkills}/4 games explored this week →
+            </p>
           </Link>
 
-          <Link href="/community" className="surface-soft rounded-2xl p-5 transition hover:ring-2 hover:ring-primary/20">
+          <Link
+            href="/community"
+            className="surface-soft rounded-2xl p-5 transition hover:ring-2 hover:ring-primary/20"
+          >
             <Users className="h-5 w-5 text-primary" aria-hidden="true" />
             <h2 className="mt-3 font-bold">Community</h2>
             <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
@@ -87,11 +96,15 @@ export default function CompanionTodayPage({ state }: { state: CompanionState })
             <p className="mt-3 text-xs font-semibold text-primary">Open Community →</p>
           </Link>
 
-          <Link href="/companion/readiness" className="surface-soft rounded-2xl p-5 transition hover:ring-2 hover:ring-primary/20 sm:col-span-2">
+          <Link
+            href="/companion/readiness"
+            className="surface-soft rounded-2xl p-5 transition hover:ring-2 hover:ring-primary/20 sm:col-span-2"
+          >
             <BookOpenCheck className="h-5 w-5 text-primary" aria-hidden="true" />
             <h2 className="mt-3 font-bold">Private readiness reflection</h2>
             <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-              Think through housing, time, finances, household alignment, support, and care planning. No score and no automatic sharing.
+              Think through housing, time, finances, household alignment, support, and care
+              planning. No score and no automatic sharing.
             </p>
             <p className="mt-3 text-xs font-semibold text-primary">Reflect on readiness →</p>
           </Link>
@@ -101,14 +114,17 @@ export default function CompanionTodayPage({ state }: { state: CompanionState })
           <p className="eyebrow">Real-world opportunities</p>
           <h2 className="mt-1 text-lg font-bold">Partner authority before placement prompts.</h2>
           <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-            Woof does not fabricate shelter inventory or scrape a dog into your profile. Foster, volunteer, and adoption opportunities will appear only from authorized partner sources with their own eligibility and placement authority.
+            Woof does not fabricate shelter inventory or scrape a dog into your profile. Foster,
+            volunteer, and adoption opportunities will appear only from authorized partner sources
+            with their own eligibility and placement authority.
           </p>
         </section>
 
         <section className="mt-6 rounded-3xl border border-border/70 bg-card/50 p-5">
           <h2 className="font-bold">Your role can change.</h2>
           <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-            If you now live with a dog, switch to Pet Guardian. Woof will still require a real pet or authorized household relationship before opening pet-specific surfaces.
+            If you now live with a dog, switch to Pet Guardian. Woof will still require a real pet
+            or authorized household relationship before opening pet-specific surfaces.
           </p>
           <Button
             variant="outline"

--- a/apps/web/src/components/today/guardian-today-page.tsx
+++ b/apps/web/src/components/today/guardian-today-page.tsx
@@ -1,0 +1,597 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  Brain,
+  Check,
+  Footprints,
+  Heart,
+  HeartHandshake,
+  Loader2,
+  MoonStar,
+  PawPrint,
+  ShieldCheck,
+  Sparkles,
+  TreePine,
+  X,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { BottomNav } from '@/components/bottom-nav';
+import { ConciergeBriefing } from '@/components/concierge/concierge-briefing';
+import { PetSwitcher } from '@/components/pets/pet-switcher';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { adventureApi, type AdventureQuest, type WellbeingPathway } from '@/lib/api/adventure';
+
+const pathwayIcons: Record<WellbeingPathway, typeof PawPrint> = {
+  MOVE: Footprints,
+  EXPLORE: TreePine,
+  ENRICH: Sparkles,
+  LEARN: Brain,
+  CONNECT: HeartHandshake,
+  CARE: ShieldCheck,
+  RECOVER: MoonStar,
+  BOND: Heart,
+};
+
+const dogChoices = [
+  { value: 'loved_it' as const, emoji: '😄', label: 'Loved it' },
+  { value: 'comfortable' as const, emoji: '😌', label: 'Comfortable' },
+  { value: 'not_their_thing' as const, emoji: '😕', label: 'Not their thing' },
+];
+
+const ownerChoices = [
+  { value: 'great' as const, emoji: '✨', label: 'Great' },
+  { value: 'fine' as const, emoji: '🙂', label: 'Fine' },
+  { value: 'a_lot_today' as const, emoji: '😮‍💨', label: 'A lot today' },
+];
+
+type CompletionReceipt = {
+  message: string;
+  rewardCopy: string;
+  rewardExplanation: string;
+  duplicate: boolean;
+};
+
+function QuestActions({
+  quest,
+  startingQuestId,
+  onStart,
+  onComplete,
+  onSafeStop,
+  prominent = false,
+}: {
+  quest: AdventureQuest;
+  startingQuestId: string | null;
+  onStart: (quest: AdventureQuest) => void;
+  onComplete: (quest: AdventureQuest) => void;
+  onSafeStop: (quest: AdventureQuest) => void;
+  prominent?: boolean;
+}) {
+  return (
+    <div className={prominent ? 'mt-5 space-y-2' : 'mt-3 flex flex-wrap gap-2'}>
+      <Button
+        size={prominent ? 'lg' : 'sm'}
+        className={prominent ? 'w-full sm:w-auto' : undefined}
+        disabled={startingQuestId !== null}
+        onClick={() => onStart(quest)}
+      >
+        {startingQuestId === quest.id && (
+          <Loader2 className="mr-1.5 h-4 w-4 animate-spin" aria-hidden="true" />
+        )}
+        {quest.actionLabel}
+      </Button>
+      <div className={prominent ? 'flex flex-wrap gap-2' : 'contents'}>
+        <Button
+          variant="outline"
+          size="sm"
+          className="bg-transparent"
+          onClick={() => onComplete(quest)}
+        >
+          <Check className="mr-1.5 h-4 w-4" aria-hidden="true" />
+          Close the loop
+        </Button>
+        {quest.safeStopEligible && (
+          <Button variant="ghost" size="sm" onClick={() => onSafeStop(quest)}>
+            I listened and stopped
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function HomePage() {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const [closingQuest, setClosingQuest] = useState<AdventureQuest | null>(null);
+  const [startingQuestId, setStartingQuestId] = useState<string | null>(null);
+  const [dogExperience, setDogExperience] = useState<
+    'loved_it' | 'comfortable' | 'not_their_thing' | null
+  >(null);
+  const [safeOptOut, setSafeOptOut] = useState(false);
+  const [completionReceipt, setCompletionReceipt] = useState<CompletionReceipt | null>(null);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['adventure', 'me'],
+    queryFn: () => adventureApi.getMine(),
+    retry: false,
+  });
+
+  const completeMutation = useMutation({
+    mutationFn: ({
+      quest,
+      ownerExperience,
+    }: {
+      quest: AdventureQuest;
+      ownerExperience: 'great' | 'fine' | 'a_lot_today';
+    }) => {
+      if (!data || !dogExperience) throw new Error('Outcome is incomplete');
+      return adventureApi.completeQuest(quest.id, {
+        petId: data.pet.id,
+        dogExperience,
+        ownerExperience,
+        safeOptOut,
+      });
+    },
+    onSuccess: async (result) => {
+      const rewardCopy = result.reward.duplicate
+        ? 'Already saved · no additional Bond XP'
+        : result.reward.bondXp > 0
+          ? `+${result.reward.bondXp} Bond XP`
+          : 'No Bond XP this time';
+      setCompletionReceipt({
+        message: result.message,
+        rewardCopy,
+        rewardExplanation: result.reward.explanation,
+        duplicate: result.reward.duplicate,
+      });
+      await queryClient.invalidateQueries({ queryKey: ['adventure', 'me'] });
+    },
+  });
+
+  const startQuest = async (quest: AdventureQuest) => {
+    if (!data || startingQuestId) return;
+
+    setStartingQuestId(quest.id);
+    try {
+      await adventureApi.selectQuest(quest.id, data.pet.id);
+    } finally {
+      // Selection persistence improves continuity, but a transient analytics/network
+      // failure must never trap the user on Today instead of letting them do the activity.
+      setStartingQuestId(null);
+      router.push(quest.href);
+    }
+  };
+
+  const closeOutcome = () => {
+    setClosingQuest(null);
+    setDogExperience(null);
+    setSafeOptOut(false);
+    setCompletionReceipt(null);
+    completeMutation.reset();
+  };
+
+  const openCompletion = (quest: AdventureQuest, optOut = false) => {
+    setClosingQuest(quest);
+    setCompletionReceipt(null);
+    setSafeOptOut(optOut);
+    setDogExperience(optOut ? 'not_their_thing' : null);
+  };
+
+  const bestQuest = data?.quests[0] ?? null;
+  const alternatives = data?.quests.slice(1) ?? [];
+
+  return (
+    <div className="min-h-screen pb-24">
+      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/88 backdrop-blur-2xl">
+        <div className="mx-auto flex h-16 max-w-xl items-center px-4">
+          <Link href="/" className="flex items-center gap-3" aria-label="Woof Today">
+            <span className="brand-mark flex h-9 w-9 items-center justify-center rounded-xl">
+              <PawPrint className="h-5 w-5 text-primary-foreground" aria-hidden="true" />
+            </span>
+            <span>
+              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                Dog + human
+              </span>
+              <span className="block text-lg font-bold tracking-tight">Today</span>
+            </span>
+          </Link>
+        </div>
+      </header>
+
+      <main id="main-content" className="mx-auto max-w-xl px-4 pb-8 pt-5">
+        {isLoading ? (
+          <div className="flex min-h-[60vh] items-center justify-center" role="status">
+            <div className="text-center">
+              <Loader2 className="mx-auto h-7 w-7 animate-spin text-primary" aria-hidden="true" />
+              <p className="mt-3 text-sm text-muted-foreground">
+                Finding one good thing to do together…
+              </p>
+            </div>
+          </div>
+        ) : error || !data ? (
+          <section className="surface-soft rounded-3xl p-6 text-center">
+            <PawPrint className="mx-auto h-8 w-8 text-primary" aria-hidden="true" />
+            <h1 className="mt-3 text-xl font-bold">Adventure mode is unavailable</h1>
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+              Adventure may be paused or temporarily unavailable. Your existing Coach, Health,
+              Library, and social tools are still available.
+            </p>
+            <Button
+              className="mt-5"
+              onClick={() => queryClient.invalidateQueries({ queryKey: ['adventure'] })}
+            >
+              Try again
+            </Button>
+          </section>
+        ) : (
+          <>
+            <PetSwitcher currentPetId={data.pet.id} label="Today is for" withDivider={false} />
+
+            {bestQuest ? (
+              <section
+                data-today-primary-quest
+                className="mt-4 rounded-3xl border border-primary/25 bg-gradient-to-br from-primary/[0.12] via-card/95 to-secondary/[0.06] p-5 shadow-sm sm:p-6"
+                aria-labelledby="today-primary-quest-heading"
+              >
+                <div className="flex items-start gap-4">
+                  <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-sm">
+                    {(() => {
+                      const Icon = pathwayIcons[bestQuest.primaryPathway];
+                      return <Icon className="h-6 w-6" aria-hidden="true" />;
+                    })()}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="eyebrow">A good place to start with {data.pet.name}</p>
+                    <h1
+                      id="today-primary-quest-heading"
+                      className="mt-1 text-3xl font-bold tracking-tight text-balance"
+                    >
+                      {bestQuest.title}
+                    </h1>
+                  </div>
+                </div>
+
+                <p className="mt-4 text-base leading-relaxed text-foreground/90">
+                  {bestQuest.description}
+                </p>
+
+                <div className="mt-4 rounded-2xl border border-border/70 bg-background/55 p-4">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+                    Why this one today
+                  </p>
+                  <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                    {bestQuest.why}
+                  </p>
+                </div>
+
+                <QuestActions
+                  quest={bestQuest}
+                  startingQuestId={startingQuestId}
+                  onStart={(quest) => void startQuest(quest)}
+                  onComplete={(quest) => openCompletion(quest)}
+                  onSafeStop={(quest) => openCompletion(quest, true)}
+                  prominent
+                />
+
+                <p className="mt-4 text-xs leading-relaxed text-muted-foreground">
+                  Woof recommends, you choose. Changing your mind, making it easier, or stopping
+                  when
+                  {` ${data.pet.name}`} is done can all be the right outcome.
+                </p>
+              </section>
+            ) : (
+              <section className="mt-4 surface-soft rounded-3xl p-6 text-center">
+                <PawPrint className="mx-auto h-7 w-7 text-primary" aria-hidden="true" />
+                <h1 className="mt-3 text-xl font-bold">Nothing needs pushing today</h1>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  Woof does not have a useful quest to recommend right now. Rest or your usual
+                  routine is a valid choice.
+                </p>
+              </section>
+            )}
+
+            {alternatives.length > 0 && (
+              <details
+                data-today-alternatives
+                className="mt-4 rounded-2xl border border-border/70 bg-card/65 px-4 py-3"
+              >
+                <summary className="cursor-pointer text-sm font-semibold">
+                  Want a different kind of day?{' '}
+                  <span className="font-normal text-muted-foreground">
+                    {alternatives.length} other {alternatives.length === 1 ? 'option' : 'options'}
+                  </span>
+                </summary>
+                <div className="mt-3 space-y-3 border-t border-border/60 pt-3">
+                  {alternatives.map((quest) => {
+                    const Icon = pathwayIcons[quest.primaryPathway];
+                    return (
+                      <article key={quest.id} className="rounded-2xl bg-background/50 p-4">
+                        <div className="flex items-start gap-3">
+                          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                            <Icon className="h-4 w-4" aria-hidden="true" />
+                          </span>
+                          <div className="min-w-0 flex-1">
+                            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                              {quest.variant === 'wildcard' ? 'Something different' : 'Alternative'}{' '}
+                              · {quest.primaryPathway.toLowerCase()}
+                            </p>
+                            <h2 className="mt-1 font-bold tracking-tight">{quest.title}</h2>
+                            <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                              {quest.description}
+                            </p>
+                            <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                              {quest.why}
+                            </p>
+                            <QuestActions
+                              quest={quest}
+                              startingQuestId={startingQuestId}
+                              onStart={(candidate) => void startQuest(candidate)}
+                              onComplete={(candidate) => openCompletion(candidate)}
+                              onSafeStop={(candidate) => openCompletion(candidate, true)}
+                            />
+                          </div>
+                        </div>
+                      </article>
+                    );
+                  })}
+                </div>
+              </details>
+            )}
+
+            {data.learningSummary.length > 0 && (
+              <section
+                data-today-learning
+                className="mt-6 rounded-3xl border border-secondary/20 bg-secondary/[0.05] p-5"
+              >
+                <p className="eyebrow">What Woof is learning</p>
+                <ul className="mt-3 space-y-2 text-sm leading-relaxed text-muted-foreground">
+                  {data.learningSummary.slice(0, 3).map((line) => (
+                    <li key={line} className="flex gap-2">
+                      <Sparkles
+                        className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+                        aria-hidden="true"
+                      />
+                      <span>{line}</span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            <details
+              data-today-concierge
+              className="mt-6 rounded-2xl border border-border/70 bg-card/50 px-4 py-3"
+            >
+              <summary className="cursor-pointer text-sm font-semibold">
+                More context for today{' '}
+                <span className="font-normal text-muted-foreground">from Concierge</span>
+              </summary>
+              <div className="mt-4 border-t border-border/60 pt-4">
+                <ConciergeBriefing showPetSwitcher={false} />
+              </div>
+            </details>
+
+            <section data-today-progress className="mt-7" aria-labelledby="recent-rhythm-heading">
+              <div className="flex items-end justify-between gap-3">
+                <div>
+                  <p className="eyebrow">Recent rhythm</p>
+                  <h2 id="recent-rhythm-heading" className="mt-1 text-lg font-bold tracking-tight">
+                    Context, not today&apos;s assignment
+                  </h2>
+                </div>
+                <Link href="/compass" className="text-sm font-semibold text-primary">
+                  Full compass →
+                </Link>
+              </div>
+
+              <div className="mt-3 grid grid-cols-2 gap-3">
+                <div className="surface-soft rounded-2xl p-4">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                    Bond XP
+                  </p>
+                  <p className="mt-1 text-xl font-bold text-primary">{data.bondXp}</p>
+                  <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+                    Game progress, not a wellbeing score.
+                  </p>
+                </div>
+                <div className="surface-soft rounded-2xl p-4">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                    {data.rhythm.label}
+                  </p>
+                  <p className="mt-1 text-xl font-bold text-primary">
+                    {data.rhythm.activeWeeks}/{data.rhythm.windowWeeks}
+                  </p>
+                  <Progress
+                    className="mt-2 h-1.5"
+                    value={(data.rhythm.activeWeeks / data.rhythm.windowWeeks) * 100}
+                  />
+                </div>
+              </div>
+
+              {data.compass.length > 0 && (
+                <details className="mt-3 rounded-2xl border border-border/70 bg-background/40 px-4 py-3">
+                  <summary className="cursor-pointer text-sm font-semibold">
+                    See recent Pawprint Compass opportunities
+                  </summary>
+                  <div className="mt-3 grid grid-cols-2 gap-3 border-t border-border/60 pt-3">
+                    {data.compass.slice(0, 4).map((item) => {
+                      const Icon = pathwayIcons[item.pathway];
+                      return (
+                        <div key={item.pathway} className="surface-soft rounded-2xl p-4">
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="flex items-center gap-2 text-sm font-semibold">
+                              <Icon className="h-4 w-4 text-primary" aria-hidden="true" />
+                              {item.label}
+                            </span>
+                            <span className="text-xs font-bold text-primary">
+                              {item.recentDays}d
+                            </span>
+                          </div>
+                          <Progress className="mt-3 h-1.5" value={item.coverage} />
+                          <p className="mt-2 text-[11px] text-muted-foreground">
+                            Recent opportunity coverage · 28-day window
+                          </p>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </details>
+              )}
+            </section>
+
+            <p className="mt-5 text-center text-xs leading-relaxed text-muted-foreground">
+              {data.disclaimer}
+            </p>
+          </>
+        )}
+      </main>
+
+      {closingQuest && data && (
+        <div
+          className="fixed inset-0 z-[70] flex items-end justify-center bg-background/70 p-3 backdrop-blur-sm sm:items-center"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Quest outcome"
+        >
+          <div className="w-full max-w-md rounded-3xl border border-border bg-card p-5 shadow-2xl">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="eyebrow">Five-second learning loop</p>
+                <h2 className="mt-1 text-xl font-bold">{closingQuest.title}</h2>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={closeOutcome}
+                aria-label="Close outcome flow"
+              >
+                <X className="h-5 w-5" aria-hidden="true" />
+              </Button>
+            </div>
+
+            {completionReceipt ? (
+              <div className="mt-5 rounded-2xl bg-primary/10 p-5">
+                <div className="flex items-start gap-3">
+                  <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-primary text-primary-foreground">
+                    <PawPrint className="h-5 w-5" aria-hidden="true" />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="eyebrow">What Woof learned</p>
+                    <p className="mt-1 font-semibold leading-relaxed">
+                      {completionReceipt.message}
+                    </p>
+                    <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                      {completionReceipt.duplicate
+                        ? 'This outcome was already in your shared history, so Woof did not count it twice.'
+                        : `This outcome is now part of ${data.pet.name}'s recent shared pattern and can influence future quest ranking.`}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="mt-4 rounded-xl border border-border/70 bg-background/55 p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                      Game progress
+                    </p>
+                    <span className="text-xs font-bold text-primary">
+                      {completionReceipt.rewardCopy}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+                    {completionReceipt.rewardExplanation}
+                  </p>
+                </div>
+
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <Button onClick={closeOutcome}>Done</Button>
+                  <Button variant="outline" asChild className="bg-transparent">
+                    <Link href="/library">Add a memory</Link>
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <>
+                {safeOptOut ? (
+                  <div className="mt-5 rounded-2xl border border-primary/20 bg-primary/[0.05] p-4">
+                    <p className="font-semibold text-primary">You listened.</p>
+                    <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                      Woof will treat giving space or ending the interaction as successful dog
+                      literacy.
+                    </p>
+                  </div>
+                ) : !dogExperience ? (
+                  <div className="mt-5">
+                    <p className="text-sm font-semibold">How was it for {data.pet.name}?</p>
+                    <div className="mt-3 grid grid-cols-3 gap-2">
+                      {dogChoices.map((choice) => (
+                        <button
+                          key={choice.value}
+                          type="button"
+                          onClick={() => setDogExperience(choice.value)}
+                          className="rounded-2xl border border-border bg-background/55 p-3 text-center transition-colors hover:border-primary/40 hover:bg-primary/[0.05]"
+                        >
+                          <span className="block text-2xl" aria-hidden="true">
+                            {choice.emoji}
+                          </span>
+                          <span className="mt-1 block text-xs font-semibold">{choice.label}</span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+
+                {(dogExperience || safeOptOut) && (
+                  <div className="mt-5">
+                    <p className="text-sm font-semibold">How was it for you?</p>
+                    <div className="mt-3 grid grid-cols-3 gap-2">
+                      {ownerChoices.map((choice) => (
+                        <button
+                          key={choice.value}
+                          type="button"
+                          disabled={completeMutation.isPending}
+                          onClick={() =>
+                            completeMutation.mutate({
+                              quest: closingQuest,
+                              ownerExperience: choice.value,
+                            })
+                          }
+                          className="rounded-2xl border border-border bg-background/55 p-3 text-center transition-colors hover:border-primary/40 hover:bg-primary/[0.05] disabled:opacity-50"
+                        >
+                          <span className="block text-2xl" aria-hidden="true">
+                            {choice.emoji}
+                          </span>
+                          <span className="mt-1 block text-xs font-semibold">{choice.label}</span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {completeMutation.isPending && (
+                  <div
+                    className="mt-4 flex items-center justify-center gap-2 text-sm text-muted-foreground"
+                    role="status"
+                  >
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                    Learning from the outcome…
+                  </div>
+                )}
+                {completeMutation.isError && (
+                  <p className="mt-4 text-center text-sm text-destructive">
+                    That outcome could not be saved. Nothing was lost from your existing history.
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      <BottomNav />
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -8,6 +8,14 @@ type AuthResponse = {
   user: AuthUser;
 };
 
+type RegistrationRequest = {
+  handle: string;
+  email: string;
+  password: string;
+  bio?: string;
+  registrationKey?: string;
+};
+
 type StorageObject = {
   key: string;
   url: string;
@@ -38,7 +46,7 @@ function authHeader(token: string) {
 }
 
 export const authApi = {
-  register: async (data: { handle: string; email: string; password: string; bio?: string }) => {
+  register: async (data: RegistrationRequest) => {
     const response = await apiClient.post<AuthResponse>('/auth/register', data);
     if (response.access_token && response.user) {
       useAuthStore.getState().setAuth(response.user, response.access_token);
@@ -88,128 +96,12 @@ export const petsApi = {
   getPet: (petId: string) => apiClient.get<AuthPet>(`/pets/${petId}`),
 };
 
-export const activitiesApi = {
-  getActivities: () => apiClient.get<unknown[]>('/activities'),
-  logActivity: (data: {
-    petId: string;
-    type: string;
-    distance?: number;
-    duration: number;
-    calories?: number;
-  }) => apiClient.post<unknown>('/activities', data),
-};
-
-export const socialApi = {
-  getFeed: () => apiClient.get<unknown[]>('/social/posts'),
-  createPost: (data: { text: string; mediaUrls?: string[]; petId?: string }) =>
+export const postsApi = {
+  getFeed: () => apiClient.get<unknown[]>('/social/feed'),
+  createPost: (data: { content?: string; [key: string]: unknown }) =>
     apiClient.post<unknown>('/social/posts', data),
-  likePost: (postId: string) => apiClient.post<void>(`/social/posts/${postId}/likes`, {}),
-  addComment: (postId: string, commentText: string) =>
-    apiClient.post<unknown>(`/social/posts/${postId}/comments`, { text: commentText }),
-  getComments: (postId: string) => apiClient.get<unknown[]>(`/social/posts/${postId}/comments`),
-};
-
-export const meetupsApi = {
-  getMeetups: () => apiClient.get<unknown[]>('/meetups'),
-  createMeetup: (data: {
-    title: string;
-    datetime: string;
-    location: string;
-    description?: string;
-  }) => apiClient.post<unknown>('/meetups', data),
-  rsvp: (meetupId: string, response: 'yes' | 'no' | 'maybe') =>
-    apiClient.post<unknown>(`/meetups/${meetupId}/rsvp`, { response }),
-};
-
-type RawCompatibilityRecommendation = {
-  id: string;
-  pet: {
-    id: string;
-    ownerId: string;
-    name: string;
-    species: string;
-    breed?: string | null;
-    birthdate?: string | null;
-    avatarUrl?: string | null;
-    temperament?: string[];
-    owner?: {
-      id: string;
-      handle: string;
-      bio?: string | null;
-      avatarUrl?: string | null;
-      isVerified?: boolean;
-    };
-  };
-  compatibilityScore: number;
-  confidence?: number;
-  source?: string;
-  factors?: Record<string, number>;
-  explanation?: string[];
-  status?: 'PROPOSED' | 'CONFIRMED' | 'AVOID';
-  lastInteractionAt?: string | null;
-};
-
-type RawRecommendationsResponse = {
-  recommendations?: RawCompatibilityRecommendation[];
-};
-
-const asPercent = (value: number | undefined, fallback = 0) =>
-  Math.round(Math.max(0, Math.min(1, value ?? fallback)) * 100);
-
-const ageFromBirthdate = (birthdate?: string | null) => {
-  if (!birthdate) return undefined;
-  const born = new Date(birthdate);
-  if (Number.isNaN(born.getTime())) return undefined;
-
-  const now = new Date();
-  let age = now.getFullYear() - born.getFullYear();
-  const beforeBirthday =
-    now.getMonth() < born.getMonth() ||
-    (now.getMonth() === born.getMonth() && now.getDate() < born.getDate());
-  if (beforeBirthday) age -= 1;
-  return Math.max(0, age);
-};
-
-const normalizeRecommendation = (recommendation: RawCompatibilityRecommendation): Match => {
-  const rawFactors = recommendation.factors ?? {};
-  const owner = recommendation.pet.owner;
-
-  return {
-    id: recommendation.id,
-    owner: {
-      id: owner?.id ?? recommendation.pet.ownerId,
-      name: owner?.handle ?? 'Woof member',
-      bio: owner?.bio ?? undefined,
-      avatarUrl: owner?.avatarUrl ?? undefined,
-      isVerified: owner?.isVerified,
-    },
-    pet: {
-      id: recommendation.pet.id,
-      ownerId: recommendation.pet.ownerId,
-      name: recommendation.pet.name,
-      species: recommendation.pet.species,
-      breed: recommendation.pet.breed ?? undefined,
-      age: ageFromBirthdate(recommendation.pet.birthdate),
-      temperament: recommendation.pet.temperament ?? [],
-      photoUrl: recommendation.pet.avatarUrl ?? undefined,
-    },
-    compatibility: {
-      overall: asPercent(recommendation.compatibilityScore),
-      confidence: asPercent(recommendation.confidence, 0.5),
-      source: recommendation.source ?? 'unknown',
-      factors: {
-        species: asPercent(rawFactors.species),
-        ...(rawFactors.temperament !== undefined
-          ? { temperament: asPercent(rawFactors.temperament) }
-          : {}),
-        ...(rawFactors.age !== undefined ? { age: asPercent(rawFactors.age) } : {}),
-        ...(rawFactors.breed !== undefined ? { breed: asPercent(rawFactors.breed) } : {}),
-      },
-      explanation: recommendation.explanation ?? [],
-    },
-    status: recommendation.status,
-    matchedAt: recommendation.lastInteractionAt ?? undefined,
-  };
+  likePost: (postId: string) => apiClient.post<void>(`/social/posts/${postId}/like`, {}),
+  unlikePost: (postId: string) => apiClient.delete<void>(`/social/posts/${postId}/like`),
 };
 
 export const compatibilityApi = {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -96,12 +96,128 @@ export const petsApi = {
   getPet: (petId: string) => apiClient.get<AuthPet>(`/pets/${petId}`),
 };
 
-export const postsApi = {
-  getFeed: () => apiClient.get<unknown[]>('/social/feed'),
-  createPost: (data: { content?: string; [key: string]: unknown }) =>
+export const activitiesApi = {
+  getActivities: () => apiClient.get<unknown[]>('/activities'),
+  logActivity: (data: {
+    petId: string;
+    type: string;
+    distance?: number;
+    duration: number;
+    calories?: number;
+  }) => apiClient.post<unknown>('/activities', data),
+};
+
+export const socialApi = {
+  getFeed: () => apiClient.get<unknown[]>('/social/posts'),
+  createPost: (data: { text: string; mediaUrls?: string[]; petId?: string }) =>
     apiClient.post<unknown>('/social/posts', data),
-  likePost: (postId: string) => apiClient.post<void>(`/social/posts/${postId}/like`, {}),
-  unlikePost: (postId: string) => apiClient.delete<void>(`/social/posts/${postId}/like`),
+  likePost: (postId: string) => apiClient.post<void>(`/social/posts/${postId}/likes`, {}),
+  addComment: (postId: string, commentText: string) =>
+    apiClient.post<unknown>(`/social/posts/${postId}/comments`, { text: commentText }),
+  getComments: (postId: string) => apiClient.get<unknown[]>(`/social/posts/${postId}/comments`),
+};
+
+export const meetupsApi = {
+  getMeetups: () => apiClient.get<unknown[]>('/meetups'),
+  createMeetup: (data: {
+    title: string;
+    datetime: string;
+    location: string;
+    description?: string;
+  }) => apiClient.post<unknown>('/meetups', data),
+  rsvp: (meetupId: string, response: 'yes' | 'no' | 'maybe') =>
+    apiClient.post<unknown>(`/meetups/${meetupId}/rsvp`, { response }),
+};
+
+type RawCompatibilityRecommendation = {
+  id: string;
+  pet: {
+    id: string;
+    ownerId: string;
+    name: string;
+    species: string;
+    breed?: string | null;
+    birthdate?: string | null;
+    avatarUrl?: string | null;
+    temperament?: string[];
+    owner?: {
+      id: string;
+      handle: string;
+      bio?: string | null;
+      avatarUrl?: string | null;
+      isVerified?: boolean;
+    };
+  };
+  compatibilityScore: number;
+  confidence?: number;
+  source?: string;
+  factors?: Record<string, number>;
+  explanation?: string[];
+  status?: 'PROPOSED' | 'CONFIRMED' | 'AVOID';
+  lastInteractionAt?: string | null;
+};
+
+type RawRecommendationsResponse = {
+  recommendations?: RawCompatibilityRecommendation[];
+};
+
+const asPercent = (value: number | undefined, fallback = 0) =>
+  Math.round(Math.max(0, Math.min(1, value ?? fallback)) * 100);
+
+const ageFromBirthdate = (birthdate?: string | null) => {
+  if (!birthdate) return undefined;
+  const born = new Date(birthdate);
+  if (Number.isNaN(born.getTime())) return undefined;
+
+  const now = new Date();
+  let age = now.getFullYear() - born.getFullYear();
+  const beforeBirthday =
+    now.getMonth() < born.getMonth() ||
+    (now.getMonth() === born.getMonth() && now.getDate() < born.getDate());
+  if (beforeBirthday) age -= 1;
+  return Math.max(0, age);
+};
+
+const normalizeRecommendation = (recommendation: RawCompatibilityRecommendation): Match => {
+  const rawFactors = recommendation.factors ?? {};
+  const owner = recommendation.pet.owner;
+
+  return {
+    id: recommendation.id,
+    owner: {
+      id: owner?.id ?? recommendation.pet.ownerId,
+      name: owner?.handle ?? 'Woof member',
+      bio: owner?.bio ?? undefined,
+      avatarUrl: owner?.avatarUrl ?? undefined,
+      isVerified: owner?.isVerified,
+    },
+    pet: {
+      id: recommendation.pet.id,
+      ownerId: recommendation.pet.ownerId,
+      name: recommendation.pet.name,
+      species: recommendation.pet.species,
+      breed: recommendation.pet.breed ?? undefined,
+      age: ageFromBirthdate(recommendation.pet.birthdate),
+      temperament: recommendation.pet.temperament ?? [],
+      photoUrl: recommendation.pet.avatarUrl ?? undefined,
+    },
+    compatibility: {
+      overall: asPercent(recommendation.compatibilityScore),
+      confidence: asPercent(recommendation.confidence, 0.5),
+      source: recommendation.source ?? 'unknown',
+      factors: {
+        species: asPercent(rawFactors.species),
+        ...(rawFactors.temperament !== undefined
+          ? { temperament: asPercent(rawFactors.temperament) }
+          : {}),
+        ...(rawFactors.age !== undefined ? { age: asPercent(rawFactors.age) } : {}),
+        ...(rawFactors.breed !== undefined ? { breed: asPercent(rawFactors.breed) } : {}),
+      },
+      explanation: recommendation.explanation ?? [],
+    },
+    status: recommendation.status,
+    matchedAt: recommendation.lastInteractionAt ?? undefined,
+  };
 };
 
 export const compatibilityApi = {

--- a/apps/web/src/lib/api/companion.ts
+++ b/apps/web/src/lib/api/companion.ts
@@ -1,19 +1,10 @@
 import { apiClient } from './client';
 
 export type CompanionMode = 'PET_GUARDIAN' | 'ANIMAL_ALLY' | 'FOSTER_CAREGIVER';
-export type CompanionLanding =
-  | 'NEEDS_MODE'
-  | 'NEEDS_PET_SETUP'
-  | 'PET_TODAY'
-  | 'COMPANION_TODAY';
+export type CompanionLanding = 'NEEDS_MODE' | 'NEEDS_PET_SETUP' | 'PET_TODAY' | 'COMPANION_TODAY';
 export type ReadinessStatus = 'NOT_SURE' | 'WORKING_ON_IT' | 'READY_TO_DISCUSS';
 export type ReadinessDimension =
-  | 'housing'
-  | 'householdAlignment'
-  | 'timeCapacity'
-  | 'financialPlan'
-  | 'supportPlan'
-  | 'carePlan';
+  'housing' | 'householdAlignment' | 'timeCapacity' | 'financialPlan' | 'supportPlan' | 'carePlan';
 
 export type CompanionState = {
   mode: CompanionMode | null;

--- a/apps/web/src/lib/api/companion.ts
+++ b/apps/web/src/lib/api/companion.ts
@@ -1,0 +1,47 @@
+import { apiClient } from './client';
+
+export type CompanionMode = 'PET_GUARDIAN' | 'ANIMAL_ALLY' | 'FOSTER_CAREGIVER';
+export type CompanionLanding =
+  | 'NEEDS_MODE'
+  | 'NEEDS_PET_SETUP'
+  | 'PET_TODAY'
+  | 'COMPANION_TODAY';
+export type ReadinessStatus = 'NOT_SURE' | 'WORKING_ON_IT' | 'READY_TO_DISCUSS';
+export type ReadinessDimension =
+  | 'housing'
+  | 'householdAlignment'
+  | 'timeCapacity'
+  | 'financialPlan'
+  | 'supportPlan'
+  | 'carePlan';
+
+export type CompanionState = {
+  mode: CompanionMode | null;
+  modeSource: 'PERSISTED' | 'PET_AUTHORITY_COMPAT' | 'UNSET';
+  hasAuthorizedPet: boolean;
+  landing: CompanionLanding;
+  authority: {
+    modeControlsPresentation: boolean;
+    petAccessComesFromRelationships: boolean;
+    modeNeverCreatesPetAuthority: boolean;
+  };
+};
+
+export type ReadinessReflection = {
+  dimensions: Record<ReadinessDimension, ReadinessStatus | null>;
+  updatedAt: string | null;
+  statuses: readonly ReadinessStatus[];
+  disclaimer: string;
+};
+
+export const companionApi = {
+  state: () => apiClient.get<CompanionState>('/companion/state'),
+  updateMode: (mode: CompanionMode) =>
+    apiClient.put<CompanionState, { mode: CompanionMode }>('/companion/mode', { mode }),
+  readiness: () => apiClient.get<ReadinessReflection>('/companion/readiness'),
+  updateReadiness: (patch: Partial<Record<ReadinessDimension, ReadinessStatus>>) =>
+    apiClient.put<ReadinessReflection, Partial<Record<ReadinessDimension, ReadinessStatus>>>(
+      '/companion/readiness',
+      patch
+    ),
+};

--- a/docs/DOGOS_COMPANION_ONRAMP_V1.md
+++ b/docs/DOGOS_COMPANION_ONRAMP_V1.md
@@ -1,0 +1,160 @@
+# dogOS Companion Onramp v1
+
+Companion Onramp makes Woof useful before, between, and beyond pet ownership without manufacturing a dog profile or weakening pet authorization.
+
+## Product rule
+
+**Account mode controls presentation. Pet relationships control pet authority.**
+
+Those are separate systems.
+
+A user may choose one of three presentation modes:
+
+- `PET_GUARDIAN`
+- `ANIMAL_ALLY`
+- `FOSTER_CAREGIVER`
+
+`AUTHORIZED_CAREGIVER` is intentionally not a global account mode in v1. Caregiver authority belongs to a bounded household/pet relationship, not an identity label that could accidentally grant access elsewhere.
+
+## Landing state machine
+
+The server resolves one of four landings:
+
+- `NEEDS_MODE`: no selected mode and no authorized pet context;
+- `NEEDS_PET_SETUP`: Pet Guardian selected, but no real pet relationship exists yet;
+- `PET_TODAY`: the account has authorized pet context and may use the existing dog-human Today loop;
+- `COMPANION_TODAY`: Animal Ally or Foster Caregiver experience.
+
+A mode never creates a pet, household membership, or authorization edge.
+
+Existing owners are migration-backfilled as `PET_GUARDIAN`. A user with shared household pet access but no persisted mode may temporarily reach `PET_TODAY` through `PET_AUTHORITY_COMPAT`; this preserves real relationship authority without falsely relabeling that account as the owner/guardian.
+
+## Petless Today
+
+Companion Today gives a useful loop without fake Bond XP or fictional dog state:
+
+1. practice Human Skill games in Skillcraft Arcade;
+2. participate in Community and privacy-bounded Packs;
+3. use a private readiness reflection;
+4. later switch to Pet Guardian if a real dog relationship begins.
+
+Pet-only Compass, Story, Autopilot, and Coach navigation do not appear unless the server positively resolves `PET_TODAY`.
+
+Navigation fails closed. If Companion state cannot be verified, the client exposes only pet-independent surfaces rather than guessing that a pet relationship exists.
+
+## Readiness reflection
+
+The readiness surface records six named dimensions:
+
+- housing;
+- household alignment;
+- time capacity;
+- financial plan;
+- support plan;
+- care plan.
+
+Each dimension is one of:
+
+- `NOT_SURE`;
+- `WORKING_ON_IT`;
+- `READY_TO_DISCUSS`.
+
+There is deliberately **no readiness score**.
+
+Woof does not convert the reflection into a percentage, rank, adoption recommendation, foster recommendation, financial assessment, housing assessment, or welfare clearance. The answers are private operational state and are not automatically copied into Social Adventure, pet state, recommendation evidence, or shelter workflows.
+
+`READY_TO_DISCUSS` means only that the user feels prepared to discuss that dimension. It does not mean a shelter, rescue, foster program, landlord, veterinarian, trainer, or other responsible party has approved it.
+
+## New-user onramp
+
+The login surface now sends new users to `/onboarding/companion`.
+
+The sequence is:
+
+1. create the human account;
+2. choose a starting role;
+3. if Pet Guardian is selected, continue into the existing durable pet + First Adventure onboarding;
+4. otherwise enter Companion Today immediately.
+
+Registration keeps the replay-key semantics already used by First Adventure onboarding.
+
+## Operational schema
+
+Companion state lives in `dogos_companion`, separate from canonical Prisma models.
+
+### `profiles`
+
+Stores only:
+
+- `user_id`;
+- chosen presentation `mode`;
+- timestamps.
+
+It cascades on account deletion.
+
+### `readiness_reflections`
+
+Stores:
+
+- `user_id`;
+- a bounded JSON object of named readiness dimensions;
+- timestamps.
+
+It cascades on account deletion and contains no score column.
+
+The migration backfills `PET_GUARDIAN` only from existing owned-pet rows. It intentionally does not turn shared household access into a permanent account identity.
+
+## Real-world opportunities
+
+v1 does not fabricate foster, volunteer, shelter, or adoption inventory.
+
+Future opportunity surfaces must use partner-authorized sources and preserve the placement organization's eligibility and decision authority. Companion mode itself is not evidence that a user should receive an animal.
+
+## Authority boundaries
+
+Companion Onramp preserves the larger dogOS authority model:
+
+- presentation mode != pet authorization;
+- readiness reflection != adoption/foster assessment;
+- Human Skill practice != professional credential;
+- social score != recommendation truth;
+- petless learning != fictional pet state;
+- household caregiver access != global account ownership;
+- shelter opportunity != placement authority.
+
+## UI surfaces
+
+- `/`: server-resolved router between Pet Today, Companion Today, mode choice, and pet setup;
+- `/onboarding/companion`: human-first mode selection for new accounts;
+- `/companion/readiness`: private, non-scored readiness reflection;
+- `/arcade`: available without a pet;
+- `/community`: available without a pet;
+- bottom navigation: mode-aware and fail-closed for pet-only routes.
+
+The previous guardian Today implementation is preserved intact behind the new router as `GuardianTodayPage`.
+
+## Release invariants
+
+Companion Onramp v1 must fail qualification if:
+
+- Companion mode code creates a pet or relationship grant;
+- Pet Guardian reaches pet Today without real authorized pet context;
+- Animal Ally or Foster Caregiver requires a pet;
+- pet-only navigation is exposed before `PET_TODAY` is positively resolved;
+- a readiness score column or composite score is introduced;
+- operational rows survive account deletion;
+- the operational schema leaks into canonical Prisma state;
+- API/web lint, type checks, tests, or production builds fail.
+
+## Next releases
+
+This is the foundation for the remaining #64 work. Follow-on releases should add:
+
+1. explicit invitation/grant UX for authorized caregivers while keeping grants pet/household scoped;
+2. partner-authorized shelter, foster, and volunteer opportunity connectors;
+3. organization-owned eligibility forms instead of Woof inventing placement criteria;
+4. transition receipts when a foster/adoption relationship begins, preserving human learning while starting dog-specific assumptions from zero;
+5. richer petless learning paths reviewed with qualified trainers and shelter/foster professionals;
+6. privacy controls for deleting or exporting Companion reflections.
+
+The release succeeds if someone can use Woof honestly before owning a dog, while the full dogOS relationship loop still opens only when a real authorized pet relationship exists.

--- a/packages/database/prisma/migrations/20260828193000_add_dogos_companion_onramp_v1/migration.sql
+++ b/packages/database/prisma/migrations/20260828193000_add_dogos_companion_onramp_v1/migration.sql
@@ -1,0 +1,32 @@
+CREATE SCHEMA IF NOT EXISTS dogos_companion;
+
+CREATE TABLE dogos_companion.profiles (
+  user_id TEXT PRIMARY KEY REFERENCES public.users(id) ON DELETE CASCADE,
+  mode TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT companion_profile_mode_valid
+    CHECK (mode IS NULL OR mode IN ('PET_GUARDIAN', 'ANIMAL_ALLY', 'FOSTER_CAREGIVER'))
+);
+
+CREATE INDEX companion_profiles_mode_idx
+  ON dogos_companion.profiles (mode)
+  WHERE mode IS NOT NULL;
+
+CREATE TABLE dogos_companion.readiness_reflections (
+  user_id TEXT PRIMARY KEY REFERENCES public.users(id) ON DELETE CASCADE,
+  dimensions JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT readiness_dimensions_object
+    CHECK (jsonb_typeof(dimensions) = 'object')
+);
+
+-- Preserve the existing guardian experience for users who already own a pet.
+-- Shared household access intentionally does not backfill a global identity mode:
+-- caregiver authority belongs to the relationship, not the account label.
+INSERT INTO dogos_companion.profiles (user_id, mode)
+SELECT DISTINCT pet.owner_id, 'PET_GUARDIAN'
+FROM public.pets pet
+JOIN public.users account ON account.id = pet.owner_id
+ON CONFLICT (user_id) DO NOTHING;

--- a/packages/database/prisma/migrations/20260828193000_add_dogos_companion_onramp_v1/migration.sql
+++ b/packages/database/prisma/migrations/20260828193000_add_dogos_companion_onramp_v1/migration.sql
@@ -13,13 +13,35 @@ CREATE INDEX companion_profiles_mode_idx
   ON dogos_companion.profiles (mode)
   WHERE mode IS NOT NULL;
 
+CREATE FUNCTION dogos_companion.readiness_dimensions_valid(value JSONB)
+RETURNS BOOLEAN
+LANGUAGE SQL
+IMMUTABLE
+AS $$
+  SELECT
+    jsonb_typeof(value) = 'object'
+    AND NOT EXISTS (
+      SELECT 1
+      FROM jsonb_each_text(value) AS entry(key, status)
+      WHERE key NOT IN (
+        'housing',
+        'householdAlignment',
+        'timeCapacity',
+        'financialPlan',
+        'supportPlan',
+        'carePlan'
+      )
+      OR status NOT IN ('NOT_SURE', 'WORKING_ON_IT', 'READY_TO_DISCUSS')
+    );
+$$;
+
 CREATE TABLE dogos_companion.readiness_reflections (
   user_id TEXT PRIMARY KEY REFERENCES public.users(id) ON DELETE CASCADE,
   dimensions JSONB NOT NULL DEFAULT '{}'::jsonb,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  CONSTRAINT readiness_dimensions_object
-    CHECK (jsonb_typeof(dimensions) = 'object')
+  CONSTRAINT readiness_dimensions_bounded
+    CHECK (dogos_companion.readiness_dimensions_valid(dimensions))
 );
 
 -- Preserve the existing guardian experience for users who already own a pet.


### PR DESCRIPTION
Supersedes #66 **only because the connected GitHub draft-transition mutation is broken**. The implementation branch and exact code head are unchanged.

Replacement head at creation:

`1d6c9fd5bb0266e4c2f5b002ce1ee594fdc01327`

#66 previously completed 18/18 PR workflows green on this exact SHA, but this replacement PR must independently rerun and pass its own complete CI matrix before merge. No prior green is being treated as a substitute for this PR's fresh evidence.

Part of #64.

## Product change

Make Woof useful before and beyond pet ownership without inventing a dog profile or weakening pet authorization.

### Account modes

Adds three presentation modes:
- `PET_GUARDIAN`
- `ANIMAL_ALLY`
- `FOSTER_CAREGIVER`

Mode controls presentation, not pet authority.

### Server-resolved landing state

The Companion API resolves:
- `NEEDS_MODE`
- `NEEDS_PET_SETUP`
- `PET_TODAY`
- `COMPANION_TODAY`

Pet Guardian reaches Pet Today only with real owner/active-household authority. Animal Ally and Foster Caregiver can use Woof with zero pets. Existing authorized-pet users without a persisted mode retain a compatibility path without being falsely relabeled as owners.

### Operational schema

Adds additive `dogos_companion` state:
- `profiles` for account presentation mode;
- `readiness_reflections` for private named readiness dimensions.

Readiness JSON is PostgreSQL-bounded to the six documented dimensions and three qualitative statuses. There is no composite readiness score.

### Petless Today

Companion Today exposes pet-independent value:
- Human Skill Arcade;
- Community + privacy-bounded Local Packs;
- private readiness reflection;
- explicit transition into Pet Guardian if a real pet relationship begins.

No fake pet, fake Bond XP, or fictional dog-specific learning is created.

### Navigation / authority behavior

Pet-only Compass, Story, Autopilot, Coach, and cooperative pet quests appear only after positive `PET_TODAY` resolution. Failed Companion authority settles into a petless-safe UI. Navigation observes authority state but does not silently restart a failed authority query; explicit retry remains owned by the Today surface.

### New-user flow + recovery

New users enter `/onboarding/companion`, create the human account, choose a starting role, then either continue into real pet onboarding or enter Companion Today. Registration replay safety is explicit in the web transport contract, and an already-authenticated interrupted flow resumes at role selection rather than asking the user to recreate credentials.

### Real-world placement boundary

This release does not scrape or fabricate shelter/foster/adoption inventory. Future opportunities must come from partner-authorized sources and preserve the responsible organization's placement authority.

## Qualification required on this replacement PR

The replacement must freshly prove:
- full migration chain + Prisma drift isolation;
- Companion DB constraints and deletion semantics;
- mode != pet authority;
- Pet Guardian requires actual pet authority;
- petless modes resolve without a pet;
- fail-closed navigation/community behavior;
- interrupted authenticated onboarding recovery;
- production-like persisted browser auth + canonical `/auth/me` fallback without CSP relaxation;
- unavailable Companion authority settles instead of mount-retry looping;
- formatting/lint/type checks;
- focused Companion policy tests;
- full backend/web tests;
- dedicated Companion Playwright authority contracts;
- root browser integration suite;
- API/web production builds;
- all inherited dogOS authority/realtime/product lanes triggered by the exact head.

## Follow-up

#67 remains the next authority-focused product slice after merge, with #75 now defining the operational-state/receipt conventions it should follow. #68/#69 are being handled in external PRs #72/#73 and currently remain under requested changes.