### PR TITLE
Bind operational telemetry to exact releases and close replay privacy

### DIFF
--- a/.github/scripts/assert-operational-privacy-release.py
+++ b/.github/scripts/assert-operational-privacy-release.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Fail closed when release identity or telemetry privacy authority drifts."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(path: str) -> str:
+    target = ROOT / path
+    if not target.is_file():
+        raise SystemExit(f"required operational privacy source missing: {path}")
+    return target.read_text()
+
+
+def require(path: str, *markers: str) -> None:
+    text = read(path)
+    missing = [marker for marker in markers if marker not in text]
+    if missing:
+        raise SystemExit(f"{path}: missing required markers: {missing}")
+
+
+def reject(path: str, *markers: str) -> None:
+    text = read(path)
+    present = [marker for marker in markers if marker in text]
+    if present:
+        raise SystemExit(f"{path}: forbidden operational privacy markers: {present}")
+
+
+require(
+    "apps/api/src/observability/release-identity.ts",
+    "GIT_SHA_PATTERN",
+    "UNKNOWN_RELEASE",
+    "process.env.WOOF_RELEASE_SHA",
+)
+require(
+    "apps/api/src/observability/observability.service.ts",
+    "release: this.releaseIdentity",
+    "resolveReleaseIdentity",
+)
+require(
+    "apps/api/src/sentry.ts",
+    "release: resolveReleaseIdentity()",
+    "sendDefaultPii: false",
+    "scrubSentryEvent",
+)
+
+require(
+    "apps/web/src/lib/observability/sentry-policy.ts",
+    "NEXT_PUBLIC_WOOF_RELEASE_SHA",
+    "NEXT_PUBLIC_SENTRY_REPLAY_ENABLED",
+    "UNKNOWN_RELEASE",
+    "sessionSampleRate: enabled ? 0.01 : 0",
+    "errorSampleRate: enabled ? 0.1 : 0",
+)
+require(
+    "apps/web/sentry.client.config.ts",
+    "release: resolveWebReleaseIdentity()",
+    "maskAllText: true",
+    "blockAllMedia: true",
+    "scrubBrowserSentryEvent",
+)
+reject(
+    "apps/web/sentry.client.config.ts",
+    "maskAllText: false",
+    "blockAllMedia: false",
+    "replaysOnErrorSampleRate: 1",
+)
+for path in ["apps/web/sentry.server.config.ts", "apps/web/sentry.edge.config.ts"]:
+    require(path, "release: resolveWebReleaseIdentity()")
+
+require(
+    "infra/docker/Dockerfile.api",
+    "ARG WOOF_RELEASE_SHA=unknown",
+    "ENV WOOF_RELEASE_SHA=${WOOF_RELEASE_SHA}",
+)
+for path in [
+    ".github/workflows/deploy-production.yml",
+    ".github/workflows/deploy-staging.yml",
+]:
+    require(
+        path,
+        '--build-arg WOOF_RELEASE_SHA="${GITHUB_SHA}"',
+        "NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ github.sha }}",
+        "NEXT_PUBLIC_SENTRY_REPLAY_ENABLED: 'false'",
+        "Enforce deployed API release identity",
+    )
+
+print("Operational privacy contract preserves exact release identity and privacy-closed replay.")

