### PR TITLE
[QUALIFIED DRAFT / SUPERSEDED] Converge browser authentication onto one canonical client authority

### DIFF
--- a/.github/scripts/assert-client-reality.py
+++ b/.github/scripts/assert-client-reality.py
@@ -117,6 +117,8 @@ require(api_client_test, "clearStaleSessionAfterUnauthorized")
 for source in (WEB / "src").rglob("*"):
     if source.suffix not in {".ts", ".tsx"} or source == persist:
         continue
+    if ".test." in source.name or ".spec." in source.name:
+        continue
     reject(source, "woof-session-storage")
 
 for marker in [

--- a/.github/scripts/assert-client-reality.py
+++ b/.github/scripts/assert-client-reality.py
@@ -22,6 +22,11 @@ def reject(path: Path, marker: str) -> None:
 config = WEB / "playwright.config.ts"
 persist = WEB / "src" / "lib" / "stores" / "auth-persist.ts"
 auth_store = WEB / "src" / "lib" / "stores" / "auth-store.ts"
+auth_store_test = WEB / "src" / "lib" / "stores" / "auth-store.test.ts"
+legacy_projection = WEB / "src" / "store" / "session.ts"
+api_client = WEB / "src" / "lib" / "api" / "client.ts"
+api_client_test = WEB / "src" / "lib" / "api" / "client.test.ts"
+api_hooks = WEB / "src" / "lib" / "api" / "hooks.ts"
 helper = WEB / "e2e" / "support" / "session.ts"
 auth_spec = WEB / "e2e" / "auth.spec.ts"
 workflow = ROOT / ".github" / "workflows" / "client-reality-ci.yml"
@@ -32,7 +37,20 @@ matrix_suites = [
     WEB / "e2e" / "caregiver-authority.spec.ts",
 ]
 
-for path in [config, persist, auth_store, helper, auth_spec, workflow, *matrix_suites]:
+for path in [
+    config,
+    persist,
+    auth_store,
+    auth_store_test,
+    legacy_projection,
+    api_client,
+    api_client_test,
+    api_hooks,
+    helper,
+    auth_spec,
+    workflow,
+    *matrix_suites,
+]:
     if not path.is_file():
         raise SystemExit(f"required client-reality source missing: {path.relative_to(ROOT)}")
 
@@ -47,10 +65,59 @@ for marker in [
 for marker in [
     "AUTH_PERSIST_VERSION",
     "AUTH_STORAGE_KEY",
+    "LEGACY_SESSION_STORAGE_KEY",
+    "retireLegacySessionStorage",
+    "localStorage.removeItem(LEGACY_SESSION_STORAGE_KEY)",
     "name: AUTH_STORAGE_KEY",
     "version: AUTH_PERSIST_VERSION",
 ]:
     require(auth_store, marker)
+
+# The historical module may remain temporarily as a UI alias projection, but it
+# must never regain authentication or persistence authority.
+for marker in [
+    "useAuthStore",
+    "Compatibility-only presentation projection",
+    "projectUser",
+    "projectPet",
+]:
+    require(legacy_projection, marker)
+for marker in [
+    "persist(",
+    "refreshToken",
+    "authToken",
+    "/auth/me",
+    "isAuthenticated",
+    "refreshSession",
+    "setSession",
+    "clearSession",
+    "localStorage",
+]:
+    reject(legacy_projection, marker)
+
+for marker in [
+    "useAuthStore",
+    "clearStaleSessionAfterUnauthorized",
+    "auth.logout()",
+]:
+    require(api_client, marker)
+reject(api_client, "localStorage.removeItem('authToken')")
+
+require(api_hooks, "useAuthStore")
+require(api_hooks, "auth.updateUser({ pets: [...currentPets, pet] })")
+reject(api_hooks, "useSessionStore")
+reject(api_hooks, "refreshSession")
+
+for path in [auth_store_test, api_client_test]:
+    require(path, "LEGACY_SESSION_STORAGE_KEY")
+require(api_client_test, "clearStaleSessionAfterUnauthorized")
+
+# No production source may spell the retired persistence key directly. The one
+# constant owner remains auth-persist.ts so stale-state cleanup can be explicit.
+for source in (WEB / "src").rglob("*"):
+    if source.suffix not in {".ts", ".tsx"} or source == persist:
+        continue
+    reject(source, "woof-session-storage")
 
 for marker in [
     "serializePersistedAuthSession",
@@ -101,6 +168,8 @@ for marker in [
     "e2e/navigation-spine.spec.ts",
     "e2e/caregiver-authority.spec.ts",
     "playwright install --with-deps ${{ matrix.browser }}",
+    "src/lib/stores/auth-store.test.ts",
+    "src/lib/api/client.test.ts",
 ]:
     require(workflow, marker)
 

--- a/.github/workflows/client-reality-ci.yml
+++ b/.github/workflows/client-reality-ci.yml
@@ -48,8 +48,13 @@ jobs:
           pnpm exec prettier --check
           apps/web/playwright.config.ts
           apps/web/src/lib/stores/auth-store.ts
+          apps/web/src/lib/stores/auth-store.test.ts
           apps/web/src/lib/stores/auth-persist.ts
           apps/web/src/lib/stores/auth-persist.test.ts
+          apps/web/src/store/session.ts
+          apps/web/src/lib/api/client.ts
+          apps/web/src/lib/api/client.test.ts
+          apps/web/src/lib/api/hooks.ts
           apps/web/e2e/support/session.ts
           apps/web/e2e/companion-onramp.spec.ts
           apps/web/e2e/navigation-spine.spec.ts
@@ -61,8 +66,13 @@ jobs:
           pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
           playwright.config.ts
           src/lib/stores/auth-store.ts
+          src/lib/stores/auth-store.test.ts
           src/lib/stores/auth-persist.ts
           src/lib/stores/auth-persist.test.ts
+          src/store/session.ts
+          src/lib/api/client.ts
+          src/lib/api/client.test.ts
+          src/lib/api/hooks.ts
           e2e/support/session.ts
           e2e/companion-onramp.spec.ts
           e2e/navigation-spine.spec.ts
@@ -77,8 +87,12 @@ jobs:
       - name: Type-check web
         run: pnpm --filter @woof/web type-check
 
-      - name: Run persisted auth contract
-        run: pnpm --filter @woof/web exec vitest run src/lib/stores/auth-persist.test.ts
+      - name: Run canonical auth authority contracts
+        run: >-
+          pnpm --filter @woof/web exec vitest run
+          src/lib/stores/auth-persist.test.ts
+          src/lib/stores/auth-store.test.ts
+          src/lib/api/client.test.ts
 
   browser-matrix:
     name: Critical path (${{ matrix.slug }})

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LEGACY_SESSION_STORAGE_KEY } from '@/lib/stores/auth-persist';
+import { useAuthStore } from '@/lib/stores/auth-store';
+import { clearStaleSessionAfterUnauthorized } from './client';
+
+const user = { id: 'user-1', handle: 'trailpaws', email: 'trailpaws@example.com' };
+
+describe('API unauthorized session boundary', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAuthStore.setState({
+      user: null,
+      token: null,
+      isAuthenticated: false,
+      isLoading: false,
+    });
+  });
+
+  it('clears canonical and historical browser auth state after an authenticated 401', () => {
+    useAuthStore.getState().setAuth(user, 'access-token');
+    localStorage.setItem(LEGACY_SESSION_STORAGE_KEY, '{"stale":true}');
+
+    expect(clearStaleSessionAfterUnauthorized()).toBe(true);
+    expect(localStorage.getItem('authToken')).toBeNull();
+    expect(localStorage.getItem(LEGACY_SESSION_STORAGE_KEY)).toBeNull();
+    expect(useAuthStore.getState()).toMatchObject({
+      user: null,
+      token: null,
+      isAuthenticated: false,
+    });
+  });
+
+  it('does not manufacture a logout when no authenticated browser state exists', () => {
+    expect(clearStaleSessionAfterUnauthorized()).toBe(false);
+    expect(useAuthStore.getState().isAuthenticated).toBe(false);
+  });
+});

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -41,17 +41,24 @@ axiosClient.interceptors.request.use((config) => {
   return config;
 });
 
