### PR TITLE
Qualify resolved iOS Pods and Xcode 26 built app

### DIFF
--- a/.github/scripts/audit-ios-cocoapods-build.py
+++ b/.github/scripts/audit-ios-cocoapods-build.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+import json
+import plistlib
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MOBILE = ROOT / "apps" / "mobile"
+IOS = MOBILE / "ios"
+REPORT = ROOT / "ios-cocoapods-build-report.json"
+LOCK = IOS / "Podfile.lock"
+PODS_PROJECT = IOS / "Pods" / "Pods.xcodeproj" / "project.pbxproj"
+EXPECTED_BUNDLE_ID = "com.woof.app"
+
+
+def load_plist(path: Path):
+    with path.open("rb") as handle:
+        return plistlib.load(handle)
+
+
+def reason_union_from_rows(rows):
+    union = {}
+    for row in rows or []:
+        if not isinstance(row, dict):
+            continue
+        api_type = row.get("NSPrivacyAccessedAPIType")
+        if not api_type:
+            continue
+        union.setdefault(api_type, set()).update(row.get("NSPrivacyAccessedAPITypeReasons", []) or [])
+    return {key: sorted(values) for key, values in sorted(union.items())}
+
+
+def display(path: Path | None):
+    if path is None:
+        return None
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+errors = []
+source = json.loads((MOBILE / "app.json").read_text(encoding="utf-8"))
+source_privacy = source.get("expo", {}).get("ios", {}).get("privacyManifests", {}) or {}
+expected_reasons = reason_union_from_rows(source_privacy.get("NSPrivacyAccessedAPITypes", []))
+
+lock_text = ""
+if not LOCK.is_file():
+    errors.append("Podfile.lock was not generated")
+else:
+    lock_text = LOCK.read_text(encoding="utf-8")
+
+for forbidden in ["GoogleMaps", "Google-Maps-iOS-Utils", "react-native-maps/Google"]:
+    if forbidden in lock_text:
+        errors.append(f"unexpected Google Maps pod authority resolved: {forbidden}")
+
+resolved_pods = sorted(
+    {
+        match.group(1)
+        for match in re.finditer(r"^  - ([A-Za-z0-9_.+/-]+)(?: \(|:)", lock_text, re.MULTILINE)
+    }
+)
+
+pods_project_text = PODS_PROJECT.read_text(encoding="utf-8") if PODS_PROJECT.is_file() else ""
+privacy_resource_references = sorted(
+    set(re.findall(r"[^\n]*PrivacyInfo\.xcprivacy[^\n]*", pods_project_text))
+)
+
+built_apps = sorted(
+    path
+    for path in (IOS / "build" / "DerivedData" / "Build" / "Products").glob("**/Woof.app")
+    if path.is_dir() and "iphonesimulator" in str(path.parent)
+)
+if len(built_apps) != 1:
+    errors.append(f"expected exactly one built iOS Simulator Woof.app, found {len(built_apps)}")
+    built_app = built_apps[0] if built_apps else None
+else:
+    built_app = built_apps[0]
+
+built_info = {}
+built_privacy = {}
+actual_reasons = {}
+if built_app:
+    info_path = built_app / "Info.plist"
+    privacy_path = built_app / "PrivacyInfo.xcprivacy"
+    if not info_path.is_file():
+        errors.append("built app is missing root Info.plist")
+    else:
+        built_info = load_plist(info_path)
+        if built_info.get("CFBundleIdentifier") != EXPECTED_BUNDLE_ID:
+            errors.append(
+                f"built app bundle id mismatch: expected {EXPECTED_BUNDLE_ID!r}, "
+                f"got {built_info.get('CFBundleIdentifier')!r}"
+            )
+    if not privacy_path.is_file():
+        errors.append("built app is missing root PrivacyInfo.xcprivacy")
+    else:
+        built_privacy = load_plist(privacy_path)
+        actual_reasons = reason_union_from_rows(built_privacy.get("NSPrivacyAccessedAPITypes", []))
+        if actual_reasons != expected_reasons:
+            errors.append(
+                "built app required-reason manifest differs from app-config authority: "
+                f"expected={expected_reasons!r}, actual={actual_reasons!r}"
+            )
+
+report = {
+    "podfileLock": display(LOCK if LOCK.is_file() else None),
+    "resolvedPodCount": len(resolved_pods),
+    "resolvedPods": resolved_pods,
+    "googleMapsResolved": any(
+        marker in lock_text for marker in ["GoogleMaps", "Google-Maps-iOS-Utils", "react-native-maps/Google"]
+    ),
+    "podsPrivacyResourceReferenceCount": len(privacy_resource_references),
+    "podsPrivacyResourceReferences": privacy_resource_references,
+    "builtApp": display(built_app),
+    "builtBundleIdentifier": built_info.get("CFBundleIdentifier"),
+    "expectedRequiredReasonUnion": expected_reasons,
+    "builtRequiredReasonUnion": actual_reasons,
+    "builtPrivacyTracking": built_privacy.get("NSPrivacyTracking") if built_privacy else None,
+    "builtPrivacyTrackingDomains": built_privacy.get("NSPrivacyTrackingDomains", []) if built_privacy else [],
+    "errors": errors,
+}
+REPORT.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+print(f"resolved pods: {len(resolved_pods)}")
+print(f"Pods privacy resource references: {len(privacy_resource_references)}")
+print(f"built app: {report['builtApp']}")
+print(json.dumps(actual_reasons, indent=2, sort_keys=True))
+
+if errors:
+    print("CocoaPods/Xcode qualification discrepancies:")
+    for error in errors:
+        print(f"- {error}")
+    raise SystemExit(1)
+
+print("iOS CocoaPods + built app authority: OK")

