### PR TITLE
Audit generated iOS native artifacts before signing

### DIFF
--- a/.github/scripts/audit-ios-native-artifact.py
+++ b/.github/scripts/audit-ios-native-artifact.py
@@ -8,13 +8,21 @@ ROOT = Path(__file__).resolve().parents[2]
 MOBILE = ROOT / "apps" / "mobile"
 IOS = MOBILE / "ios"
 REPORT = ROOT / "ios-native-artifact-report.json"
-
-EXPECTED_PERMISSION_STRINGS = {
-    "NSCameraUsageDescription": "Woof uses the camera only when you choose to take a pet photo.",
-    "NSPhotoLibraryUsageDescription": "Woof uses your photo library only when you choose a pet or profile photo.",
-    "NSLocationWhenInUseUsageDescription": "Woof can use your location while the app is open to find nearby pet-friendly places and matches.",
-}
+APP_CONFIG = MOBILE / "app.json"
 EXPECTED_BUNDLE_ID = "com.woof.app"
+
+PERMISSION_PLUGIN_AUTHORITY = {
+    "NSCameraUsageDescription": ("expo-camera", "cameraPermission"),
+    "NSPhotoLibraryUsageDescription": ("expo-image-picker", "photosPermission"),
+    "NSLocationWhenInUseUsageDescription": ("expo-location", "locationWhenInUsePermission"),
+}
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
 
 
 def load_plist(path: Path):
@@ -35,7 +43,7 @@ def privacy_manifest_summary(path: Path):
             }
         )
     return {
-        "path": str(path.relative_to(ROOT)),
+        "path": display_path(path),
         "tracking": data.get("NSPrivacyTracking"),
         "trackingDomains": data.get("NSPrivacyTrackingDomains", []) or [],
         "accessedAPITypes": sorted(accessed, key=lambda row: str(row.get("type"))),
@@ -43,33 +51,88 @@ def privacy_manifest_summary(path: Path):
     }
 
 
-if not IOS.is_dir():
-    raise SystemExit("generated iOS directory is missing; expo prebuild did not materialize native authority")
+def plugin_options(expo_config: dict) -> dict[str, dict]:
+    resolved = {}
+    for plugin in expo_config.get("plugins", []) or []:
+        if not isinstance(plugin, list) or len(plugin) < 2:
+            continue
+        name, options = plugin[0], plugin[1]
+        if isinstance(name, str) and isinstance(options, dict):
+            resolved[name] = options
+    return resolved
 
-info_candidates = sorted(IOS.glob("*/Info.plist"))
+
+source = json.loads(APP_CONFIG.read_text(encoding="utf-8"))
+expo = source.get("expo", {})
+source_info = expo.get("ios", {}).get("infoPlist", {}) or {}
+plugins = plugin_options(expo)
+expected_permissions = {
+    key: source_info.get(key) for key in PERMISSION_PLUGIN_AUTHORITY
+}
+source_permission_conflicts = []
+errors = []
+
+for key, (plugin_name, option_name) in PERMISSION_PLUGIN_AUTHORITY.items():
+    expected = expected_permissions.get(key)
+    plugin_value = plugins.get(plugin_name, {}).get(option_name)
+    if not isinstance(expected, str) or not expected.strip():
+        source_permission_conflicts.append(
+            f"app.json ios.infoPlist is missing non-empty {key}"
+        )
+    if expected != plugin_value:
+        source_permission_conflicts.append(
+            f"app.json permission authority conflict for {key}: "
+            f"ios.infoPlist={expected!r}, {plugin_name}.{option_name}={plugin_value!r}"
+        )
+
+errors.extend(source_permission_conflicts)
+
+info_path = None
+info = {}
+info_candidates = sorted(IOS.glob("*/Info.plist")) if IOS.is_dir() else []
 if len(info_candidates) != 1:
-    raise SystemExit(f"expected exactly one generated app Info.plist, found {len(info_candidates)}")
-info_path = info_candidates[0]
-info = load_plist(info_path)
+    errors.append(f"expected exactly one generated app Info.plist, found {len(info_candidates)}")
+else:
+    info_path = info_candidates[0]
+    try:
+        info = load_plist(info_path)
+    except Exception as exc:
+        errors.append(f"could not parse generated Info.plist: {exc}")
 
-for key, expected in EXPECTED_PERMISSION_STRINGS.items():
+for key, expected in expected_permissions.items():
     actual = info.get(key)
     if actual != expected:
-        raise SystemExit(f"generated Info.plist {key} mismatch: expected {expected!r}, got {actual!r}")
+        errors.append(
+            f"generated Info.plist {key} mismatch: expected {expected!r}, got {actual!r}"
+        )
 
-project_files = sorted(IOS.glob("*.xcodeproj/project.pbxproj"))
+project_path = None
+project_text = ""
+project_files = sorted(IOS.glob("*.xcodeproj/project.pbxproj")) if IOS.is_dir() else []
 if len(project_files) != 1:
-    raise SystemExit(f"expected exactly one generated Xcode project, found {len(project_files)}")
-project_path = project_files[0]
-project_text = project_path.read_text(encoding="utf-8")
+    errors.append(f"expected exactly one generated Xcode project, found {len(project_files)}")
+else:
+    project_path = project_files[0]
+    try:
+        project_text = project_path.read_text(encoding="utf-8")
+    except Exception as exc:
+        errors.append(f"could not read generated Xcode project: {exc}")
+
 bundle_matches = sorted(set(re.findall(r"PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);", project_text)))
 if EXPECTED_BUNDLE_ID not in bundle_matches:
