### PR TITLE
Harden Behavior Vision provider failures against private diagnostic leakage

### DIFF
--- a/.github/scripts/assert-behavior-vision-transport.py
+++ b/.github/scripts/assert-behavior-vision-transport.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Fail closed if Behavior Vision provider failures regain private diagnostic logging."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MODEL = ROOT / "apps/api/src/behavior-vision/behavior-vision.model.ts"
+TEST = ROOT / "apps/api/src/behavior-vision/behavior-vision.model.spec.ts"
+WORKFLOW = ROOT / ".github/workflows/dogos-behavior-moments-ci.yml"
+
+for path in [MODEL, TEST, WORKFLOW]:
+    if not path.is_file():
+        raise SystemExit(f"required Behavior Vision transport source missing: {path.relative_to(ROOT)}")
+
+model = MODEL.read_text()
+test = TEST.read_text()
+workflow = WORKFLOW.read_text()
+
+required_model = [
+    "type BehaviorVisionFailureReason =",
+    "'provider_http_error'",
+    "'invalid_json'",
+    "'timeout'",
+    "'transport_error'",
+    "headers.Authorization = `Bearer ${this.serviceToken}`",
+    "this.warnFailure('provider_http_error', response.status)",
+    "this.warnFailure('invalid_json')",
+    "this.warnFailure('timeout')",
+    "this.errorFailure('transport_error')",
+    "Behavior vision provider failure reason=${reason}",
+]
+missing = [marker for marker in required_model if marker not in model]
+if missing:
+    raise SystemExit(f"Behavior Vision transport privacy contract is incomplete: {missing}")
+
+for forbidden in [
+    "response.text()",
+    "await response.text",
+    "error.message",
+    "JSON.stringify(error)",
+    "logger.warn(error",
+    "logger.error(error",
+]:
+    if forbidden in model:
+        raise SystemExit(
+            f"apps/api/src/behavior-vision/behavior-vision.model.ts: forbidden private diagnostic logging marker {forbidden!r}"
+        )
+
+required_tests = [
+    "never reads private provider error bodies into logs or the API error boundary",
+    "fails closed on invalid JSON without logging provider response content",
+    "classifies AbortError as a timeout without logging the underlying exception message",
+    "classifies transport failures without logging arbitrary fetch exception details",
+    "removes audio-derived evidence when audio analysis is disabled",
+    "Authorization: `Bearer ${releaseConfig.BEHAVIOR_VISION_SERVICE_TOKEN}`",
+]
+missing = [marker for marker in required_tests if marker not in test]
+if missing:
+    raise SystemExit(f"Behavior Vision transport privacy tests are incomplete: {missing}")
+
+required_workflow = [
+    ".github/scripts/assert-behavior-vision-transport.py",
+    "python -m py_compile .github/scripts/assert-behavior-vision-transport.py",
+    "python .github/scripts/assert-behavior-vision-transport.py",
+]
+missing = [marker for marker in required_workflow if marker not in workflow]
+if missing:
+    raise SystemExit(f"Behavior Moments CI does not own transport privacy regression: {missing}")
+
+print(
+    "Behavior Vision transport contract preserves bearer authentication, bounded failure classes, "
+    "private provider-body suppression, and audio-disabled evidence filtering."
+)

--- a/.github/workflows/dogos-behavior-moments-ci.yml
+++ b/.github/workflows/dogos-behavior-moments-ci.yml
@@ -14,6 +14,7 @@ on:
       - 'apps/web/src/app/coach/observe/shadow/**'
       - 'apps/web/e2e/behavior-moments-shadow.spec.ts'
       - 'ml/behavior_vision/**'
+      - '.github/scripts/assert-behavior-vision-transport.py'
       - '.github/workflows/dogos-behavior-moments-ci.yml'
       - 'docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md'
       - 'docs/DOGOS_BEHAVIOR_VISION_RELEASE_AUTHORITY.md'
@@ -57,9 +58,9 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter @woof/database db:generate
 
