### PR TITLE
Qualify operational incident runbooks and recovery authority

### DIFF
--- a/.github/scripts/assert-operational-runbooks.py
+++ b/.github/scripts/assert-operational-runbooks.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Fail closed when operational runbook authority drifts from maintained Woof source."""
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTRY = ROOT / "ops/runbooks/runbook-registry.v1.json"
+ALERT_POLICY = ROOT / "ops/alerts/woof-api-alert-policy.v1.json"
+AUTH = ROOT / "apps/api/src/auth/auth.controller.ts"
+SESSION_AUTHORITY = ROOT / "apps/api/src/auth/session-authority.service.ts"
+CHAT = ROOT / "apps/api/src/chat/chat.gateway.ts"
+REALTIME_ADMISSION = ROOT / "apps/api/src/chat/realtime-admission.service.ts"
+CAREGIVER = ROOT / "apps/api/src/caregiver/caregiver.service.ts"
+CONNECTOR_GUARD = ROOT / "apps/api/src/connectors/connectors-enabled.guard.ts"
+CONNECTORS = ROOT / "apps/api/src/connectors/connectors.service.ts"
+ENV = ROOT / "apps/api/src/config/env.validation.ts"
+METRICS = ROOT / "apps/api/src/observability/operational-metrics.service.ts"
+SENTRY = ROOT / "apps/api/src/sentry.ts"
+INTEGRATIONS = ROOT / "docs/EXTERNAL_INTEGRATION_INVENTORY.json"
+WORKFLOW = ROOT / ".github/workflows/operational-runbooks-ci.yml"
+
+required_files = [
+    REGISTRY,
+    ALERT_POLICY,
+    AUTH,
+    SESSION_AUTHORITY,
+    CHAT,
+    REALTIME_ADMISSION,
+    CAREGIVER,
+    CONNECTOR_GUARD,
+    CONNECTORS,
+    ENV,
+    METRICS,
+    SENTRY,
+    INTEGRATIONS,
+    WORKFLOW,
+]
+for path in required_files:
+    if not path.is_file():
+        raise SystemExit(f"required runbook authority source missing: {path.relative_to(ROOT)}")
+
+registry = json.loads(REGISTRY.read_text())
+policy = json.loads(ALERT_POLICY.read_text())
+integrations = json.loads(INTEGRATIONS.read_text())
+
+if registry.get("version") != "woof-operational-runbooks-v1":
+    raise SystemExit("unexpected operational runbook registry version")
+if registry.get("alertPolicy") != "ops/alerts/woof-api-alert-policy.v1.json":
+    raise SystemExit("runbook registry must point at the canonical v1 alert policy")
+if registry.get("liveRehearsalStatus") != "NOT_YET_PROVEN":
+    raise SystemExit("repository runbooks must not claim live rehearsal evidence")
+
+authority = registry.get("authority") or {}
+if authority.get("productionQualified") is not False:
+    raise SystemExit("operational runbooks must not claim production qualification")
+if authority.get("repositoryQualified") not in {False, True}:
+    raise SystemExit("repositoryQualified must be an explicit boolean")
+repository_qualification = (
+    "CODE_QUALIFIED" if authority.get("repositoryQualified") is True else "PENDING"
+)
+
+runbooks = registry.get("runbooks")
+if not isinstance(runbooks, list) or not runbooks:
+    raise SystemExit("runbook registry must contain at least one runbook")
+
+ids = [entry.get("id") for entry in runbooks]
+if any(not isinstance(value, str) or not value for value in ids):
+    raise SystemExit("every runbook must have a non-empty id")
+if len(ids) != len(set(ids)):
+    raise SystemExit("runbook ids must be unique")
+
+required_ids = {
+    "deployment-readiness",
+    "database-migration",
+    "auth-session",
+    "api-degradation",
+    "connector-ingestion",
+    "privacy-telemetry",
+    "realtime",
+}
+if set(ids) != required_ids:
+    raise SystemExit(f"runbook registry ids drifted: expected {sorted(required_ids)}, got {sorted(ids)}")
+
+required_sections = [
+    "## Authority boundary",
+    "## Detection",
+    "## Impact",
+    "## Containment",
+    "## Diagnosis",
+    "## Recovery",
+    "## Rollback",
+    "## Verification",
+    "## Evidence",
+    "## Rehearsal",
+]
+
+allowed_manual_signals = {"privacy_or_secret_exposure"}
+registered_alerts: set[str] = set()
+registered_manual: set[str] = set()
+runbook_by_id = {}
+
+for entry in runbooks:
+    runbook_id = entry["id"]
+    runbook_by_id[runbook_id] = entry
+    owner = entry.get("owner")
+    if not isinstance(owner, str) or not owner.strip():
+        raise SystemExit(f"runbook {runbook_id} must declare a non-empty owner role")
+    if entry.get("liveRehearsalStatus") != "NOT_YET_PROVEN":
+        raise SystemExit(f"runbook {runbook_id} must remain NOT_YET_PROVEN until a real drill")
+
+    relative = entry.get("path")
+    if not isinstance(relative, str) or not relative.startswith("ops/runbooks/") or not relative.endswith(".md"):
+        raise SystemExit(f"runbook {runbook_id} has invalid path {relative!r}")
+    path = ROOT / relative
+    if not path.is_file():
+        raise SystemExit(f"registered runbook is missing: {relative}")
+
+    text = path.read_text()
+    if f"Runbook ID: `{runbook_id}`" not in text:
+        raise SystemExit(f"runbook id marker missing from {relative}")
+    if f"Repository qualification: `{repository_qualification}`" not in text:
+        raise SystemExit(
+            f"runbook {runbook_id} must match repository qualification {repository_qualification}"
+        )
+    if "Live rehearsal status: `NOT_YET_PROVEN`" not in text:
+        raise SystemExit(f"live rehearsal marker missing from {relative}")
+    for section in required_sections:
+        if section not in text:
+            raise SystemExit(f"runbook {runbook_id} is missing required section {section}")
+
+    alerts = entry.get("alerts")
+    manual = entry.get("manualSignals")
+    if not isinstance(alerts, list) or not all(isinstance(value, str) and value for value in alerts):
+        raise SystemExit(f"runbook {runbook_id} alerts must be a string list")
+    if not isinstance(manual, list) or not all(isinstance(value, str) and value for value in manual):
+        raise SystemExit(f"runbook {runbook_id} manualSignals must be a string list")
+    if len(alerts) != len(set(alerts)) or len(manual) != len(set(manual)):
+        raise SystemExit(f"runbook {runbook_id} contains duplicate alert/manual signal mappings")
+    registered_alerts.update(alerts)
+    registered_manual.update(manual)
+
+policy_meta = {"version", "service", "evaluationInterval", "deferredSignals"}
+policy_alerts = set(policy) - policy_meta
+unknown_alerts = registered_alerts - policy_alerts
+missing_alerts = policy_alerts - registered_alerts
+if unknown_alerts:
+    raise SystemExit(f"runbooks reference unknown alert-policy keys: {sorted(unknown_alerts)}")
+if missing_alerts:
+    raise SystemExit(f"alert-policy keys have no incident runbook: {sorted(missing_alerts)}")
+
+policy_deferred_entries = policy.get("deferredSignals")
+if not isinstance(policy_deferred_entries, list):
+    raise SystemExit("alert policy deferredSignals must be a list")
+policy_deferred = {
+    entry.get("name")
+    for entry in policy_deferred_entries
+    if isinstance(entry, dict) and isinstance(entry.get("name"), str)
+}
+registry_deferred = registry.get("deferredSignals")
+if not isinstance(registry_deferred, dict):
+    raise SystemExit("runbook registry deferredSignals must be an object")
+if set(registry_deferred) != policy_deferred:
+    raise SystemExit(
+        f"deferred-signal registry drift: policy={sorted(policy_deferred)}, registry={sorted(registry_deferred)}"
+    )
+
+for signal, detail in registry_deferred.items():
+    if not isinstance(detail, dict) or detail.get("detectionMode") != "manual_deferred":
+        raise SystemExit(f"deferred signal {signal} must remain manual_deferred")
+    runbook_id = detail.get("runbook")
+    if runbook_id not in runbook_by_id:
+        raise SystemExit(f"deferred signal {signal} points to unknown runbook {runbook_id!r}")
+    if signal not in runbook_by_id[runbook_id].get("manualSignals", []):
+        raise SystemExit(f"deferred signal {signal} is not declared by runbook {runbook_id}")
+
+unknown_manual = registered_manual - policy_deferred - allowed_manual_signals
+if unknown_manual:
+    raise SystemExit(f"runbooks contain undeclared manual signals: {sorted(unknown_manual)}")
+if "privacy_or_secret_exposure" not in registered_manual:
+    raise SystemExit("privacy/security incidents need an explicit manual signal")
+
+# Runtime authority markers: runbooks must fail when underlying recovery assumptions disappear.
+def require(path: Path, markers: list[str], label: str):
+    text = path.read_text()
+    for marker in markers:
+        if marker not in text:
+            raise SystemExit(f"{label} authority marker missing from {path.relative_to(ROOT)}: {marker}")
+
+require(AUTH, ["@Post('logout')", "@Post('logout-all')"], "auth revocation")
+require(
+    SESSION_AUTHORITY,
+    ["async withActiveSession<", "async revokeSession(", "async revokeAllSessions("],
+    "session authority",
+)
+require(
+    CHAT,
+    [
+        "this.sessionAuthority.withActiveSession(",
+        "session:ready",
+        "session:revoked",
+        "session:expired",
+        "withAuthorizedRealtimeRecipients",
+    ],
+    "realtime session/recipient",
+)
+require(
+    REALTIME_ADMISSION,
+    ["message: [", "typing: [", "membership: [", "MAX_REALTIME_BUCKETS = 10_000"],
+    "realtime admission",
+)
+require(
+    CAREGIVER,
+    [
+        "async issueGrant(",
+        "async acceptGrant(",
+        "async declineGrant(",
+        "async revokeGrant(",
+        "authorityClass: 'CONTEXT_ONLY'",
+        "bondXpAuthority: false",
+        "recommendationEvidenceAuthority: false",
+    ],
+    "caregiver authority",
+)
+require(CONNECTOR_GUARD, ["ENABLE_DOGOS_CONNECTORS", "NotFoundException"], "connector feature guard")
+require(
+    CONNECTORS,
+    [
+        "undocumentedOAuthAllowed: false",
+        "browserProviderImpersonationAllowed: false",
+        "importedWearablesRewardEligible: false",
+        "rawProviderPayloadStored: false",
+        "remoteRevocation: 'NOT_CONFIGURED'",
+        "external_object_changed_after_import",
+    ],
+    "connector ingestion",
+)
+require(
+    ENV,
+    [
+        "CONNECTOR_CREDENTIALS_KEY is required and must decode to 32 bytes when connectors are enabled in production",
+        "OPS_METRICS_TOKEN must be at least 32 characters when configured",
+    ],
+    "production configuration",
+)
+require(
+    METRICS,
+    [
+        "userIdentifiersCollected: false",
+        "petIdentifiersCollected: false",
+        "providerExternalIdentifiersCollected: false",
+        "rawPayloadsCollected: false",
+        "requestUrlsCollected: false",
+    ],
+    "operational metric privacy",
+)
+require(
+    SENTRY,
+    [
+        "sendDefaultPii: false",
+        "delete event.request",
+        "delete event.user",
+        "delete event.extra",
+        "delete event.breadcrumbs",
+        "delete span.data",
+    ],
+    "Sentry privacy",
+)
+
+for entry in integrations.get("integrations", []):
+    if entry.get("productionQualified") is not False:
+        raise SystemExit(
+            f"runbooks cannot coexist with unproven production integration claim: {entry.get('id')}"
+        )
+
+# Reject committed credential-like literals while allowing variable names and placeholders.
+for entry in runbooks:
+    path = ROOT / entry["path"]
+    text = path.read_text()
+    forbidden_patterns = [
+        (r"Authorization:\s*Bearer\s+eyJ[A-Za-z0-9_-]{10,}", "literal JWT"),
+        (r"AKIA[0-9A-Z]{16}", "AWS access key"),
+        (r"sk-[A-Za-z0-9_-]{20,}", "provider API key"),
+        (r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----", "private key"),
+    ]
+    for pattern, label in forbidden_patterns:
+        if re.search(pattern, text):
+            raise SystemExit(f"runbook {entry['id']} contains a credential-like {label}")
+
+workflow = WORKFLOW.read_text()
+for marker in [
+    ".github/scripts/assert-operational-runbooks.py",
+    "ops/runbooks/**",
+    "ops/alerts/woof-api-alert-policy.v1.json",
+    "apps/api/src/auth/**",
+    "apps/api/src/chat/**",
+    "apps/api/src/connectors/**",
+    "apps/api/src/caregiver/**",
+    "apps/api/src/observability/**",
+    "docs/EXTERNAL_INTEGRATION_INVENTORY.json",
+    "python .github/scripts/assert-operational-runbooks.py",
+]:
+    if marker not in workflow:
+        raise SystemExit(f"operational runbook CI ownership marker missing: {marker}")
+
+print(
+    "Operational runbook authority is coherent: every alert is routed, deferred signals remain explicit, "
+    "runtime assumptions are source-bound, private evidence stays minimized, and live production rehearsal is unclaimed."
+)

--- a/.github/workflows/operational-runbooks-ci.yml
+++ b/.github/workflows/operational-runbooks-ci.yml
@@ -1,0 +1,67 @@
+name: dogOS Operational Runbooks CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'ops/runbooks/**'
+      - 'ops/alerts/woof-api-alert-policy.v1.json'
+      - '.github/scripts/assert-operational-runbooks.py'
+      - '.github/workflows/operational-runbooks-ci.yml'
+      - 'apps/api/src/auth/**'
+      - 'apps/api/src/chat/**'
+      - 'apps/api/src/connectors/**'
+      - 'apps/api/src/caregiver/**'
+      - 'apps/api/src/observability/**'
+      - 'apps/api/src/sentry.ts'
+      - 'apps/api/src/config/env.validation.ts'
+      - 'docs/EXTERNAL_INTEGRATION_INVENTORY.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: operational-runbooks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  qualify:
+    name: Incident authority + runbook truth
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+
+      - name: Reject whitespace damage
+        run: |
+          git diff --check HEAD^ HEAD -- . ':(exclude)ops/runbooks/*.md'
+          python - <<'PY'
+          from pathlib import Path
+
+          for path in Path('ops/runbooks').glob('*.md'):
+              for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+                  if not line.endswith((' ', '\t')):
+                      continue
+                  intentional_break = (
+                      line.endswith('  ')
+                      and not line.endswith('   ')
+                      and (
+                          line.startswith('Runbook ID: `')
+                          or line.startswith('Repository qualification: `')
+                      )
+                  )
+                  if not intentional_break:
+                      raise SystemExit(f'{path}:{line_number}: unexpected trailing whitespace')
+          PY
+
+      - name: Validate runbook and alert JSON
+        run: |
+          python -m json.tool ops/runbooks/runbook-registry.v1.json >/dev/null
+          python -m json.tool ops/alerts/woof-api-alert-policy.v1.json >/dev/null
+
+      - name: Validate operational runbook authority
+        run: |
+          python -m py_compile .github/scripts/assert-operational-runbooks.py
+          python .github/scripts/assert-operational-runbooks.py

--- a/ops/runbooks/api-degradation.md
+++ b/ops/runbooks/api-degradation.md
@@ -1,0 +1,168 @@
+# API degradation and caregiver authority incident runbook
+
+Runbook ID: `api-degradation`  
+Repository qualification: `CODE_QUALIFIED`  
+Live rehearsal status: `NOT_YET_PROVEN`
+
+## Authority boundary
+
+This runbook covers application degradation after process and database readiness have been separated from user-facing correctness. The authoritative alert policy remains `ops/alerts/woof-api-alert-policy.v1.json`; low traffic that does not meet a ratio or latency sample floor is `INSUFFICIENT_DATA`, not healthy evidence.
+
+Today/read latency authority currently covers exact controller operations:
+
+- `AdventureController.getMine`;
+- `CompanionController.getState`;
+- `CompanionController.getReadiness`;
+- `CaregiverController.getCaregiverToday`.
+
+Caregiver transition authority covers exact issue, accept, decline, and revoke operations. Caregiver access remains capability-gated, replay-aware, block-aware, time-bounded, and context-only where observations are permitted. This runbook does not authorize weakening those semantics to recover availability.
+
+## Detection
+
+Use this runbook for:
+
+- `todayReadP95Ms`;
+- `caregiverTransition5xx`;
+- `deviceContractRejections` when the problem presents as an API/contract regression rather than a specific connected provider;
+- application `http5xx`;
+- `application5xxBurst`;
+- `requestDurationInvalid`.
+
+Start by recording readiness and exact release identity:
+
+```bash
+export WOOF_API_ORIGIN="https://woof-api-prod.fly.dev"
+curl --fail-with-body --silent --show-error \
+  "$WOOF_API_ORIGIN/api/v1/ops/health/ready" | jq
+```
+
+When operational metrics authority is available:
+
+```bash
+test -n "${OPS_METRICS_TOKEN:-}" || { echo "OPS_METRICS_TOKEN unavailable" >&2; exit 2; }
+curl --fail-with-body --silent --show-error \
+  -H "x-woof-ops-token: ${OPS_METRICS_TOKEN}" \
+  "$WOOF_API_ORIGIN/api/v1/ops/metrics.json" | jq
+```
+
+Do not print or persist the operational token.
+
+## Impact
+
+Classify the smallest failing authority surface before making changes:
+
+- **Today/read latency regression:** one exact read operation is slow while readiness remains healthy;
+- **caregiver transition availability:** issue/accept/decline/revoke returns server failures;
+- **caregiver correctness:** transition succeeds or fails with the wrong authority semantics;
+- **device envelope contract drift:** pre-provider envelopes are rejected before a trusted provider label exists;
+- **instrumentation corruption:** request timing is invalid rather than genuinely slow;
+- **broad API regression:** multiple unrelated operations fail on one release.
+
+A 4xx authorization or validation outcome is not automatically an availability failure. Do not convert correct denials into success to reduce an error rate.
+
+## Containment
+
+1. Preserve the exact release SHA and operation name before changing state.
+2. If only one optional product surface is implicated and it has a maintained feature/configuration boundary, prefer disabling that bounded surface over weakening shared auth, caregiver, validation, or reward authority.
+3. Do not bypass `JwtAuthGuard`, caregiver capability checks, block checks, request-key replay protection, or observation context authority.
+4. Do not manually edit caregiver grant rows to make a transition appear successful.
+5. Do not discard invalid timing samples or rewrite them to zero. Broken timing is its own alert condition.
+6. Do not infer that an endpoint is healthy solely because a ratio/latency alert is inactive below its sample floor.
+7. If readiness is failing too, move first to `database-migration.md` or `deployment-readiness.md` rather than treating the symptom as endpoint-local.
+
+## Diagnosis
+
+For Today/read degradation, isolate one exact operation at a time. Use synthetic or non-private requests and compare:
+
+- successful request count;
+- p95 window state from external alert evaluation when available;
+- 5xx count/ratio;
+- invalid timing count;
+- current release versus the immediately previous known-good release.
+
+Do not treat Nest handler latency as browser, CDN, TLS, or full response-flush latency.
+
+For caregiver transitions, exercise a synthetic grant lifecycle against maintained endpoints:
+
+```text
+POST /api/v1/caregiver/grants
+POST /api/v1/caregiver/grants/:grantId/accept
+POST /api/v1/caregiver/grants/:grantId/decline
+POST /api/v1/caregiver/grants/:grantId/revoke
+```
+
+Use a unique synthetic request key for new issuance. Retrying the same issuance with the same semantics should be replay-safe; reusing its request key for different semantics must remain a conflict. Do not copy real grant IDs, user IDs, notes, or pet data into incident evidence.
+
+For a device contract spike, distinguish:
+
+- pre-provider envelope rejection, which increments `deviceContractRejections` without a provider label;
+- a verified provider/kind import rejection, which belongs in `connector-ingestion.md`.
+
+## Recovery
+
+### Endpoint or release regression
+
+Prefer a narrow forward fix when the defect is understood. If exact previous-image recovery is safer, use `deployment-readiness.md` and satisfy its database compatibility gate before redeploying an older image.
+
+### Caregiver transition regression
+
+Repair the transition implementation or persistence boundary while preserving:
+
+- issuer/recipient authority;
+- capability bundle constraints;
+- block-state checks;
+- expiry semantics;
+- replay/idempotency behavior;
+- context-only observation authority;
+- no Bond XP or recommendation-evidence authority for caregiver observations.
+
+Never recover by broadening caregiver permissions or restoring revoked/expired grants.
+
+### Timing instrumentation regression
+
+Repair the timing source or interceptor. Keep invalid samples excluded from latency histograms while continuing to count them as invalid. Do not suppress the alert merely because request outcomes are otherwise successful.
+
+## Rollback
+
+Application rollback follows `deployment-readiness.md`. A rollback must not:
+
+- reverse or mutate caregiver state manually;
+- restore a revoked caregiver grant;
+- change reward eligibility to compensate for a broken flow;
+- weaken authorization or validation;
+- reinterpret insufficient sample data as a passed latency qualification.
+
+If the failing release includes schema changes, follow `database-migration.md` before using an older image.
+
+## Verification
+
+Require the smallest representative synthetic journey plus alert recovery:
+
+1. `/ops/health/ready` is healthy and reports the intended release SHA.
+2. Each affected Today/read endpoint returns the expected bounded response under an authorized synthetic account.
+3. A caregiver issuance can be replayed safely with the same request key and semantics.
+4. Reusing that request key for different issuance semantics remains rejected.
+5. Accept/decline/revoke preserve actor authority and terminal-state semantics.
+6. A revoked, expired, blocked, or under-capability caregiver cannot regain access through the recovered path.
+7. Caregiver observations remain `CONTEXT_ONLY` and do not become Bond XP or recommendation authority.
+8. Invalid request-duration samples stop increasing after an instrumentation fix.
+9. The triggering alert clears for its configured evaluation window, or low-volume evidence is explicitly labeled `INSUFFICIENT_DATA` rather than `OK`.
+
+## Evidence
+
+Capture only low-cardinality operational evidence:
+
+- alert key and exact controller operation;
+- release SHA;
+- bounded status-class/count/latency classification;
+- synthetic fixture label;
+- recovery SHA/image;
+- verification timestamps and pass/fail outcomes.
+
+Do not retain real caregiver identities, pet IDs, grant IDs, request bodies, observation notes, device payloads, tokens, or query parameters.
+
+## Rehearsal
+
+Live rehearsal status: `NOT_YET_PROVEN`
+
+Promotion to `PROVEN` requires a production-like synthetic drill that exercises at least one Today/read degradation and the complete caregiver issue/accept/revoke authority path, demonstrates containment without weakening authorization, and verifies recovery against an exact release.

--- a/ops/runbooks/auth-session.md
+++ b/ops/runbooks/auth-session.md
@@ -1,0 +1,152 @@
+# Authentication and session incident runbook
+
+Runbook ID: `auth-session`  
+Repository qualification: `CODE_QUALIFIED`  
+Live rehearsal status: `NOT_YET_PROVEN`
+
+## Authority boundary
+
+Woof authentication sessions are server-authoritative database records. The maintained user-facing revocation endpoints are:
+
+- `POST /api/v1/auth/logout` to revoke the current authenticated session;
+- `POST /api/v1/auth/logout-all` to revoke all active sessions for the current authenticated user.
+
+There is **no maintained operator endpoint that revokes arbitrary users' sessions**. This runbook must not invent one. A broad JWT-secret rotation would invalidate authentication globally and is a high-impact credential/deployment action, not a first-line response.
+
+## Detection
+
+Use this runbook for:
+
+- `auth5xx`
+- authentication-related `http5xx`
+- authentication-related `application5xxBurst`
+- reports of sessions that should have been revoked but remain usable
+- suspected JWT signing-secret or session-authority compromise
+
+Use guarded metrics when available:
+
+```bash
+export WOOF_API_ORIGIN="https://woof-api-prod.fly.dev"
+test -n "${OPS_METRICS_TOKEN:-}" || { echo "OPS_METRICS_TOKEN unavailable" >&2; exit 2; }
+curl --fail-with-body --silent --show-error \
+  -H "x-woof-ops-token: ${OPS_METRICS_TOKEN}" \
+  "$WOOF_API_ORIGIN/api/v1/ops/metrics.json" | jq
+```
+
+The `auth5xx` policy covers maintained auth operations including register, login, logout, logout-all, and profile retrieval. A 401/403 increase is not automatically an availability incident; distinguish expected authentication rejection from server failure.
+
+## Impact
+
+Classify:
+
+- **login availability:** valid users cannot authenticate;
+- **session validation:** issued sessions cannot be checked or are incorrectly rejected;
+- **revocation failure:** logout/logout-all does not invalidate expected sessions;
+- **credential compromise:** signing secret, password credential, token, or session material may be exposed;
+- **authorization confusion:** authentication succeeds but the wrong principal/authority is used.
+
+Treat suspected credential compromise as a security incident even if availability metrics are green.
+
+## Containment
+
+1. Preserve auth error-rate and readiness evidence without copying tokens or passwords.
+2. If only one user suspects compromise and can authenticate, direct that user through the maintained `logout-all` authority.
+3. If an individual user cannot authenticate and arbitrary operator revocation is required, escalate to an authorized database/security procedure. Do not fabricate an admin API.
+4. If the JWT signing secret itself may be compromised, stop ordinary release work and escalate to production secret-rotation authority.
+5. Do not disable session-authority checks to restore login availability.
+6. Do not change authentication failures into successful anonymous access.
+
+## Diagnosis
+
+Check general runtime health first:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  "$WOOF_API_ORIGIN/api/v1/ops/health/ready" | jq
+```
+
+Then determine whether the failure is:
+
+- before credential verification;
+- during password verification;
+- during session-row creation;
+- during JWT issuance;
+- during `SessionAuthorityService.assertActive` / session lookup;
+- during logout/revocation;
+- a general database/runtime failure affecting auth incidentally.
+
+For user-driven revocation, the real API boundary is:
+
+```text
+POST /api/v1/auth/logout-all
+Authorization: Bearer <current-user-token>
+```
+
+Do not place a real token in a runbook transcript. Validate this flow only with an authorized synthetic/test account during rehearsal.
+
+Record the active application `releaseSha`, auth alert window, and whether database readiness is healthy. If auth 5xx coincides with general 5xx/readiness failure, follow `deployment-readiness.md` and `database-migration.md` before making auth-specific changes.
+
+## Recovery
+
+### User-scoped compromise
+
+Use the maintained authenticated `logout-all` flow when the user can still authenticate. Then require reauthentication and verify old sessions are rejected.
+
+### Auth availability regression
+
+Prefer a reviewed forward fix or exact previous-image recovery after database compatibility review. Session authority must remain enabled during recovery.
+
+### JWT signing-secret compromise
+
+Rotate the signing secret only through the authorized production secret-management/deployment path. Treat this as global session invalidation:
+
+- expect all currently issued JWTs to stop authenticating;
+- communicate the forced sign-in impact;
+- redeploy/restart the runtime as required by the platform so the new secret is authoritative;
+- never write the replacement secret into the repository, PR, issue, incident note, or shell transcript;
+- verify both newly issued sessions and rejection of tokens signed under the previous key.
+
+Because current production secret authority is an external blocker, this repository runbook does not claim that rotation can be executed from this connector session.
+
+## Rollback
+
+Rollback auth code through the same exact-image procedure as `deployment-readiness.md`, subject to database/schema compatibility.
+
+Do not roll back a compromised JWT secret to its previous value. Secret rotation is a one-way security boundary even if the application code is rolled back.
+
+Do not restore previously revoked session rows to recover availability.
+
+## Verification
+
+Use an authorized synthetic account and verify:
+
+1. login succeeds with correct credentials;
+2. `/api/v1/auth/me` succeeds for the new session;
+3. `POST /api/v1/auth/logout` rejects subsequent use of that revoked session;
+4. a newly logged-in session can call `POST /api/v1/auth/logout-all`;
+5. every session for that synthetic user created before logout-all is subsequently rejected;
+6. unrelated users are not revoked during user-scoped recovery;
+7. auth 5xx alert windows clear;
+8. readiness remains healthy and reports the intended `releaseSha`.
+
+For a global secret rotation, additionally prove an old-key token is rejected and a new-key token is accepted.
+
+## Evidence
+
+Capture only:
+
+- alert key/window;
+- release SHA;
+- synthetic account identifier or fixture label, not a real user identity;
+- revocation action type (`logout`, `logout-all`, global key rotation);
+- bounded HTTP status outcomes;
+- recovery SHA/image;
+- verification timestamps.
+
+Never capture passwords, JWTs, session IDs, authorization headers, password hashes, signing secrets, or raw database session rows.
+
+## Rehearsal
+
+Live rehearsal status: `NOT_YET_PROVEN`
+
+Promotion to `PROVEN` requires a production-like synthetic-user drill demonstrating login, current-session revocation, all-session revocation, and post-revocation rejection. Global JWT rotation requires a separately authorized drill because it intentionally invalidates all active authentication.

--- a/ops/runbooks/connector-ingestion.md
+++ b/ops/runbooks/connector-ingestion.md
@@ -1,0 +1,151 @@
+# Connector ingestion incident runbook
+
+Runbook ID: `connector-ingestion`  
+Repository qualification: `CODE_QUALIFIED`  
+Live rehearsal status: `NOT_YET_PROVEN`
+
+## Authority boundary
+
+Woof connector ingestion is a verified internal transport seam, not a browser-supplied provider-data API. Production connector routes are hidden unless `ENABLE_DOGOS_CONNECTORS=true`, and enabling connectors in production requires a valid 32-byte `CONNECTOR_CREDENTIALS_KEY`.
+
+Current connector authority deliberately preserves these boundaries:
+
+- undocumented OAuth is not allowed;
+- browser provider impersonation is not allowed;
+- raw provider payloads are not stored;
+- provider observations must map to an owned Woof pet;
+- verified imports are idempotent through persisted import receipts and canonical payload hashes;
+- imported wearable observations are not reward eligible;
+- local disconnect removes local credentials and records local revocation, but remote provider revocation is currently `NOT_CONFIGURED`.
+
+Do not describe a local disconnect as remote OAuth/provider revocation.
+
+## Detection
+
+Use this runbook for:
+
+- `connectorRejected`;
+- connector-related `http5xx`;
+- connector-related `application5xxBurst`;
+- provider/kind-specific import drift;
+- connector credentials becoming `REAUTH_REQUIRED`;
+- verified device transport failures after an envelope has a trusted provider identity.
+
+Use the guarded metrics boundary when available:
+
+```bash
+export WOOF_API_ORIGIN="https://woof-api-prod.fly.dev"
+test -n "${OPS_METRICS_TOKEN:-}" || { echo "OPS_METRICS_TOKEN unavailable" >&2; exit 2; }
+curl --fail-with-body --silent --show-error \
+  -H "x-woof-ops-token: ${OPS_METRICS_TOKEN}" \
+  "$WOOF_API_ORIGIN/api/v1/ops/metrics.json" | jq
+```
+
+Connector metrics intentionally expose only verified provider, observation kind, outcome, count, and bounded timing aggregates. Do not add external account IDs, external object IDs, user IDs, pet IDs, or raw payloads for diagnosis.
+
+Pre-provider envelope rejection belongs to `deviceContractRejections`; use `api-degradation.md` if the failure occurs before provider identity is trusted.
+
+## Impact
+
+Classify:
+
+- **transport contract drift:** verified provider envelopes no longer normalize under the maintained contract;
+- **credential state failure:** encrypted local credential cannot be used and connection is moved to `REAUTH_REQUIRED`;
+- **identity mapping failure:** external pet identity is not mapped to an owned Woof pet;
+- **idempotency conflict:** the same provider external object ID arrives with changed canonical content;
+- **persistence failure:** canonical observation succeeds or begins but the import receipt cannot be persisted consistently;
+- **credential compromise:** connector encryption material or a stored provider credential may have been exposed;
+- **provider outage:** an external transport is unavailable without a Woof contract regression.
+
+A rejected import is not evidence that canonical pet data should be mutated manually.
+
+## Containment
+
+1. If connector ingestion cannot be trusted, prefer setting `ENABLE_DOGOS_CONNECTORS=false` through authorized production configuration and redeploying/restarting as required. The production guard then returns 404 rather than exposing a degraded pseudo-integration.
+2. Do not enable an undocumented OAuth path to work around partner/provider failure.
+3. Do not allow browser callers to submit provider-owned observations directly.
+4. Do not bypass credential-state checks, pet identity mapping, import receipts, or payload-hash conflict detection.
+5. Do not mark imported wearable data reward eligible to compensate for ingestion issues.
+6. If credential compromise is suspected, also invoke `privacy-telemetry.md`. Do not log, export, or copy decrypted credential material for debugging.
+7. Do not claim remote revocation after a local disconnect. Follow the external provider's authorized revocation path only when a verified runtime exists.
+
+## Diagnosis
+
+Start with API readiness and exact release identity. Then classify by trusted provider + kind only:
+
+- `DAILY_ACTIVITY`;
+- `DEVICE_STATUS`.
+
+Inspect whether the connection is `CONNECTED`, `REAUTH_REQUIRED`, or locally `REVOKED` through an authorized synthetic account. Never paste real connection records or credentials into incident notes.
+
+For an idempotency incident, use synthetic transport fixtures and verify these three cases:
+
+1. first import of a new external object creates the canonical result and import receipt;
+2. exact replay returns the existing semantic result rather than duplicating canonical state;
+3. the same external object ID with different canonical content is rejected as `external_object_changed_after_import`.
+
+For a credential-state incident, distinguish a missing/invalid encryption key from an expired/revoked provider credential. Production connector startup/configuration authority must remain fail closed when the connector encryption key is invalid.
+
+For apparent provider failure, do not infer provider payload details from metrics. Use the provider's separately authorized operational surface when available.
+
+## Recovery
+
+### Contract or application regression
+
+Ship a reviewed forward fix that preserves the versioned device contract, identity mapping, idempotent receipt semantics, privacy boundaries, and no-reward policy. Use exact-image recovery from `deployment-readiness.md` only after database compatibility is confirmed.
+
+### Credential requires reauthorization
+
+Leave the connection in `REAUTH_REQUIRED` until a verified provider transport can obtain valid credentials. Do not fabricate or manually edit provider credentials.
+
+### Connector encryption key compromise
+
+Treat the key as compromised secret material. Rotate it through authorized production secret authority and define an explicit credential migration/re-authentication plan. Existing encrypted envelopes cannot be assumed decryptable under a replacement key. Do not retain the old key merely to preserve convenience after compromise.
+
+### Provider outage
+
+Keep provider-owned ingestion degraded or disabled without altering canonical Woof data. Restore normal ingestion only after the verified transport succeeds again.
+
+## Rollback
+
+Rollback code through `deployment-readiness.md`. Do not roll back:
+
+- a compromised credential-encryption key;
+- an already recorded local revocation merely to make a connector look connected;
+- payload hashes/import receipts to force a conflicting external object through;
+- canonical pet ownership or identity mappings by hand;
+- the rule that imported wearable observations are not reward eligible.
+
+## Verification
+
+Using synthetic provider/account/pet fixtures, require:
+
+1. production-disabled connector routes remain unavailable when `ENABLE_DOGOS_CONNECTORS=false`;
+2. a configured connector still requires usable encrypted credentials;
+3. a verified provider pet must map to a pet owned by the authenticated Woof user;
+4. a first valid import produces one canonical observation and one semantic import receipt;
+5. an exact replay remains duplicate-safe;
+6. changed content under the same external object ID is rejected;
+7. provider/kind rejection metrics recover without adding identifying labels;
+8. local disconnect removes local credentials, marks the connection locally revoked, and continues to report remote revocation as `NOT_CONFIGURED` unless a real remote path has since been implemented;
+9. imported wearable observations remain non-reward-eligible.
+
+## Evidence
+
+Capture only:
+
+- release SHA;
+- provider enum and observation kind;
+- outcome class (`IMPORTED`, `DUPLICATE`, `REJECTED`);
+- alert threshold/window;
+- synthetic fixture labels;
+- bounded HTTP/result classification;
+- recovery SHA and verification timestamps.
+
+Never capture provider access/refresh tokens, connector encryption keys, external account IDs, external object IDs, external pet IDs, raw provider payloads, user IDs, pet IDs, or decrypted credential envelopes.
+
+## Rehearsal
+
+Live rehearsal status: `NOT_YET_PROVEN`
+
+Promotion to `PROVEN` requires a production-like synthetic transport drill demonstrating valid import, exact replay, changed-object conflict rejection, credential degradation, local disconnect semantics, and safe connector disablement without changing reward authority.

--- a/ops/runbooks/database-migration.md
+++ b/ops/runbooks/database-migration.md
@@ -1,0 +1,151 @@
+# Database and migration incident runbook
+
+Runbook ID: `database-migration`  
+Repository qualification: `CODE_QUALIFIED`  
+Live rehearsal status: `NOT_YET_PROVEN`
+
+## Authority boundary
+
+Woof production deploys run `pnpm --filter @woof/database db:migrate:deploy` as the Fly release command before application rollout. A successful application image rollback does not reverse schema changes.
+
+There is currently no dedicated privacy-safe database connection-pool saturation gauge. `database_pool_saturation` remains a manual/deferred signal. Readiness must not be described as pool telemetry.
+
+This runbook does not authorize destructive production SQL, migration-history editing, or unreviewed schema rollback.
+
+## Detection
+
+Use this runbook for:
+
+- `readinessFailures`
+- `http5xx`
+- `application5xxBurst`
+- manual/deferred `database_pool_saturation`
+- release-command migration failures
+- schema incompatibility discovered during deployment rollback analysis
+
+Check liveness and readiness separately:
+
+```bash
+export WOOF_API_ORIGIN="https://woof-api-prod.fly.dev"
+curl --fail-with-body --silent --show-error \
+  "$WOOF_API_ORIGIN/api/v1/ops/health/live" | jq
+curl --fail-with-body --silent --show-error \
+  "$WOOF_API_ORIGIN/api/v1/ops/health/ready" | jq
+```
+
+A readiness failure can indicate database unavailability, but it is not sufficient evidence of connection-pool saturation.
+
+## Impact
+
+Classify the incident before recovery:
+
+- **Migration admission failure:** release command failed before new Machines became authoritative.
+- **Runtime database outage:** previously healthy release cannot reach or use the database.
+- **Schema/application mismatch:** application revision and schema are individually reachable but incompatible.
+- **Suspected saturation:** latency/timeouts suggest pressure, but no dedicated pool metric exists yet.
+- **Data-integrity concern:** writes may have partially succeeded or invariants may be violated. Escalate immediately and stop speculative repair.
+
+## Containment
+
+1. Stop subsequent application deploys while migration state is unknown.
+2. Do not run another migration merely because the first attempt failed.
+3. Preserve release-command logs and the migration name that was executing.
+4. If writes may be unsafe, disable the narrow affected product surface when a qualified feature/config boundary exists. Do not globally disable unrelated reads without evidence.
+5. Do not use a previous application image until schema compatibility with that image has been reviewed.
+6. Never expose `DATABASE_URL` in incident notes, terminal transcripts, screenshots, or tickets.
+
+## Diagnosis
+
+Record:
+
+- current application `releaseSha` when readiness is reachable;
+- intended release SHA;
+- exact migration directory names introduced by the suspect release;
+- whether the release command completed, failed, or timed out;
+- whether failure affects reads, writes, both, or one bounded operation;
+- whether the current schema is backward compatible with the previous image.
+
+Inspect the release history without changing state:
+
+```bash
+export FLY_APP="woof-api-prod"
+fly releases --app "$FLY_APP" --image
+```
+
+Inspect repository migration history from the exact release source. Do not infer production migration state solely from the repository.
+
+For suspected pool saturation, collect bounded evidence such as request latency, database timeout classes, and provider/platform connection telemetry if production authority exposes it. Because Woof has no maintained pool gauge yet, mark the conclusion as `UNCONFIRMED_POOL_PRESSURE` unless direct database/platform evidence exists.
+
+## Recovery
+
+### Migration failed before rollout
+
+Prefer fixing the migration or environment and re-running the normal deployment path. Prisma `migrate deploy` should remain the authority for applying committed production migrations.
+
+A failed migration must be understood before retry. If the migration is non-transactional or can partially apply, determine actual database state first through authorized database tooling.
+
+### Application/schema mismatch after rollout
+
+Prefer a forward-compatible application fix or a reviewed compensating migration. The recovery should make both the current and immediately previous application version compatible whenever practical, restoring rollback room.
+
+### Database unavailable
+
+Restore database/network/provider availability first. Do not mask a database outage by weakening readiness.
+
+### Suspected saturation
+
+Reduce load only through bounded, reversible mechanisms. Examples include disabling a high-volume optional worker or import path through its maintained feature/config boundary. Do not introduce an unreviewed global rate limit during the incident unless there is no safer containment path.
+
+## Rollback
+
+Database rollback is **not automatic** when redeploying a prior Fly image.
+
+Before application image rollback, answer all three:
+
+1. What schema changes have already reached the database?
+2. Is the prior image compatible with that schema?
+3. Can the prior image be deployed with the release command skipped so its older migration set does not run?
+
+When the answer is verified yes, follow `deployment-readiness.md` and use the exact prior image with `--skip-release-command`.
+
+If schema compensation is required, ship it as a reviewed migration with explicit forward behavior. Do not:
+
+- run `prisma migrate reset`;
+- drop the production database or schema;
+- delete or edit Prisma migration-history rows as an incident shortcut;
+- manually mark a failed migration successful without verifying actual schema state;
+- reverse a destructive migration from memory;
+- restore a backup over live production without a separate authorized recovery plan and impact review.
+
+## Verification
+
+Require:
+
+1. release command/migration step exits successfully for the intended release;
+2. `/ops/health/ready` is healthy and reports the intended `releaseSha`;
+3. representative reads succeed;
+4. representative writes succeed only in non-private test fixtures or controlled synthetic records;
+5. affected alert windows clear;
+6. no unexpected migration remains pending for the release;
+7. application version immediately before the incident is classified as compatible or incompatible with the recovered schema;
+8. any manual saturation conclusion is labeled with the evidence source rather than promoted from readiness alone.
+
+## Evidence
+
+Capture:
+
+- release SHA and Fly release/image identifier;
+- migration directory names;
+- release-command status and bounded error class;
+- schema-compatibility decision for rollback;
+- recovery migration/fix SHA;
+- health/readiness results;
+- alert clearance time.
+
+Never capture row contents, private object keys, credentials, connection strings, or raw database/provider exception payloads unless a separately authorized forensic process requires them.
+
+## Rehearsal
+
+Live rehearsal status: `NOT_YET_PROVEN`
+
+Promotion to `PROVEN` requires a production-like drill that demonstrates a failed release command or schema mismatch, prevents destructive shortcuts, exercises the compatibility gate, and restores a revision that passes readiness and a synthetic read/write journey.

--- a/ops/runbooks/deployment-readiness.md
+++ b/ops/runbooks/deployment-readiness.md
@@ -1,0 +1,182 @@
+# Deployment and readiness incident runbook
+
+Runbook ID: `deployment-readiness`  
+Repository qualification: `CODE_QUALIFIED`  
+Live rehearsal status: `NOT_YET_PROVEN`
+
+## Authority boundary
+
+This runbook is executable guidance for Woof's maintained production workflow and observability endpoints. It is not evidence that the Fly.io API app, Vercel Web app, production secrets, or a real rollback target are currently available.
+
+The maintained production API deployment target is `woof-api-prod`. The deployment workflow requires readiness to return the exact deployed Git revision before it accepts API rollout success. A green CI build is not a production deployment.
+
+Never paste `OPS_METRICS_TOKEN`, JWT material, provider credentials, database URLs, or other secrets into incident notes or shell history.
+
+## Detection
+
+Use this runbook for these alert-policy keys:
+
+- `telemetryMissing`
+- `unknownRelease`
+- `readinessFailures`
+- `http5xx`
+- `application5xxBurst`
+- `requestDurationInvalid`
+
+Start with the public readiness boundary:
+
+```bash
+export WOOF_API_ORIGIN="https://woof-api-prod.fly.dev"
+curl --fail-with-body --silent --show-error \
+  "$WOOF_API_ORIGIN/api/v1/ops/health/ready" | jq
+```
+
+Expected healthy shape includes `status: "ready"` and a non-placeholder `releaseSha`.
+
+If operational metrics access is available, read it without printing the token:
+
+```bash
+test -n "${OPS_METRICS_TOKEN:-}" || { echo "OPS_METRICS_TOKEN unavailable" >&2; exit 2; }
+curl --fail-with-body --silent --show-error \
+  -H "x-woof-ops-token: ${OPS_METRICS_TOKEN}" \
+  "$WOOF_API_ORIGIN/api/v1/ops/metrics.json" | jq
+```
+
+`/ops/metrics` and `/ops/metrics.json` intentionally fail closed when the operational token is absent. Do not weaken the guard during an incident.
+
+## Impact
+
+Treat readiness failure as a release-admission problem, not automatically as total process death. Liveness, database readiness, release identity, and user-facing requests answer different questions.
+
+Treat missing telemetry as an observability incident even when user traffic appears healthy. Do not declare recovery from a dashboard that stopped receiving data.
+
+Treat an unknown release identity as a provenance incident. Do not assume the running image corresponds to the latest `main` commit.
+
+## Containment
+
+1. Stop manual production deploys until the running release identity is known.
+2. Do not merge a new release solely to overwrite an unexplained bad release.
+3. If an active deploy is failing readiness, preserve the deployment/release logs before retrying.
+4. If the failure began immediately after a deploy and the previous image is known-good, prepare an image rollback only after the database-compatibility gate below is satisfied.
+5. If the failure is isolated to one optional integration, prefer disabling that integration through its qualified configuration boundary over rolling back the entire application.
+
+## Diagnosis
+
+Record these facts before changing state:
+
+```bash
+export FLY_APP="woof-api-prod"
+fly status --app "$FLY_APP"
+fly releases --app "$FLY_APP" --image
+```
+
+Also record:
+
+- alert key and first observed time;
+- current `releaseSha` from `/ops/health/ready` when reachable;
+- intended Git SHA from the deployment workflow or release record;
+- whether database migrations ran for the suspect release;
+- whether failure affects readiness, user requests, Web only, API only, or an optional provider;
+- the smallest reproducible user-facing request that demonstrates the incident, without private user data.
+
+If `/health/live` is reachable while `/health/ready` is not, inspect database/release readiness before assuming process failure:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  "$WOOF_API_ORIGIN/api/v1/ops/health/live" | jq
+```
+
+Do not use HTTP health counters to infer WebSocket/realtime health. Realtime has a separate manual/deferred runbook until its dedicated metric exists.
+
+## Recovery
+
+### Forward recovery
+
+Prefer a forward fix when:
+
+- the suspect release ran a schema migration that may not be backward compatible;
+- the previous image is unavailable;
+- the failure is configuration-specific and can be corrected without code rollback;
+- a small, reviewed fix has lower blast radius than reverting application state.
+
+After deploying a fix, require readiness to identify the exact intended revision. The maintained production workflow already enforces this for automated API deploys.
+
+### Previous-image recovery
+
+Fly rollback is a redeployment of a prior image, not database time travel. List exact release images:
+
+```bash
+fly releases --app "$FLY_APP" --image
+```
+
+Set `PRIOR_IMAGE` only after identifying a known-good release:
+
+```bash
+export PRIOR_IMAGE="registry.fly.io/woof-api-prod:deployment-REPLACE_WITH_VERIFIED_IMAGE"
+```
+
+Before redeploying it, perform the database compatibility gate:
+
+- Did the failed release run any migration?
+- Can the previous image operate safely against the current schema?
+- Would its configured `release_command` try to run an old migration set?
+
+If and only if the current schema is verified compatible with the prior image, redeploy the exact image and skip the release command so rollback does not rerun old migrations:
+
+```bash
+fly deploy \
+  --app "$FLY_APP" \
+  --config apps/api/fly.toml \
+  --image "$PRIOR_IMAGE" \
+  --remote-only \
+  --skip-release-command
+```
+
+If schema compatibility is unknown, **do not execute this rollback**. Escalate to `database-migration.md` and use a reviewed forward/compensating migration plan.
+
+## Rollback
+
+There is intentionally no `fly releases rollback` command in this runbook. Woof rollback authority is the exact prior container image plus a database-compatibility decision.
+
+Do not:
+
+- run `prisma migrate reset` in production;
+- delete migration-history rows to force a release through;
+- deploy an older image and assume the database reverted with it;
+- use `--strategy immediate` merely to make an uncertain rollback faster;
+- accept a release that is healthy but reports the wrong `releaseSha`.
+
+## Verification
+
+Recovery is not complete until all applicable checks pass:
+
+1. `/api/v1/ops/health/live` succeeds.
+2. `/api/v1/ops/health/ready` succeeds.
+3. `releaseSha` equals the intended deployed Git revision.
+4. Guarded operational metrics are available when they were configured before the incident.
+5. The triggering alert condition has cleared for at least one full alert evaluation window.
+6. A representative authenticated API journey succeeds without private test fixtures.
+7. If Web was involved, its production endpoint resolves and talks to the intended API origin.
+8. No new migration or provider failure was introduced during recovery.
+
+## Evidence
+
+Capture only low-sensitivity operational evidence:
+
+- incident start/end timestamps;
+- alert names and threshold states;
+- intended Git SHA and observed `releaseSha`;
+- Fly release version and image identifier;
+- deployment workflow run ID;
+- migration identifiers, never database contents;
+- command exit codes and bounded health responses;
+- recovery image/fix SHA;
+- verification checklist result.
+
+Do not copy request bodies, access tokens, push subscription material, health/behavior provider bodies, object keys, or user identifiers into the incident artifact.
+
+## Rehearsal
+
+Live rehearsal status: `NOT_YET_PROVEN`
+
+Promotion to `PROVEN` requires a recorded production-like or authorized production drill that demonstrates exact release identification, a safe recovery path, readiness verification, and rollback behavior with the database compatibility decision explicitly exercised.

--- a/ops/runbooks/privacy-telemetry.md
+++ b/ops/runbooks/privacy-telemetry.md
@@ -1,0 +1,143 @@
+# Privacy and telemetry incident runbook
+
+Runbook ID: `privacy-telemetry`  
+Repository qualification: `CODE_QUALIFIED`  
+Live rehearsal status: `NOT_YET_PROVEN`
+
+## Authority boundary
+
+This runbook covers suspected exposure of private user/pet content, credentials, provider diagnostics, object identifiers, push subscription material, or telemetry that violates Woof's privacy-minimized operational contracts.
+
+Current code-qualified boundaries include:
+
+- operational metrics are low-cardinality and declare that user IDs, pet IDs, provider external IDs, request URLs, and raw payloads are not collected;
+- API Sentry is configured with `sendDefaultPii: false` and strips request, user, extra, breadcrumbs, span data, and free-form span descriptions before egress;
+- Health Lens and Behavior Vision reduce provider failures to bounded classes rather than reading/logging private provider error bodies or arbitrary exception messages;
+- private Storage suppresses object-key/filename/provider-detail telemetry and normalizes raw S3 errors before they escape upward;
+- Web Push telemetry suppresses user IDs, notification content, endpoint/key material, and provider exception content;
+- external integration configuration or CI evidence is not production qualification.
+
+This repository does not itself establish live provider retention, routing, deletion, or secret-rotation authority. Those require the deployed provider/platform controls.
+
+## Detection
+
+Use this runbook for manual signal `privacy_or_secret_exposure`, including:
+
+- a credential or token visible in logs, issue trackers, CI output, screenshots, chat, or telemetry;
+- user/pet/request/provider payload content visible in operational metrics or Sentry;
+- Health/Behavior provider bodies or arbitrary exception details escaping the bounded failure boundary;
+- private object keys or filenames appearing in logs;
+- push endpoint, `p256dh`, `auth`, title, body, or user identity appearing in telemetry;
+- an integration being represented as production-qualified without live deployment evidence.
+
+Do not reproduce the suspect sensitive value in the incident record to prove the incident. Record its **class**, location, time range, release SHA, and bounded count instead.
+
+## Impact
+
+Classify the incident:
+
+- **secret exposure:** JWT, operational metrics token, connector credential-encryption key, provider API key/token, S3 credentials, VAPID private key, deployment token, or equivalent secret;
+- **private payload exposure:** health concern/image context, behavior evidence, notification content, request body/query, caregiver note, chat content, or provider payload;
+- **identifier exposure:** user/pet IDs, private object keys, push endpoints/keys, provider external IDs, session IDs;
+- **provider diagnostic exposure:** arbitrary upstream error body/message/stack that can contain request/private context;
+- **status inflation:** repository/configuration evidence is represented as live production evidence;
+- **unknown scope:** evidence is incomplete. Treat scope as unresolved, not zero.
+
+A privacy incident can be severe even when availability and error-rate metrics are green.
+
+## Containment
+
+1. Stop further exposure through the narrowest qualified boundary available.
+2. If one optional integration is responsible, disable that integration through its maintained configuration boundary rather than weakening global security/privacy controls.
+3. If a secret may be exposed, rotate or revoke it through the owning production/provider authority as soon as that authority is available. Do not wait for code cleanup before invalidating a usable exposed credential.
+4. If the connector encryption key is compromised, invoke the migration/reauthorization implications in `connector-ingestion.md`; do not merely replace the key and assume old ciphertext remains usable.
+5. If JWT signing material is compromised, follow `auth-session.md` and treat rotation as global session invalidation.
+6. Do not paste raw private payloads or secrets into GitHub issues, PRs, Slack/chatops, email, or new debugging logs.
+7. Do not disable Sentry scrubbers, operational metric privacy rules, Storage normalization, Health/Behavior failure normalization, or Push telemetry suppression to gain diagnostic detail.
+8. Preserve low-sensitivity metadata before deleting/rotating provider-side evidence when policy and authority permit.
+
+## Diagnosis
+
+Record:
+
+- exact application release SHA;
+- first/last observed timestamps;
+- exposure class from the Impact section;
+- code path or telemetry destination;
+- whether the exposed value was usable as a credential or only private content/identifier;
+- whether the source was application-owned, CI, provider-owned, or manually copied;
+- bounded count of affected events when available without querying raw private payloads.
+
+Use synthetic marker tests to reproduce the **class** of exposure. Never replay a real secret or private user payload.
+
+For Sentry-related incidents, inspect source authority first: `scrubSentryEvent` removes request/user/extra/breadcrumbs, while transaction scrubbing removes span data and free-form descriptions. A live-provider verification still requires authorized Sentry access and is separate evidence.
+
+For integration telemetry, compare against `docs/EXTERNAL_INTEGRATION_INVENTORY.json`. Every current external runtime remains `productionQualified: false` unless a later release explicitly changes that classification with live evidence.
+
+For Web Push data at rest, note that migration of persisted subscription material to encrypted envelopes is a distinct data-migration concern. Treat exposed endpoint/key material as sensitive regardless of whether that migration has completed.
+
+## Recovery
+
+### Code-owned telemetry regression
+
+Remove the sensitive field or raw diagnostic at the earliest owning boundary, add a synthetic privacy test, and add/strengthen a fail-closed source contract so the same pattern cannot quietly return.
+
+### Exposed credential
+
+Rotate/revoke through the authoritative external secret/provider path. Then update deployment/runtime configuration without committing the replacement secret. Verify the old credential is rejected when the provider supports a safe check and the new credential works only from the intended target.
+
+### Provider-side retained data
+
+Use the provider's authorized deletion/retention controls when available. Repository changes cannot prove provider-side deletion. Record provider receipt/confirmation without copying the deleted content back into Woof evidence.
+
+### Status inflation
+
+Correct documentation/product claims to distinguish repository-qualified, configured, deployed, and live-black-box-proven states. Do not fix inflated claims by lowering technical gates.
+
+## Rollback
+
+Rollback privacy/security code only through `deployment-readiness.md` and only if the previous image preserves or strengthens the relevant privacy boundary.
+
+Never roll back:
+
+- to a known-compromised secret;
+- to a release that logs raw provider bodies/messages/stacks;
+- to a release that exposes private object keys or Push subscription/content data;
+- to Sentry configuration with weaker PII scrubbing;
+- a credential revocation merely because rotation caused operational friction.
+
+If an older application image requires a compromised credential to function, prefer a forward recovery.
+
+## Verification
+
+Use synthetic markers and require:
+
+1. operational metrics contain no user ID, pet ID, provider external ID, request URL/query/body, or raw payload marker;
+2. Sentry scrubber tests prove request/user/extra/breadcrumb/span data is removed before egress;
+3. Health Lens and Behavior Vision synthetic private provider error bodies/messages do not appear in logs or surfaced exceptions;
+4. Storage synthetic filenames/object keys/provider messages do not appear in telemetry and raw provider failures are normalized;
+5. Push synthetic user/content/endpoint/key/provider-message markers do not appear in telemetry;
+6. any rotated credential is absent from repository history introduced by the recovery change and is no longer accepted where provider verification is safely available;
+7. external integration inventory still refuses production qualification without live evidence;
+8. the triggering exposure path is absent for at least one representative synthetic execution after recovery.
+
+## Evidence
+
+Store only privacy-minimized incident metadata:
+
+- exposure class;
+- exact release SHA;
+- affected component/provider name;
+- first/last observed time;
+- bounded event count;
+- rotation/revocation receipt identifier when it is itself non-secret;
+- recovery SHA;
+- synthetic verification results.
+
+Do not store the exposed secret/private value, raw request/provider body, user/pet identity, object key, push endpoint/key, chat text, caregiver note, or health/behavior content in the incident artifact.
+
+## Rehearsal
+
+Live rehearsal status: `NOT_YET_PROVEN`
+
+Promotion to `PROVEN` requires an authorized production-like drill using synthetic canary markers that demonstrates containment, credential rotation or bounded feature disablement when applicable, privacy-safe evidence capture, and post-recovery verification without placing real private data into the incident workflow.

--- a/ops/runbooks/realtime.md
+++ b/ops/runbooks/realtime.md
@@ -1,0 +1,160 @@
+# Realtime authorization incident runbook
+
+Runbook ID: `realtime`  
+Repository qualification: `CODE_QUALIFIED`  
+Live rehearsal status: `NOT_YET_PROVEN`
+
+## Authority boundary
+
+Woof realtime chat is server-authoritative. A socket is admitted only after JWT verification yields a user ID, session ID, and valid expiry, and the database-backed session authority confirms that session is active. Sensitive socket actions re-check active-session authority before work is accepted.
+
+Current maintained realtime semantics include:
+
+- session expiry clears socket authority, emits `session:expired`, and disconnects;
+- revoked/inactive session detection clears authority, emits `session:revoked`, and disconnects;
+- chat messages are persisted before successful delivery;
+- conversation access and recipient eligibility are checked through chat security;
+- recipients are filtered against currently active sessions before emission;
+- message, typing, and membership actions have bounded in-memory admission policies;
+- arbitrary exception messages are not logged; realtime rejection telemetry currently exposes only bounded exception class names.
+
+There is **no dedicated low-cardinality realtime admission/error metric yet**. `realtime_admission_error_rate` remains manual/deferred. HTTP request counters are not a substitute for socket health.
+
+## Detection
+
+Use this runbook for manual/deferred signal `realtime_admission_error_rate`, or reports of:
+
+- valid sessions unable to establish realtime state;
+- revoked or expired sessions continuing to act;
+- unauthorized users receiving conversation events;
+- block/conversation membership changes not taking effect;
+- unexpected message duplication or delivery before persistence;
+- admission/rate-limit storms;
+- sockets remaining connected after authority is revoked.
+
+Because no maintained realtime health metric exists, detection currently requires an authorized synthetic client journey, bounded server logs, or direct operator observation. Label evidence `MANUAL_DEFERRED` rather than pretending it came from Prometheus.
+
+## Impact
+
+Classify:
+
+- **connection admission:** valid synthetic session cannot reach `session:ready`;
+- **stale session authority:** revoked/expired session remains usable;
+- **recipient authorization:** a user outside the authorized recipient set receives message/typing events;
+- **conversation authorization:** join/send/typing succeeds without current conversation access;
+- **delivery integrity:** an unpersisted or duplicate message is emitted as new;
+- **rate-limit abuse:** admission buckets reject excessive message/typing/membership traffic;
+- **general runtime failure:** realtime is affected because database/auth/application runtime is unhealthy.
+
+Treat stale-session or unauthorized-recipient behavior as a security incident even when ordinary HTTP/readiness is green.
+
+## Containment
+
+1. Do not disable session revalidation, chat-security recipient filtering, conversation access checks, or realtime admission limits to restore connectivity.
+2. If the issue is session compromise, use `auth-session.md` for user/global revocation authority.
+3. If unauthorized recipient delivery is confirmed and there is no dedicated realtime kill switch, stop or roll forward/back the affected API release through the production runtime authority. Do not invent an undocumented socket bypass or operator endpoint.
+4. Preserve bounded release and event-class evidence without copying chat text, room IDs tied to users, JWTs, session IDs, or private conversation payloads.
+5. If the failure follows database/readiness degradation, follow `database-migration.md` before treating it as a socket-local defect.
+6. Do not increase rate limits during an incident merely to make rejection symptoms disappear. Determine whether the traffic is legitimate, abusive, or a client retry loop first.
+
+## Diagnosis
+
+Start with HTTP liveness/readiness to exclude broad process/database failure:
+
+```bash
+export WOOF_API_ORIGIN="https://woof-api-prod.fly.dev"
+curl --fail-with-body --silent --show-error \
+  "$WOOF_API_ORIGIN/api/v1/ops/health/live" | jq
+curl --fail-with-body --silent --show-error \
+  "$WOOF_API_ORIGIN/api/v1/ops/health/ready" | jq
+```
+
+Then use an authorized synthetic account pair and inspect only bounded outcomes:
+
+1. connect with a valid JWT/session and require `session:ready`;
+2. connect with missing/invalid/expired auth and require disconnect without ready state;
+3. revoke the synthetic session through maintained auth authority, then attempt a sensitive realtime action;
+4. verify the socket is rejected/disconnected and cannot continue sending;
+5. exercise a conversation available to both synthetic users and a conversation unavailable to one user;
+6. verify unauthorized join/send/typing is rejected;
+7. verify only authorized active recipients receive the event;
+8. exercise admission thresholds using synthetic traffic and confirm bounded `rate_limited` responses.
+
+Current rate policies are process-local:
+
+- message: 5 per second and 60 per minute;
+- typing: 8 per 5 seconds and 60 per minute;
+- membership: 10 per 5 seconds and 60 per minute.
+
+Do not treat these process-local buckets as a distributed/global abuse limit across replicas.
+
+## Recovery
+
+### Session-authority regression
+
+Repair the admission/revalidation path while preserving database-backed session checks on connect and sensitive actions. If a session is revoked or expired, recovery must continue to remove its socket authority rather than merely hiding the disconnect signal.
+
+### Recipient/conversation authorization regression
+
+Repair chat-security and active-session filtering. Prefer fail-closed delivery over broadcasting to an uncertain recipient set.
+
+### Delivery-integrity regression
+
+Restore persist-before-emit behavior and idempotent client-message handling. Do not emit a successful message before canonical persistence succeeds.
+
+### Rate-limit/client retry regression
+
+Fix the client/server retry behavior while preserving bounded admission. Any policy change should be a reviewed product/abuse-control decision, not incident-time convenience.
+
+### Release regression
+
+Use a reviewed forward fix or `deployment-readiness.md` exact-image recovery subject to database compatibility.
+
+## Rollback
+
+Realtime code rollback follows `deployment-readiness.md` and must preserve:
+
+- database-backed active session authority;
+- expiry/revocation disconnect semantics;
+- conversation membership/block authorization;
+- active-session recipient filtering;
+- persist-before-emit messaging;
+- idempotent message semantics;
+- bounded admission policies.
+
+Do not roll back to a release that relied on token verification alone without server-side session authority or that broadcast realtime presence/events globally.
+
+## Verification
+
+Using synthetic accounts and conversations, require:
+
+1. valid active session reaches `session:ready`;
+2. invalid/expired session cannot become ready;
+3. current-session or all-session revocation prevents subsequent sensitive socket actions and disconnects the affected socket;
+4. token expiry emits `session:expired` and removes authority;
+5. revoked authority emits `session:revoked` when detected and removes authority;
+6. unauthorized conversation join/send/typing remains rejected;
+7. blocked/ineligible/revoked recipients do not receive new events;
+8. one logical message is persisted once and emitted as new at most once;
+9. message/typing/membership admission policies still return bounded rate-limit outcomes under synthetic excess traffic;
+10. HTTP readiness remains healthy on the intended release;
+11. realtime evidence is still labeled manual/deferred until a dedicated privacy-safe metric exists.
+
+## Evidence
+
+Capture only:
+
+- exact release SHA;
+- synthetic fixture label;
+- event class (`connect`, `message`, `typing`, `membership`, `revocation`, `expiry`);
+- bounded outcome (`ready`, `unauthorized`, `rate_limited`, `revoked`, `expired`, `delivered`);
+- timestamps;
+- recovery SHA/image and verification pass/fail.
+
+Never capture JWTs, session IDs, user IDs, conversation IDs from real users, chat text, media URLs, socket handshake auth, block targets, or raw exception payloads.
+
+## Rehearsal
+
+Live rehearsal status: `NOT_YET_PROVEN`
+
+Promotion to `PROVEN` requires a production-like synthetic socket drill that demonstrates valid admission, session revocation/expiry propagation, unauthorized-conversation rejection, authorized-recipient filtering, persist-before-emit/idempotency behavior, and bounded admission under excess traffic. A dedicated realtime metric remains a separate prerequisite before realtime alert routing can be called code-qualified.

--- a/ops/runbooks/runbook-registry.v1.json
+++ b/ops/runbooks/runbook-registry.v1.json
@@ -1,0 +1,100 @@
+{
+  "version": "woof-operational-runbooks-v1",
+  "alertPolicy": "ops/alerts/woof-api-alert-policy.v1.json",
+  "liveRehearsalStatus": "NOT_YET_PROVEN",
+  "authority": {
+    "repositoryQualified": true,
+    "productionQualified": false,
+    "productionQualificationRequires": [
+      "real production deployment authority",
+      "target-environment credentials and networking",
+      "at least one recorded live or production-like incident drill per runbook",
+      "evidence that recovery and rollback commands work against the deployed platform",
+      "explicit operator ownership and escalation path"
+    ]
+  },
+  "runbooks": [
+    {
+      "id": "deployment-readiness",
+      "path": "ops/runbooks/deployment-readiness.md",
+      "alerts": [
+        "telemetryMissing",
+        "unknownRelease",
+        "readinessFailures",
+        "http5xx",
+        "application5xxBurst",
+        "requestDurationInvalid"
+      ],
+      "manualSignals": [],
+      "owner": "production-runtime",
+      "liveRehearsalStatus": "NOT_YET_PROVEN"
+    },
+    {
+      "id": "database-migration",
+      "path": "ops/runbooks/database-migration.md",
+      "alerts": ["readinessFailures", "http5xx", "application5xxBurst"],
+      "manualSignals": ["database_pool_saturation"],
+      "owner": "database-runtime",
+      "liveRehearsalStatus": "NOT_YET_PROVEN"
+    },
+    {
+      "id": "auth-session",
+      "path": "ops/runbooks/auth-session.md",
+      "alerts": ["auth5xx", "http5xx", "application5xxBurst"],
+      "manualSignals": [],
+      "owner": "auth-runtime",
+      "liveRehearsalStatus": "NOT_YET_PROVEN"
+    },
+    {
+      "id": "api-degradation",
+      "path": "ops/runbooks/api-degradation.md",
+      "alerts": [
+        "todayReadP95Ms",
+        "caregiverTransition5xx",
+        "deviceContractRejections",
+        "http5xx",
+        "application5xxBurst",
+        "requestDurationInvalid"
+      ],
+      "manualSignals": [],
+      "owner": "api-runtime",
+      "liveRehearsalStatus": "NOT_YET_PROVEN"
+    },
+    {
+      "id": "connector-ingestion",
+      "path": "ops/runbooks/connector-ingestion.md",
+      "alerts": ["connectorRejected", "http5xx", "application5xxBurst"],
+      "manualSignals": [],
+      "owner": "connectors-runtime",
+      "liveRehearsalStatus": "NOT_YET_PROVEN"
+    },
+    {
+      "id": "privacy-telemetry",
+      "path": "ops/runbooks/privacy-telemetry.md",
+      "alerts": [],
+      "manualSignals": ["privacy_or_secret_exposure"],
+      "owner": "security-privacy",
+      "liveRehearsalStatus": "NOT_YET_PROVEN"
+    },
+    {
+      "id": "realtime",
+      "path": "ops/runbooks/realtime.md",
+      "alerts": [],
+      "manualSignals": ["realtime_admission_error_rate"],
+      "owner": "realtime-runtime",
+      "liveRehearsalStatus": "NOT_YET_PROVEN"
+    }
+  ],
+  "deferredSignals": {
+    "realtime_admission_error_rate": {
+      "detectionMode": "manual_deferred",
+      "runbook": "realtime",
+      "reason": "No dedicated low-cardinality realtime admission/error metric exists yet. HTTP counters must not be used as a substitute for socket health."
+    },
+    "database_pool_saturation": {
+      "detectionMode": "manual_deferred",
+      "runbook": "database-migration",
+      "reason": "No privacy-safe connection-pool saturation gauge exists yet. Readiness must not be described as pool telemetry."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Advances **Phase 3 of #100** by turning Woof's existing alert/runtime authority into executable, source-bound incident runbooks. This does not close #100; backup/restore rehearsal, bounded load qualification, and live monitoring/routing/drills remain separate phases.

## Runbook authority

Adds a machine-readable registry plus seven incident runbooks covering:

- deployment/readiness and exact-release recovery;
- database/migration incidents;
- authentication/session revocation and credential compromise;
- API degradation, Today/read latency, caregiver transitions, and device-contract regressions;
- connector ingestion, idempotency, credential state, and safe disablement;
- privacy/telemetry and secret exposure;
- realtime admission, session revocation/expiry, recipient authorization, persistence, and rate limits.

The runbooks bind to maintained Woof behavior instead of inventing operator powers. Examples include real `/ops/health/live`, `/ready`, guarded metrics, user-scoped `logout`/`logout-all`, Fly exact-image recovery, production connector disablement, caregiver replay/capability authority, connector receipt/hash semantics, and database-backed realtime session checks.

## Fail-closed qualification

Adds `dogOS Operational Runbooks CI` and `.github/scripts/assert-operational-runbooks.py`.

The contract verifies:

- every Phase 2 alert-policy key maps to at least one runbook;
- every runbook has an explicit owner role and required containment/diagnosis/recovery/rollback/verification/evidence/rehearsal structure;
- realtime admission/error rate and database pool saturation remain explicitly `manual_deferred` while dedicated privacy-safe metrics are absent;
- auth/session, realtime, caregiver, connector, production-config, operational-metric privacy, Sentry scrubber, and external-integration authority markers still exist in source;
- runbooks do not contain obvious literal credentials;
- no external integration is silently promoted to production-qualified status.

The workflow intentionally uses only checkout, Git, JSON parsing, and Python so the recovery documentation remains qualifiable even if the Node dependency/toolchain surface is degraded.

## Evidence boundary

Initial branch state intentionally remains:

- `repositoryQualified: false`;
- runbook `Repository qualification: PENDING`;
- `productionQualified: false`;
- `liveRehearsalStatus: NOT_YET_PROVEN`.

After the complete pre-promotion exact head is green, repository qualification can be promoted in a separate final commit and requalified. CI success will still not constitute a live drill or production deployment claim.

## Deliberate non-goals

This PR does not:

- claim production scraping, paging, Sentry receipt, or alert routing is live;
- claim realtime or DB pool alerts exist when their dedicated metrics do not;
- perform a real backup/restore rehearsal;
- establish RPO/RTO guarantees;
- provide production capacity/load evidence;
- invent arbitrary operator session-revocation or connector OAuth APIs;
- treat application-image rollback as database rollback;
- paste private payloads or credentials into incident evidence.

## Exit boundary

If qualified and merged, **#100 Phase 3 becomes code-qualified**. Phases 4, 5, and 6 remain open and require real environment/provider evidence.