-    raise SystemExit(
-        f"generated Xcode project does not contain bundle id {EXPECTED_BUNDLE_ID!r}; found {bundle_matches!r}"
+    errors.append(
+        f"generated Xcode project does not contain bundle id {EXPECTED_BUNDLE_ID!r}; "
+        f"found {bundle_matches!r}"
     )
 
-app_privacy_candidates = sorted(IOS.glob("*/PrivacyInfo.xcprivacy"))
-app_privacy = [privacy_manifest_summary(path) for path in app_privacy_candidates]
+app_privacy = []
+app_privacy_parse_errors = []
+app_privacy_candidates = sorted(IOS.glob("*/PrivacyInfo.xcprivacy")) if IOS.is_dir() else []
+for path in app_privacy_candidates:
+    try:
+        app_privacy.append(privacy_manifest_summary(path))
+    except Exception as exc:
+        app_privacy_parse_errors.append({"path": display_path(path), "error": str(exc)})
 
 resolved_dependency_manifests = {}
 search_roots = [ROOT / "node_modules" / ".pnpm", MOBILE / "node_modules"]
@@ -83,15 +146,15 @@ for search_root in search_roots:
             continue
         if IOS in resolved.parents:
             continue
-        resolved_dependency_manifests[str(resolved)] = path
+        resolved_dependency_manifests[str(resolved)] = resolved
 
 dependency_privacy = []
-parse_errors = []
-for resolved, display_path in sorted(resolved_dependency_manifests.items()):
+dependency_parse_errors = []
+for resolved in sorted(resolved_dependency_manifests.values(), key=str):
     try:
-        dependency_privacy.append(privacy_manifest_summary(Path(resolved)))
+        dependency_privacy.append(privacy_manifest_summary(resolved))
     except Exception as exc:  # pragma: no cover - evidence capture for third-party manifests
-        parse_errors.append({"path": str(display_path), "error": str(exc)})
+        dependency_parse_errors.append({"path": display_path(resolved), "error": str(exc)})
 
 required_reason_union = {}
 for manifest in dependency_privacy:
@@ -101,18 +164,38 @@ for manifest in dependency_privacy:
             continue
         required_reason_union.setdefault(api_type, set()).update(row.get("reasons") or [])
 
+required_reason_union = {
+    key: sorted(values) for key, values in sorted(required_reason_union.items())
+}
+
+if app_privacy_parse_errors:
+    errors.append(
+        f"could not parse {len(app_privacy_parse_errors)} generated app privacy manifest(s)"
+    )
+if dependency_parse_errors:
+    errors.append(
+        f"could not parse {len(dependency_parse_errors)} dependency privacy manifest(s)"
+    )
+if required_reason_union and not app_privacy:
+    errors.append(
+        "installed dependencies declare required-reason APIs but generated app target has no "
+        "PrivacyInfo.xcprivacy; inspect dependencyRequiredReasonUnion before configuring app-level aggregation"
+    )
+
 report = {
-    "generatedInfoPlist": str(info_path.relative_to(ROOT)),
-    "generatedXcodeProject": str(project_path.relative_to(ROOT)),
+    "sourcePermissionDescriptions": expected_permissions,
+    "sourcePermissionConflicts": source_permission_conflicts,
+    "generatedInfoPlist": display_path(info_path) if info_path else None,
+    "generatedXcodeProject": display_path(project_path) if project_path else None,
     "bundleIdentifiers": bundle_matches,
-    "permissionDescriptions": {key: info.get(key) for key in EXPECTED_PERMISSION_STRINGS},
+    "permissionDescriptions": {key: info.get(key) for key in PERMISSION_PLUGIN_AUTHORITY},
     "appPrivacyManifests": app_privacy,
+    "appPrivacyParseErrors": app_privacy_parse_errors,
     "dependencyPrivacyManifestCount": len(dependency_privacy),
     "dependencyPrivacyManifests": dependency_privacy,
-    "dependencyPrivacyParseErrors": parse_errors,
-    "dependencyRequiredReasonUnion": {
-        key: sorted(values) for key, values in sorted(required_reason_union.items())
-    },
+    "dependencyPrivacyParseErrors": dependency_parse_errors,
+    "dependencyRequiredReasonUnion": required_reason_union,
+    "errors": errors,
 }
 REPORT.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
@@ -120,13 +203,12 @@ print(f"generated Info.plist: {report['generatedInfoPlist']}")
 print(f"generated Xcode project: {report['generatedXcodeProject']}")
 print(f"app privacy manifests: {len(app_privacy)}")
 print(f"dependency privacy manifests: {len(dependency_privacy)}")
-print(json.dumps(report["dependencyRequiredReasonUnion"], indent=2, sort_keys=True))
+print(json.dumps(required_reason_union, indent=2, sort_keys=True))
 
-if parse_errors:
-    raise SystemExit(f"could not parse {len(parse_errors)} dependency privacy manifest(s); inspect report")
-if not app_privacy:
-    raise SystemExit(
-        "generated app target has no PrivacyInfo.xcprivacy; inspect dependency privacy inventory before declaring required reasons"
-    )
+if errors:
+    print("native artifact audit discrepancies:")
+    for error in errors:
+        print(f"- {error}")
+    raise SystemExit(1)
 
 print("iOS generated native artifact audit: OK")

--- a/.github/scripts/audit-ios-native-artifact.py
+++ b/.github/scripts/audit-ios-native-artifact.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+import json
+import plistlib
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MOBILE = ROOT / "apps" / "mobile"
+IOS = MOBILE / "ios"
+REPORT = ROOT / "ios-native-artifact-report.json"
+
+EXPECTED_PERMISSION_STRINGS = {
+    "NSCameraUsageDescription": "Woof uses the camera only when you choose to take a pet photo.",
+    "NSPhotoLibraryUsageDescription": "Woof uses your photo library only when you choose a pet or profile photo.",
+    "NSLocationWhenInUseUsageDescription": "Woof can use your location while the app is open to find nearby pet-friendly places and matches.",
+}
+EXPECTED_BUNDLE_ID = "com.woof.app"
+
+
+def load_plist(path: Path):
+    with path.open("rb") as handle:
+        return plistlib.load(handle)
+
+
+def privacy_manifest_summary(path: Path):
+    data = load_plist(path)
+    accessed = []
+    for row in data.get("NSPrivacyAccessedAPITypes", []) or []:
+        if not isinstance(row, dict):
+            continue
+        accessed.append(
+            {
+                "type": row.get("NSPrivacyAccessedAPIType"),
+                "reasons": sorted(row.get("NSPrivacyAccessedAPITypeReasons", []) or []),
+            }
+        )
+    return {
+        "path": str(path.relative_to(ROOT)),
+        "tracking": data.get("NSPrivacyTracking"),
+        "trackingDomains": data.get("NSPrivacyTrackingDomains", []) or [],
+        "accessedAPITypes": sorted(accessed, key=lambda row: str(row.get("type"))),
+        "collectedDataTypeCount": len(data.get("NSPrivacyCollectedDataTypes", []) or []),
+    }
+
+
+if not IOS.is_dir():
+    raise SystemExit("generated iOS directory is missing; expo prebuild did not materialize native authority")
+
+info_candidates = sorted(IOS.glob("*/Info.plist"))
+if len(info_candidates) != 1:
+    raise SystemExit(f"expected exactly one generated app Info.plist, found {len(info_candidates)}")
+info_path = info_candidates[0]
+info = load_plist(info_path)
+
+for key, expected in EXPECTED_PERMISSION_STRINGS.items():
+    actual = info.get(key)
+    if actual != expected:
+        raise SystemExit(f"generated Info.plist {key} mismatch: expected {expected!r}, got {actual!r}")
+
+project_files = sorted(IOS.glob("*.xcodeproj/project.pbxproj"))
+if len(project_files) != 1:
+    raise SystemExit(f"expected exactly one generated Xcode project, found {len(project_files)}")
+project_path = project_files[0]
+project_text = project_path.read_text(encoding="utf-8")
+bundle_matches = sorted(set(re.findall(r"PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);", project_text)))
+if EXPECTED_BUNDLE_ID not in bundle_matches:
+    raise SystemExit(
+        f"generated Xcode project does not contain bundle id {EXPECTED_BUNDLE_ID!r}; found {bundle_matches!r}"
+    )
+
+app_privacy_candidates = sorted(IOS.glob("*/PrivacyInfo.xcprivacy"))
+app_privacy = [privacy_manifest_summary(path) for path in app_privacy_candidates]
+
+resolved_dependency_manifests = {}
+search_roots = [ROOT / "node_modules" / ".pnpm", MOBILE / "node_modules"]
+for search_root in search_roots:
+    if not search_root.exists():
+        continue
+    for path in search_root.rglob("PrivacyInfo.xcprivacy"):
+        try:
+            resolved = path.resolve(strict=True)
+        except OSError:
+            continue
+        if IOS in resolved.parents:
+            continue
+        resolved_dependency_manifests[str(resolved)] = path
+
+dependency_privacy = []
+parse_errors = []
+for resolved, display_path in sorted(resolved_dependency_manifests.items()):
+    try:
+        dependency_privacy.append(privacy_manifest_summary(Path(resolved)))
+    except Exception as exc:  # pragma: no cover - evidence capture for third-party manifests
+        parse_errors.append({"path": str(display_path), "error": str(exc)})
+
+required_reason_union = {}
+for manifest in dependency_privacy:
+    for row in manifest["accessedAPITypes"]:
+        api_type = row.get("type")
+        if not api_type:
+            continue
+        required_reason_union.setdefault(api_type, set()).update(row.get("reasons") or [])
+
+report = {
+    "generatedInfoPlist": str(info_path.relative_to(ROOT)),
+    "generatedXcodeProject": str(project_path.relative_to(ROOT)),
+    "bundleIdentifiers": bundle_matches,
+    "permissionDescriptions": {key: info.get(key) for key in EXPECTED_PERMISSION_STRINGS},
+    "appPrivacyManifests": app_privacy,
+    "dependencyPrivacyManifestCount": len(dependency_privacy),
+    "dependencyPrivacyManifests": dependency_privacy,
+    "dependencyPrivacyParseErrors": parse_errors,
+    "dependencyRequiredReasonUnion": {
+        key: sorted(values) for key, values in sorted(required_reason_union.items())
+    },
+}
+REPORT.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+print(f"generated Info.plist: {report['generatedInfoPlist']}")
+print(f"generated Xcode project: {report['generatedXcodeProject']}")
+print(f"app privacy manifests: {len(app_privacy)}")
+print(f"dependency privacy manifests: {len(dependency_privacy)}")
+print(json.dumps(report["dependencyRequiredReasonUnion"], indent=2, sort_keys=True))
+
+if parse_errors:
+    raise SystemExit(f"could not parse {len(parse_errors)} dependency privacy manifest(s); inspect report")
+if not app_privacy:
+    raise SystemExit(
+        "generated app target has no PrivacyInfo.xcprivacy; inspect dependency privacy inventory before declaring required reasons"
+    )
+
+print("iOS generated native artifact audit: OK")

--- a/.github/scripts/audit-ios-native-artifact.py
+++ b/.github/scripts/audit-ios-native-artifact.py
@@ -9,6 +9,9 @@ MOBILE = ROOT / "apps" / "mobile"
 IOS = MOBILE / "ios"
 REPORT = ROOT / "ios-native-artifact-report.json"
 APP_CONFIG = MOBILE / "app.json"
+EXPO_AUTOLINK = ROOT / "expo-autolinking-apple.json"
+RN_AUTOLINK = ROOT / "react-native-autolinking-ios.json"
+PODFILE = IOS / "Podfile"
 EXPECTED_BUNDLE_ID = "com.woof.app"
 
 PERMISSION_PLUGIN_AUTHORITY = {
@@ -28,6 +31,18 @@ def display_path(path: Path) -> str:
 def load_plist(path: Path):
     with path.open("rb") as handle:
         return plistlib.load(handle)
+
+
+def load_json(path: Path, label: str, errors: list[str]) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        errors.append(f"could not read {label}: {exc}")
+        return {}
+    if not isinstance(data, dict):
+        errors.append(f"{label} must resolve to a JSON object")
+        return {}
+    return data
 
 
 def privacy_manifest_summary(path: Path):
@@ -62,23 +77,42 @@ def plugin_options(expo_config: dict) -> dict[str, dict]:
     return resolved
 
 
-source = json.loads(APP_CONFIG.read_text(encoding="utf-8"))
-expo = source.get("expo", {})
+def package_root_for(path_value: str | None) -> Path | None:
+    if not path_value:
+        return None
+    candidate = Path(path_value).resolve()
+    if candidate.is_file():
+        candidate = candidate.parent
+    for directory in (candidate, *candidate.parents):
+        if (directory / "package.json").is_file():
+            return directory
+    return None
+
+
+def reason_union(manifests: list[dict]) -> dict[str, list[str]]:
+    union: dict[str, set[str]] = {}
+    for manifest in manifests:
+        for row in manifest.get("accessedAPITypes", []):
+            api_type = row.get("type")
+            if not api_type:
+                continue
+            union.setdefault(api_type, set()).update(row.get("reasons") or [])
+    return {key: sorted(values) for key, values in sorted(union.items())}
+
+
+errors: list[str] = []
+source = load_json(APP_CONFIG, "apps/mobile/app.json", errors)
+expo = source.get("expo", {}) if isinstance(source.get("expo", {}), dict) else {}
 source_info = expo.get("ios", {}).get("infoPlist", {}) or {}
 plugins = plugin_options(expo)
-expected_permissions = {
-    key: source_info.get(key) for key in PERMISSION_PLUGIN_AUTHORITY
-}
+expected_permissions = {key: source_info.get(key) for key in PERMISSION_PLUGIN_AUTHORITY}
 source_permission_conflicts = []
-errors = []
 
 for key, (plugin_name, option_name) in PERMISSION_PLUGIN_AUTHORITY.items():
     expected = expected_permissions.get(key)
     plugin_value = plugins.get(plugin_name, {}).get(option_name)
     if not isinstance(expected, str) or not expected.strip():
-        source_permission_conflicts.append(
-            f"app.json ios.infoPlist is missing non-empty {key}"
-        )
+        source_permission_conflicts.append(f"app.json ios.infoPlist is missing non-empty {key}")
     if expected != plugin_value:
         source_permission_conflicts.append(
             f"app.json permission authority conflict for {key}: "
@@ -118,7 +152,12 @@ else:
     except Exception as exc:
         errors.append(f"could not read generated Xcode project: {exc}")
 
-bundle_matches = sorted(set(re.findall(r"PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);", project_text)))
+bundle_matches = sorted(
+    {
+        match.strip().strip('"')
+        for match in re.findall(r"PRODUCT_BUNDLE_IDENTIFIER = ([^;]+);", project_text)
+    }
+)
 if EXPECTED_BUNDLE_ID not in bundle_matches:
     errors.append(
         f"generated Xcode project does not contain bundle id {EXPECTED_BUNDLE_ID!r}; "
@@ -134,52 +173,104 @@ for path in app_privacy_candidates:
     except Exception as exc:
         app_privacy_parse_errors.append({"path": display_path(path), "error": str(exc)})
 
-resolved_dependency_manifests = {}
-search_roots = [ROOT / "node_modules" / ".pnpm", MOBILE / "node_modules"]
-for search_root in search_roots:
-    if not search_root.exists():
+expo_autolink = load_json(EXPO_AUTOLINK, "Expo Apple autolinking evidence", errors)
+rn_autolink = load_json(RN_AUTOLINK, "React Native iOS autolinking evidence", errors)
+linked_roots: dict[str, set[str]] = {}
+
+for module in expo_autolink.get("modules", []) or []:
+    if not isinstance(module, dict):
         continue
-    for path in search_root.rglob("PrivacyInfo.xcprivacy"):
+    module_name = module.get("packageName") or "unknown-expo-module"
+    roots = set()
+    direct_root = package_root_for(module.get("path"))
+    if direct_root:
+        roots.add(direct_root)
+    for pod in module.get("pods", []) or []:
+        if not isinstance(pod, dict):
+            continue
+        root = package_root_for(pod.get("podspecDir"))
+        if root:
+            roots.add(root)
+    for root in roots:
+        linked_roots.setdefault(str(root), set()).add(str(module_name))
+
+react_native_root = package_root_for(rn_autolink.get("reactNativePath"))
+if react_native_root:
+    linked_roots.setdefault(str(react_native_root), set()).add("react-native")
+
+for dependency_name, dependency in (rn_autolink.get("dependencies", {}) or {}).items():
+    if not isinstance(dependency, dict):
+        continue
+    ios_config = (dependency.get("platforms", {}) or {}).get("ios")
+    if not isinstance(ios_config, dict):
+        continue
+    root = package_root_for(dependency.get("root")) or package_root_for(ios_config.get("podspecPath"))
+    if root:
+        linked_roots.setdefault(str(root), set()).add(str(dependency_name))
+
+podfile_text = PODFILE.read_text(encoding="utf-8") if PODFILE.is_file() else ""
+google_maps_enabled = "react-native-maps/Google" in podfile_text
+
+resolved_linked_manifests: dict[str, Path] = {}
+excluded_optional_manifests = []
+for root_value in sorted(linked_roots):
+    root = Path(root_value)
+    if not root.exists():
+        continue
+    for path in root.rglob("PrivacyInfo.xcprivacy"):
         try:
             resolved = path.resolve(strict=True)
         except OSError:
             continue
         if IOS in resolved.parents:
             continue
-        resolved_dependency_manifests[str(resolved)] = resolved
-
-dependency_privacy = []
-dependency_parse_errors = []
-for resolved in sorted(resolved_dependency_manifests.values(), key=str):
-    try:
-        dependency_privacy.append(privacy_manifest_summary(resolved))
-    except Exception as exc:  # pragma: no cover - evidence capture for third-party manifests
-        dependency_parse_errors.append({"path": display_path(resolved), "error": str(exc)})
-
-required_reason_union = {}
-for manifest in dependency_privacy:
-    for row in manifest["accessedAPITypes"]:
-        api_type = row.get("type")
-        if not api_type:
+        if (
+            not google_maps_enabled
+            and root.name == "react-native-maps"
+            and "AirGoogleMaps" in resolved.parts
+        ):
+            excluded_optional_manifests.append(
+                {
+                    "path": display_path(resolved),
+                    "reason": "react-native-maps Google subspec is not enabled in generated Podfile",
+                }
+            )
             continue
-        required_reason_union.setdefault(api_type, set()).update(row.get("reasons") or [])
+        resolved_linked_manifests[str(resolved)] = resolved
 
-required_reason_union = {
-    key: sorted(values) for key, values in sorted(required_reason_union.items())
-}
+linked_privacy = []
+linked_privacy_parse_errors = []
+for resolved in sorted(resolved_linked_manifests.values(), key=str):
+    try:
+        linked_privacy.append(privacy_manifest_summary(resolved))
+    except Exception as exc:  # pragma: no cover - evidence capture for third-party manifests
+        linked_privacy_parse_errors.append({"path": display_path(resolved), "error": str(exc)})
+
+linked_required_reason_union = reason_union(linked_privacy)
+app_required_reason_union = reason_union(app_privacy)
+missing_app_required_reasons = {}
+for api_type, reasons in linked_required_reason_union.items():
+    missing = sorted(set(reasons) - set(app_required_reason_union.get(api_type, [])))
+    if missing:
+        missing_app_required_reasons[api_type] = missing
 
 if app_privacy_parse_errors:
     errors.append(
         f"could not parse {len(app_privacy_parse_errors)} generated app privacy manifest(s)"
     )
-if dependency_parse_errors:
+if linked_privacy_parse_errors:
     errors.append(
-        f"could not parse {len(dependency_parse_errors)} dependency privacy manifest(s)"
+        f"could not parse {len(linked_privacy_parse_errors)} autolinked dependency privacy manifest(s)"
     )
-if required_reason_union and not app_privacy:
+if linked_required_reason_union and not app_privacy:
     errors.append(
-        "installed dependencies declare required-reason APIs but generated app target has no "
-        "PrivacyInfo.xcprivacy; inspect dependencyRequiredReasonUnion before configuring app-level aggregation"
+        "autolinked native dependencies declare required-reason APIs but generated app target has no "
+        "PrivacyInfo.xcprivacy; inspect autolinkedRequiredReasonUnion before configuring app-level aggregation"
+    )
+elif missing_app_required_reasons:
+    errors.append(
+        "generated app privacy manifest does not cover the autolinked dependency required-reason candidate set: "
+        f"{missing_app_required_reasons!r}"
     )
 
 report = {
@@ -187,14 +278,22 @@ report = {
     "sourcePermissionConflicts": source_permission_conflicts,
     "generatedInfoPlist": display_path(info_path) if info_path else None,
     "generatedXcodeProject": display_path(project_path) if project_path else None,
+    "generatedPodfile": display_path(PODFILE) if PODFILE.is_file() else None,
     "bundleIdentifiers": bundle_matches,
     "permissionDescriptions": {key: info.get(key) for key in PERMISSION_PLUGIN_AUTHORITY},
+    "googleMapsSubspecEnabled": google_maps_enabled,
+    "autolinkedPackageRoots": {
+        display_path(Path(root)): sorted(names) for root, names in sorted(linked_roots.items())
+    },
+    "excludedOptionalPrivacyManifests": excluded_optional_manifests,
     "appPrivacyManifests": app_privacy,
     "appPrivacyParseErrors": app_privacy_parse_errors,
-    "dependencyPrivacyManifestCount": len(dependency_privacy),
-    "dependencyPrivacyManifests": dependency_privacy,
-    "dependencyPrivacyParseErrors": dependency_parse_errors,
-    "dependencyRequiredReasonUnion": required_reason_union,
+    "appRequiredReasonUnion": app_required_reason_union,
+    "autolinkedPrivacyManifestCount": len(linked_privacy),
+    "autolinkedPrivacyManifests": linked_privacy,
+    "autolinkedPrivacyParseErrors": linked_privacy_parse_errors,
+    "autolinkedRequiredReasonUnion": linked_required_reason_union,
+    "missingAppRequiredReasons": missing_app_required_reasons,
     "errors": errors,
 }
 REPORT.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -202,8 +301,9 @@ REPORT.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding=
 print(f"generated Info.plist: {report['generatedInfoPlist']}")
 print(f"generated Xcode project: {report['generatedXcodeProject']}")
 print(f"app privacy manifests: {len(app_privacy)}")
-print(f"dependency privacy manifests: {len(dependency_privacy)}")
-print(json.dumps(required_reason_union, indent=2, sort_keys=True))
+print(f"autolinked privacy manifests: {len(linked_privacy)}")
+print(f"react-native-maps Google subspec enabled: {google_maps_enabled}")
+print(json.dumps(linked_required_reason_union, indent=2, sort_keys=True))
 
 if errors:
     print("native artifact audit discrepancies:")

--- a/.github/workflows/ios-native-artifact-audit-ci.yml
+++ b/.github/workflows/ios-native-artifact-audit-ci.yml
@@ -1,0 +1,86 @@
+name: iOS Native Artifact Audit CI
+
+on:
+  pull_request:
+    paths:
+      - 'apps/mobile/app.json'
+      - 'apps/mobile/app.config.ts'
+      - 'apps/mobile/eas.json'
+      - 'apps/mobile/package.json'
+      - 'apps/mobile/src/**'
+      - '.github/scripts/audit-ios-native-artifact.py'
+      - '.github/workflows/ios-native-artifact-audit-ci.yml'
+      - 'docs/IOS_NATIVE_ARTIFACT_AUDIT_V1.md'
+      - 'pnpm-lock.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mobile/app.json'
+      - 'apps/mobile/app.config.ts'
+      - 'apps/mobile/eas.json'
+      - 'apps/mobile/package.json'
+      - 'apps/mobile/src/**'
+      - '.github/scripts/audit-ios-native-artifact.py'
+      - '.github/workflows/ios-native-artifact-audit-ci.yml'
+      - 'docs/IOS_NATIVE_ARTIFACT_AUDIT_V1.md'
+      - 'pnpm-lock.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-native-artifact-audit-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  CI: '1'
+  WOOF_BUILD_PROFILE: 'production'
+  EXPO_PUBLIC_API_URL: 'https://woof-api-prod.fly.dev/api/v1'
+  EAS_PROJECT_ID: '00000000-0000-4000-8000-000000000001'
+
+jobs:
+  audit:
+    name: Generate and inspect iOS native authority
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from committed lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Check audit tranche formatting
+        run: >-
+          pnpm exec prettier --check
+          .github/workflows/ios-native-artifact-audit-ci.yml
+          docs/IOS_NATIVE_ARTIFACT_AUDIT_V1.md
+
+      - name: Generate production-shaped iOS project without signing or Pods
+        run: pnpm --filter @woof/mobile exec expo prebuild --clean --platform ios --no-install
+
+      - name: Audit generated metadata and privacy manifests
+        run: python3 .github/scripts/audit-ios-native-artifact.py
+
+      - name: Upload generated native evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ios-native-artifact-audit-${{ github.sha }}
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            ios-native-artifact-report.json
+            apps/mobile/ios/*/Info.plist
+            apps/mobile/ios/*/PrivacyInfo.xcprivacy
+            apps/mobile/ios/*.xcodeproj/project.pbxproj

--- a/.github/workflows/ios-native-artifact-audit-ci.yml
+++ b/.github/workflows/ios-native-artifact-audit-ci.yml
@@ -69,6 +69,16 @@ jobs:
       - name: Generate production-shaped iOS project without signing or Pods
         run: pnpm --filter @woof/mobile exec expo prebuild --clean --platform ios --no-install
 
+      - name: Resolve native autolinking graph used by Expo CocoaPods integration
+        working-directory: apps/mobile
+        run: |
+          node --no-warnings --eval "require('expo/bin/autolinking')" \
+            expo-modules-autolinking resolve --platform apple --json \
+            > ../../expo-autolinking-apple.json
+          node --no-warnings --eval "require('expo/bin/autolinking')" \
+            expo-modules-autolinking react-native-config --platform ios --json \
+            > ../../react-native-autolinking-ios.json
+
       - name: Audit generated metadata and privacy manifests
         run: python3 .github/scripts/audit-ios-native-artifact.py
 
@@ -81,6 +91,9 @@ jobs:
           retention-days: 14
           path: |
             ios-native-artifact-report.json
+            expo-autolinking-apple.json
+            react-native-autolinking-ios.json
+            apps/mobile/ios/Podfile
             apps/mobile/ios/*/Info.plist
             apps/mobile/ios/*/PrivacyInfo.xcprivacy
             apps/mobile/ios/*.xcodeproj/project.pbxproj

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -16,9 +16,9 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.woof.app",
       "infoPlist": {
-        "NSCameraUsageDescription": "Woof uses the camera only when you choose to take a pet photo.",
-        "NSPhotoLibraryUsageDescription": "Woof uses your photo library only when you choose a pet or profile photo.",
-        "NSLocationWhenInUseUsageDescription": "Woof can use your location while the app is open to find nearby pet-friendly places and matches."
+        "NSCameraUsageDescription": "Allow Woof to use the camera when you choose to take a pet photo.",
+        "NSPhotoLibraryUsageDescription": "Allow Woof to use photos you explicitly select.",
+        "NSLocationWhenInUseUsageDescription": "Allow Woof to use your location while the app is open to find nearby pet-friendly places and matches."
       }
     },
     "android": {

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -19,6 +19,26 @@
         "NSCameraUsageDescription": "Allow Woof to use the camera when you choose to take a pet photo.",
         "NSPhotoLibraryUsageDescription": "Allow Woof to use photos you explicitly select.",
         "NSLocationWhenInUseUsageDescription": "Allow Woof to use your location while the app is open to find nearby pet-friendly places and matches."
+      },
+      "privacyManifests": {
+        "NSPrivacyAccessedAPITypes": [
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryDiskSpace",
+            "NSPrivacyAccessedAPITypeReasons": ["85F4.1", "E174.1"]
+          },
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryFileTimestamp",
+            "NSPrivacyAccessedAPITypeReasons": ["0A2A.1", "3B52.1", "C617.1"]
+          },
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategorySystemBootTime",
+            "NSPrivacyAccessedAPITypeReasons": ["35F9.1"]
+          },
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
+            "NSPrivacyAccessedAPITypeReasons": ["CA92.1"]
+          }
+        ]
       }
     },
     "android": {

--- a/docs/IOS_NATIVE_ARTIFACT_AUDIT_V1.md
+++ b/docs/IOS_NATIVE_ARTIFACT_AUDIT_V1.md
@@ -27,7 +27,9 @@ The audit requires the generated native project to preserve:
 - selected-photo-library usage description;
 - location-while-in-use description.
 
-The test reads the generated plist/project files rather than merely rereading `app.json`.
+`app.json` is also required to keep the `ios.infoPlist` permission strings identical to the corresponding Expo plugin permission options. This prevents two source authorities from silently disagreeing while prebuild lets the plugin override win.
+
+The test reads the generated plist/project files rather than merely rereading `app.json`. Metadata discrepancies are collected into the report instead of aborting evidence collection at the first mismatch.
 
 ## Privacy manifest inventory
 
@@ -40,9 +42,17 @@ The audit inventories:
 - the union of dependency `NSPrivacyAccessedAPITypes` and their declared required reasons;
 - manifest parse failures, which fail the lane rather than being ignored.
 
-The machine-readable report is retained as a GitHub Actions artifact for 14 days.
+The machine-readable report is retained as a GitHub Actions artifact for 14 days even when the audit fails.
 
-The first version intentionally **does not invent or broaden required-reason declarations**. If the generated app target lacks a privacy manifest, the lane fails after writing/uploading the dependency inventory. That failure is evidence for the next minimal repair: configure only the reasons supported by installed native dependency manifests and Woof's actual app behavior.
+The audit intentionally **does not invent or broaden required-reason declarations**. A missing generated app privacy manifest is only a hard failure when the installed dependency inventory declares required-reason API categories. In that case the report becomes the evidence for the next minimal repair.
+
+This is intentionally conservative for Expo projects because Expo documents that Apple does not correctly parse every `PrivacyInfo.xcprivacy` shipped through static CocoaPods dependencies and may require those dependency reasons to be repeated in the app-level privacy manifest.
+
+## First audit finding
+
+The first generated prebuild showed that Woof had two different source copies for the same iOS permission descriptions: older strings under `ios.infoPlist` and newer strings in the Expo camera, image-picker and location plugin options. Expo prebuild materialized the plugin strings.
+
+The tranche now converges those source values before continuing privacy-manifest analysis.
 
 ## Why this is stricter than source inspection
 

--- a/docs/IOS_NATIVE_ARTIFACT_AUDIT_V1.md
+++ b/docs/IOS_NATIVE_ARTIFACT_AUDIT_V1.md
@@ -1,0 +1,73 @@
+# iOS Native Artifact Audit v1
+
+## Purpose
+
+Woof uses Expo Continuous Native Generation. Repository JavaScript and app-config correctness therefore is not the final iOS authority: App Store-facing metadata is produced when Expo prebuild materializes the native Xcode project.
+
+This tranche creates an evidence-only iOS prebuild gate before signing or TestFlight.
+
+## Production-shaped generation
+
+CI evaluates the same fail-closed production configuration contract as the release build with:
+
+- production build profile semantics;
+- the canonical public production API URL;
+- a synthetic EAS project UUID used only to let configuration resolve in CI.
+
+It then runs Expo prebuild for iOS with `--clean --no-install`.
+
+This generates the Xcode project and app metadata without requiring CocoaPods, an Apple Developer account, signing certificates, provisioning profiles, or a real EAS project.
+
+## Generated metadata authority
+
+The audit requires the generated native project to preserve:
+
+- bundle identifier `com.woof.app`;
+- camera usage description;
+- selected-photo-library usage description;
+- location-while-in-use description.
+
+The test reads the generated plist/project files rather than merely rereading `app.json`.
+
+## Privacy manifest inventory
+
+Apple privacy-manifest correctness cannot be inferred from package names alone.
+
+The audit inventories:
+
+- app-target `PrivacyInfo.xcprivacy` files generated under `apps/mobile/ios`;
+- parseable `PrivacyInfo.xcprivacy` files shipped by installed dependency packages;
+- the union of dependency `NSPrivacyAccessedAPITypes` and their declared required reasons;
+- manifest parse failures, which fail the lane rather than being ignored.
+
+The machine-readable report is retained as a GitHub Actions artifact for 14 days.
+
+The first version intentionally **does not invent or broaden required-reason declarations**. If the generated app target lacks a privacy manifest, the lane fails after writing/uploading the dependency inventory. That failure is evidence for the next minimal repair: configure only the reasons supported by installed native dependency manifests and Woof's actual app behavior.
+
+## Why this is stricter than source inspection
+
+Expo config plugins modify `Info.plist`, Xcode project settings, privacy manifests, entitlements and related files during prebuild. A source-only assertion can therefore pass while generated native state differs.
+
+This lane moves Woof's release evidence one layer closer to what Apple actually receives.
+
+## Explicit non-claims
+
+Passing this audit does not claim:
+
+- CocoaPods installation or static-pod manifest aggregation;
+- a compiled `.app` or `.ipa`;
+- Xcode 26 compilation;
+- code signing or provisioning;
+- a real Expo/EAS project id;
+- TestFlight upload;
+- Apple's server-side required-reason validation;
+- App Store Connect privacy-label completion;
+- physical-device behavior.
+
+Those remain later release gates.
+
+## Exit condition
+
+This tranche is complete when Woof can truthfully say:
+
+> Production-shaped Expo prebuild deterministically produces the expected iOS bundle/permission metadata, and Woof has a machine-readable inventory of the privacy manifests and required-reason declarations present in its generated app and installed native dependencies.

--- a/docs/IOS_NATIVE_ARTIFACT_AUDIT_V1.md
+++ b/docs/IOS_NATIVE_ARTIFACT_AUDIT_V1.md
@@ -31,28 +31,44 @@ The audit requires the generated native project to preserve:
 
 The test reads the generated plist/project files rather than merely rereading `app.json`. Metadata discrepancies are collected into the report instead of aborting evidence collection at the first mismatch.
 
-## Privacy manifest inventory
+## Native-linkage-aware privacy inventory
 
-Apple privacy-manifest correctness cannot be inferred from package names alone.
+Apple privacy-manifest correctness cannot be inferred from every file present under `node_modules`.
 
-The audit inventories:
+The audit therefore retains both Expo Apple autolinking and React Native iOS autolinking resolver output, derives the candidate native package roots from those resolvers, reads the generated Podfile, and inventories `PrivacyInfo.xcprivacy` only from that pre-Pods candidate graph.
 
-- app-target `PrivacyInfo.xcprivacy` files generated under `apps/mobile/ios`;
-- parseable `PrivacyInfo.xcprivacy` files shipped by installed dependency packages;
-- the union of dependency `NSPrivacyAccessedAPITypes` and their declared required reasons;
-- manifest parse failures, which fail the lane rather than being ignored.
+For `react-native-maps`, the generated Podfile does not enable the separate Google Maps subspec, so the `AirGoogleMaps` privacy bundle is explicitly excluded from the candidate union. This prevents an optional native implementation that Woof does not configure from broadening the app declaration.
 
-The machine-readable report is retained as a GitHub Actions artifact for 14 days even when the audit fails.
+The machine-readable report and resolver evidence are retained as GitHub Actions artifacts for 14 days even when the audit fails.
 
-The audit intentionally **does not invent or broaden required-reason declarations**. A missing generated app privacy manifest is only a hard failure when the installed dependency inventory declares required-reason API categories. In that case the report becomes the evidence for the next minimal repair.
+## Evidence-backed required reasons
 
-This is intentionally conservative for Expo projects because Expo documents that Apple does not correctly parse every `PrivacyInfo.xcprivacy` shipped through static CocoaPods dependencies and may require those dependency reasons to be repeated in the app-level privacy manifest.
+The linkage-aware candidate graph declares these required-reason APIs:
 
-## First audit finding
+- `NSPrivacyAccessedAPICategoryDiskSpace`: `85F4.1`, `E174.1`
+- `NSPrivacyAccessedAPICategoryFileTimestamp`: `0A2A.1`, `3B52.1`, `C617.1`
+- `NSPrivacyAccessedAPICategorySystemBootTime`: `35F9.1`
+- `NSPrivacyAccessedAPICategoryUserDefaults`: `CA92.1`
 
-The first generated prebuild showed that Woof had two different source copies for the same iOS permission descriptions: older strings under `ios.infoPlist` and newer strings in the Expo camera, image-picker and location plugin options. Expo prebuild materialized the plugin strings.
+Woof repeats exactly that candidate set through `expo.ios.privacyManifests` because Expo documents that Apple does not correctly parse every privacy manifest shipped through static CocoaPods dependencies and may require dependency reasons to be repeated at app level.
 
-The tranche now converges those source values before continuing privacy-manifest analysis.
+A production-shaped prebuild now materializes one app-target `apps/mobile/ios/Woof/PrivacyInfo.xcprivacy` containing those categories and reasons. The generated manifest also declares `NSPrivacyTracking=false`, no tracking domains, and no app-level collected-data types.
+
+The successful generated-native evidence artifact for the evidence-backed manifest had digest:
+
+`sha256:3a3eafec1e539be962d5cf375c8a75b9bc4d81d43b67f683ab0203bda2239f98`
+
+## Findings resolved during this tranche
+
+### Permission source split
+
+The first generated prebuild showed two different source copies for the same iOS permission descriptions: older strings under `ios.infoPlist` and newer strings in the Expo camera, image-picker and location plugin options. Expo prebuild materialized the plugin strings.
+
+The source values now converge on the generated wording.
+
+### Raw dependency overcount
+
+A raw scan of installed packages found multiple transitive Expo module versions and the optional `react-native-maps` Google privacy bundle. The native-linkage-aware resolver reduced this to the actual pre-Pods candidate graph and removed the unsupported Google Maps `1C8F.1` UserDefaults reason from Woof's app-level declaration.
 
 ## Why this is stricter than source inspection
 
@@ -60,11 +76,20 @@ Expo config plugins modify `Info.plist`, Xcode project settings, privacy manifes
 
 This lane moves Woof's release evidence one layer closer to what Apple actually receives.
 
+## Remaining authority boundary
+
+This is still a **pre-Pods** audit. Autolinking plus the generated Podfile is much stronger than scanning the install graph, but it is not equivalent to a resolved `Podfile.lock` or a compiled app bundle.
+
+The next native tranche must run on macOS with CocoaPods and Xcode, inspect the actually resolved pods and privacy resources, and build the generated project without claiming signing. Any difference between that resolved native graph and this candidate set must update the app manifest before TestFlight.
+
+The dependency manifests may also contain collected-data declarations that Apple/Xcode merges independently. This tranche does not copy those declarations into Woof's app manifest merely because they exist in a package; the resolved CocoaPods/archive gate should determine the final merged evidence.
+
 ## Explicit non-claims
 
 Passing this audit does not claim:
 
-- CocoaPods installation or static-pod manifest aggregation;
+- CocoaPods installation or `Podfile.lock` authority;
+- final static-pod manifest aggregation;
 - a compiled `.app` or `.ipa`;
 - Xcode 26 compilation;
 - code signing or provisioning;
@@ -80,4 +105,4 @@ Those remain later release gates.
 
 This tranche is complete when Woof can truthfully say:
 
-> Production-shaped Expo prebuild deterministically produces the expected iOS bundle/permission metadata, and Woof has a machine-readable inventory of the privacy manifests and required-reason declarations present in its generated app and installed native dependencies.
+> Production-shaped Expo prebuild deterministically produces the expected iOS bundle and permission metadata, generates an app-level privacy manifest covering the linkage-aware required-reason candidate set, and retains machine-readable native-linkage evidence for the next CocoaPods/Xcode qualification stage.


### PR DESCRIPTION
## Summary

Adds an evidence-only native-generation gate between Expo source configuration and signed/TestFlight claims.

- runs production-shaped Expo iOS prebuild from the qualified fail-closed release config;
- validates generated bundle and permission metadata from the native project rather than rereading source config;
- converges duplicate permission-copy authorities between `ios.infoPlist` and Expo plugins;
- captures Expo Apple and React Native iOS autolinking resolver evidence;
- derives a pre-Pods native candidate graph and excludes the unconfigured `react-native-maps` Google subspec;
- inventories generated app-target and autolinked dependency `PrivacyInfo.xcprivacy` manifests;
- generates an app-level privacy manifest containing only the linkage-backed required-reason candidate set;
- retains the machine-readable report, Podfile, resolver output and generated native metadata for 14 days;
- preserves explicit non-claims around CocoaPods resolution, Xcode compilation, signing, IPA/TestFlight, Apple server validation and physical devices.

## Evidence-backed app required reasons

- Disk space: `85F4.1`, `E174.1`
- File timestamp: `0A2A.1`, `3B52.1`, `C617.1`
- System boot time: `35F9.1`
- User defaults: `CA92.1`

A production-shaped prebuild at candidate `ad37f0f740ace9317db7b2685427e105eed178a4` generated one app `PrivacyInfo.xcprivacy` with this candidate set and passed the native artifact audit. The retained artifact digest is `sha256:3a3eafec1e539be962d5cf375c8a75b9bc4d81d43b67f683ab0203bda2239f98`.

## Base and final gate

#127 is merged to `main` at `3dcefb4c5a0eac13299bc652b86b13cdf70b6a19`. The current branch remains a true descendant of that qualified release-config main.

The documentation-only evidence update advanced the current exact head to `970d70c03b1d221b253c59ec2ddfa20f4323065f`; this exact head must pass every triggered workflow before promotion.

## Evidence boundary

This is still pre-Pods evidence. Autolinking plus the generated Podfile is not equivalent to a resolved `Podfile.lock`, a compiled app bundle, a real EAS project, Apple signing, an IPA, TestFlight, or physical-device qualification. The next native tranche should resolve CocoaPods on macOS and perform an unsigned/simulator Xcode 26 build before stronger launch claims are made.