-      - name: Check Behavior Moments formatting
+      - name: Materialize Behavior Moments formatting
         run: >-
-          pnpm exec prettier --check
+          pnpm exec prettier --write
           apps/api/src/behavior-vision
           apps/api/src/config/env.validation.ts
           apps/api/src/config/env.validation.spec.ts
@@ -71,6 +72,9 @@ jobs:
           .github/workflows/dogos-behavior-moments-ci.yml
           docs/DOGOS_BEHAVIOR_MOMENTS_SHADOW.md
           docs/DOGOS_BEHAVIOR_VISION_RELEASE_AUTHORITY.md
+
+      - name: Enforce committed Behavior Moments formatting
+        run: git diff --exit-code
 
       - name: Lint Behavior Moments API surface
         run: >-
@@ -87,6 +91,11 @@ jobs:
           src/app/coach/layout.tsx
           src/app/coach/observe/shadow/page.tsx
           e2e/behavior-moments-shadow.spec.ts
+
+      - name: Validate provider transport privacy contract
+        run: |
+          python -m py_compile .github/scripts/assert-behavior-vision-transport.py
+          python .github/scripts/assert-behavior-vision-transport.py
 
       - name: Reject canonical pet mutation from Behavior Vision
         run: |

--- a/apps/api/src/behavior-vision/behavior-vision.model.spec.ts
+++ b/apps/api/src/behavior-vision/behavior-vision.model.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { BehaviorVisionModelService } from './behavior-vision.model';
 import {
@@ -67,12 +68,23 @@ const input = {
   },
 };
 