--- a/.github/scripts/assert-operational-privacy-release.py
+++ b/.github/scripts/assert-operational-privacy-release.py
@@ -35,8 +35,9 @@ require(
 )
 require(
     "apps/api/src/observability/observability.service.ts",
-    "release: this.releaseIdentity",
-    "resolveReleaseIdentity",
+    "release: resolveReleaseIdentity()",
+    "const release = resolveReleaseIdentity()",
+    "release,",
 )
 require(
     "apps/api/src/sentry.ts",

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -43,26 +43,7 @@ jobs:
           --config apps/api/fly.toml
           --build-arg WOOF_RELEASE_SHA="${GITHUB_SHA}"
 
-      - name: Verify API liveness, readiness and release identity
-        run: |
-          live=$(curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 \
-            https://woof-api-prod.fly.dev/api/v1/ops/health/live)
-          ready=$(curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 \
-            https://woof-api-prod.fly.dev/api/v1/ops/health/ready)
-          node -e '
-            const expected = process.env.GITHUB_SHA;
-            for (const [name, raw] of Object.entries({ live: process.env.LIVE_BODY, ready: process.env.READY_BODY })) {
-              const parsed = JSON.parse(raw);
-              if (parsed.release !== expected) {
-                throw new Error(`${name} release mismatch: expected ${expected}, received ${parsed.release}`);
-              }
-            }
-          '
-        env:
-          LIVE_BODY: ${{ steps.release_bodies.outputs.live }}
-          READY_BODY: ${{ steps.release_bodies.outputs.ready }}
-
-      - name: Capture release verification bodies
+      - name: Capture liveness and readiness evidence
         id: release_bodies
         run: |
           live=$(curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 \

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,19 +35,63 @@ jobs:
         with:
           version: 0.4.76
 
-      - name: Deploy API with migration and readiness gates
+      - name: Deploy API with migration, release identity and readiness gates
         run: >-
           flyctl deploy .
           --remote-only
           --app woof-api-prod
           --config apps/api/fly.toml
+          --build-arg WOOF_RELEASE_SHA="${GITHUB_SHA}"
 
-      - name: Verify API liveness and readiness
+      - name: Verify API liveness, readiness and release identity
         run: |
-          curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 \
-            https://woof-api-prod.fly.dev/api/v1/ops/health/live
-          curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 \
-            https://woof-api-prod.fly.dev/api/v1/ops/health/ready
+          live=$(curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 \
+            https://woof-api-prod.fly.dev/api/v1/ops/health/live)
+          ready=$(curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 \
+            https://woof-api-prod.fly.dev/api/v1/ops/health/ready)
+          node -e '
+            const expected = process.env.GITHUB_SHA;
+            for (const [name, raw] of Object.entries({ live: process.env.LIVE_BODY, ready: process.env.READY_BODY })) {
+              const parsed = JSON.parse(raw);
+              if (parsed.release !== expected) {
+                throw new Error(`${name} release mismatch: expected ${expected}, received ${parsed.release}`);
+              }
+            }
+          '
+        env:
+          LIVE_BODY: ${{ steps.release_bodies.outputs.live }}
+          READY_BODY: ${{ steps.release_bodies.outputs.ready }}
+
+      - name: Capture release verification bodies
+        id: release_bodies
+        run: |
+          live=$(curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 \
+            https://woof-api-prod.fly.dev/api/v1/ops/health/live)
+          ready=$(curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 \
+            https://woof-api-prod.fly.dev/api/v1/ops/health/ready)
+          {
+            echo 'live<<EOF'
+            echo "$live"
+            echo EOF
+            echo 'ready<<EOF'
+            echo "$ready"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Enforce deployed API release identity
+        env:
+          LIVE_BODY: ${{ steps.release_bodies.outputs.live }}
+          READY_BODY: ${{ steps.release_bodies.outputs.ready }}
+        run: |
+          node - <<'NODE'
+          const expected = process.env.GITHUB_SHA;
+          for (const [name, raw] of Object.entries({ live: process.env.LIVE_BODY, ready: process.env.READY_BODY })) {
+            const parsed = JSON.parse(raw);
+            if (parsed.release !== expected) {
+              throw new Error(`${name} release mismatch: expected ${expected}, received ${parsed.release}`);
+            }
+          }
+          NODE
 
       - name: Notify production API deployment when configured
         if: ${{ always() }}
@@ -105,6 +149,8 @@ jobs:
         working-directory: apps/web
         env:
           NEXT_PUBLIC_API_URL: https://woof-api-prod.fly.dev/api/v1
+          NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ github.sha }}
+          NEXT_PUBLIC_SENTRY_REPLAY_ENABLED: 'false'
 
       - name: Deploy to Vercel
         run: vercel deploy --prebuilt --prod --token="${VERCEL_TOKEN}"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -33,19 +33,44 @@ jobs:
         with:
           version: 0.4.76
 
-      - name: Deploy API with migration and readiness gates
+      - name: Deploy API with migration, release identity and readiness gates
         run: >-
           flyctl deploy .
           --remote-only
           --app woof-api-staging
           --config apps/api/fly.toml
+          --build-arg WOOF_RELEASE_SHA="${GITHUB_SHA}"
 
-      - name: Verify API liveness and readiness
+      - name: Capture liveness and readiness evidence
+        id: release_bodies
         run: |
-          curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 \
-            https://woof-api-staging.fly.dev/api/v1/ops/health/live
-          curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 \
-            https://woof-api-staging.fly.dev/api/v1/ops/health/ready
+          live=$(curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 \
+            https://woof-api-staging.fly.dev/api/v1/ops/health/live)
+          ready=$(curl --fail --silent --show-error --retry 8 --retry-all-errors --retry-delay 3 \
+            https://woof-api-staging.fly.dev/api/v1/ops/health/ready)
+          {
+            echo 'live<<EOF'
+            echo "$live"
+            echo EOF
+            echo 'ready<<EOF'
+            echo "$ready"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Enforce deployed API release identity
+        env:
+          LIVE_BODY: ${{ steps.release_bodies.outputs.live }}
+          READY_BODY: ${{ steps.release_bodies.outputs.ready }}
+        run: |
+          node - <<'NODE'
+          const expected = process.env.GITHUB_SHA;
+          for (const [name, raw] of Object.entries({ live: process.env.LIVE_BODY, ready: process.env.READY_BODY })) {
+            const parsed = JSON.parse(raw);
+            if (parsed.release !== expected) {
+              throw new Error(`${name} release mismatch: expected ${expected}, received ${parsed.release}`);
+            }
+          }
+          NODE
 
   deploy-web-staging:
     name: Deploy Web to Staging
@@ -84,6 +109,8 @@ jobs:
         working-directory: apps/web
         env:
           NEXT_PUBLIC_API_URL: https://woof-api-staging.fly.dev/api/v1
+          NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ github.sha }}
+          NEXT_PUBLIC_SENTRY_REPLAY_ENABLED: 'false'
 
       - name: Deploy to Vercel
         run: vercel deploy --prebuilt --token="${VERCEL_TOKEN}"

--- a/.github/workflows/dogos-operational-privacy-ci.yml
+++ b/.github/workflows/dogos-operational-privacy-ci.yml
@@ -1,0 +1,115 @@
+name: dogOS Operational Privacy + Release CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/observability/release-identity.ts'
+      - 'apps/api/src/observability/release-identity.spec.ts'
+      - 'apps/api/src/observability/observability.service.ts'
+      - 'apps/api/src/sentry.ts'
+      - 'apps/web/sentry.client.config.ts'
+      - 'apps/web/sentry.server.config.ts'
+      - 'apps/web/sentry.edge.config.ts'
+      - 'apps/web/src/lib/observability/**'
+      - 'infra/docker/Dockerfile.api'
+      - '.github/workflows/deploy-production.yml'
+      - '.github/workflows/deploy-staging.yml'
+      - '.github/scripts/assert-operational-privacy-release.py'
+      - '.github/workflows/dogos-operational-privacy-ci.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: operational-privacy-release-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  TEST_RELEASE_SHA: '0123456789abcdef0123456789abcdef01234567'
+
+jobs:
+  qualify:
+    name: Release identity + telemetry privacy qualification
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from committed lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Check operational privacy formatting
+        run: >-
+          pnpm exec prettier --check
+          apps/api/src/observability/release-identity.ts
+          apps/api/src/observability/release-identity.spec.ts
+          apps/api/src/observability/observability.service.ts
+          apps/api/src/sentry.ts
+          apps/web/sentry.client.config.ts
+          apps/web/sentry.server.config.ts
+          apps/web/sentry.edge.config.ts
+          apps/web/src/lib/observability/sentry-policy.ts
+          apps/web/src/lib/observability/sentry-policy.test.ts
+          .github/workflows/deploy-production.yml
+          .github/workflows/deploy-staging.yml
+          .github/workflows/dogos-operational-privacy-ci.yml
+
+      - name: Lint API operational privacy surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/observability/release-identity.ts
+          src/observability/release-identity.spec.ts
+          src/observability/observability.service.ts
+          src/sentry.ts
+
+      - name: Lint Web telemetry privacy surface
+        run: >-
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          sentry.client.config.ts
+          sentry.server.config.ts
+          sentry.edge.config.ts
+          src/lib/observability/sentry-policy.ts
+          src/lib/observability/sentry-policy.test.ts
+
+      - name: Validate source contract
+        run: python -m py_compile .github/scripts/assert-operational-privacy-release.py
+
+      - name: Enforce source contract
+        run: python .github/scripts/assert-operational-privacy-release.py
+
+      - name: Type-check API and Web
+        run: |
+          pnpm --filter @woof/api type-check
+          pnpm --filter @woof/web type-check
+
+      - name: Run release identity contract
+        run: pnpm --filter @woof/api exec jest src/observability/release-identity.spec.ts --runInBand
+
+      - name: Run Web telemetry privacy contract
+        run: pnpm --filter @woof/web exec vitest run src/lib/observability/sentry-policy.test.ts
+
+      - name: Build API with exact release identity source
+        env:
+          WOOF_RELEASE_SHA: ${{ env.TEST_RELEASE_SHA }}
+        run: pnpm --filter @woof/api build
+
+      - name: Build Web with replay privacy closed
+        env:
+          NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ env.TEST_RELEASE_SHA }}
+          NEXT_PUBLIC_SENTRY_REPLAY_ENABLED: 'false'
+          NEXT_PUBLIC_API_URL: http://127.0.0.1:4000/api/v1
+        run: pnpm --filter @woof/web build

--- a/.github/workflows/dogos-operational-privacy-ci.yml
+++ b/.github/workflows/dogos-operational-privacy-ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Install from committed lockfile
         run: pnpm install --frozen-lockfile
 
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
       - name: Check operational privacy formatting
         run: >-
           pnpm exec prettier --check

--- a/apps/api/src/observability/observability.service.ts
+++ b/apps/api/src/observability/observability.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, ServiceUnavailableException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import { resolveReleaseIdentity } from './release-identity';
 
 @Injectable()
 export class ObservabilityService {
@@ -11,16 +12,19 @@ export class ObservabilityService {
       timestamp: new Date().toISOString(),
       uptimeSeconds: process.uptime(),
       environment: process.env.NODE_ENV || 'development',
+      release: resolveReleaseIdentity(),
     };
   }
 
   async readiness() {
     const started = performance.now();
+    const release = resolveReleaseIdentity();
     try {
       await this.prisma.$queryRaw`SELECT 1`;
       return {
         status: 'ready' as const,
         timestamp: new Date().toISOString(),
+        release,
         database: {
           status: 'ready' as const,
           latencyMs: Math.max(0, performance.now() - started),
@@ -30,6 +34,7 @@ export class ObservabilityService {
       return {
         status: 'not_ready' as const,
         timestamp: new Date().toISOString(),
+        release,
         database: {
           status: 'unavailable' as const,
           latencyMs: Math.max(0, performance.now() - started),

--- a/apps/api/src/observability/release-identity.spec.ts
+++ b/apps/api/src/observability/release-identity.spec.ts
@@ -1,0 +1,21 @@
+import { UNKNOWN_RELEASE, resolveReleaseIdentity } from './release-identity';
+
+describe('release identity authority', () => {
+  it('accepts and normalizes one exact Git SHA', () => {
+    expect(resolveReleaseIdentity('ABCDEF0123456789ABCDEF0123456789ABCDEF01')).toBe(
+      'abcdef0123456789abcdef0123456789abcdef01'
+    );
+  });
+
+  it.each([
+    undefined,
+    '',
+    'main',
+    'latest',
+    'abcdef',
+    'abcdef0123456789abcdef0123456789abcdef0z',
+    'abcdef0123456789abcdef0123456789abcdef0123',
+  ])('fails visibly closed for non-SHA deployment identity %#', (value) => {
+    expect(resolveReleaseIdentity(value)).toBe(UNKNOWN_RELEASE);
+  });
+});

--- a/apps/api/src/observability/release-identity.ts
+++ b/apps/api/src/observability/release-identity.ts
@@ -1,0 +1,12 @@
+const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+export const UNKNOWN_RELEASE = 'unknown' as const;
+
+/**
+ * Deployment identity is authoritative only when it is an exact Git commit SHA.
+ * Arbitrary environment text must never become a trusted release identifier.
+ */
+export function resolveReleaseIdentity(value = process.env.WOOF_RELEASE_SHA): string {
+  const normalized = value?.trim().toLowerCase() ?? '';
+  return GIT_SHA_PATTERN.test(normalized) ? normalized : UNKNOWN_RELEASE;
+}

--- a/apps/api/src/sentry.ts
+++ b/apps/api/src/sentry.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/node';
 import { nodeProfilingIntegration } from '@sentry/profiling-node';
+import { resolveReleaseIdentity } from './observability/release-identity';
 
 type StatusCarrier = {
   status?: unknown;
@@ -41,6 +42,7 @@ export function initSentry() {
     Sentry.init({
       dsn: process.env.SENTRY_DSN,
       environment: process.env.NODE_ENV || 'development',
+      release: resolveReleaseIdentity(),
       sendDefaultPii: false,
       integrations: [
         nodeProfilingIntegration(),

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -1,21 +1,33 @@
 import * as Sentry from '@sentry/nextjs';
+import {
+  resolveReplayPolicy,
+  resolveWebReleaseIdentity,
+  scrubBrowserSentryEvent,
+} from './src/lib/observability/sentry-policy';
+
+const replay = resolveReplayPolicy();
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   environment: process.env.NODE_ENV || 'development',
+  release: resolveWebReleaseIdentity(),
 
   // Performance Monitoring
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
 
-  // Session Replay
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
+  // Session Replay is privacy-closed by default and must be explicitly enabled at build time.
+  replaysSessionSampleRate: replay.sessionSampleRate,
+  replaysOnErrorSampleRate: replay.errorSampleRate,
 
   integrations: [
-    Sentry.replayIntegration({
-      maskAllText: false,
-      blockAllMedia: false,
-    }),
+    ...(replay.enabled
+      ? [
+          Sentry.replayIntegration({
+            maskAllText: true,
+            blockAllMedia: true,
+          }),
+        ]
+      : []),
     Sentry.browserTracingIntegration(),
   ],
 
@@ -35,12 +47,12 @@ Sentry.init({
     // Filter out 4xx errors
     const error = hint.originalException;
     if (error && typeof error === 'object' && 'status' in error) {
-      const status = (error as any).status;
-      if (status >= 400 && status < 500) {
+      const status = (error as { status?: unknown }).status;
+      if (typeof status === 'number' && status >= 400 && status < 500) {
         return null;
       }
     }
 
-    return event;
+    return scrubBrowserSentryEvent(event);
   },
 });

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -1,7 +1,18 @@
 import * as Sentry from '@sentry/nextjs';
+import {
+  resolveWebReleaseIdentity,
+  scrubBrowserSentryEvent,
+} from './src/lib/observability/sentry-policy';
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   environment: process.env.NODE_ENV || 'development',
+  release: resolveWebReleaseIdentity(),
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
+  beforeSend(event) {
+    if (process.env.NODE_ENV !== 'production') {
+      return null;
+    }
+    return scrubBrowserSentryEvent(event);
+  },
 });

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -1,8 +1,13 @@
 import * as Sentry from '@sentry/nextjs';
+import {
+  resolveWebReleaseIdentity,
+  scrubBrowserSentryEvent,
+} from './src/lib/observability/sentry-policy';
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   environment: process.env.NODE_ENV || 'development',
+  release: resolveWebReleaseIdentity(),
 
   // Performance Monitoring
   tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
@@ -12,12 +17,12 @@ Sentry.init({
   // Ignore expected errors
   ignoreErrors: ['NEXT_NOT_FOUND', 'NEXT_REDIRECT'],
 
-  beforeSend(event, hint) {
+  beforeSend(event) {
     // Don't send in development
     if (process.env.NODE_ENV !== 'production') {
       return null;
     }
 
-    return event;
+    return scrubBrowserSentryEvent(event);
   },
 });

--- a/apps/web/src/lib/observability/sentry-policy.test.ts
+++ b/apps/web/src/lib/observability/sentry-policy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  UNKNOWN_RELEASE,
+  resolveReplayPolicy,
+  resolveWebReleaseIdentity,
+  scrubBrowserSentryEvent,
+} from './sentry-policy';
+
+describe('Web telemetry policy', () => {
+  it('trusts only exact Git SHA release identity', () => {
+    expect(resolveWebReleaseIdentity('ABCDEF0123456789ABCDEF0123456789ABCDEF01')).toBe(
+      'abcdef0123456789abcdef0123456789abcdef01'
+    );
+    expect(resolveWebReleaseIdentity('latest')).toBe(UNKNOWN_RELEASE);
+    expect(resolveWebReleaseIdentity(undefined)).toBe(UNKNOWN_RELEASE);
+  });
+
+  it('keeps Session Replay disabled unless explicitly enabled', () => {
+    expect(resolveReplayPolicy(undefined)).toEqual({
+      enabled: false,
+      sessionSampleRate: 0,
+      errorSampleRate: 0,
+    });
+    expect(resolveReplayPolicy('false').enabled).toBe(false);
+    expect(resolveReplayPolicy('true')).toEqual({
+      enabled: true,
+      sessionSampleRate: 0.01,
+      errorSampleRate: 0.1,
+    });
+  });
+
+  it('removes user/request/extra/breadcrumb fields before browser error transport', () => {
+    const event = {
+      message: 'example',
+      request: { url: '/pets/private' },
+      user: { id: 'user-1' },
+      extra: { private: 'context' },
+      breadcrumbs: [{ message: 'private action' }],
+    };
+
+    expect(scrubBrowserSentryEvent(event)).toEqual({ message: 'example' });
+  });
+});

--- a/apps/web/src/lib/observability/sentry-policy.ts
+++ b/apps/web/src/lib/observability/sentry-policy.ts
@@ -1,0 +1,34 @@
+const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+export const UNKNOWN_RELEASE = 'unknown' as const;
+
+export function resolveWebReleaseIdentity(
+  value = process.env.NEXT_PUBLIC_WOOF_RELEASE_SHA
+): string {
+  const normalized = value?.trim().toLowerCase() ?? '';
+  return GIT_SHA_PATTERN.test(normalized) ? normalized : UNKNOWN_RELEASE;
+}
+
+export function resolveReplayPolicy(value = process.env.NEXT_PUBLIC_SENTRY_REPLAY_ENABLED) {
+  const enabled = value === 'true';
+  return {
+    enabled,
+    sessionSampleRate: enabled ? 0.01 : 0,
+    errorSampleRate: enabled ? 0.1 : 0,
+  } as const;
+}
+
+type PrivacySafeBrowserEvent = {
+  request?: unknown;
+  user?: unknown;
+  extra?: unknown;
+  breadcrumbs?: unknown;
+};
+
+export function scrubBrowserSentryEvent<T extends PrivacySafeBrowserEvent>(event: T) {
+  delete event.request;
+  delete event.user;
+  delete event.extra;
+  delete event.breadcrumbs;
+  return event;
+}

--- a/docs/DOGOS_OPERATIONAL_PRIVACY_RELEASE_IDENTITY.md
+++ b/docs/DOGOS_OPERATIONAL_PRIVACY_RELEASE_IDENTITY.md
@@ -1,0 +1,89 @@
+# dogOS Operational Privacy + Release Identity v1
+
+## Purpose
+
+This contract makes production telemetry answer two questions without gaining product-data authority:
+
+1. **Which exact code release emitted this signal?**
+2. **Can operational telemetry observe failures without becoming a second store of private dog, household, health, message, or location context?**
+
+It does not create a new analytics system and it does not claim live production monitoring until deployment authority under #77 is configured and exercised.
+
+## Canonical release identity
+
+`WOOF_RELEASE_SHA` / `NEXT_PUBLIC_WOOF_RELEASE_SHA` is authoritative only when it is an exact 40-character hexadecimal Git commit SHA. Values such as `main`, `latest`, a branch name, a shortened SHA, malformed input, or a missing value resolve visibly to `unknown`.
+
+The same intended GitHub Actions `GITHUB_SHA` is injected into:
+
+- the Fly API image through Docker build argument `WOOF_RELEASE_SHA`;
+- API Sentry release metadata;
+- API liveness/readiness responses;
+- the Vercel Web build through `NEXT_PUBLIC_WOOF_RELEASE_SHA`;
+- Web Sentry release metadata.
+
+Production/staging deployment verifies the public API liveness and readiness documents report the exact intended SHA. A healthy HTTP status with a different release identity is a failed deployment qualification.
+
+Release identity is public operational metadata. It must never contain credentials, tokens, environment secrets, user IDs, pet IDs, or arbitrary client-provided labels.
+
+## Session Replay privacy
+
+Browser Session Replay is **disabled by default**.
+
+The build-time switch `NEXT_PUBLIC_SENTRY_REPLAY_ENABLED=true` is required to enable it. The committed production and staging deployment workflows explicitly set it to `false`.
+
+If a future, separately reviewed deployment enables replay:
+
+- normal-session sample rate is capped at 1%;
+- error-session sample rate is capped at 10%;
+- all text is masked;
+- all media is blocked;
+- browser Sentry events strip request, user, extra, and breadcrumb payloads before transport.
+
+Enabling replay in code is not permission to collect sensitive content. Product/legal/privacy review and live provider configuration remain separate requirements.
+
+## API telemetry privacy
+
+The existing API Sentry boundary continues to:
+
+- disable default PII;
+- drop request/user/extra/breadcrumb payloads;
+- strip span data and replace descriptions with bounded operation names;
+- ignore expected client errors where appropriate.
+
+Release identity adds attribution, not payload collection.
+
+## Health semantics
+
+Liveness and readiness expose the resolved release SHA so operators can distinguish:
+
+- expected release;
+- stale deployment;
+- deployment/configuration that failed to carry release identity (`unknown`).
+
+Readiness remains database-backed. A matching SHA cannot make an unavailable database healthy.
+
+## Qualification
+
+`dogOS Operational Privacy + Release CI` proves:
+
+- exact-SHA parsing and fail-visible `unknown` behavior;
+- privacy-closed replay defaults and bounded opt-in rates;
+- browser event scrubbing;
+- API/Web format, lint, typecheck, and production builds;
+- deployment source contracts for Git SHA injection and release verification;
+- absence of the prior `maskAllText: false`, `blockAllMedia: false`, and 100% error replay configuration.
+
+Existing Production Runtime, Security Baseline, CodeQL, and root CI remain independent release gates when their owned paths are triggered.
+
+## Live evidence still required
+
+After #77 is resolved, operational readiness under #100 still requires:
+
+- a deployed release whose API reports the intended SHA;
+- Sentry events attributed to that same SHA;
+- external metric scraping and alert routing;
+- non-destructive alert/recovery drills;
+- backup/restore rehearsal;
+- bounded load qualification.
+
+Code qualification is not being described as live operational proof.

--- a/infra/docker/Dockerfile.api
+++ b/infra/docker/Dockerfile.api
@@ -20,6 +20,7 @@ RUN pnpm --filter @woof/api build
 
 FROM node:${NODE_VERSION}-alpine AS runner
 ARG PNPM_VERSION
+ARG WOOF_RELEASE_SHA=unknown
 
 RUN apk add --no-cache openssl libc6-compat \
   && npm install --global pnpm@${PNPM_VERSION}
@@ -43,6 +44,7 @@ COPY --chown=node:node --from=builder /app/packages ./packages
 ENV NODE_ENV=production
 ENV PORT=4000
 ENV NODE_OPTIONS=--enable-source-maps
+ENV WOOF_RELEASE_SHA=${WOOF_RELEASE_SHA}
 
 EXPOSE 4000
 


### PR DESCRIPTION
Advances #100 from the qualified client-reality main boundary.

## Why

Woof already exposes real DB-backed readiness, privacy-safe operational metrics, and Sentry hooks, but those signals were missing a canonical deployed release identity. More importantly, browser Session Replay was configured far too permissively for dogOS: 10% of sessions and 100% of error sessions with text and media unmasked.

Operational visibility must not become a second private-data store.

## Changes

- defines one exact 40-hex Git SHA release identity for API and Web; malformed, shortened, branch-name, `latest`, or absent identity resolves visibly to `unknown`;
- exposes the resolved release in API liveness/readiness and binds API/Web Sentry to the same release contract;
- injects `GITHUB_SHA` into Fly API image builds and Vercel Web builds in staging and production;
- makes staging/production deployment verify the deployed API `/live` and `/ready` documents report the exact intended SHA;
- disables browser Session Replay by default and explicitly keeps it disabled in committed staging/production workflows;
- if replay is separately enabled later, caps it at 1% normal / 10% error sessions, masks all text and blocks all media;
- strips request, user, extra, and breadcrumb payloads from browser Sentry error transport;
- adds API and Web unit contracts for release/replay authority;
- adds a fail-closed source contract preventing return of the old unmasked / 100%-error replay configuration;
- adds a dedicated Operational Privacy + Release CI lane;
- documents what is code-qualified versus what still requires live deployment and operator drills.

## Qualification

The dedicated lane requires:

- formatting and focused API/Web lint;
- source-contract compilation and enforcement;
- API/Web typecheck;
- release identity Jest contract;
- Web Sentry privacy Vitest contract;
- production API and Web builds with a deterministic exact-SHA fixture and Replay disabled.

Existing Production Runtime, Security Baseline, CodeQL, root CI, and any other path-owned workflows remain independent requirements.

## Non-claims

- This does not claim production Sentry is connected or inspected.
- This does not claim external metrics scraping/alert routing exists.
- This does not claim backup/restore or load qualification has happened.
- Deployment remains externally blocked under #77 until Fly + Vercel authority is configured.
- A Playwright/WebKit green matrix is code evidence, not physical-device or live-production evidence.

This implements the code portion of #100 Phase 1 and fixes the immediate browser telemetry privacy defect. Keep #100 open for alert policy, runbooks, recovery drills, load evidence, and live operational qualification.