+export function clearStaleSessionAfterUnauthorized() {
+  if (typeof window === 'undefined') return false;
+
+  const auth = useAuthStore.getState();
+  const requestHadAuthToken = Boolean(
+    localStorage.getItem('authToken') || auth.token || auth.isAuthenticated
+  );
+  if (!requestHadAuthToken) return false;
+
+  auth.logout();
+  return true;
+}
+
 axiosClient.interceptors.response.use(
   (response) => response.data,
   (error) => {
-    const auth = useAuthStore.getState();
-    const requestHadAuthToken =
-      typeof window !== 'undefined' &&
-      Boolean(localStorage.getItem('authToken') || auth.token || auth.isAuthenticated);
-
-    if (error.response?.status === 401 && requestHadAuthToken) {
+    if (error.response?.status === 401 && clearStaleSessionAfterUnauthorized()) {
       console.warn('Authenticated API request returned 401; clearing the stale session');
-      auth.logout();
       if (window.location.pathname !== '/login') {
         window.location.pathname = '/login';
       }

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -1,4 +1,5 @@
 import axios, { type AxiosInstance, type AxiosRequestConfig } from 'axios';
+import { useAuthStore } from '@/lib/stores/auth-store';
 
 type UnwrappedAxiosInstance = Omit<
   AxiosInstance,
@@ -43,12 +44,14 @@ axiosClient.interceptors.request.use((config) => {
 axiosClient.interceptors.response.use(
   (response) => response.data,
   (error) => {
+    const auth = useAuthStore.getState();
     const requestHadAuthToken =
-      typeof window !== 'undefined' && Boolean(localStorage.getItem('authToken'));
+      typeof window !== 'undefined' &&
+      Boolean(localStorage.getItem('authToken') || auth.token || auth.isAuthenticated);
 
     if (error.response?.status === 401 && requestHadAuthToken) {
       console.warn('Authenticated API request returned 401; clearing the stale session');
-      localStorage.removeItem('authToken');
+      auth.logout();
       if (window.location.pathname !== '/login') {
         window.location.pathname = '/login';
       }

--- a/apps/web/src/lib/api/hooks.ts
+++ b/apps/web/src/lib/api/hooks.ts
@@ -5,8 +5,8 @@ import {
   type UseMutationOptions,
   type UseQueryOptions,
 } from '@tanstack/react-query';
+import { useAuthStore } from '@/lib/stores/auth-store';
 import type { MLFeatureVector, QuizSession } from '@/types/quiz';
-import { useSessionStore } from '@/store/session';
 import { apiClient } from './client';
 
 type ManagedQueryOptions<T> = Omit<
@@ -407,8 +407,8 @@ export function useUpdateActivity(
 ) {
   const queryClient = useQueryClient();
 
-  return useMutation<Activity, Error, { id: string; data: Partial<Activity> }>({
-    mutationFn: ({ id, data }) => apiClient.put<Activity>(`/activities/${id}`, data),
+  return useMutation<Activity, Error, Partial<Activity> & { id: string }>({
+    mutationFn: ({ id, ...data }) => apiClient.put<Activity>(`/activities/${id}`, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.activities });
     },
@@ -450,9 +450,17 @@ export function useCreatePet(
 
   return useMutation<PetProfile, Error, Record<string, unknown>>({
     mutationFn: (data) => apiClient.post<PetProfile>('/pets', data),
-    onSuccess: () => {
+    onSuccess: (pet) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.friends });
-      void useSessionStore.getState().refreshSession();
+      queryClient.invalidateQueries({ queryKey: ['auth-profile'] });
+
+      const auth = useAuthStore.getState();
+      if (auth.user) {
+        const currentPets = auth.user.pets ?? [];
+        if (!currentPets.some((current) => current.id === pet.id)) {
+          auth.updateUser({ pets: [...currentPets, pet] });
+        }
+      }
     },
     ...options,
   });
@@ -550,7 +558,7 @@ export function useSubmitQuiz(
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: queryKeys.userProfile(useSessionStore.getState().user?.id ?? ''),
+        queryKey: queryKeys.userProfile(useAuthStore.getState().user?.id ?? ''),
       });
     },
     ...options,

--- a/apps/web/src/lib/api/hooks.ts
+++ b/apps/web/src/lib/api/hooks.ts
@@ -407,8 +407,8 @@ export function useUpdateActivity(
 ) {
   const queryClient = useQueryClient();
 
-  return useMutation<Activity, Error, Partial<Activity> & { id: string }>({
-    mutationFn: ({ id, ...data }) => apiClient.put<Activity>(`/activities/${id}`, data),
+  return useMutation<Activity, Error, { id: string; data: Partial<Activity> }>({
+    mutationFn: ({ id, data }) => apiClient.put<Activity>(`/activities/${id}`, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.activities });
     },

--- a/apps/web/src/lib/stores/auth-store.test.ts
+++ b/apps/web/src/lib/stores/auth-store.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LEGACY_SESSION_STORAGE_KEY } from './auth-persist';
 import { useAuthStore } from './auth-store';
 
 describe('Auth Store', () => {
@@ -23,27 +24,35 @@ describe('Auth Store', () => {
     expect(isAuthenticated).toBe(false);
   });
 
-  it('should set auth correctly', () => {
+  it('should set auth correctly and retire historical session persistence', () => {
     const mockUser = { id: '123', handle: 'testuser', email: 'test@example.com' };
     const mockToken = 'mock-jwt-token';
+    localStorage.setItem(LEGACY_SESSION_STORAGE_KEY, '{"stale":true}');
+
     useAuthStore.getState().setAuth(mockUser, mockToken);
+
     const { user, token, isAuthenticated } = useAuthStore.getState();
     expect(user).toEqual(mockUser);
     expect(token).toBe(mockToken);
     expect(isAuthenticated).toBe(true);
     expect(localStorage.getItem('authToken')).toBe(mockToken);
+    expect(localStorage.getItem(LEGACY_SESSION_STORAGE_KEY)).toBeNull();
   });
 
-  it('should logout correctly', () => {
+  it('should logout correctly and fail closed across historical storage', () => {
     const mockUser = { id: '123', handle: 'testuser', email: 'test@example.com' };
     const mockToken = 'mock-jwt-token';
     useAuthStore.getState().setAuth(mockUser, mockToken);
+    localStorage.setItem(LEGACY_SESSION_STORAGE_KEY, '{"stale":true}');
+
     useAuthStore.getState().logout();
+
     const { user, token, isAuthenticated } = useAuthStore.getState();
     expect(user).toBeNull();
     expect(token).toBeNull();
     expect(isAuthenticated).toBe(false);
     expect(localStorage.getItem('authToken')).toBeNull();
+    expect(localStorage.getItem(LEGACY_SESSION_STORAGE_KEY)).toBeNull();
   });
 
   it('should update user correctly', () => {

--- a/apps/web/src/lib/stores/auth-store.ts
+++ b/apps/web/src/lib/stores/auth-store.ts
@@ -1,10 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import {
-  AUTH_PERSIST_VERSION,
-  AUTH_STORAGE_KEY,
-  LEGACY_SESSION_STORAGE_KEY,
-} from './auth-persist';
+import { AUTH_PERSIST_VERSION, AUTH_STORAGE_KEY, LEGACY_SESSION_STORAGE_KEY } from './auth-persist';
 
 export interface AuthPet {
   id: string;

--- a/apps/web/src/lib/stores/auth-store.ts
+++ b/apps/web/src/lib/stores/auth-store.ts
@@ -1,6 +1,10 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { AUTH_PERSIST_VERSION, AUTH_STORAGE_KEY } from './auth-persist';
+import {
+  AUTH_PERSIST_VERSION,
+  AUTH_STORAGE_KEY,
+  LEGACY_SESSION_STORAGE_KEY,
+} from './auth-persist';
 
 export interface AuthPet {
   id: string;
@@ -11,6 +15,7 @@ export interface AuthPet {
   birthdate?: string | null;
   temperament?: unknown;
   avatarUrl?: string | null;
+  bio?: string | null;
 }
 
 export interface AuthUser {
@@ -24,6 +29,7 @@ export interface AuthUser {
   totalPoints?: number;
   isVerified?: boolean;
   createdAt?: string;
+  location?: string | null;
   pets?: AuthPet[];
   _count?: {
     posts?: number;
@@ -42,6 +48,18 @@ interface AuthState {
   setLoading: (loading: boolean) => void;
 }
 
+function retireLegacySessionStorage() {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem(LEGACY_SESSION_STORAGE_KEY);
+  }
+}
+
+// Historical clients may still carry the second `woof-session-storage` Zustand
+// snapshot. It is never allowed to hydrate into authority again. Loading the
+// canonical store opportunistically retires it, while /auth/me remains the
+// server-authoritative recovery path for any still-valid raw bearer session.
+retireLegacySessionStorage();
+
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
@@ -54,6 +72,7 @@ export const useAuthStore = create<AuthState>()(
         if (typeof window !== 'undefined') {
           localStorage.setItem('authToken', token);
         }
+        retireLegacySessionStorage();
         set({ user, token, isAuthenticated: true, isLoading: false });
       },
 
@@ -61,6 +80,7 @@ export const useAuthStore = create<AuthState>()(
         if (typeof window !== 'undefined') {
           localStorage.removeItem('authToken');
         }
+        retireLegacySessionStorage();
         set({ user: null, token: null, isAuthenticated: false, isLoading: false });
       },
 

--- a/apps/web/src/lib/stores/auth-store.ts
+++ b/apps/web/src/lib/stores/auth-store.ts
@@ -54,10 +54,10 @@ function retireLegacySessionStorage() {
   }
 }
 
-// Historical clients may still carry the second `woof-session-storage` Zustand
-// snapshot. It is never allowed to hydrate into authority again. Loading the
-// canonical store opportunistically retires it, while /auth/me remains the
-// server-authoritative recovery path for any still-valid raw bearer session.
+// Historical clients may still carry the retired second Zustand session snapshot.
+// It is never allowed to hydrate into authority again. Loading the canonical store
+// opportunistically retires it, while /auth/me remains the server-authoritative
+// recovery path for any still-valid raw bearer session.
 retireLegacySessionStorage();
 
 export const useAuthStore = create<AuthState>()(

--- a/apps/web/src/store/session.ts
+++ b/apps/web/src/store/session.ts
@@ -1,5 +1,7 @@
-import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+'use client';
+
+import { useMemo } from 'react';
+import { useAuthStore, type AuthPet, type AuthUser } from '@/lib/stores/auth-store';
 
 export interface SessionPet {
   id: string;
@@ -30,107 +32,74 @@ export interface SessionUser {
   pets?: SessionPet[];
 }
 
-interface SessionState {
+export interface SessionViewState {
   user: SessionUser | null;
   pets: SessionPet[];
-  token: string | null;
-  refreshToken: string | null;
-  isAuthenticated: boolean;
-  login: (user: SessionUser, token: string, refreshToken?: string) => void;
-  logout: () => void;
-  setSession: (user: SessionUser, token: string) => void;
-  clearSession: () => void;
-  refreshSession: () => Promise<void>;
 }
 
-function normalizePet(pet: SessionPet): SessionPet {
+function ageFromBirthdate(birthdate?: string | null) {
+  if (!birthdate) return undefined;
+  const born = new Date(birthdate);
+  if (Number.isNaN(born.getTime())) return undefined;
+
+  const now = new Date();
+  let age = now.getFullYear() - born.getFullYear();
+  const beforeBirthday =
+    now.getMonth() < born.getMonth() ||
+    (now.getMonth() === born.getMonth() && now.getDate() < born.getDate());
+  if (beforeBirthday) age -= 1;
+  return Math.max(0, age);
+}
+
+function projectPet(pet: AuthPet): SessionPet {
   return {
-    ...pet,
-    avatar: pet.avatar ?? pet.avatarUrl,
+    id: pet.id,
+    name: pet.name,
+    species: pet.species,
+    breed: pet.breed ?? undefined,
+    age: ageFromBirthdate(pet.birthdate),
+    avatar: pet.avatarUrl ?? undefined,
+    avatarUrl: pet.avatarUrl ?? undefined,
+    bio: pet.bio ?? undefined,
   };
 }
 
-function normalizeUser(user: SessionUser): SessionUser {
-  const pets = user.pets?.map(normalizePet);
+function projectUser(user: AuthUser | null): SessionUser | null {
+  if (!user) return null;
+  const pets = user.pets?.map(projectPet);
+
   return {
-    ...user,
-    username: user.username ?? user.handle ?? user.name,
-    avatar: user.avatar ?? user.avatarUrl,
+    id: user.id,
+    email: user.email,
+    username: user.handle,
+    handle: user.handle,
+    avatar: user.avatarUrl ?? undefined,
+    avatarUrl: user.avatarUrl ?? undefined,
+    bio: user.bio ?? undefined,
+    location: user.location ?? undefined,
+    createdAt: user.createdAt,
     points: user.points ?? user.totalPoints ?? 0,
+    totalPoints: user.totalPoints,
+    isVerified: user.isVerified,
     pets,
   };
 }
 
-export const useSessionStore = create<SessionState>()(
-  persist(
-    (set, get) => {
-      const applySession = (user: SessionUser, token: string, refreshToken?: string) => {
-        const normalized = normalizeUser(user);
-        if (typeof window !== 'undefined') {
-          localStorage.setItem('authToken', token);
-        }
-        set({
-          user: normalized,
-          pets: normalized.pets ?? [],
-          token,
-          refreshToken: refreshToken ?? get().refreshToken,
-          isAuthenticated: true,
-        });
-      };
+/**
+ * Compatibility-only presentation projection for older UI surfaces.
+ *
+ * This module owns no credentials, persistence, authenticated state, logout,
+ * refresh lifecycle, or server authority. All values derive synchronously from
+ * the canonical `useAuthStore`; callers should migrate to that store directly.
+ */
+export function useSessionStore(): SessionViewState;
+export function useSessionStore<T>(selector: (state: SessionViewState) => T): T;
+export function useSessionStore<T>(selector?: (state: SessionViewState) => T) {
+  const authUser = useAuthStore((state) => state.user);
+  const view = useMemo<SessionViewState>(() => {
+    const user = projectUser(authUser);
+    return { user, pets: user?.pets ?? [] };
+  }, [authUser]);
 
-      const clear = () => {
-        if (typeof window !== 'undefined') {
-          localStorage.removeItem('authToken');
-        }
-        set({
-          user: null,
-          pets: [],
-          token: null,
-          refreshToken: null,
-          isAuthenticated: false,
-        });
-      };
-
-      return {
-        user: null,
-        pets: [],
-        token: null,
-        refreshToken: null,
-        isAuthenticated: false,
-        login: applySession,
-        logout: clear,
-        setSession: (user, token) => applySession(user, token),
-        clearSession: clear,
-        refreshSession: async () => {
-          const token = get().token;
-          const apiBase = process.env.NEXT_PUBLIC_API_URL;
-          if (!token || !apiBase) return;
-
-          const response = await fetch(`${apiBase}/auth/me`, {
-            headers: { Authorization: `Bearer ${token}` },
-          });
-          if (response.status === 401) {
-            clear();
-            return;
-          }
-          if (!response.ok) {
-            throw new Error(`Session refresh failed with status ${response.status}`);
-          }
-
-          const user = (await response.json()) as SessionUser;
-          applySession(user, token);
-        },
-      };
-    },
-    {
-      name: 'woof-session-storage',
-      partialize: (state) => ({
-        user: state.user,
-        pets: state.pets,
-        token: state.token,
-        refreshToken: state.refreshToken,
-        isAuthenticated: state.isAuthenticated,
-      }),
-    }
-  )
-);
+  return selector ? selector(view) : view;
+}


### PR DESCRIPTION
Superseded only because the connected GitHub GraphQL wrapper cannot transition draft -> ready: its response selection currently requests an invalid `Repository.fullDatabaseId` field. GitHub REST correctly refuses merging a draft.

The implementation itself is fully qualified on exact head `e70652a611070cb9c037712a97ef4c77698c44f7`:

- root CI including backend/API tests, frontend unit/browser/accessibility/visual contracts, static gates, API build, and Web production build: green;
- dogOS Client Reality contract: green;
- desktop Chromium, Mobile Chromium, Firefox, and WebKit critical paths: green;
- Security Baseline: green;
- CodeQL: green;
- CI Action Runtime Qualification: green.

No implementation commit is being changed to work around the connector defect. A replacement non-draft PR will be opened from this exact branch/head and must qualify again before merge.

Implementation summary remains:

- canonical `useAuthStore` retires historical `woof-session-storage` state on load/auth/logout;
- historical `store/session.ts` is presentation-only and owns no token, refresh token, persistence, authenticated state, localStorage, logout, or `/auth/me` lifecycle;
- API hooks no longer depend on legacy session actions;
- create-pet updates canonical pet projection;
- HTTP 401 clears canonical auth state fail-closed;
- source/unit/browser contracts prevent regression.
