### PR TITLE
Qualify external integration truth and private failure boundaries

### DIFF
--- a/.github/scripts/assert-integration-truth.py
+++ b/.github/scripts/assert-integration-truth.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Fail closed when external integration authority or privacy boundaries drift."""
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+INVENTORY = ROOT / "docs/EXTERNAL_INTEGRATION_INVENTORY.json"
+HEALTH = ROOT / "apps/api/src/health-lens/health-ai.service.ts"
+HEALTH_TEST = ROOT / "apps/api/src/health-lens/health-ai.service.spec.ts"
+STORAGE = ROOT / "apps/api/src/storage/storage.service.ts"
+STORAGE_TEST = ROOT / "apps/api/src/storage/storage.service.spec.ts"
+PUSH = ROOT / "apps/api/src/notifications/notifications.service.ts"
+PUSH_TEST = ROOT / "apps/api/src/notifications/notifications.service.spec.ts"
+ENV = ROOT / "apps/api/src/config/env.validation.ts"
+ENV_EXAMPLE = ROOT / "apps/api/.env.example"
+N8N_README = ROOT / "n8n-workflows/README.md"
+MEDIA_WORKER = ROOT / "apps/api/src/media-library/media-derivative.worker.ts"
+MEDIA_TEST = ROOT / "apps/api/src/media-library/media-derivative.worker.spec.ts"
+WORKFLOW = ROOT / ".github/workflows/integration-truth-ci.yml"
+
+required_files = [
+    INVENTORY,
+    HEALTH,
+    HEALTH_TEST,
+    STORAGE,
+    STORAGE_TEST,
+    PUSH,
+    PUSH_TEST,
+    ENV,
+    ENV_EXAMPLE,
+    N8N_README,
+    MEDIA_WORKER,
+    MEDIA_TEST,
+    WORKFLOW,
+]
+for path in required_files:
+    if not path.is_file():
+        raise SystemExit(f"required integration-truth source missing: {path.relative_to(ROOT)}")
+
+inventory = json.loads(INVENTORY.read_text())
+allowed_statuses = {"ACTIVE", "OPTIONAL_QUALIFIED", "RESERVED", "RETIRED"}
+entries = {entry["id"]: entry for entry in inventory.get("integrations", [])}
+expected = {
+    "openai_health_lens": "OPTIONAL_QUALIFIED",
+    "behavior_vision": "OPTIONAL_QUALIFIED",
+    "s3_private_storage": "OPTIONAL_QUALIFIED",
+    "media_derivatives": "OPTIONAL_QUALIFIED",
+    "web_push": "OPTIONAL_QUALIFIED",
+    "n8n": "RESERVED",
+}
+if set(expected) - set(entries):
+    raise SystemExit(f"integration inventory is incomplete: {sorted(set(expected) - set(entries))}")
+for integration_id, expected_status in expected.items():
+    entry = entries[integration_id]
+    if entry.get("status") not in allowed_statuses:
+        raise SystemExit(f"invalid status for {integration_id}: {entry.get('status')!r}")
+    if entry.get("status") != expected_status:
+        raise SystemExit(
+            f"integration authority drift for {integration_id}: expected {expected_status}, got {entry.get('status')}"
+        )
+    if entry.get("productionQualified") is not False:
+        raise SystemExit(
+            f"{integration_id} must not claim production qualification without deployment evidence"
+        )
+
+health = HEALTH.read_text()
+for required in [
+    "type HealthProviderFailureReason =",
+    "'provider_http_error'",
+    "'invalid_json'",
+    "'timeout'",
+    "'transport_error'",
+    "Authorization: `Bearer ${this.apiKey}`",
+    "store: false",
+    "Health model provider failure reason=${reason}",
+]:
+    if required not in health:
+        raise SystemExit(f"Health Lens privacy/authority marker missing: {required}")
+for forbidden in [
+    "response.text()",
+    "await response.text",
+    "error.message",
+    "error.stack",
+    "JSON.stringify(error)",
+    "logger.warn(error",
+    "logger.error(error",
+]:
+    if forbidden in health:
+        raise SystemExit(f"Health Lens contains forbidden private diagnostic marker: {forbidden}")
+
+health_test = HEALTH_TEST.read_text()
+for required in [
+    "never reads private provider error bodies into logs or the API error boundary",
+    "classifies malformed provider JSON without logging response content",
+    "classifies AbortError as timeout without logging the exception message",
+    "classifies transport failures without logging arbitrary exception details",
+    "fails closed before network access when the provider is unconfigured",
+]:
+    if required not in health_test:
+        raise SystemExit(f"Health Lens defining privacy test missing: {required}")
+
+storage = STORAGE.read_text()
+for required in [
+    "type StorageOperation =",
+    "private async providerCall<T>",
+    "Object storage provider failure operation=${operation}",
+    "Media storage operation is temporarily unavailable",
+]:
+    if required not in storage:
+        raise SystemExit(f"Storage provider boundary marker missing: {required}")
+for forbidden in [
+    "error.message",
+    "error.stack",
+    "Private file uploaded successfully:",
+    "Private streamed file uploaded successfully:",
+    "File deleted successfully:",
+]:
+    if forbidden in storage:
+        raise SystemExit(f"Storage contains forbidden private diagnostic marker: {forbidden}")
+
+storage_test = STORAGE_TEST.read_text()
+for required in [
+    "keeps generated private keys and filenames out of successful telemetry",
+    "normalizes upload SDK failures without logging or rethrowing provider details",
+    "normalizes delete SDK failures without logging the private object key",
+    "fails closed before provider access when private storage is unconfigured",
+]:
+    if required not in storage_test:
+        raise SystemExit(f"Storage defining privacy test missing: {required}")
+
+push = PUSH.read_text()
+for forbidden in ["pushError.message", "pushError.stack", "candidate.message", "candidate.stack"]:
+    if forbidden in push:
+        raise SystemExit(f"Web Push contains forbidden provider diagnostic marker: {forbidden}")
+for line in push.splitlines():
+    if "this.logger." in line and any(
+        marker in line for marker in ["${userId}", "${title}", "${body}", "endpoint", "p256dh", "auth"]
+    ):
+        raise SystemExit(f"Web Push logger contains a private identifier/content marker: {line.strip()}")
+for required in [
+    "Push notification delivered",
+    "Push delivery failed${statusSuffix}",
+    "Expired push subscription removed status=${pushError.statusCode}",
+]:
+    if required not in push:
+        raise SystemExit(f"Web Push bounded telemetry marker missing: {required}")
+
+push_test = PUSH_TEST.read_text()
+for required in [
+    "sends the intended payload without logging private content",
+    "reduces arbitrary provider failures to status-only telemetry",
+    "removes stale subscriptions on provider status %s without identifier leakage",
+    "returns a truthful disabled state before database/provider access when VAPID is unconfigured",
+]:
+    if required not in push_test:
+        raise SystemExit(f"Web Push defining privacy test missing: {required}")
+
+env = ENV.read_text()
+env_example = ENV_EXAMPLE.read_text()
+if "N8N_WEBHOOK_SECRET" in env or "N8N_WEBHOOK_SECRET" in env_example:
+    raise SystemExit("n8n is RESERVED and must not expose a runtime secret/configuration knob")
+if "VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY must be configured together" not in env:
+    raise SystemExit("production Web Push keypair contract is missing")
+
+runtime_markers = ["N8N_WEBHOOK_SECRET", "webhooks/n8n", "localhost:5678"]
+for path in (ROOT / "apps/api/src").rglob("*.ts"):
+    text = path.read_text()
+    for marker in runtime_markers:
+        if marker in text:
+            raise SystemExit(
+                f"n8n is RESERVED but runtime marker {marker!r} exists in {path.relative_to(ROOT)}"
+            )
+
+n8n = N8N_README.read_text()
+for required in [
+    "reference prototypes only",
+    "no maintained `N8nWebhooksController`",
+    "no default n8n credentials",
+    "replay safety and idempotency",
+    "Deployment evidence",
+]:
+    if required not in n8n:
+        raise SystemExit(f"n8n reserved-authority documentation marker missing: {required}")
+for forbidden in ["woofadmin", "Username: `admin`", "N8N_WEBHOOK_SECRET=", "docker logs woof-n8n"]:
+    if forbidden in n8n:
+        raise SystemExit(f"n8n prototype documentation still looks deployment-authoritative: {forbidden}")
+
+workflow = WORKFLOW.read_text()
+for required in [
+    ".github/scripts/assert-integration-truth.py",
+    "docs/EXTERNAL_INTEGRATION_INVENTORY.json",
+    "apps/api/src/storage/storage.service.spec.ts",
+    "apps/api/src/notifications/notifications.service.spec.ts",
+    "apps/api/src/media-library/media-derivative.worker.spec.ts",
+    "python .github/scripts/assert-integration-truth.py",
+]:
+    if required not in workflow:
+        raise SystemExit(f"integration-truth CI ownership marker missing: {required}")
+
+print(
+    "External integration truth is explicit: implemented optional runtimes are repository-qualified, "
+    "n8n remains reserved, private provider diagnostics are suppressed, and production claims require live evidence."
+)

--- a/.github/scripts/assert-integration-truth.py
+++ b/.github/scripts/assert-integration-truth.py
@@ -173,14 +173,15 @@ for path in (ROOT / "apps/api/src").rglob("*.ts"):
             )
 
 n8n = N8N_README.read_text()
+n8n_lower = n8n.lower()
 for required in [
     "reference prototypes only",
-    "no maintained `N8nWebhooksController`",
+    "no maintained `n8nwebhookscontroller`",
     "no default n8n credentials",
     "replay safety and idempotency",
-    "Deployment evidence",
+    "deployment evidence",
 ]:
-    if required not in n8n:
+    if required not in n8n_lower:
         raise SystemExit(f"n8n reserved-authority documentation marker missing: {required}")
 for forbidden in ["woofadmin", "Username: `admin`", "N8N_WEBHOOK_SECRET=", "docker logs woof-n8n"]:
     if forbidden in n8n:

--- a/.github/workflows/integration-truth-ci.yml
+++ b/.github/workflows/integration-truth-ci.yml
@@ -1,0 +1,109 @@
+name: dogOS External Integration Truth CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/health-lens/**'
+      - 'apps/api/src/storage/**'
+      - 'apps/api/src/notifications/**'
+      - 'apps/api/src/media-library/media-derivative.worker.ts'
+      - 'apps/api/src/media-library/media-derivative.worker.spec.ts'
+      - 'apps/api/src/config/env.validation.ts'
+      - 'apps/api/src/config/env.validation.spec.ts'
+      - 'apps/api/.env.example'
+      - 'n8n-workflows/**'
+      - 'docs/EXTERNAL_INTEGRATION_INVENTORY.json'
+      - '.github/scripts/assert-integration-truth.py'
+      - '.github/workflows/integration-truth-ci.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: integration-truth-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  NODE_ENV: test
+  JWT_SECRET: ci-only-test-secret
+  ML_SERVICE_ENABLED: 'false'
+
+jobs:
+  qualify:
+    name: Runtime truth + private failure boundaries
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Materialize integration-truth formatting
+        run: >-
+          pnpm exec prettier --write
+          .github/workflows/integration-truth-ci.yml
+          apps/api/src/health-lens/health-ai.service.ts
+          apps/api/src/health-lens/health-ai.service.spec.ts
+          apps/api/src/storage/storage.service.ts
+          apps/api/src/storage/storage.service.spec.ts
+          apps/api/src/notifications/notifications.service.ts
+          apps/api/src/notifications/notifications.service.spec.ts
+          apps/api/src/config/env.validation.ts
+          apps/api/src/config/env.validation.spec.ts
+          n8n-workflows/README.md
+          docs/EXTERNAL_INTEGRATION_INVENTORY.json
+
+      - name: Enforce committed integration-truth formatting
+        run: git diff --exit-code
+
+      - name: Validate integration authority and privacy source contract
+        run: |
+          python -m py_compile .github/scripts/assert-integration-truth.py
+          python .github/scripts/assert-integration-truth.py
+
+      - name: Lint owned API boundaries
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/health-lens/health-ai.service.ts
+          src/health-lens/health-ai.service.spec.ts
+          src/storage/storage.service.ts
+          src/storage/storage.service.spec.ts
+          src/notifications/notifications.service.ts
+          src/notifications/notifications.service.spec.ts
+          src/config/env.validation.ts
+          src/config/env.validation.spec.ts
+          src/media-library/media-derivative.worker.ts
+          src/media-library/media-derivative.worker.spec.ts
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Run integration privacy and lifecycle contracts
+        run: >-
+          pnpm --filter @woof/api exec jest --runInBand
+          src/health-lens/health-ai.service.spec.ts
+          src/storage/storage.service.spec.ts
+          src/notifications/notifications.service.spec.ts
+          src/config/env.validation.spec.ts
+          src/media-library/media-derivative.worker.spec.ts
+
+      - name: Build API
+        run: pnpm --filter @woof/api build

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -46,10 +46,8 @@ MAX_FILE_SIZE=10485760
 # Redis (optional)
 REDIS_URL=redis://localhost:6379
 
-# Reserved external-integration configuration.
-# These variables are not evidence that the corresponding provider integration is
-# runtime-active. They remain for compatibility while #108 decides whether each
-# seam is implemented + qualified or retired.
+# Reserved external-integration configuration. These remain future-facing seams and are
+# not runtime capability claims. See docs/EXTERNAL_INTEGRATION_INVENTORY.json.
 GOOGLE_MAPS_API_KEY=
 APPLE_HEALTH_CLIENT_ID=
 GOOGLE_FIT_CLIENT_ID=
@@ -57,14 +55,15 @@ GOOGLE_FIT_CLIENT_ID=
 # Concierge intentionally has no live-weather setting in v1. Until a verified
 # weather transport is added, its API returns weather.status=NOT_CONFIGURED.
 
-# RESERVED: prospective Pet Health Lens provider configuration.
-# There is currently no qualified OpenAI runtime transport in this repository.
-# Do not set these in production as evidence that OpenAI-backed health screening is live.
+# OPTIONAL_QUALIFIED: OpenAI-backed Health Lens runtime.
+# Source-level contracts cover bearer authentication, store=false, structured output,
+# conservative health authority, and privacy-safe failures. Setting a key does NOT prove
+# target deployment/networking or black-box provider qualification.
 OPENAI_API_KEY=
 OPENAI_HEALTH_MODEL=gpt-5.6-luna
 OPENAI_HEALTH_TIMEOUT_MS=12000
 
-# Specialized behavior-video worker (optional, runtime-active when configured).
+# OPTIONAL_QUALIFIED: specialized behavior-video worker.
 # Recommended production deployment: private service network + bearer token.
 # Woof fails closed when this worker is absent; it does not invent video observations.
 # When SERVICE_URL is configured, all four release-pin fields below are required.
@@ -83,9 +82,10 @@ BEHAVIOR_VISION_ARTIFACT_SHA256=
 # breadcrumb payloads, and span data before egress.
 SENTRY_DSN=
 
-# RESERVED: prospective S3/R2 media-storage configuration.
-# Current source does not contain a qualified S3 client/storage transport. These settings
-# must not be interpreted as proof that private media is stored in or signed from S3/R2.
+# OPTIONAL_QUALIFIED: S3-compatible private object storage runtime.
+# Private media does not require S3_PUBLIC_URL; that setting is only for explicitly public
+# delivery. Credentials/configuration are not evidence that a target bucket, ACL policy,
+# or signed-URL path has been black-box qualified in production.
 S3_ENDPOINT=
 S3_BUCKET=woof-uploads
 S3_ACCESS_KEY_ID=
@@ -93,23 +93,23 @@ S3_SECRET_ACCESS_KEY=
 S3_PUBLIC_URL=
 AWS_REGION=auto
 
-# Private pet-media policy limits. These limits may be consumed independently of a
-# future external object-storage integration.
+# Private pet-media policy limits.
 MEDIA_LIBRARY_IMAGE_MAX_BYTES=26214400
 MEDIA_LIBRARY_VIDEO_MAX_BYTES=524288000
 MEDIA_LIBRARY_USER_QUOTA_BYTES=10737418240
 
-# RESERVED: prospective media-derivative worker configuration.
-# No qualified ffmpeg derivative runtime should be inferred from these variables alone.
+# OPTIONAL_QUALIFIED: media derivative worker. Enabling it in production requires private
+# object storage. Repository tests are not evidence of deployed ffmpeg/ffprobe binaries.
 MEDIA_DERIVATIVES_ENABLED=false
 MEDIA_FFMPEG_PATH=ffmpeg
 MEDIA_FFPROBE_PATH=ffprobe
 
-# RESERVED: prospective Web Push configuration. No qualified VAPID delivery transport
-# should be inferred until subscription lifecycle and delivery contracts exist.
+# OPTIONAL_QUALIFIED: Web Push runtime. Production configuration requires the public and
+# private VAPID keys together. Repository delivery/lifecycle tests are not proof of a real
+# browser subscription or provider delivery in the target deployment.
 VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
 
-# RESERVED: prospective n8n webhook authentication. No qualified n8n webhook transport
-# should be inferred until authenticated replay-safe webhook contracts exist.
-N8N_WEBHOOK_SECRET=
+# n8n is RESERVED. There is intentionally no n8n runtime secret/configuration knob here.
+# n8n-workflows/ contains design prototypes only; promotion requires a maintained,
+# authenticated, replay-safe runtime and independent deployment evidence.

--- a/apps/api/src/config/env.validation.spec.ts
+++ b/apps/api/src/config/env.validation.spec.ts
@@ -117,6 +117,33 @@ describe('validateEnvironment', () => {
     ).toThrow(/BEHAVIOR_VISION_SERVICE_TOKEN/i);
   });
 
+  it('requires Web Push VAPID keys to be configured as a pair in production', () => {
+    expect(() =>
+      validateEnvironment({
+        ...productionBase,
+        VAPID_PUBLIC_KEY: 'public-key-only',
+      })
+    ).toThrow(/VAPID_PUBLIC_KEY.*VAPID_PRIVATE_KEY.*together/i);
+
+    expect(() =>
+      validateEnvironment({
+        ...productionBase,
+        VAPID_PRIVATE_KEY: 'private-key-only',
+      })
+    ).toThrow(/VAPID_PUBLIC_KEY.*VAPID_PRIVATE_KEY.*together/i);
+  });
+
+  it('accepts a complete non-development Web Push VAPID keypair in production', () => {
+    const config = validateEnvironment({
+      ...productionBase,
+      VAPID_PUBLIC_KEY: 'public-production-key',
+      VAPID_PRIVATE_KEY: 'private-production-key',
+    });
+
+    expect(config.VAPID_PUBLIC_KEY).toBe('public-production-key');
+    expect(config.VAPID_PRIVATE_KEY).toBe('private-production-key');
+  });
+
   it('fails closed when production CORS falls back to localhost', () => {
     expect(() =>
       validateEnvironment({

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -47,7 +47,6 @@ const envSchema = z.object({
   MEDIA_FFPROBE_PATH: z.string().min(1).default('ffprobe'),
   VAPID_PUBLIC_KEY: z.string().optional(),
   VAPID_PRIVATE_KEY: z.string().optional(),
-  N8N_WEBHOOK_SECRET: z.string().optional(),
   OPENAI_API_KEY: z.string().min(20).optional(),
   OPENAI_HEALTH_MODEL: z.string().default('gpt-5.6-luna'),
   OPENAI_HEALTH_TIMEOUT_MS: z.coerce.number().int().min(3000).max(30000).default(12000),
@@ -138,6 +137,10 @@ export function validateEnvironment(config: Record<string, unknown>) {
 
     if (env.VAPID_PRIVATE_KEY && knownDevelopmentSecret.test(env.VAPID_PRIVATE_KEY)) {
       throw new Error('VAPID_PRIVATE_KEY must be replaced with a production key before startup');
+    }
+
+    if (Boolean(env.VAPID_PUBLIC_KEY) !== Boolean(env.VAPID_PRIVATE_KEY)) {
+      throw new Error('VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY must be configured together');
     }
 
     if (env.BEHAVIOR_VISION_SERVICE_URL && !env.BEHAVIOR_VISION_SERVICE_TOKEN) {

--- a/apps/api/src/health-lens/health-ai.service.spec.ts
+++ b/apps/api/src/health-lens/health-ai.service.spec.ts
@@ -1,5 +1,10 @@
-import { ServiceUnavailableException } from '@nestjs/common';
-import { normalizeHealthModelResult, type PetHealthModelResult } from './health-ai.service';
+import { Logger, ServiceUnavailableException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  HealthAiService,
+  normalizeHealthModelResult,
+  type PetHealthModelResult,
+} from './health-ai.service';
 
 function assessment(overrides: Partial<PetHealthModelResult> = {}): PetHealthModelResult {
   return {
@@ -24,6 +29,56 @@ function assessment(overrides: Partial<PetHealthModelResult> = {}): PetHealthMod
     },
     ...overrides,
   };
+}
+
+function service(overrides: Record<string, string | undefined> = {}) {
+  const values: Record<string, string | undefined> = {
+    OPENAI_API_KEY: 'openai-test-key-that-is-long-enough',
+    OPENAI_HEALTH_MODEL: 'health-test-model',
+    OPENAI_HEALTH_TIMEOUT_MS: '12000',
+    ...overrides,
+  };
+  const config = {
+    get: jest.fn((key: string) => values[key]),
+  };
+  return new HealthAiService(config as unknown as ConfigService);
+}
+
+const input = {
+  pet: {
+    name: 'Nova',
+    species: 'DOG',
+    breed: null,
+    ageYears: 4,
+    temperament: null,
+  },
+  concern: 'A small red patch appeared today.',
+  recentContext: [],
+  priorHealthObservations: [],
+};
+
+function providerResponse(result: PetHealthModelResult = assessment()) {
+  return new Response(
+    JSON.stringify({
+      output: [
+        {
+          content: [{ type: 'output_text', text: JSON.stringify(result) }],
+        },
+      ],
+    }),
+    { status: 200 }
+  );
+}
+
+function loggerSpies() {
+  return {
+    warn: jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined),
+    error: jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined),
+  };
+}
+
+function serializedLogCalls(spies: ReturnType<typeof loggerSpies>) {
+  return JSON.stringify([...spies.warn.mock.calls, ...spies.error.mock.calls]);
 }
 
 describe('Health Lens model output authority', () => {
@@ -166,5 +221,116 @@ describe('Health Lens model output authority', () => {
     ).toThrow(
       new ServiceUnavailableException('Health screening model returned an invalid assessment')
     );
+  });
+});
+
+describe('HealthAiService provider privacy boundary', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('uses bearer authentication and store=false without weakening output normalization', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue(providerResponse());
+
+    const result = await service().analyze(input);
+
+    expect(result.triage).toBe('monitor');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const request = fetchMock.mock.calls[0]?.[1];
+    expect(request?.headers).toMatchObject({
+      Authorization: 'Bearer openai-test-key-that-is-long-enough',
+      'Content-Type': 'application/json',
+    });
+    const body = JSON.parse(String(request?.body)) as Record<string, unknown>;
+    expect(body.store).toBe(false);
+    expect(body.model).toBe('health-test-model');
+  });
+
+  it('never reads private provider error bodies into logs or the API error boundary', async () => {
+    const privateMarker = 'PRIVATE_HEALTH_OWNER_NOTE=nova-red-patch-at-home';
+    const spies = loggerSpies();
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(`${privateMarker}; provider-secret-detail`, { status: 503 }));
+
+    await expect(service().analyze({ ...input, concern: privateMarker })).rejects.toThrow(
+      'Health screening model is temporarily unavailable'
+    );
+
+    expect(spies.warn).toHaveBeenCalledWith(
+      'Health model provider failure reason=provider_http_error status=503'
+    );
+    expect(serializedLogCalls(spies)).not.toContain(privateMarker);
+    expect(serializedLogCalls(spies)).not.toContain('provider-secret-detail');
+  });
+
+  it('classifies malformed provider JSON without logging response content', async () => {
+    const privateMarker = 'PRIVATE_MALFORMED_HEALTH_RESPONSE';
+    const spies = loggerSpies();
+    jest.spyOn(global, 'fetch').mockResolvedValue(new Response(`{${privateMarker}`, { status: 200 }));
+
+    await expect(service().analyze(input)).rejects.toThrow(
+      'Health screening model is temporarily unavailable'
+    );
+
+    expect(spies.warn).toHaveBeenCalledWith('Health model provider failure reason=invalid_json');
+    expect(serializedLogCalls(spies)).not.toContain(privateMarker);
+  });
+
+  it('classifies malformed structured output text without logging generated content', async () => {
+    const privateMarker = 'PRIVATE_INVALID_STRUCTURED_OUTPUT';
+    const spies = loggerSpies();
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          output: [{ content: [{ type: 'output_text', text: `{${privateMarker}` }] }],
+        }),
+        { status: 200 }
+      )
+    );
+
+    await expect(service().analyze(input)).rejects.toThrow(
+      'Health screening model is temporarily unavailable'
+    );
+
+    expect(spies.warn).toHaveBeenCalledWith('Health model provider failure reason=invalid_json');
+    expect(serializedLogCalls(spies)).not.toContain(privateMarker);
+  });
+
+  it('classifies AbortError as timeout without logging the exception message', async () => {
+    const privateMarker = 'PRIVATE_HEALTH_TIMEOUT_CONTEXT';
+    const spies = loggerSpies();
+    jest
+      .spyOn(global, 'fetch')
+      .mockRejectedValue(Object.assign(new Error(privateMarker), { name: 'AbortError' }));
+
+    await expect(service().analyze(input)).rejects.toThrow('Health screening model timed out');
+
+    expect(spies.warn).toHaveBeenCalledWith('Health model provider failure reason=timeout');
+    expect(serializedLogCalls(spies)).not.toContain(privateMarker);
+  });
+
+  it('classifies transport failures without logging arbitrary exception details', async () => {
+    const privateMarker = 'PRIVATE_HEALTH_TRANSPORT_DETAIL';
+    const spies = loggerSpies();
+    jest.spyOn(global, 'fetch').mockRejectedValue(new Error(privateMarker));
+
+    await expect(service().analyze(input)).rejects.toThrow(
+      'Health screening model is temporarily unavailable'
+    );
+
+    expect(spies.error).toHaveBeenCalledWith(
+      'Health model provider failure reason=transport_error'
+    );
+    expect(serializedLogCalls(spies)).not.toContain(privateMarker);
+  });
+
+  it('fails closed before network access when the provider is unconfigured', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch');
+
+    await expect(service({ OPENAI_API_KEY: undefined }).analyze(input)).rejects.toThrow(
+      /not configured/i
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/health-lens/health-ai.service.spec.ts
+++ b/apps/api/src/health-lens/health-ai.service.spec.ts
@@ -267,7 +267,9 @@ describe('HealthAiService provider privacy boundary', () => {
   it('classifies malformed provider JSON without logging response content', async () => {
     const privateMarker = 'PRIVATE_MALFORMED_HEALTH_RESPONSE';
     const spies = loggerSpies();
-    jest.spyOn(global, 'fetch').mockResolvedValue(new Response(`{${privateMarker}`, { status: 200 }));
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(`{${privateMarker}`, { status: 200 }));
 
     await expect(service().analyze(input)).rejects.toThrow(
       'Health screening model is temporarily unavailable'

--- a/apps/api/src/health-lens/health-ai.service.ts
+++ b/apps/api/src/health-lens/health-ai.service.ts
@@ -52,10 +52,7 @@ export type PetHealthModelInput = {
 type VetHandoffTiming = PetHealthModelResult['vetHandoff']['timing'];
 type ModelRecord = Record<string, unknown>;
 type HealthProviderFailureReason =
-  | 'provider_http_error'
-  | 'invalid_json'
-  | 'timeout'
-  | 'transport_error';
+  'provider_http_error' | 'invalid_json' | 'timeout' | 'transport_error';
 
 const TRIAGE_LEVELS = new Set<HealthTriageLevel>([
   'emergency_now',

--- a/apps/api/src/health-lens/health-ai.service.ts
+++ b/apps/api/src/health-lens/health-ai.service.ts
@@ -50,8 +50,12 @@ export type PetHealthModelInput = {
 };
 
 type VetHandoffTiming = PetHealthModelResult['vetHandoff']['timing'];
-
 type ModelRecord = Record<string, unknown>;
+type HealthProviderFailureReason =
+  | 'provider_http_error'
+  | 'invalid_json'
+  | 'timeout'
+  | 'transport_error';
 
 const TRIAGE_LEVELS = new Set<HealthTriageLevel>([
   'emergency_now',
@@ -404,16 +408,22 @@ export class HealthAiService {
       });
 
       if (!response.ok) {
-        const body = await response.text();
-        this.logger.warn(
-          `Health model request failed with ${response.status}: ${body.slice(0, 500)}`
-        );
+        this.warnFailure('provider_http_error', response.status);
         throw new ServiceUnavailableException('Health screening model is temporarily unavailable');
       }
 
-      const payload = (await response.json()) as {
+      let payload: {
         output?: Array<{ content?: Array<{ type?: string; text?: string }> }>;
       };
+      try {
+        payload = (await response.json()) as {
+          output?: Array<{ content?: Array<{ type?: string; text?: string }> }>;
+        };
+      } catch {
+        this.warnFailure('invalid_json');
+        throw new ServiceUnavailableException('Health screening model is temporarily unavailable');
+      }
+
       const text = payload.output
         ?.flatMap((item) => item.content ?? [])
         .find((item) => item.type === 'output_text' && typeof item.text === 'string')?.text;
@@ -424,15 +434,22 @@ export class HealthAiService {
         );
       }
 
-      return normalizeHealthModelResult(JSON.parse(text) as unknown);
+      let assessment: unknown;
+      try {
+        assessment = JSON.parse(text) as unknown;
+      } catch {
+        this.warnFailure('invalid_json');
+        throw new ServiceUnavailableException('Health screening model is temporarily unavailable');
+      }
+
+      return normalizeHealthModelResult(assessment);
     } catch (error) {
       if (error instanceof ServiceUnavailableException) throw error;
       if (error instanceof Error && error.name === 'AbortError') {
+        this.warnFailure('timeout');
         throw new ServiceUnavailableException('Health screening model timed out');
       }
-      this.logger.error(
-        `Health model analysis failed: ${error instanceof Error ? error.message : 'unknown error'}`
-      );
+      this.errorFailure('transport_error');
       throw new ServiceUnavailableException('Health screening model is temporarily unavailable');
     } finally {
       clearTimeout(timeout);
@@ -456,5 +473,14 @@ export class HealthAiService {
       recentContext: [],
       priorHealthObservations: [],
     });
+  }
+
+  private warnFailure(reason: HealthProviderFailureReason, status?: number) {
+    const statusSuffix = status === undefined ? '' : ` status=${status}`;
+    this.logger.warn(`Health model provider failure reason=${reason}${statusSuffix}`);
+  }
+
+  private errorFailure(reason: HealthProviderFailureReason) {
+    this.logger.error(`Health model provider failure reason=${reason}`);
   }
 }

--- a/apps/api/src/notifications/notifications.service.spec.ts
+++ b/apps/api/src/notifications/notifications.service.spec.ts
@@ -38,10 +38,12 @@ function prisma(row: ReturnType<typeof storedSubscription> | null = storedSubscr
   };
 }
 
-function service(options: {
-  configured?: boolean;
-  prisma?: ReturnType<typeof prisma>;
-} = {}) {
+function service(
+  options: {
+    configured?: boolean;
+    prisma?: ReturnType<typeof prisma>;
+  } = {}
+) {
   const configured = options.configured ?? true;
   const values: Record<string, string | undefined> = {
     VAPID_PUBLIC_KEY: configured ? 'test-public-vapid-key' : undefined,
@@ -153,29 +155,32 @@ describe('NotificationsService Web Push privacy boundary', () => {
     expect(logs).not.toContain(endpoint);
   });
 
-  it.each([404, 410])('removes stale subscriptions on provider status %s without identifier leakage', async (statusCode) => {
-    const privateMarker = `PRIVATE_EXPIRED_PUSH_${statusCode}`;
-    const spies = loggerSpies();
-    sendNotification.mockRejectedValue(
-      Object.assign(new Error(privateMarker), { statusCode, stack: privateMarker })
-    );
-    const database = prisma();
-    const { notifications } = service({ prisma: database });
+  it.each([404, 410])(
+    'removes stale subscriptions on provider status %s without identifier leakage',
+    async (statusCode) => {
+      const privateMarker = `PRIVATE_EXPIRED_PUSH_${statusCode}`;
+      const spies = loggerSpies();
+      sendNotification.mockRejectedValue(
+        Object.assign(new Error(privateMarker), { statusCode, stack: privateMarker })
+      );
+      const database = prisma();
+      const { notifications } = service({ prisma: database });
 
-    const result = await notifications.sendPushNotification({ userId, title, body });
+      const result = await notifications.sendPushNotification({ userId, title, body });
 
-    expect(result).toEqual({ success: false, reason: 'subscription_expired' });
-    expect(database.integrationToken.delete).toHaveBeenCalledWith({
-      where: { id: 'push-token-row-1' },
-    });
-    expect(spies.warn).toHaveBeenCalledWith(
-      `Expired push subscription removed status=${statusCode}`
-    );
-    const logs = serializedLogCalls(spies);
-    expect(logs).not.toContain(privateMarker);
-    expect(logs).not.toContain(userId);
-    expect(logs).not.toContain(endpoint);
-  });
+      expect(result).toEqual({ success: false, reason: 'subscription_expired' });
+      expect(database.integrationToken.delete).toHaveBeenCalledWith({
+        where: { id: 'push-token-row-1' },
+      });
+      expect(spies.warn).toHaveBeenCalledWith(
+        `Expired push subscription removed status=${statusCode}`
+      );
+      const logs = serializedLogCalls(spies);
+      expect(logs).not.toContain(privateMarker);
+      expect(logs).not.toContain(userId);
+      expect(logs).not.toContain(endpoint);
+    }
+  );
 
   it('returns a truthful disabled state before database/provider access when VAPID is unconfigured', async () => {
     const spies = loggerSpies();

--- a/apps/api/src/notifications/notifications.service.spec.ts
+++ b/apps/api/src/notifications/notifications.service.spec.ts
@@ -1,0 +1,196 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as webPush from 'web-push';
+import { PrismaService } from '../prisma/prisma.service';
+import { NotificationsService } from './notifications.service';
+
+jest.mock('web-push', () => ({
+  setVapidDetails: jest.fn(),
+  sendNotification: jest.fn(),
+}));
+
+const userId = 'user-private-123';
+const endpoint = 'https://push.example.com/private-subscription-endpoint';
+const title = 'Private achievement title';
+const body = 'Private notification body';
+
+function storedSubscription() {
+  return {
+    id: 'push-token-row-1',
+    data: {
+      endpoint,
+      expirationTime: null,
+      keys: {
+        p256dh: 'private-p256dh-key',
+        auth: 'private-auth-key',
+      },
+    },
+  };
+}
+
+function prisma(row: ReturnType<typeof storedSubscription> | null = storedSubscription()) {
+  return {
+    integrationToken: {
+      findFirst: jest.fn().mockResolvedValue(row),
+      delete: jest.fn().mockResolvedValue(row),
+      upsert: jest.fn().mockResolvedValue(row),
+    },
+  };
+}
+
+function service(options: {
+  configured?: boolean;
+  prisma?: ReturnType<typeof prisma>;
+} = {}) {
+  const configured = options.configured ?? true;
+  const values: Record<string, string | undefined> = {
+    VAPID_PUBLIC_KEY: configured ? 'test-public-vapid-key' : undefined,
+    VAPID_PRIVATE_KEY: configured ? 'test-private-vapid-key' : undefined,
+  };
+  const config = {
+    get: jest.fn((key: string) => values[key]),
+  };
+  const database = options.prisma ?? prisma();
+  return {
+    database,
+    notifications: new NotificationsService(
+      database as unknown as PrismaService,
+      config as unknown as ConfigService
+    ),
+  };
+}
+
+function loggerSpies() {
+  return {
+    log: jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined),
+    debug: jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined),
+    warn: jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined),
+    error: jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined),
+  };
+}
+
+function serializedLogCalls(spies: ReturnType<typeof loggerSpies>) {
+  return JSON.stringify([
+    ...spies.log.mock.calls,
+    ...spies.debug.mock.calls,
+    ...spies.warn.mock.calls,
+    ...spies.error.mock.calls,
+  ]);
+}
+
+describe('NotificationsService Web Push privacy boundary', () => {
+  const sendNotification = webPush.sendNotification as jest.Mock;
+  const setVapidDetails = webPush.setVapidDetails as jest.Mock;
+
+  beforeEach(() => {
+    sendNotification.mockReset();
+    setVapidDetails.mockReset();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('configures VAPID delivery and sends the intended payload without logging private content', async () => {
+    const spies = loggerSpies();
+    sendNotification.mockResolvedValue({ statusCode: 201 });
+    const { notifications } = service();
+
+    const result = await notifications.sendPushNotification({
+      userId,
+      title,
+      body,
+      url: '/private-destination',
+      data: { privateContext: 'only-for-device-payload' },
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(setVapidDetails).toHaveBeenCalledWith(
+      'mailto:support@woof.app',
+      'test-public-vapid-key',
+      'test-private-vapid-key'
+    );
+    expect(sendNotification).toHaveBeenCalledTimes(1);
+    const sentPayload = String(sendNotification.mock.calls[0]?.[1]);
+    expect(sentPayload).toContain(title);
+    expect(sentPayload).toContain(body);
+
+    const logs = serializedLogCalls(spies);
+    for (const privateValue of [
+      userId,
+      endpoint,
+      title,
+      body,
+      'private-p256dh-key',
+      'private-auth-key',
+      'only-for-device-payload',
+    ]) {
+      expect(logs).not.toContain(privateValue);
+    }
+    expect(spies.log).toHaveBeenCalledWith('Push notification delivered');
+  });
+
+  it('reduces arbitrary provider failures to status-only telemetry', async () => {
+    const privateMarker = 'PRIVATE_PUSH_PROVIDER_MESSAGE endpoint-and-request-details';
+    const spies = loggerSpies();
+    sendNotification.mockRejectedValue(
+      Object.assign(new Error(privateMarker), {
+        statusCode: 500,
+        stack: `stack:${privateMarker}`,
+      })
+    );
+    const { notifications } = service();
+
+    const result = await notifications.sendPushNotification({ userId, title, body });
+
+    expect(result).toEqual({ success: false, reason: 'delivery_failed' });
+    expect(spies.error).toHaveBeenCalledWith('Push delivery failed status=500');
+    const logs = serializedLogCalls(spies);
+    expect(logs).not.toContain(privateMarker);
+    expect(logs).not.toContain(userId);
+    expect(logs).not.toContain(title);
+    expect(logs).not.toContain(body);
+    expect(logs).not.toContain(endpoint);
+  });
+
+  it.each([404, 410])('removes stale subscriptions on provider status %s without identifier leakage', async (statusCode) => {
+    const privateMarker = `PRIVATE_EXPIRED_PUSH_${statusCode}`;
+    const spies = loggerSpies();
+    sendNotification.mockRejectedValue(
+      Object.assign(new Error(privateMarker), { statusCode, stack: privateMarker })
+    );
+    const database = prisma();
+    const { notifications } = service({ prisma: database });
+
+    const result = await notifications.sendPushNotification({ userId, title, body });
+
+    expect(result).toEqual({ success: false, reason: 'subscription_expired' });
+    expect(database.integrationToken.delete).toHaveBeenCalledWith({
+      where: { id: 'push-token-row-1' },
+    });
+    expect(spies.warn).toHaveBeenCalledWith(
+      `Expired push subscription removed status=${statusCode}`
+    );
+    const logs = serializedLogCalls(spies);
+    expect(logs).not.toContain(privateMarker);
+    expect(logs).not.toContain(userId);
+    expect(logs).not.toContain(endpoint);
+  });
+
+  it('returns a truthful disabled state before database/provider access when VAPID is unconfigured', async () => {
+    const spies = loggerSpies();
+    const database = prisma();
+    const { notifications } = service({ configured: false, prisma: database });
+
+    const result = await notifications.sendPushNotification({ userId, title, body });
+
+    expect(result).toEqual({ success: false, reason: 'push_not_configured' });
+    expect(database.integrationToken.findFirst).not.toHaveBeenCalled();
+    expect(sendNotification).not.toHaveBeenCalled();
+    expect(spies.debug).toHaveBeenCalledWith('Push delivery skipped reason=not_configured');
+    const logs = serializedLogCalls(spies);
+    expect(logs).not.toContain(userId);
+    expect(logs).not.toContain(title);
+    expect(logs).not.toContain(body);
+  });
+});

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -16,8 +16,6 @@ type StoredPushSubscription = {
 
 type PushDeliveryError = {
   statusCode?: number;
-  message?: string;
-  stack?: string;
 };
 
 function toStoredSubscription(subscription: PushSubscriptionDto): Prisma.InputJsonObject {
@@ -57,8 +55,6 @@ function readPushError(error: unknown): PushDeliveryError {
   const candidate = error as Record<string, unknown>;
   return {
     statusCode: typeof candidate.statusCode === 'number' ? candidate.statusCode : undefined,
-    message: typeof candidate.message === 'string' ? candidate.message : undefined,
-    stack: typeof candidate.stack === 'string' ? candidate.stack : undefined,
   };
 }
 
@@ -69,7 +65,7 @@ export class NotificationsService {
 
   constructor(
     private prisma: PrismaService,
-    private configService: ConfigService,
+    private configService: ConfigService
   ) {
     const publicKey = this.configService.get<string>('VAPID_PUBLIC_KEY');
     const privateKey = this.configService.get<string>('VAPID_PRIVATE_KEY');
@@ -110,7 +106,7 @@ export class NotificationsService {
       },
     });
 
-    this.logger.log(`Push subscription saved for user ${userId}`);
+    this.logger.log('Push subscription saved');
     return token;
   }
 
@@ -131,7 +127,7 @@ export class NotificationsService {
       await this.prisma.integrationToken.delete({
         where: { id: subscription.id },
       });
-      this.logger.log(`Push subscription removed for user ${userId}`);
+      this.logger.log('Push subscription removed');
     }
 
     return { success: true };
@@ -141,7 +137,7 @@ export class NotificationsService {
     const { userId, title, body, icon, url, data: payload } = data;
 
     if (!this.pushConfigured) {
-      this.logger.debug(`Push skipped for user ${userId}: VAPID not configured`);
+      this.logger.debug('Push delivery skipped reason=not_configured');
       return { success: false, reason: 'push_not_configured' };
     }
 
@@ -153,13 +149,13 @@ export class NotificationsService {
     });
 
     if (!subscription) {
-      this.logger.debug(`No push subscription found for user ${userId}`);
+      this.logger.debug('Push delivery skipped reason=no_subscription');
       return { success: false, reason: 'no_subscription' };
     }
 
     const pushSubscription = readStoredSubscription(subscription.data);
     if (!pushSubscription) {
-      this.logger.warn(`Invalid stored push subscription removed for user ${userId}`);
+      this.logger.warn('Invalid stored push subscription removed');
       await this.unsubscribePushNotification(userId);
       return { success: false, reason: 'invalid_subscription' };
     }
@@ -177,27 +173,26 @@ export class NotificationsService {
 
     try {
       await webPush.sendNotification(pushSubscription, notificationPayload);
-      this.logger.log(`Push notification sent to user ${userId}: ${title}`);
+      this.logger.log('Push notification delivered');
       return { success: true };
     } catch (error: unknown) {
       const pushError = readPushError(error);
       if (pushError.statusCode === 410 || pushError.statusCode === 404) {
-        this.logger.warn(`Expired push subscription removed for user ${userId}`);
+        this.logger.warn(`Expired push subscription removed status=${pushError.statusCode}`);
         await this.unsubscribePushNotification(userId);
         return { success: false, reason: 'subscription_expired' };
       }
 
-      this.logger.error(
-        `Failed to send push notification: ${pushError.message || 'unknown error'}`,
-        pushError.stack,
-      );
+      const statusSuffix =
+        pushError.statusCode === undefined ? '' : ` status=${pushError.statusCode}`;
+      this.logger.error(`Push delivery failed${statusSuffix}`);
       return { success: false, reason: 'delivery_failed' };
     }
   }
 
   async sendBulkPushNotifications(userIds: string[], data: Omit<SendPushDto, 'userId'>) {
     const results = await Promise.all(
-      userIds.map((userId) => this.sendPushNotification({ ...data, userId })),
+      userIds.map((userId) => this.sendPushNotification({ ...data, userId }))
     );
 
     const successful = results.filter((result) => result.success).length;
@@ -211,7 +206,7 @@ export class NotificationsService {
     userId: string,
     nudgeType: string,
     message: string,
-    data?: Record<string, unknown>,
+    data?: Record<string, unknown>
   ) {
     return this.sendPushNotification({
       userId,

--- a/apps/api/src/storage/storage.service.spec.ts
+++ b/apps/api/src/storage/storage.service.spec.ts
@@ -1,0 +1,138 @@
+import { Logger, ServiceUnavailableException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { StorageService } from './storage.service';
+
+function service(overrides: Record<string, string | undefined> = {}) {
+  const values: Record<string, string | undefined> = {
+    AWS_REGION: 'us-west-2',
+    S3_BUCKET: 'private-test-bucket',
+    S3_ACCESS_KEY_ID: 'test-access-key',
+    S3_SECRET_ACCESS_KEY: 'test-secret-key',
+    ...overrides,
+  };
+  const config = {
+    get: jest.fn((key: string) => values[key]),
+  };
+  return new StorageService(config as unknown as ConfigService);
+}
+
+function replaceClient(storage: StorageService, send: jest.Mock) {
+  (storage as unknown as { s3Client: { send: jest.Mock } | null }).s3Client = { send };
+}
+
+function loggerSpies() {
+  return {
+    log: jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined),
+    warn: jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined),
+    error: jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined),
+  };
+}
+
+function serializedLogCalls(spies: ReturnType<typeof loggerSpies>) {
+  return JSON.stringify([
+    ...spies.log.mock.calls,
+    ...spies.warn.mock.calls,
+    ...spies.error.mock.calls,
+  ]);
+}
+
+describe('StorageService private provider boundary', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('keeps generated private keys and filenames out of successful telemetry', async () => {
+    const spies = loggerSpies();
+    const storage = service();
+    const send = jest.fn().mockResolvedValue({});
+    replaceClient(storage, send);
+
+    const result = await storage.uploadPrivateBytes({
+      bytes: Buffer.from('private-bytes'),
+      filename: 'owner-private-health-photo.jpg',
+      contentType: 'image/jpeg',
+      folder: 'private/health',
+    });
+
+    expect(result.bucket).toBe('private-test-bucket');
+    expect(result.key).toMatch(/^private\/health\//);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(serializedLogCalls(spies)).not.toContain(result.key);
+    expect(serializedLogCalls(spies)).not.toContain('owner-private-health-photo.jpg');
+  });
+
+  it('normalizes upload SDK failures without logging or rethrowing provider details', async () => {
+    const privateMarker = 'PRIVATE_S3_PROVIDER_DETAIL owner-object-key token=secret';
+    const spies = loggerSpies();
+    const storage = service();
+    const send = jest.fn().mockRejectedValue(new Error(privateMarker));
+    replaceClient(storage, send);
+
+    await expect(
+      storage.uploadPrivateBytes({
+        bytes: Buffer.from('private-bytes'),
+        filename: 'owner-private-photo.jpg',
+        contentType: 'image/jpeg',
+      })
+    ).rejects.toEqual(
+      new ServiceUnavailableException('Media storage operation is temporarily unavailable')
+    );
+
+    expect(spies.error).toHaveBeenCalledWith(
+      'Object storage provider failure operation=upload_private_bytes'
+    );
+    expect(serializedLogCalls(spies)).not.toContain(privateMarker);
+    expect(serializedLogCalls(spies)).not.toContain('owner-private-photo.jpg');
+  });
+
+  it('normalizes delete SDK failures without logging the private object key', async () => {
+    const privateMarker = 'PRIVATE_DELETE_PROVIDER_RESPONSE';
+    const objectKey = 'private/health/user-specific-object.jpg';
+    const spies = loggerSpies();
+    const storage = service();
+    const send = jest.fn().mockRejectedValue(new Error(privateMarker));
+    replaceClient(storage, send);
+
+    await expect(storage.deleteFile(objectKey)).rejects.toThrow(
+      'Media storage operation is temporarily unavailable'
+    );
+
+    expect(spies.error).toHaveBeenCalledWith(
+      'Object storage provider failure operation=delete_object'
+    );
+    expect(serializedLogCalls(spies)).not.toContain(privateMarker);
+    expect(serializedLogCalls(spies)).not.toContain(objectKey);
+  });
+
+  it('preserves bounded application errors without misclassifying them as provider diagnostics', async () => {
+    const spies = loggerSpies();
+    const storage = service();
+    const send = jest.fn().mockResolvedValue({ ContentLength: 2048, Body: {} });
+    replaceClient(storage, send);
+
+    await expect(storage.getObjectBytes('private/object.bin', 1024)).rejects.toThrow(
+      'Media object exceeds the export size limit'
+    );
+    expect(spies.error).not.toHaveBeenCalled();
+  });
+
+  it('fails closed before provider access when private storage is unconfigured', async () => {
+    const spies = loggerSpies();
+    const storage = service({
+      S3_ACCESS_KEY_ID: undefined,
+      S3_SECRET_ACCESS_KEY: undefined,
+    });
+
+    await expect(
+      storage.uploadPrivateBytes({
+        bytes: Buffer.from('private-bytes'),
+        filename: 'private.jpg',
+        contentType: 'image/jpeg',
+      })
+    ).rejects.toThrow(/not configured/i);
+
+    expect(spies.warn).toHaveBeenCalledWith(
+      'Object storage is not configured; durable media storage is disabled'
+    );
+  });
+});

--- a/apps/api/src/storage/storage.service.ts
+++ b/apps/api/src/storage/storage.service.ts
@@ -224,10 +224,7 @@ export class StorageService {
     return { key, uploadUrl, expiresIn, requiredHeaders };
   }
 
-  async uploadFiles(
-    files: Express.Multer.File[],
-    folder = 'uploads'
-  ): Promise<UploadResult[]> {
+  async uploadFiles(files: Express.Multer.File[], folder = 'uploads'): Promise<UploadResult[]> {
     return Promise.all(files.map((file) => this.uploadFile(file, folder)));
   }
 
@@ -401,9 +398,7 @@ export class StorageService {
 
   private requireClient(): S3Client {
     if (!this.s3Client || !this.configured) {
-      throw new ServiceUnavailableException(
-        'Media storage is not configured in this environment'
-      );
+      throw new ServiceUnavailableException('Media storage is not configured in this environment');
     }
     return this.s3Client;
   }
@@ -411,7 +406,10 @@ export class StorageService {
   private generateKey(filename: string, folder: string): string {
     const safeFolder =
       folder.replace(/[^a-zA-Z0-9/_-]/g, '').replace(/^\/+|\/+$/g, '') || 'uploads';
-    const ext = path.extname(filename).toLowerCase().replace(/[^.a-z0-9]/g, '');
+    const ext = path
+      .extname(filename)
+      .toLowerCase()
+      .replace(/[^.a-z0-9]/g, '');
     const hash = crypto.randomBytes(16).toString('hex');
     return `${safeFolder}/${Date.now()}-${hash}${ext}`;
   }

--- a/apps/api/src/storage/storage.service.ts
+++ b/apps/api/src/storage/storage.service.ts
@@ -41,6 +41,18 @@ export interface PrivateObjectInfo {
   etag: string | null;
 }
 
+type StorageOperation =
+  | 'upload_private_bytes'
+  | 'upload_private_stream'
+  | 'sign_private_upload'
+  | 'delete_object'
+  | 'sign_private_download'
+  | 'head_object'
+  | 'read_object_header'
+  | 'download_object'
+  | 'upload_derivative'
+  | 'read_object';
+
 @Injectable()
 export class StorageService {
   private readonly logger = new Logger(StorageService.name);
@@ -90,7 +102,7 @@ export class StorageService {
   async uploadFile(file: Express.Multer.File, folder = 'uploads'): Promise<UploadResult> {
     if (!this.publicUrl) {
       throw new ServiceUnavailableException(
-        'Public media delivery is not configured in this environment',
+        'Public media delivery is not configured in this environment'
       );
     }
 
@@ -103,7 +115,7 @@ export class StorageService {
 
   async uploadPrivateFile(
     file: Express.Multer.File,
-    folder = 'private/uploads',
+    folder = 'private/uploads'
   ): Promise<PrivateUploadResult> {
     return this.uploadPrivateBytes({
       bytes: file.buffer,
@@ -124,8 +136,8 @@ export class StorageService {
     const key = this.generateKey(input.filename, folder);
     const bytes = Buffer.isBuffer(input.bytes) ? input.bytes : Buffer.from(input.bytes);
 
-    try {
-      await client.send(
+    await this.providerCall('upload_private_bytes', () =>
+      client.send(
         new PutObjectCommand({
           Bucket: this.bucket,
           Key: key,
@@ -136,14 +148,10 @@ export class StorageService {
             originalName: input.filename.slice(0, 240),
             size: String(bytes.byteLength),
           },
-        }),
-      );
-      this.logger.log(`Private file uploaded successfully: ${key}`);
-      return { key, bucket: this.bucket };
-    } catch (error) {
-      this.logStorageError('Failed to upload private file', error);
-      throw error;
-    }
+        })
+      )
+    );
+    return { key, bucket: this.bucket };
   }
 
   async uploadPrivateWebStream(input: {
@@ -155,7 +163,7 @@ export class StorageService {
   }): Promise<PrivateUploadResult> {
     if (!Number.isFinite(input.contentLength) || input.contentLength <= 0) {
       throw new ServiceUnavailableException(
-        'Streaming media import requires a positive content length',
+        'Streaming media import requires a positive content length'
       );
     }
     const client = this.requireClient();
@@ -163,24 +171,24 @@ export class StorageService {
     const body = Readable.fromWeb(input.body as unknown as NodeReadableStream<Uint8Array>);
 
     try {
-      await client.send(
-        new PutObjectCommand({
-          Bucket: this.bucket,
-          Key: key,
-          Body: body,
-          ContentLength: input.contentLength,
-          ContentType: input.contentType,
-          Metadata: {
-            originalName: input.filename.slice(0, 240),
-            size: String(input.contentLength),
-          },
-        }),
+      await this.providerCall('upload_private_stream', () =>
+        client.send(
+          new PutObjectCommand({
+            Bucket: this.bucket,
+            Key: key,
+            Body: body,
+            ContentLength: input.contentLength,
+            ContentType: input.contentType,
+            Metadata: {
+              originalName: input.filename.slice(0, 240),
+              size: String(input.contentLength),
+            },
+          })
+        )
       );
-      this.logger.log(`Private streamed file uploaded successfully: ${key}`);
       return { key, bucket: this.bucket };
     } catch (error) {
       body.destroy();
-      this.logStorageError('Failed to stream private file', error);
       throw error;
     }
   }
@@ -200,15 +208,17 @@ export class StorageService {
       'x-amz-meta-expected-size': String(input.expectedSizeBytes),
     };
 
-    const uploadUrl = await getSignedUrl(
-      client,
-      new PutObjectCommand({
-        Bucket: this.bucket,
-        Key: key,
-        ContentType: input.contentType,
-        Metadata: { expectedSize: String(input.expectedSizeBytes) },
-      }),
-      { expiresIn },
+    const uploadUrl = await this.providerCall('sign_private_upload', () =>
+      getSignedUrl(
+        client,
+        new PutObjectCommand({
+          Bucket: this.bucket,
+          Key: key,
+          ContentType: input.contentType,
+          Metadata: { expectedSize: String(input.expectedSizeBytes) },
+        }),
+        { expiresIn }
+      )
     );
 
     return { key, uploadUrl, expiresIn, requiredHeaders };
@@ -216,42 +226,34 @@ export class StorageService {
 
   async uploadFiles(
     files: Express.Multer.File[],
-    folder = 'uploads',
+    folder = 'uploads'
   ): Promise<UploadResult[]> {
     return Promise.all(files.map((file) => this.uploadFile(file, folder)));
   }
 
   async deleteFile(key: string): Promise<void> {
     const client = this.requireClient();
-
-    try {
-      await client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
-      this.logger.log(`File deleted successfully: ${key}`);
-    } catch (error) {
-      this.logStorageError('Failed to delete file', error);
-      throw error;
-    }
+    await this.providerCall('delete_object', () =>
+      client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }))
+    );
   }
 
   async getSignedUrl(key: string, expiresIn = 900): Promise<string> {
     const client = this.requireClient();
     const boundedExpiry = Math.max(60, Math.min(3600, expiresIn));
 
-    try {
-      return await getSignedUrl(
-        client,
-        new GetObjectCommand({ Bucket: this.bucket, Key: key }),
-        { expiresIn: boundedExpiry },
-      );
-    } catch (error) {
-      this.logStorageError('Failed to generate signed URL', error);
-      throw error;
-    }
+    return this.providerCall('sign_private_download', () =>
+      getSignedUrl(client, new GetObjectCommand({ Bucket: this.bucket, Key: key }), {
+        expiresIn: boundedExpiry,
+      })
+    );
   }
 
   async headObject(key: string): Promise<PrivateObjectInfo> {
     const client = this.requireClient();
-    const response = await client.send(new HeadObjectCommand({ Bucket: this.bucket, Key: key }));
+    const response = await this.providerCall('head_object', () =>
+      client.send(new HeadObjectCommand({ Bucket: this.bucket, Key: key }))
+    );
     return {
       key,
       sizeBytes: Number(response.ContentLength ?? 0),
@@ -263,51 +265,59 @@ export class StorageService {
   async getObjectHeader(key: string, bytes = 64): Promise<Buffer> {
     const client = this.requireClient();
     const bounded = Math.max(16, Math.min(4096, Math.round(bytes)));
-    const response = await client.send(
-      new GetObjectCommand({
-        Bucket: this.bucket,
-        Key: key,
-        Range: `bytes=0-${bounded - 1}`,
-      }),
-    );
-    if (!response.Body) throw new ServiceUnavailableException('Media object returned no body');
 
-    const body = response.Body as typeof response.Body & {
-      transformToByteArray?: () => Promise<Uint8Array>;
-    };
-    if (body.transformToByteArray) {
-      return Buffer.from(await body.transformToByteArray()).subarray(0, bounded);
-    }
+    return this.providerCall('read_object_header', async () => {
+      const response = await client.send(
+        new GetObjectCommand({
+          Bucket: this.bucket,
+          Key: key,
+          Range: `bytes=0-${bounded - 1}`,
+        })
+      );
+      if (!response.Body) throw new ServiceUnavailableException('Media object returned no body');
 
-    const chunks: Buffer[] = [];
-    let total = 0;
-    for await (const chunk of response.Body as AsyncIterable<Uint8Array>) {
-      chunks.push(Buffer.from(chunk));
-      total += chunk.byteLength;
-      if (total >= bounded) break;
-    }
-    return Buffer.concat(chunks).subarray(0, bounded);
+      const body = response.Body as typeof response.Body & {
+        transformToByteArray?: () => Promise<Uint8Array>;
+      };
+      if (body.transformToByteArray) {
+        return Buffer.from(await body.transformToByteArray()).subarray(0, bounded);
+      }
+
+      const chunks: Buffer[] = [];
+      let total = 0;
+      for await (const chunk of response.Body as AsyncIterable<Uint8Array>) {
+        chunks.push(Buffer.from(chunk));
+        total += chunk.byteLength;
+        if (total >= bounded) break;
+      }
+      return Buffer.concat(chunks).subarray(0, bounded);
+    });
   }
 
   async downloadObjectToFile(key: string, destination: string, maxBytes: number): Promise<number> {
     const client = this.requireClient();
-    const response = await client.send(new GetObjectCommand({ Bucket: this.bucket, Key: key }));
-    const declared = Number(response.ContentLength ?? 0);
-    if (declared > maxBytes) {
-      throw new ServiceUnavailableException('Media object exceeds processing limit');
-    }
-    if (!response.Body) throw new ServiceUnavailableException('Media object returned no body');
 
     try {
-      await pipeline(
-        Readable.from(response.Body as AsyncIterable<Uint8Array>),
-        createWriteStream(destination, { flags: 'wx' }),
-      );
-      const info = await stat(destination);
-      if (info.size <= 0 || info.size > maxBytes) {
-        throw new ServiceUnavailableException('Downloaded media exceeded processing bounds');
-      }
-      return info.size;
+      return await this.providerCall('download_object', async () => {
+        const response = await client.send(new GetObjectCommand({ Bucket: this.bucket, Key: key }));
+        const declared = Number(response.ContentLength ?? 0);
+        if (declared > maxBytes) {
+          throw new ServiceUnavailableException('Media object exceeds processing limit');
+        }
+        if (!response.Body) {
+          throw new ServiceUnavailableException('Media object returned no body');
+        }
+
+        await pipeline(
+          Readable.from(response.Body as AsyncIterable<Uint8Array>),
+          createWriteStream(destination, { flags: 'wx' })
+        );
+        const info = await stat(destination);
+        if (info.size <= 0 || info.size > maxBytes) {
+          throw new ServiceUnavailableException('Downloaded media exceeded processing bounds');
+        }
+        return info.size;
+      });
     } catch (error) {
       await rm(destination, { force: true }).catch(() => undefined);
       throw error;
@@ -326,54 +336,59 @@ export class StorageService {
       throw new ServiceUnavailableException('Derivative output was not a readable file');
     }
     const key = this.generateKey(input.filename, input.folder ?? 'private/derivatives');
-    await client.send(
-      new PutObjectCommand({
-        Bucket: this.bucket,
-        Key: key,
-        Body: createReadStream(input.filePath),
-        ContentLength: info.size,
-        ContentType: input.contentType,
-        Metadata: { generated: 'true', size: String(info.size) },
-      }),
+    await this.providerCall('upload_derivative', () =>
+      client.send(
+        new PutObjectCommand({
+          Bucket: this.bucket,
+          Key: key,
+          Body: createReadStream(input.filePath),
+          ContentLength: info.size,
+          ContentType: input.contentType,
+          Metadata: { generated: 'true', size: String(info.size) },
+        })
+      )
     );
     return { key, bucket: this.bucket };
   }
 
   async getObjectBytes(key: string, maxBytes = 600 * 1024 * 1024): Promise<Buffer> {
     const client = this.requireClient();
-    const response = await client.send(new GetObjectCommand({ Bucket: this.bucket, Key: key }));
-    const declared = Number(response.ContentLength ?? 0);
-    if (declared > maxBytes) {
-      throw new ServiceUnavailableException('Media object exceeds the export size limit');
-    }
-    if (!response.Body) throw new ServiceUnavailableException('Media object returned no body');
 
-    const body = response.Body as typeof response.Body & {
-      transformToByteArray?: () => Promise<Uint8Array>;
-      [Symbol.asyncIterator]?: () => AsyncIterator<Uint8Array>;
-    };
-
-    if (body.transformToByteArray) {
-      const bytes = await body.transformToByteArray();
-      if (bytes.byteLength > maxBytes) {
+    return this.providerCall('read_object', async () => {
+      const response = await client.send(new GetObjectCommand({ Bucket: this.bucket, Key: key }));
+      const declared = Number(response.ContentLength ?? 0);
+      if (declared > maxBytes) {
         throw new ServiceUnavailableException('Media object exceeds the export size limit');
       }
-      return Buffer.from(bytes);
-    }
+      if (!response.Body) throw new ServiceUnavailableException('Media object returned no body');
 
-    const chunks: Buffer[] = [];
-    let total = 0;
-    if (!body[Symbol.asyncIterator]) {
-      throw new ServiceUnavailableException('Media object stream is not readable');
-    }
-    for await (const chunk of body as AsyncIterable<Uint8Array>) {
-      total += chunk.byteLength;
-      if (total > maxBytes) {
-        throw new ServiceUnavailableException('Media object exceeds the export size limit');
+      const body = response.Body as typeof response.Body & {
+        transformToByteArray?: () => Promise<Uint8Array>;
+        [Symbol.asyncIterator]?: () => AsyncIterator<Uint8Array>;
+      };
+
+      if (body.transformToByteArray) {
+        const result = await body.transformToByteArray();
+        if (result.byteLength > maxBytes) {
+          throw new ServiceUnavailableException('Media object exceeds the export size limit');
+        }
+        return Buffer.from(result);
       }
-      chunks.push(Buffer.from(chunk));
-    }
-    return Buffer.concat(chunks);
+
+      const chunks: Buffer[] = [];
+      let total = 0;
+      if (!body[Symbol.asyncIterator]) {
+        throw new ServiceUnavailableException('Media object stream is not readable');
+      }
+      for await (const chunk of body as AsyncIterable<Uint8Array>) {
+        total += chunk.byteLength;
+        if (total > maxBytes) {
+          throw new ServiceUnavailableException('Media object exceeds the export size limit');
+        }
+        chunks.push(Buffer.from(chunk));
+      }
+      return Buffer.concat(chunks);
+    });
   }
 
   validateFileType(file: Express.Multer.File, allowedTypes: string[]): boolean {
@@ -387,7 +402,7 @@ export class StorageService {
   private requireClient(): S3Client {
     if (!this.s3Client || !this.configured) {
       throw new ServiceUnavailableException(
-        'Media storage is not configured in this environment',
+        'Media storage is not configured in this environment'
       );
     }
     return this.s3Client;
@@ -401,9 +416,13 @@ export class StorageService {
     return `${safeFolder}/${Date.now()}-${hash}${ext}`;
   }
 
-  private logStorageError(message: string, error: unknown) {
-    const detail = error instanceof Error ? error.message : 'unknown error';
-    const stack = error instanceof Error ? error.stack : undefined;
-    this.logger.error(`${message}: ${detail}`, stack);
+  private async providerCall<T>(operation: StorageOperation, action: () => Promise<T>): Promise<T> {
+    try {
+      return await action();
+    } catch (error) {
+      if (error instanceof ServiceUnavailableException) throw error;
+      this.logger.error(`Object storage provider failure operation=${operation}`);
+      throw new ServiceUnavailableException('Media storage operation is temporarily unavailable');
+    }
   }
 }

--- a/docs/EXTERNAL_INTEGRATION_INVENTORY.json
+++ b/docs/EXTERNAL_INTEGRATION_INVENTORY.json
@@ -16,11 +16,7 @@
         ".github/workflows/dogos-health-lens-ci.yml",
         ".github/workflows/integration-truth-ci.yml"
       ],
-      "configuration": [
-        "OPENAI_API_KEY",
-        "OPENAI_HEALTH_MODEL",
-        "OPENAI_HEALTH_TIMEOUT_MS"
-      ],
+      "configuration": ["OPENAI_API_KEY", "OPENAI_HEALTH_MODEL", "OPENAI_HEALTH_TIMEOUT_MS"],
       "repositoryEvidence": [
         "Bearer-authenticated Responses API client",
         "store=false request policy",
@@ -41,9 +37,7 @@
       "id": "behavior_vision",
       "status": "OPTIONAL_QUALIFIED",
       "runtimeOwner": "apps/api/src/behavior-vision/behavior-vision.model.ts",
-      "ciOwners": [
-        ".github/workflows/dogos-behavior-moments-ci.yml"
-      ],
+      "ciOwners": [".github/workflows/dogos-behavior-moments-ci.yml"],
       "configuration": [
         "BEHAVIOR_VISION_SERVICE_URL",
         "BEHAVIOR_VISION_SERVICE_TOKEN",
@@ -71,9 +65,7 @@
       "id": "s3_private_storage",
       "status": "OPTIONAL_QUALIFIED",
       "runtimeOwner": "apps/api/src/storage/storage.service.ts",
-      "ciOwners": [
-        ".github/workflows/integration-truth-ci.yml"
-      ],
+      "ciOwners": [".github/workflows/integration-truth-ci.yml"],
       "configuration": [
         "S3_ENDPOINT",
         "S3_BUCKET",
@@ -102,14 +94,8 @@
       "id": "media_derivatives",
       "status": "OPTIONAL_QUALIFIED",
       "runtimeOwner": "apps/api/src/media-library/media-derivative.worker.ts",
-      "ciOwners": [
-        ".github/workflows/integration-truth-ci.yml"
-      ],
-      "configuration": [
-        "MEDIA_DERIVATIVES_ENABLED",
-        "MEDIA_FFMPEG_PATH",
-        "MEDIA_FFPROBE_PATH"
-      ],
+      "ciOwners": [".github/workflows/integration-truth-ci.yml"],
+      "configuration": ["MEDIA_DERIVATIVES_ENABLED", "MEDIA_FFMPEG_PATH", "MEDIA_FFPROBE_PATH"],
       "repositoryEvidence": [
         "maintained derivative worker",
         "deterministic worker contracts",
@@ -128,13 +114,8 @@
       "id": "web_push",
       "status": "OPTIONAL_QUALIFIED",
       "runtimeOwner": "apps/api/src/notifications/notifications.service.ts",
-      "ciOwners": [
-        ".github/workflows/integration-truth-ci.yml"
-      ],
-      "configuration": [
-        "VAPID_PUBLIC_KEY",
-        "VAPID_PRIVATE_KEY"
-      ],
+      "ciOwners": [".github/workflows/integration-truth-ci.yml"],
+      "configuration": ["VAPID_PUBLIC_KEY", "VAPID_PRIVATE_KEY"],
       "repositoryEvidence": [
         "subscription persistence and unsubscribe lifecycle",
         "VAPID delivery runtime",
@@ -154,13 +135,9 @@
       "id": "n8n",
       "status": "RESERVED",
       "runtimeOwner": null,
-      "ciOwners": [
-        ".github/workflows/integration-truth-ci.yml"
-      ],
+      "ciOwners": [".github/workflows/integration-truth-ci.yml"],
       "configuration": [],
-      "prototypePaths": [
-        "n8n-workflows/"
-      ],
+      "prototypePaths": ["n8n-workflows/"],
       "repositoryEvidence": [
         "prototype workflow JSON only",
         "no maintained N8nWebhooksController or webhook authentication runtime"

--- a/docs/EXTERNAL_INTEGRATION_INVENTORY.json
+++ b/docs/EXTERNAL_INTEGRATION_INVENTORY.json
@@ -1,0 +1,180 @@
+{
+  "schemaVersion": 1,
+  "scope": "Issue #108 external integration truth and privacy qualification",
+  "statusDefinitions": {
+    "ACTIVE": "Required runtime integration with deterministic repository qualification and explicit live deployment evidence.",
+    "OPTIONAL_QUALIFIED": "Real optional runtime implementation with deterministic repository qualification; configuration or CI alone is not production evidence.",
+    "RESERVED": "Prototype, documentation, or future-facing seam with no qualified runtime authority; product surfaces must not claim availability.",
+    "RETIRED": "Intentionally removed integration that must not be presented as available."
+  },
+  "integrations": [
+    {
+      "id": "openai_health_lens",
+      "status": "OPTIONAL_QUALIFIED",
+      "runtimeOwner": "apps/api/src/health-lens/health-ai.service.ts",
+      "ciOwners": [
+        ".github/workflows/dogos-health-lens-ci.yml",
+        ".github/workflows/integration-truth-ci.yml"
+      ],
+      "configuration": [
+        "OPENAI_API_KEY",
+        "OPENAI_HEALTH_MODEL",
+        "OPENAI_HEALTH_TIMEOUT_MS"
+      ],
+      "repositoryEvidence": [
+        "Bearer-authenticated Responses API client",
+        "store=false request policy",
+        "strict structured-output normalization",
+        "deterministic triage and unsafe-directive contracts",
+        "content-free provider failure telemetry"
+      ],
+      "productionQualified": false,
+      "liveEvidenceRequired": [
+        "deployed target revision",
+        "live credential authentication",
+        "target-environment networking",
+        "black-box request/response qualification",
+        "operational rollback evidence"
+      ]
+    },
+    {
+      "id": "behavior_vision",
+      "status": "OPTIONAL_QUALIFIED",
+      "runtimeOwner": "apps/api/src/behavior-vision/behavior-vision.model.ts",
+      "ciOwners": [
+        ".github/workflows/dogos-behavior-moments-ci.yml"
+      ],
+      "configuration": [
+        "BEHAVIOR_VISION_SERVICE_URL",
+        "BEHAVIOR_VISION_SERVICE_TOKEN",
+        "BEHAVIOR_VISION_TIMEOUT_MS",
+        "BEHAVIOR_VISION_RELEASE_ID",
+        "BEHAVIOR_VISION_MODEL_VERSION",
+        "BEHAVIOR_VISION_FEATURE_VERSION",
+        "BEHAVIOR_VISION_ARTIFACT_SHA256"
+      ],
+      "repositoryEvidence": [
+        "bearer-authenticated provider client",
+        "exact model release pinning",
+        "shadow-evidence-only authority",
+        "content-free provider failure telemetry"
+      ],
+      "productionQualified": false,
+      "liveEvidenceRequired": [
+        "deployed provider endpoint",
+        "live authentication",
+        "target-environment networking",
+        "black-box qualified release request"
+      ]
+    },
+    {
+      "id": "s3_private_storage",
+      "status": "OPTIONAL_QUALIFIED",
+      "runtimeOwner": "apps/api/src/storage/storage.service.ts",
+      "ciOwners": [
+        ".github/workflows/integration-truth-ci.yml"
+      ],
+      "configuration": [
+        "S3_ENDPOINT",
+        "S3_BUCKET",
+        "S3_ACCESS_KEY_ID",
+        "S3_SECRET_ACCESS_KEY",
+        "S3_PUBLIC_URL",
+        "AWS_REGION"
+      ],
+      "repositoryEvidence": [
+        "private upload/download runtime",
+        "bounded signed upload/download URLs",
+        "streaming and metadata operations",
+        "private-by-default delivery semantics",
+        "normalized content-free provider failures"
+      ],
+      "productionQualified": false,
+      "liveEvidenceRequired": [
+        "target bucket/endpoint existence",
+        "live credential authentication",
+        "private ACL/access-policy validation",
+        "signed URL black-box validation",
+        "delete/read/write black-box qualification"
+      ]
+    },
+    {
+      "id": "media_derivatives",
+      "status": "OPTIONAL_QUALIFIED",
+      "runtimeOwner": "apps/api/src/media-library/media-derivative.worker.ts",
+      "ciOwners": [
+        ".github/workflows/integration-truth-ci.yml"
+      ],
+      "configuration": [
+        "MEDIA_DERIVATIVES_ENABLED",
+        "MEDIA_FFMPEG_PATH",
+        "MEDIA_FFPROBE_PATH"
+      ],
+      "repositoryEvidence": [
+        "maintained derivative worker",
+        "deterministic worker contracts",
+        "private storage dependency",
+        "durable main pull-request CI ownership"
+      ],
+      "productionQualified": false,
+      "liveEvidenceRequired": [
+        "deployed ffmpeg/ffprobe binary identity",
+        "target storage access",
+        "representative media black-box conversion",
+        "resource-limit and cleanup observation"
+      ]
+    },
+    {
+      "id": "web_push",
+      "status": "OPTIONAL_QUALIFIED",
+      "runtimeOwner": "apps/api/src/notifications/notifications.service.ts",
+      "ciOwners": [
+        ".github/workflows/integration-truth-ci.yml"
+      ],
+      "configuration": [
+        "VAPID_PUBLIC_KEY",
+        "VAPID_PRIVATE_KEY"
+      ],
+      "repositoryEvidence": [
+        "subscription persistence and unsubscribe lifecycle",
+        "VAPID delivery runtime",
+        "404/410 stale-subscription cleanup",
+        "identifier- and content-free delivery telemetry"
+      ],
+      "productionQualified": false,
+      "liveEvidenceRequired": [
+        "deployed VAPID keypair",
+        "browser permission/consent validation",
+        "real subscription creation",
+        "provider delivery black-box observation",
+        "revocation and expiry cleanup observation"
+      ]
+    },
+    {
+      "id": "n8n",
+      "status": "RESERVED",
+      "runtimeOwner": null,
+      "ciOwners": [
+        ".github/workflows/integration-truth-ci.yml"
+      ],
+      "configuration": [],
+      "prototypePaths": [
+        "n8n-workflows/"
+      ],
+      "repositoryEvidence": [
+        "prototype workflow JSON only",
+        "no maintained N8nWebhooksController or webhook authentication runtime"
+      ],
+      "productionQualified": false,
+      "promotionRequirements": [
+        "explicit runtime owner",
+        "authenticated inbound and outbound requests",
+        "replay-safe idempotency",
+        "privacy-minimized event schemas",
+        "deterministic provider stubs/contracts",
+        "durable CI ownership",
+        "target deployment and black-box evidence"
+      ]
+    }
+  ]
+}

--- a/n8n-workflows/README.md
+++ b/n8n-workflows/README.md
@@ -1,287 +1,47 @@
-# n8n Workflow Automation Setup
+# n8n workflow prototypes
 
-This directory contains automated workflows for PetPath's user engagement, follow-ups, and reminders.
+The files in this directory are **reference prototypes only**. Woof does not currently have a qualified n8n runtime integration.
 
-## 🚀 Quick Start
+## Authority boundary
 
-### 1. Start n8n
+Current repository truth:
 
-```bash
-# Start all services including n8n
-docker-compose up -d
+- there is no maintained `N8nWebhooksController` in `apps/api/src`;
+- there is no maintained n8n webhook authentication guard in `apps/api/src`;
+- Woof does not configure an `N8N_WEBHOOK_SECRET` runtime setting;
+- these workflow JSON files are not evidence that any n8n instance is deployed, connected, authenticated, or allowed to mutate Woof data;
+- no product surface should describe n8n automation as available today.
 
-# Check n8n logs
-docker logs woof-n8n -f
-```
+The canonical machine-readable classification is `RESERVED` in `docs/EXTERNAL_INTEGRATION_INVENTORY.json`.
 
-### 2. Access n8n UI
+## What is preserved here
 
-- **URL**: http://localhost:5678
-- **Username**: `admin`
-- **Password**: `woofadmin`
+The prototype workflows capture product ideas that may be useful later, including service follow-ups, meetup feedback reminders, event reminders, and fitness-goal acknowledgements. They are retained as design references, not executable release authority.
 
-### 3. Import Workflows
+Do not copy example endpoints, identifiers, payloads, or credentials from old documentation into a production deployment. There are intentionally no default n8n credentials in this repository.
 
-1. Navigate to **Workflows** in n8n UI
-2. Click **Import from File**
-3. Import each workflow JSON file from this directory:
-   - `service-booking-followup.json` - 24h service booking follow-up
-   - `meetup-feedback-reminder.json` - Meetup confirmation requests
-   - `event-reminder-followup.json` - Event reminders and feedback
-   - `fitness-goal-achievement.json` - Daily goal tracking and rewards
+## Requirements before promotion
 
-### 4. Configure Workflow Credentials
+n8n may move from `RESERVED` to `OPTIONAL_QUALIFIED` only after a dedicated release implements and tests all of the following:
 
-Each workflow requires API credentials to connect to the Woof backend:
+1. **Explicit runtime ownership.** Maintained API services/controllers own every inbound and outbound automation path.
+2. **Authentication.** Every webhook or API request is authenticated with a dedicated secret or stronger credential mechanism. Secrets must never be transported in query strings or logged.
+3. **Replay safety and idempotency.** Repeated delivery cannot duplicate rewards, notifications, bookings, or other mutations.
+4. **Minimal event schemas.** Automation payloads carry opaque IDs and the minimum data required for the workflow. Raw private media, health text, behavior observations, push credentials, access tokens, and unnecessary profile data stay out of n8n.
+5. **Bounded failure behavior.** Network timeouts, retries, delivery failures, and provider errors have explicit limits and content-free telemetry.
+6. **Authorization.** Internal endpoints called by automation are not made broadly public merely to support n8n.
+7. **Deterministic tests.** Provider stubs prove authentication, replay rejection/idempotency, malformed payload rejection, privacy boundaries, and degraded behavior.
+8. **Durable CI ownership.** A `main` pull-request workflow owns the runtime and workflow definitions.
+9. **Deployment evidence.** A real target n8n deployment, target Woof API revision, live authentication, networking, and black-box workflow execution are independently verified before anyone calls the integration production-qualified.
 
-1. Go to **Credentials** in n8n
-2. Create **HTTP Request** credential:
-   - **Name**: `Woof API`
-   - **Authentication**: Header Auth
-   - **Header Name**: `x-api-key`
-   - **Header Value**: Your internal API key (set in backend env)
+## Prototype review
 
-## 📋 Workflows Overview
+When changing a workflow JSON file while n8n remains reserved:
 
-### 1. Service Booking 24h Follow-up
+- treat it as a design artifact;
+- do not add real credentials or copied production payloads;
+- avoid embedding personal data in fixtures;
+- keep mutations visibly non-authoritative until the runtime requirements above exist;
+- update the integration inventory if the intended authority changes.
 
-**File**: `service-booking-followup.json`
-
-**Trigger**: Webhook from backend when ServiceIntent created with `action='tap_book'`
-
-**Flow**:
-```
-Webhook → Wait 24h → Check conversion status → Send notification → Update record
-```
-
-**Backend Integration**:
-```typescript
-// apps/api/src/services/services.controller.ts
-async trackIntent(intentDto: TrackIntentDto) {
-  const intent = await this.servicesService.trackIntent(intentDto);
-
-  // Trigger n8n workflow
-  if (intent.action === 'tap_book') {
-    await fetch('http://localhost:5678/webhook/service-booking-followup', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        intentId: intent.id,
-        userId: intent.userId,
-        serviceId: intent.serviceId,
-        serviceName: intent.service.name
-      })
-    });
-  }
-}
-```
-
-### 2. Meetup Feedback Reminder
-
-**File**: `meetup-feedback-reminder.json`
-
-**Trigger**: Cron job runs every 30 minutes, checks for completed meetups
-
-**Flow**:
-```
-Cron → Query recent meetups → Check status → Send reminder → Wait for feedback
-```
-
-**Backend Integration**:
-```typescript
-// n8n makes HTTP requests to:
-// GET /meetups?datetime[lte]=${now}&datetime[gte]=${2hoursAgo}&status=pending
-// POST /notifications/send (push notification to users)
-```
-
-### 3. Event Reminder & Follow-up
-
-**File**: `event-reminder-followup.json`
-
-**Trigger**: Cron job runs every hour, checks upcoming events (3h before start)
-
-**Flow**:
-```
-Cron → Query events (3h away) → Get RSVPs → Send reminders → After event → Feedback request
-```
-
-**Backend Integration**:
-```typescript
-// n8n makes HTTP requests to:
-// GET /events?datetime[gte]=${3hoursFromNow}&datetime[lte]=${3hoursFromNow+1h}
-// GET /events/{eventId}/rsvps?response=yes
-// POST /notifications/send (event reminder)
-```
-
-### 4. Fitness Goal Achievement
-
-**File**: `fitness-goal-achievement.json`
-
-**Trigger**: Daily cron at 9 PM
-
-**Flow**:
-```
-Cron (9 PM) → Query users with goals → Calculate progress → Award points → Send notification
-```
-
-**Backend Integration**:
-```typescript
-// n8n makes HTTP requests to:
-// GET /users?hasGoals=true
-// GET /activities?userId={id}&startDate={weekStart}&endDate={now}
-// POST /gamification/points (award achievement points)
-// POST /notifications/send (congratulations notification)
-```
-
-## 🔧 Webhook Configuration
-
-### Create Internal API Key
-
-Add to `apps/api/.env`:
-```bash
-N8N_WEBHOOK_SECRET=your-random-secret-key-here
-```
-
-### Secure Webhook Endpoints
-
-```typescript
-// apps/api/src/common/guards/webhook-auth.guard.ts
-@Injectable()
-export class WebhookAuthGuard implements CanActivate {
-  canActivate(context: ExecutionContext): boolean {
-    const request = context.switchToHttp().getRequest();
-    const apiKey = request.headers['x-api-key'];
-    return apiKey === process.env.N8N_WEBHOOK_SECRET;
-  }
-}
-
-// Apply to webhook controllers
-@UseGuards(WebhookAuthGuard)
-@Controller('webhooks/n8n')
-export class N8nWebhooksController {
-  // Webhook endpoints that n8n can call
-}
-```
-
-## 📊 Monitoring & Logs
-
-### View Workflow Executions
-
-1. Go to **Executions** in n8n UI
-2. Filter by workflow name
-3. View execution details, errors, and logs
-
-### Debugging Tips
-
-- **Workflow not triggering**: Check cron expression and timezone
-- **HTTP requests failing**: Verify API credentials and endpoint URLs
-- **Webhook not receiving data**: Check network connectivity (Docker network)
-- **Notifications not sending**: Verify push subscription exists for user
-
-### Production Considerations
-
-1. **Set proper timezone** in n8n container:
-   ```yaml
-   environment:
-     - GENERIC_TIMEZONE=America/Los_Angeles
-     - TZ=America/Los_Angeles
-   ```
-
-2. **Use production webhook URL**:
-   ```yaml
-   environment:
-     - WEBHOOK_URL=https://your-domain.com/
-   ```
-
-3. **Enable execution logging**:
-   ```yaml
-   environment:
-     - EXECUTIONS_DATA_SAVE_ON_SUCCESS=all
-     - EXECUTIONS_DATA_SAVE_ON_ERROR=all
-   ```
-
-4. **Backup workflows** regularly by exporting to this directory
-
-## 🧪 Testing Workflows
-
-### Manual Testing
-
-1. **Service Follow-up**:
-   ```bash
-   curl -X POST http://localhost:5678/webhook/service-booking-followup \
-     -H "Content-Type: application/json" \
-     -d '{
-       "intentId": "test-intent-id",
-       "userId": "user-id-here",
-       "serviceId": "service-id-here",
-       "serviceName": "Golden Gate Dog Grooming"
-     }'
-   ```
-
-2. **Event Reminder**:
-   - Set event datetime to 2h 50min from now
-   - Wait for cron to trigger
-   - Check execution logs
-
-### Staging Environment
-
-Before deploying to production:
-1. Test all workflows in staging with real data
-2. Verify notifications are sent correctly
-3. Check conversion tracking updates
-4. Monitor execution times and errors
-
-## 📝 Workflow Version Control
-
-After making changes in n8n UI:
-1. Export workflow as JSON
-2. Save to this directory
-3. Commit to git
-4. Document changes in this README
-
-## 🔒 Security Best Practices
-
-1. **Never commit credentials** - Use n8n credential management
-2. **Rotate API keys** regularly
-3. **Use HTTPS** in production
-4. **Limit webhook access** with IP whitelisting if possible
-5. **Monitor execution logs** for suspicious activity
-
-## 🆘 Troubleshooting
-
-### n8n Won't Start
-
-```bash
-# Check logs
-docker logs woof-n8n
-
-# Restart n8n
-docker-compose restart n8n
-
-# Rebuild if needed
-docker-compose up -d --build n8n
-```
-
-### Database Connection Issues
-
-```bash
-# Verify postgres is running
-docker ps | grep postgres
-
-# Check n8n database
-docker exec -it woof-postgres psql -U postgres -d woof_n8n -c "SELECT * FROM public.workflow_entity;"
-```
-
-### Workflows Not Executing
-
-1. Check cron expression is valid
-2. Verify workflow is **Active** (toggle in UI)
-3. Check execution error logs
-4. Test with manual trigger first
-
-## 📚 Additional Resources
-
-- [n8n Documentation](https://docs.n8n.io)
-- [Webhook Nodes](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook/)
-- [Cron Expression Generator](https://crontab.guru/)
-- [HTTP Request Node](https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.httprequest/)
+This boundary is deliberate: preserving useful workflow ideas is cheap, while pretending a prototype is a live integration is expensive later. 🧩


### PR DESCRIPTION
## Summary

Implements #108’s corrected scope: integration truth + privacy qualification rather than phantom-integration retirement.

The repository audit found real runtime implementations for OpenAI Health Lens, private S3-compatible storage, Web Push, and media derivatives. n8n remains reserved/prototypical.

## Runtime/privacy changes

### Health Lens
- never reads non-2xx provider bodies;
- never logs arbitrary provider/generated exception content;
- reduces failures to `provider_http_error`, `invalid_json`, `timeout`, or `transport_error`;
- preserves bearer authentication, `store: false`, strict structured output, conservative health authority, and explicit unconfigured behavior;
- adds transport privacy tests.

### Private storage
- removes private object-key and filename-bearing success telemetry;
- removes arbitrary SDK message/stack telemetry;
- normalizes provider/stream failures at the storage boundary so raw S3 errors cannot escape upward;
- preserves explicit application bounds/errors;
- adds direct private-storage tests.

### Web Push
- removes user IDs, notification titles/bodies/endpoints/keys, and provider exception messages/stacks from telemetry;
- retains status-only failure classification and 404/410 subscription cleanup;
- adds deterministic delivery/privacy tests;
- production environment validation now requires VAPID public/private keys as a pair.

### n8n
- explicitly classified `RESERVED`;
- removes the unused `N8N_WEBHOOK_SECRET` configuration surface;
- rewrites the workflow README as prototype/reference documentation rather than deployed setup truth;
- removes default-looking local credentials and pseudo-runtime claims.

## Integration authority inventory

Adds `docs/EXTERNAL_INTEGRATION_INVENTORY.json` with explicit `ACTIVE`, `OPTIONAL_QUALIFIED`, `RESERVED`, and `RETIRED` semantics. Current implemented optional integrations remain `productionQualified: false`; CI/configuration is not deployment evidence.

The stale API `.env.example` is corrected so Health, S3, derivatives, and Push are no longer falsely documented as nonexistent/reserved runtimes.

## Durable CI ownership

Adds `dogOS External Integration Truth CI` on `main` pull requests, owning:
- integration inventory and n8n truth;
- Health provider privacy;
- Storage provider/privacy boundary;
- Push lifecycle/privacy boundary;
- environment contracts;
- media derivative worker contracts;
- API formatting, lint, typecheck, Jest contracts, and build.

A fail-closed Python source contract prevents privacy regressions and status inflation.

## Deliberate scope boundary

This PR does **not** migrate persisted Push subscription material to encrypted envelopes. That is a separate data-migration/rotation risk and is tracked in #114.

This PR also does not claim any integration is live in production. Live provider credentials, target networking/buckets/binaries/browser subscriptions, black-box behavior, and rollback evidence remain deployment gates.

## Base sequencing

This branch currently starts from merged Client Reality #113. Behavior Vision privacy replacement #115 is qualifying in parallel. If #115 moves `main` first, this branch will be refreshed onto that exact merge boundary and fully requalified before merge.