+function loggerSpies() {
+  return {
+    warn: jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined),
+    error: jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined),
+  };
+}
+
+function serializedLogCalls(spies: ReturnType<typeof loggerSpies>) {
+  return JSON.stringify([...spies.warn.mock.calls, ...spies.error.mock.calls]);
+}
+
 describe('BehaviorVisionModelService release qualification', () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  it('qualifies an exact pinned release and stamps qualification on the API side', async () => {
+  it('qualifies an exact pinned release, authenticates upstream, and stamps qualification on the API side', async () => {
     const upstream = payload({
       artifactSha256: ARTIFACT_SHA256.toUpperCase(),
       releaseQualification: {
@@ -113,6 +125,9 @@ describe('BehaviorVisionModelService release qualification', () => {
       artifactSha256: ARTIFACT_SHA256,
       responseContract: BEHAVIOR_OBSERVATION_SCHEMA_VERSION,
     });
+    expect(request?.headers).toMatchObject({
+      Authorization: `Bearer ${releaseConfig.BEHAVIOR_VISION_SERVICE_TOKEN}`,
+    });
   });
 
   it('rejects a model response from a different artifact before qualification', async () => {
@@ -139,6 +154,133 @@ describe('BehaviorVisionModelService release qualification', () => {
     );
 
     await expect(service().analyze(input)).rejects.toThrow(/release identity/i);
+  });
+
+  it('rejects malformed response contracts without promoting partial provider output', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ...payload(),
+          dimensions: null,
+        }),
+        { status: 200 }
+      )
+    );
+
+    await expect(service().analyze(input)).rejects.toThrow(/invalid observation contract/i);
+  });
+
+  it('never reads private provider error bodies into logs or the API error boundary', async () => {
+    const privateMarker = 'PRIVATE_OWNER_NOTE=nova-reacts-at-elm-street';
+    const spies = loggerSpies();
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(
+        new Response(`${privateMarker}; token=secret-provider-detail`, { status: 503 })
+      );
+
+    await expect(service().analyze({ ...input, question: privateMarker })).rejects.toThrow(
+      'Behavior-video analysis is temporarily unavailable'
+    );
+
+    expect(spies.warn).toHaveBeenCalledWith(
+      'Behavior vision provider failure reason=provider_http_error status=503'
+    );
+    expect(serializedLogCalls(spies)).not.toContain(privateMarker);
+    expect(serializedLogCalls(spies)).not.toContain('secret-provider-detail');
+  });
+
+  it('fails closed on invalid JSON without logging provider response content', async () => {
+    const privateMarker = 'PRIVATE_INVALID_JSON_OWNER_CONTEXT';
+    const spies = loggerSpies();
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(`{${privateMarker}`, { status: 200 }));
+
+    await expect(service().analyze(input)).rejects.toThrow(
+      'Behavior-video analysis is temporarily unavailable'
+    );
+
+    expect(spies.warn).toHaveBeenCalledWith('Behavior vision provider failure reason=invalid_json');
+    expect(serializedLogCalls(spies)).not.toContain(privateMarker);
+  });
+
+  it('classifies AbortError as a timeout without logging the underlying exception message', async () => {
+    const privateMarker = 'PRIVATE_TIMEOUT_REQUEST_STATE';
+    const spies = loggerSpies();
+    const timeoutError = Object.assign(new Error(privateMarker), { name: 'AbortError' });
+    jest.spyOn(global, 'fetch').mockRejectedValue(timeoutError);
+
+    await expect(service().analyze(input)).rejects.toThrow('Behavior-video analysis timed out');
+
+    expect(spies.warn).toHaveBeenCalledWith('Behavior vision provider failure reason=timeout');
+    expect(serializedLogCalls(spies)).not.toContain(privateMarker);
+  });
+
+  it('classifies transport failures without logging arbitrary fetch exception details', async () => {
+    const privateMarker = 'PRIVATE_TRANSPORT_DETAIL_WITH_REQUEST_METADATA';
+    const spies = loggerSpies();
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error(privateMarker));
+
+    await expect(service().analyze(input)).rejects.toThrow(
+      'Behavior-video analysis is temporarily unavailable'
+    );
+
+    expect(spies.error).toHaveBeenCalledWith(
+      'Behavior vision provider failure reason=transport_error'
+    );
+    expect(serializedLogCalls(spies)).not.toContain(privateMarker);
+  });
+
+  it('removes audio-derived evidence when audio analysis is disabled', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify(
+          payload({
+            evidence: [
+              { label: 'bark', source: 'audio', confidence: 0.9 },
+              { label: 'weight shift', source: 'pose', confidence: 0.8 },
+            ],
+            dimensions: [
+              {
+                dimension: 'arousal',
+                value: 0.7,
+                confidence: 0.8,
+                basis: ['audio bark', 'motion'],
+              },
+              {
+                dimension: 'body-tension',
+                value: 0.4,
+                confidence: 0.7,
+                basis: ['pose weight shift'],
+              },
+            ],
+          })
+        ),
+        { status: 200 }
+      )
+    );
+
+    const result = await service().analyze(input);
+
+    expect(result.evidence).toEqual([{ label: 'weight shift', source: 'pose', confidence: 0.8 }]);
+    expect(result.dimensions).toEqual([
+      {
+        dimension: 'body-tension',
+        value: 0.4,
+        confidence: 0.7,
+        basis: ['pose weight shift'],
+      },
+    ]);
+  });
+
+  it('returns an explicit unavailable boundary without making a request when no service is configured', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch');
+
+    await expect(
+      service({ BEHAVIOR_VISION_SERVICE_URL: undefined }).analyze(input)
+    ).rejects.toThrow(/not configured/i);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('refuses a configured service when deployment release pinning is incomplete', async () => {

--- a/apps/api/src/behavior-vision/behavior-vision.model.ts
+++ b/apps/api/src/behavior-vision/behavior-vision.model.ts
@@ -39,6 +39,9 @@ type ActiveReleasePin = {
   artifactSha256: string;
 };
 
+type BehaviorVisionFailureReason =
+  'provider_http_error' | 'invalid_json' | 'timeout' | 'transport_error';
+
 @Injectable()
 export class BehaviorVisionModelService {
   private readonly logger = new Logger(BehaviorVisionModelService.name);
@@ -134,23 +137,26 @@ export class BehaviorVisionModelService {
       });
 
       if (!response.ok) {
-        const body = await response.text();
-        this.logger.warn(
-          `Behavior vision service failed with ${response.status}: ${body.slice(0, 500)}`
-        );
+        this.warnFailure('provider_http_error', response.status);
         throw new ServiceUnavailableException('Behavior-video analysis is temporarily unavailable');
       }
 
-      const payload = (await response.json()) as BehaviorVisionModelAnalysis;
+      let payload: BehaviorVisionModelAnalysis;
+      try {
+        payload = (await response.json()) as BehaviorVisionModelAnalysis;
+      } catch {
+        this.warnFailure('invalid_json');
+        throw new ServiceUnavailableException('Behavior-video analysis is temporarily unavailable');
+      }
+
       return this.validate(payload, audioAllowed, this.activeRelease);
     } catch (error) {
       if (error instanceof ServiceUnavailableException) throw error;
       if (error instanceof Error && error.name === 'AbortError') {
+        this.warnFailure('timeout');
         throw new ServiceUnavailableException('Behavior-video analysis timed out');
       }
-      this.logger.error(
-        `Behavior vision analysis failed: ${error instanceof Error ? error.message : 'unknown error'}`
-      );
+      this.errorFailure('transport_error');
       throw new ServiceUnavailableException('Behavior-video analysis is temporarily unavailable');
     } finally {
       clearTimeout(timeout);
@@ -252,6 +258,15 @@ export class BehaviorVisionModelService {
           : [],
       })),
     };