--- a/.github/workflows/ios-cocoapods-xcode-ci.yml
+++ b/.github/workflows/ios-cocoapods-xcode-ci.yml
@@ -1,0 +1,124 @@
+name: iOS CocoaPods + Xcode Qualification CI
+
+on:
+  pull_request:
+    paths:
+      - 'apps/mobile/**'
+      - 'pnpm-lock.yaml'
+      - '.github/scripts/audit-ios-cocoapods-build.py'
+      - '.github/workflows/ios-cocoapods-xcode-ci.yml'
+      - 'docs/IOS_COCOAPODS_XCODE_QUALIFICATION_V1.md'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mobile/**'
+      - 'pnpm-lock.yaml'
+      - '.github/scripts/audit-ios-cocoapods-build.py'
+      - '.github/workflows/ios-cocoapods-xcode-ci.yml'
+      - 'docs/IOS_COCOAPODS_XCODE_QUALIFICATION_V1.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-cocoapods-xcode-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+  CI: '1'
+  WOOF_BUILD_PROFILE: 'production'
+  EXPO_PUBLIC_API_URL: 'https://woof-api-prod.fly.dev/api/v1'
+  EAS_PROJECT_ID: '00000000-0000-4000-8000-000000000001'
+
+jobs:
+  qualify:
+    name: Resolve Pods and compile unsigned iOS Simulator app
+    runs-on: macos-26
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Capture Apple toolchain authority
+        run: |
+          {
+            sw_vers
+            echo
+            xcodebuild -version
+            echo
+            xcode-select -p
+            echo
+            pod --version
+          } | tee ios-apple-toolchain.txt
+          xcode_major=$(xcodebuild -version | awk '/Xcode/{split($2, parts, "."); print parts[1]}')
+          if [[ "${xcode_major}" -ne 26 ]]; then
+            echo "::error title=Unexpected Xcode authority::Expected Xcode 26.x, received $(xcodebuild -version | head -n 1)"
+            exit 1
+          fi
+
+      - name: Install from committed lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate production-shaped native iOS project
+        run: pnpm --filter @woof/mobile exec expo prebuild --clean --platform ios --no-install
+
+      - name: Resolve CocoaPods authority
+        working-directory: apps/mobile/ios
+        run: |
+          pod install --repo-update | tee ../../../ios-pod-install.log
+          test -f Podfile.lock
+          test -d Woof.xcworkspace
+
+      - name: Inventory Xcode workspace
+        working-directory: apps/mobile/ios
+        run: >-
+          xcodebuild -list -json -workspace Woof.xcworkspace
+          | tee ../../../ios-xcode-workspace.json
+
+      - name: Compile Release iOS Simulator app without signing
+        working-directory: apps/mobile/ios
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -workspace Woof.xcworkspace \
+            -scheme Woof \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath build/DerivedData \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY='' \
+            build | tee ../../../ios-xcodebuild.log
+
+      - name: Audit resolved Pods and built app bundle
+        run: python3 .github/scripts/audit-ios-cocoapods-build.py
+
+      - name: Upload CocoaPods and Xcode evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ios-cocoapods-xcode-${{ github.sha }}
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            ios-apple-toolchain.txt
+            ios-pod-install.log
+            ios-xcode-workspace.json
+            ios-xcodebuild.log
+            ios-cocoapods-build-report.json
+            apps/mobile/ios/Podfile
+            apps/mobile/ios/Podfile.lock
+            apps/mobile/ios/Pods/Pods.xcodeproj/project.pbxproj
+            apps/mobile/ios/build/DerivedData/Build/Products/*-iphonesimulator/Woof.app/Info.plist
+            apps/mobile/ios/build/DerivedData/Build/Products/*-iphonesimulator/Woof.app/PrivacyInfo.xcprivacy

--- a/docs/IOS_COCOAPODS_XCODE_QUALIFICATION_V1.md
+++ b/docs/IOS_COCOAPODS_XCODE_QUALIFICATION_V1.md
@@ -1,0 +1,85 @@
+# iOS CocoaPods + Xcode Qualification v1
+
+## Purpose
+
+The prebuild/native-artifact audit proves what Expo intends to generate before CocoaPods resolves the native graph. This tranche moves one layer closer to the binary Apple receives by resolving Pods on macOS and compiling the generated iOS workspace with Xcode 26.
+
+It remains intentionally unsigned. Signing, provisioning, EAS credentials, TestFlight and physical-device behavior are separate authorities.
+
+## Environment authority
+
+The qualification lane runs on GitHub's `macos-26` hosted image and records:
+
+- macOS version;
+- exact `xcodebuild -version` output;
+- selected developer directory;
+- CocoaPods version.
+
+The lane fails if the selected Xcode major version is not 26.
+
+## Native composition sequence
+
+The lane:
+
+1. installs the repository from the frozen pnpm lockfile;
+2. runs production-shaped Expo iOS prebuild with the qualified API/config contract;
+3. runs CocoaPods resolution and requires a generated `Podfile.lock` and `Woof.xcworkspace`;
+4. inventories the resolved workspace;
+5. compiles the `Woof` Release configuration for the generic iOS Simulator with code signing disabled;
+6. inspects the built `.app` rather than only source/generated project files.
+
+## CocoaPods authority
+
+`Podfile.lock` becomes the resolved pre-binary dependency authority for this tranche.
+
+Woof does not currently configure the optional Google Maps implementation in `react-native-maps`, so the resolved lock must not unexpectedly contain Google Maps pod authority. If it does, the lane fails and the privacy/config boundary must be revisited.
+
+The audit also records privacy-manifest file references present in the resolved Pods Xcode project.
+
+## Built app privacy authority
+
+The compiled simulator app must contain at its bundle root:
+
+- `Info.plist` with bundle identifier `com.woof.app`;
+- `PrivacyInfo.xcprivacy`.
+
+The built app's required-reason union must exactly equal the `expo.ios.privacyManifests.NSPrivacyAccessedAPITypes` authority committed in `app.json`.
+
+This is stronger than merely seeing a generated privacy manifest under the source `ios` directory because Xcode must actually copy it into the built product.
+
+## Retained evidence
+
+The workflow retains for 14 days:
+
+- Apple toolchain identity;
+- CocoaPods install log;
+- generated Podfile and resolved Podfile.lock;
+- resolved Pods project;
+- workspace inventory;
+- complete Xcode build log;
+- machine-readable CocoaPods/build report;
+- built app Info.plist and PrivacyInfo.xcprivacy.
+
+Evidence is uploaded even when qualification fails so a failing native composition can be inspected rather than retried blindly.
+
+## Explicit non-claims
+
+Passing this lane does **not** claim:
+
+- an App Store-signed build;
+- distribution provisioning profiles;
+- a real EAS project identity;
+- a production `.ipa`;
+- Apple App Store Connect server-side privacy validation;
+- TestFlight upload or external review;
+- APNs production behavior;
+- physical iPhone behavior;
+- that live production currently runs the same SHA.
+
+The separate production deployment blocker remains tracked in issue #77.
+
+## Exit condition
+
+This tranche is complete when Woof can truthfully say:
+
+> On a recorded Xcode 26/macOS 26 toolchain, CocoaPods resolves the production-shaped native project, the Release iOS Simulator app compiles without signing, and the built app bundle contains the expected bundle identity and exact required-reason privacy manifest.


### PR DESCRIPTION
## Summary

Moves Woof's iOS evidence boundary from Expo prebuild into resolved CocoaPods composition and an actual Xcode-built app bundle.

- runs on GitHub `macos-26` and records exact macOS/Xcode/CocoaPods authority;
- requires Xcode major version 26;
- performs production-shaped Expo prebuild;
- resolves CocoaPods and retains `Podfile.lock` as native dependency evidence;
- rejects unexpected Google Maps pod authority while Woof does not configure that optional `react-native-maps` implementation;
- inventories resolved Pods privacy-manifest references;
- builds the Release iOS Simulator app with signing disabled;
- verifies the built `.app` has bundle id `com.woof.app` and root `PrivacyInfo.xcprivacy`;
- requires the built privacy required-reason union to exactly match the app-config authority;
- retains toolchain, Pod, workspace, build-log and built-bundle evidence even on failure.

## Restack authority

This PR is now restacked directly on merged `main` at `c792e234f073a0a240b02b3d6162d37863ad5ad3`, which includes the qualified Expo SDK 54 dependency alignment from #131. The previous CocoaPods failure on the pre-alignment graph is historical evidence only.

The exact restacked head is `048c7e94d280c60a4ea94a8276987bf2a3e21d57`, containing only the three qualification files in this tranche.

## Qualification question

The primary question is now executable rather than speculative: does the Expo SDK 54-qualified dependency graph allow CocoaPods/React Native Codegen to resolve under Xcode 26, and can that resolved workspace compile an unsigned Release simulator app whose bundle privacy authority matches the committed app config exactly?

## Evidence boundary

This tranche still does not claim Apple distribution signing, a production IPA, real EAS project credentials, App Store Connect privacy validation, TestFlight, APNs production behavior, physical-device qualification, or live production deployment. Production deploy authority remains separately blocked by issue #77.