+  }
+
+  private warnFailure(reason: BehaviorVisionFailureReason, status?: number) {
+    const statusSuffix = status === undefined ? '' : ` status=${status}`;
+    this.logger.warn(`Behavior vision provider failure reason=${reason}${statusSuffix}`);
+  }
+
+  private errorFailure(reason: BehaviorVisionFailureReason) {
+    this.logger.error(`Behavior vision provider failure reason=${reason}`);
   }
 
   private qualifyRelease(release: ActiveReleasePin): BehaviorVisionReleaseQualification {


### PR DESCRIPTION
## Summary

Fixes #107. Replacement for draft PR #112 after the connected GitHub ready-for-review mutation failed on the same upstream GraphQL `Repository.fullDatabaseId` field error previously observed on #111.

The branch was first rebased/reconstructed onto merged Client Reality #113 and fully requalified. **No code or head SHA changed after qualification.**

Exact head: `e121f806b0ee574dd3685ab48eaadc0fab1e1390`.
Base at qualification: `da86ac26210c10d28b549d9b11f054137269dca0`.

## Privacy boundary

Behavior Vision provider failures are reduced to bounded content-free classes:

- `provider_http_error` with numeric HTTP status;
- `invalid_json`;
- `timeout`;
- `transport_error`.

The runtime no longer reads provider non-2xx bodies, logs arbitrary provider/exception content, serializes transport exceptions, or returns provider diagnostics through the API boundary. Configured bearer authentication remains explicit.

## Exact-head qualification already completed

On the unchanged rebased head `e121f806b0ee574dd3685ab48eaadc0fab1e1390`:

- root CI: static quality gates, backend tests, frontend unit/browser contracts, API production build, Web production build all green;
- Behavior Moments Shadow CI: formatting, lint, provider privacy source contract, zero-authority checks, API/Web typecheck, release/shadow Jest contracts, worker contracts, Web transport contract, Shadow Lab Chromium journey, API build and Web build all green;
- Security Baseline green;
- CodeQL green;
- CI Action Runtime Qualification green.

This non-draft replacement intentionally allows a fresh pull-request event to run. Any fresh red check blocks merge even though the exact code head was already qualified.

## Scope boundary

This does not prove a deployed Behavior Vision endpoint, live provider authentication/networking, physical Safari/device behavior, or production availability. Behavior Vision remains shadow-evidence-only and cannot mutate canonical pet state or influence compatibility.