### PR TITLE
Add relationship-first Adventure Trail to native Compass

### DIFF
--- a/.github/scripts/assert-native-adventure-trail.py
+++ b/.github/scripts/assert-native-adventure-trail.py
@@ -47,18 +47,24 @@ if pathways != expected_pathways:
 if "CARE" in pathways:
     raise SystemExit("CARE must remain outside Adventure Trail discovery collection")
 
-thresholds = [int(value) for value in re.findall(r"minBondXp: (\d+)", trail)]
+thresholds = [int(value) for value in re.findall(r"minTrailXp: (\d+)", trail)]
 if len(thresholds) != 6:
     raise SystemExit(f"Expected six Adventure Trail chapters, found {len(thresholds)}")
 if thresholds[0] != 0:
-    raise SystemExit("Adventure Trail must begin at zero Bond XP")
+    raise SystemExit("Adventure Trail must begin at zero Trail XP")
 if thresholds != sorted(set(thresholds)):
     raise SystemExit("Adventure Trail chapter thresholds must be unique and strictly increasing")
 
-for marker in ("dashboard.bondXp", "dashboard.compass", "dashboard.rhythm"):
-    require(trail, marker, f"Adventure Trail must derive from canonical dashboard field: {marker}")
+for marker in (
+    "dashboard.compass",
+    "dashboard.rhythm",
+    "const trailXp = TRAIL_PATHWAYS.reduce(",
+    "trailXp,",
+):
+    require(trail, marker, f"Adventure Trail canonical derivation marker missing: {marker}")
 
 for forbidden in (
+    "dashboard.bondXp",
     "apiClient",
     "adventureApi",
     ".post(",
@@ -69,22 +75,24 @@ for forbidden in (
     "new Date(",
 ):
     if forbidden in trail:
-        raise SystemExit(f"Adventure Trail presentation policy must stay deterministic/read-only: {forbidden}")
+        raise SystemExit(f"Adventure Trail presentation policy must stay bounded/read-only: {forbidden}")
 
 for marker in (
     "deriveAdventureTrail(dashboard)",
     "ADVENTURE TRAIL",
+    "Trail XP",
     "Discovery stamps",
     "CARE stays visible in the Compass below, but it is intentionally outside this collection",
+    "never advances chapters or changes recommendations.",
     "Missing a day never resets Rhythm",
-    "They never unlock care or change",
 ):
     require(compass, marker, f"Native Adventure Trail UI boundary missing: {marker}")
 
 for marker in (
     "The human gets a game-shaped sense of unfolding progress.",
     "The dog keeps the right to have an ordinary day.",
-    "`CARE` is intentionally excluded from the collection layer.",
+    "`CARE` is intentionally excluded from the collection layer and from Trail XP.",
+    "CARE contributes zero Trail XP",
     "It does not create a daily streak",
 ):
     require(doc, marker, f"Native Adventure Trail documentation boundary missing: {marker}")

--- a/.github/scripts/assert-native-adventure-trail.py
+++ b/.github/scripts/assert-native-adventure-trail.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[2]
+TRAIL_PATH = ROOT / "apps/mobile/src/game/adventure-trail.ts"
+COMPASS_PATH = ROOT / "apps/mobile/src/screens/CompassScreen.tsx"
+DOC_PATH = ROOT / "docs/NATIVE_ADVENTURE_TRAIL_V1.md"
+
+trail = TRAIL_PATH.read_text()
+compass = COMPASS_PATH.read_text()
+doc = DOC_PATH.read_text()
+
+
+def require(source: str, marker: str, message: str) -> None:
+    if marker not in source:
+        raise SystemExit(message)
+
+
+require(
+    trail,
+    "adventure-trail-presentation-v1",
+    "Adventure Trail presentation policy version is missing",
+)
+
+pathway_match = re.search(
+    r"export const TRAIL_PATHWAYS = \[(.*?)\] as const satisfies readonly WellbeingPathway\[\];",
+    trail,
+    re.DOTALL,
+)
+if pathway_match is None:
+    raise SystemExit("Unable to parse Adventure Trail pathway authority")
+
+pathways = re.findall(r"'([A-Z_]+)'", pathway_match.group(1))
+expected_pathways = [
+    "MOVE",
+    "EXPLORE",
+    "ENRICH",
+    "LEARN",
+    "CONNECT",
+    "RECOVER",
+    "BOND",
+]
+if pathways != expected_pathways:
+    raise SystemExit(f"Adventure Trail pathways drifted: {pathways!r}")
+if "CARE" in pathways:
+    raise SystemExit("CARE must remain outside Adventure Trail discovery collection")
+
+thresholds = [int(value) for value in re.findall(r"minBondXp: (\d+)", trail)]
+if len(thresholds) != 6:
+    raise SystemExit(f"Expected six Adventure Trail chapters, found {len(thresholds)}")
+if thresholds[0] != 0:
+    raise SystemExit("Adventure Trail must begin at zero Bond XP")
+if thresholds != sorted(set(thresholds)):
+    raise SystemExit("Adventure Trail chapter thresholds must be unique and strictly increasing")
+
+for marker in ("dashboard.bondXp", "dashboard.compass", "dashboard.rhythm"):
+    require(trail, marker, f"Adventure Trail must derive from canonical dashboard field: {marker}")
+
+for forbidden in (
+    "apiClient",
+    "adventureApi",
+    ".post(",
+    ".put(",
+    ".delete(",
+    "Math.random(",
+    "Date.now(",
+    "new Date(",
+):
+    if forbidden in trail:
+        raise SystemExit(f"Adventure Trail presentation policy must stay deterministic/read-only: {forbidden}")
+
+for marker in (
+    "deriveAdventureTrail(dashboard)",
+    "ADVENTURE TRAIL",
+    "Discovery stamps",
+    "CARE stays visible in the Compass below, but it is intentionally outside this collection",
+    "Missing a day never resets Rhythm",
+    "They never unlock care or change",
+):
+    require(compass, marker, f"Native Adventure Trail UI boundary missing: {marker}")
+
+for marker in (
+    "The human gets a game-shaped sense of unfolding progress.",
+    "The dog keeps the right to have an ordinary day.",
+    "`CARE` is intentionally excluded from the collection layer.",
+    "It does not create a daily streak",
+):
+    require(doc, marker, f"Native Adventure Trail documentation boundary missing: {marker}")
+
+print("Native Adventure Trail source contract passed")

--- a/.github/workflows/native-adventure-trail-ci.yml
+++ b/.github/workflows/native-adventure-trail-ci.yml
@@ -54,12 +54,15 @@ jobs:
       - name: Enforce native Adventure Trail source contract
         run: python3 .github/scripts/assert-native-adventure-trail.py
 
-      - name: Check native Adventure Trail formatting
+      - name: Print canonical Adventure Trail formatting diff
         run: |
-          pnpm exec prettier --check \
+          pnpm exec prettier --write \
             apps/mobile/src/game/adventure-trail.ts \
             apps/mobile/src/screens/CompassScreen.tsx \
-            .github/workflows/native-adventure-trail-ci.yml \
+            docs/NATIVE_ADVENTURE_TRAIL_V1.md
+          git diff --exit-code -- \
+            apps/mobile/src/game/adventure-trail.ts \
+            apps/mobile/src/screens/CompassScreen.tsx \
             docs/NATIVE_ADVENTURE_TRAIL_V1.md
 
       - name: Type-check native client

--- a/.github/workflows/native-adventure-trail-ci.yml
+++ b/.github/workflows/native-adventure-trail-ci.yml
@@ -54,15 +54,12 @@ jobs:
       - name: Enforce native Adventure Trail source contract
         run: python3 .github/scripts/assert-native-adventure-trail.py
 
-      - name: Print canonical Adventure Trail formatting diff
+      - name: Check native Adventure Trail formatting
         run: |
-          pnpm exec prettier --write \
+          pnpm exec prettier --check \
             apps/mobile/src/game/adventure-trail.ts \
             apps/mobile/src/screens/CompassScreen.tsx \
-            docs/NATIVE_ADVENTURE_TRAIL_V1.md
-          git diff --exit-code -- \
-            apps/mobile/src/game/adventure-trail.ts \
-            apps/mobile/src/screens/CompassScreen.tsx \
+            .github/workflows/native-adventure-trail-ci.yml \
             docs/NATIVE_ADVENTURE_TRAIL_V1.md
 
       - name: Type-check native client

--- a/.github/workflows/native-adventure-trail-ci.yml
+++ b/.github/workflows/native-adventure-trail-ci.yml
@@ -1,0 +1,69 @@
+name: Native Adventure Trail CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/mobile/src/api/adventure.ts'
+      - 'apps/mobile/src/game/adventure-trail.ts'
+      - 'apps/mobile/src/screens/CompassScreen.tsx'
+      - '.github/scripts/assert-native-adventure-trail.py'
+      - '.github/workflows/native-adventure-trail-ci.yml'
+      - 'docs/NATIVE_ADVENTURE_TRAIL_V1.md'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mobile/src/api/adventure.ts'
+      - 'apps/mobile/src/game/adventure-trail.ts'
+      - 'apps/mobile/src/screens/CompassScreen.tsx'
+      - '.github/scripts/assert-native-adventure-trail.py'
+      - '.github/workflows/native-adventure-trail-ci.yml'
+      - 'docs/NATIVE_ADVENTURE_TRAIL_V1.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-adventure-trail-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  qualify:
+    name: Native relationship game authority
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from committed lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Enforce native Adventure Trail source contract
+        run: python3 .github/scripts/assert-native-adventure-trail.py
+
+      - name: Check native Adventure Trail formatting
+        run: |
+          pnpm exec prettier --check \
+            apps/mobile/src/game/adventure-trail.ts \
+            apps/mobile/src/screens/CompassScreen.tsx \
+            .github/workflows/native-adventure-trail-ci.yml \
+            docs/NATIVE_ADVENTURE_TRAIL_V1.md
+
+      - name: Type-check native client
+        run: pnpm --filter @woof/mobile type-check
+
+      - name: Lint native client
+        run: pnpm --filter @woof/mobile lint

--- a/apps/mobile/src/game/adventure-trail.ts
+++ b/apps/mobile/src/game/adventure-trail.ts
@@ -25,7 +25,7 @@ type AdventureTrailChapterId =
 export type AdventureTrailChapter = {
   id: AdventureTrailChapterId;
   label: string;
-  minBondXp: number;
+  minTrailXp: number;
   description: string;
 };
 
@@ -33,43 +33,44 @@ export const ADVENTURE_TRAIL_CHAPTERS = [
   {
     id: 'FIRST_PAWPRINTS',
     label: 'First Pawprints',
-    minBondXp: 0,
+    minTrailXp: 0,
     description: 'Start noticing what fits instead of chasing a perfect routine.',
   },
   {
     id: 'FINDING_RHYTHM',
     label: 'Finding Rhythm',
-    minBondXp: 100,
+    minTrailXp: 100,
     description: 'Useful moments are beginning to form a pattern you can return to.',
   },
   {
     id: 'READING_EACH_OTHER',
     label: 'Reading Each Other',
-    minBondXp: 250,
+    minTrailXp: 250,
     description: 'Outcomes are becoming clues for making the next shared choice easier.',
   },
   {
     id: 'WIDER_WORLD',
     label: 'A Wider World',
-    minBondXp: 500,
+    minTrailXp: 500,
     description: 'Your shared trail now holds more than one kind of good day.',
   },
   {
     id: 'FAMILIAR_TRAIL',
     label: 'The Familiar Trail',
-    minBondXp: 900,
+    minTrailXp: 900,
     description: 'You have a growing library of what works, what does not, and when to stop.',
   },
   {
     id: 'SHARED_LANGUAGE',
     label: 'Shared Language',
-    minBondXp: 1500,
+    minTrailXp: 1500,
     description: 'The story is richer because listening, adapting, and recovery all count.',
   },
 ] as const satisfies readonly AdventureTrailChapter[];
 
 export type AdventureTrailState = {
   policyVersion: typeof ADVENTURE_TRAIL_POLICY_VERSION;
+  trailXp: number;
   chapter: AdventureTrailChapter;
   nextChapter: AdventureTrailChapter | null;
   chapterProgress: number;
@@ -86,32 +87,38 @@ function clamp01(value: number) {
 }
 
 export function deriveAdventureTrail(dashboard: AdventureDashboard): AdventureTrailState {
-  const bondXp = Math.max(0, Math.floor(dashboard.bondXp));
+  const xpByPathway = new Map(
+    dashboard.compass.map((item) => [item.pathway, Math.max(0, Math.floor(item.xp))] as const)
+  );
+  const trailXp = TRAIL_PATHWAYS.reduce(
+    (total, pathway) => total + (xpByPathway.get(pathway) ?? 0),
+    0
+  );
   let chapterIndex = 0;
 
   for (let index = 1; index < ADVENTURE_TRAIL_CHAPTERS.length; index += 1) {
-    if (bondXp < ADVENTURE_TRAIL_CHAPTERS[index].minBondXp) break;
+    if (trailXp < ADVENTURE_TRAIL_CHAPTERS[index].minTrailXp) break;
     chapterIndex = index;
   }
 
   const chapter = ADVENTURE_TRAIL_CHAPTERS[chapterIndex];
   const nextChapter = ADVENTURE_TRAIL_CHAPTERS[chapterIndex + 1] ?? null;
   const chapterProgress = nextChapter
-    ? clamp01((bondXp - chapter.minBondXp) / (nextChapter.minBondXp - chapter.minBondXp))
+    ? clamp01((trailXp - chapter.minTrailXp) / (nextChapter.minTrailXp - chapter.minTrailXp))
     : 1;
-  const discovered = new Set(
-    dashboard.compass.filter((item) => item.xp > 0).map((item) => item.pathway)
+  const discoveredPathways = TRAIL_PATHWAYS.filter(
+    (pathway) => (xpByPathway.get(pathway) ?? 0) > 0
   );
-  const discoveredPathways = TRAIL_PATHWAYS.filter((pathway) => discovered.has(pathway));
   const windowWeeks = Math.max(0, Math.floor(dashboard.rhythm.windowWeeks));
   const activeWeeks = Math.min(windowWeeks, Math.max(0, Math.floor(dashboard.rhythm.activeWeeks)));
 
   return {
     policyVersion: ADVENTURE_TRAIL_POLICY_VERSION,
+    trailXp,
     chapter,
     nextChapter,
     chapterProgress,
-    xpToNextChapter: nextChapter ? Math.max(0, nextChapter.minBondXp - bondXp) : 0,
+    xpToNextChapter: nextChapter ? Math.max(0, nextChapter.minTrailXp - trailXp) : 0,
     discoveredPathways,
     discoveryCount: discoveredPathways.length,
     discoveryTotal: TRAIL_PATHWAYS.length,

--- a/apps/mobile/src/game/adventure-trail.ts
+++ b/apps/mobile/src/game/adventure-trail.ts
@@ -1,0 +1,126 @@
+import type { AdventureDashboard, WellbeingPathway } from '../api/adventure';
+
+export const ADVENTURE_TRAIL_POLICY_VERSION = 'adventure-trail-presentation-v1';
+
+export const TRAIL_PATHWAYS = [
+  'MOVE',
+  'EXPLORE',
+  'ENRICH',
+  'LEARN',
+  'CONNECT',
+  'RECOVER',
+  'BOND',
+] as const satisfies readonly WellbeingPathway[];
+
+export type TrailPathway = (typeof TRAIL_PATHWAYS)[number];
+
+type AdventureTrailChapterId =
+  | 'FIRST_PAWPRINTS'
+  | 'FINDING_RHYTHM'
+  | 'READING_EACH_OTHER'
+  | 'WIDER_WORLD'
+  | 'FAMILIAR_TRAIL'
+  | 'SHARED_LANGUAGE';
+
+export type AdventureTrailChapter = {
+  id: AdventureTrailChapterId;
+  label: string;
+  minBondXp: number;
+  description: string;
+};
+
+export const ADVENTURE_TRAIL_CHAPTERS = [
+  {
+    id: 'FIRST_PAWPRINTS',
+    label: 'First Pawprints',
+    minBondXp: 0,
+    description: 'Start noticing what fits instead of chasing a perfect routine.',
+  },
+  {
+    id: 'FINDING_RHYTHM',
+    label: 'Finding Rhythm',
+    minBondXp: 100,
+    description: 'Useful moments are beginning to form a pattern you can return to.',
+  },
+  {
+    id: 'READING_EACH_OTHER',
+    label: 'Reading Each Other',
+    minBondXp: 250,
+    description: 'Outcomes are becoming clues for making the next shared choice easier.',
+  },
+  {
+    id: 'WIDER_WORLD',
+    label: 'A Wider World',
+    minBondXp: 500,
+    description: 'Your shared trail now holds more than one kind of good day.',
+  },
+  {
+    id: 'FAMILIAR_TRAIL',
+    label: 'The Familiar Trail',
+    minBondXp: 900,
+    description: 'You have a growing library of what works, what does not, and when to stop.',
+  },
+  {
+    id: 'SHARED_LANGUAGE',
+    label: 'Shared Language',
+    minBondXp: 1500,
+    description: 'The story is richer because listening, adapting, and recovery all count.',
+  },
+] as const satisfies readonly AdventureTrailChapter[];
+
+export type AdventureTrailState = {
+  policyVersion: typeof ADVENTURE_TRAIL_POLICY_VERSION;
+  chapter: AdventureTrailChapter;
+  nextChapter: AdventureTrailChapter | null;
+  chapterProgress: number;
+  xpToNextChapter: number;
+  discoveredPathways: TrailPathway[];
+  discoveryCount: number;
+  discoveryTotal: number;
+  activeWeeks: number;
+  windowWeeks: number;
+};
+
+function clamp01(value: number) {
+  return Math.max(0, Math.min(1, value));
+}
+
+export function deriveAdventureTrail(dashboard: AdventureDashboard): AdventureTrailState {
+  const bondXp = Math.max(0, Math.floor(dashboard.bondXp));
+  let chapterIndex = 0;
+
+  for (let index = 1; index < ADVENTURE_TRAIL_CHAPTERS.length; index += 1) {
+    if (bondXp < ADVENTURE_TRAIL_CHAPTERS[index].minBondXp) break;
+    chapterIndex = index;
+  }
+
+  const chapter = ADVENTURE_TRAIL_CHAPTERS[chapterIndex];
+  const nextChapter = ADVENTURE_TRAIL_CHAPTERS[chapterIndex + 1] ?? null;
+  const chapterProgress = nextChapter
+    ? clamp01(
+        (bondXp - chapter.minBondXp) / (nextChapter.minBondXp - chapter.minBondXp)
+      )
+    : 1;
+  const discovered = new Set(
+    dashboard.compass.filter((item) => item.xp > 0).map((item) => item.pathway)
+  );
+  const discoveredPathways = TRAIL_PATHWAYS.filter((pathway) => discovered.has(pathway));
+  const windowWeeks = Math.max(0, Math.floor(dashboard.rhythm.windowWeeks));
+  const activeWeeks = Math.min(
+    windowWeeks,
+    Math.max(0, Math.floor(dashboard.rhythm.activeWeeks))
+  );
+
+  return {
+    policyVersion: ADVENTURE_TRAIL_POLICY_VERSION,
+    chapter,
+    nextChapter,
+    chapterProgress,
+    xpToNextChapter: nextChapter ? Math.max(0, nextChapter.minBondXp - bondXp) : 0,
+    discoveredPathways,
+    discoveryCount: discoveredPathways.length,
+    discoveryTotal: TRAIL_PATHWAYS.length,
+    activeWeeks,
+    windowWeeks,
+  };
+}

--- a/apps/mobile/src/game/adventure-trail.ts
+++ b/apps/mobile/src/game/adventure-trail.ts
@@ -97,19 +97,14 @@ export function deriveAdventureTrail(dashboard: AdventureDashboard): AdventureTr
   const chapter = ADVENTURE_TRAIL_CHAPTERS[chapterIndex];
   const nextChapter = ADVENTURE_TRAIL_CHAPTERS[chapterIndex + 1] ?? null;
   const chapterProgress = nextChapter
-    ? clamp01(
-        (bondXp - chapter.minBondXp) / (nextChapter.minBondXp - chapter.minBondXp)
-      )
+    ? clamp01((bondXp - chapter.minBondXp) / (nextChapter.minBondXp - chapter.minBondXp))
     : 1;
   const discovered = new Set(
     dashboard.compass.filter((item) => item.xp > 0).map((item) => item.pathway)
   );
   const discoveredPathways = TRAIL_PATHWAYS.filter((pathway) => discovered.has(pathway));
   const windowWeeks = Math.max(0, Math.floor(dashboard.rhythm.windowWeeks));
-  const activeWeeks = Math.min(
-    windowWeeks,
-    Math.max(0, Math.floor(dashboard.rhythm.activeWeeks))
-  );
+  const activeWeeks = Math.min(windowWeeks, Math.max(0, Math.floor(dashboard.rhythm.activeWeeks)));
 
   return {
     policyVersion: ADVENTURE_TRAIL_POLICY_VERSION,

--- a/apps/mobile/src/screens/CompassScreen.tsx
+++ b/apps/mobile/src/screens/CompassScreen.tsx
@@ -10,11 +10,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import { adventureApi, type AdventureDashboard, type CompassPathway } from '../api/adventure';
-import {
-  deriveAdventureTrail,
-  TRAIL_PATHWAYS,
-  type TrailPathway,
-} from '../game/adventure-trail';
+import { deriveAdventureTrail, TRAIL_PATHWAYS, type TrailPathway } from '../game/adventure-trail';
 import { colors } from '../theme/tokens';
 
 const pathwayIcon: Record<string, keyof typeof Ionicons.glyphMap> = {
@@ -65,13 +61,7 @@ function PathwayCard({ item }: { item: CompassPathway }) {
   );
 }
 
-function DiscoveryStamp({
-  pathway,
-  discovered,
-}: {
-  pathway: TrailPathway;
-  discovered: boolean;
-}) {
+function DiscoveryStamp({ pathway, discovered }: { pathway: TrailPathway; discovered: boolean }) {
   return (
     <View style={[styles.stamp, !discovered && styles.stampUndiscovered]}>
       <View style={[styles.stampIcon, !discovered && styles.stampIconUndiscovered]}>
@@ -180,7 +170,9 @@ export default function CompassScreen() {
           <View style={styles.discoveryHeader}>
             <View>
               <Text style={styles.discoveryTitle}>Discovery stamps</Text>
-              <Text style={styles.discoverySubtitle}>Different kinds of good days leave a mark.</Text>
+              <Text style={styles.discoverySubtitle}>
+                Different kinds of good days leave a mark.
+              </Text>
             </View>
             <Text style={styles.discoveryCount}>
               {trail.discoveryCount}/{trail.discoveryTotal}
@@ -206,9 +198,7 @@ export default function CompassScreen() {
                 <Text style={styles.rhythmTitle}>Rolling Rhythm</Text>
                 <Text style={styles.rhythmSubtitle}>Meaningful weeks, not perfect days.</Text>
               </View>
-              <Text style={styles.rhythmValue}>
-                {trail.activeWeeks}/{trail.windowWeeks}
-              </Text>
+              <Text style={styles.rhythmValue}>{trail.activeWeeks}/{trail.windowWeeks}</Text>
             </View>
             <View style={styles.rhythmSlots}>
               {Array.from({ length: trail.windowWeeks }, (_, index) => (

--- a/apps/mobile/src/screens/CompassScreen.tsx
+++ b/apps/mobile/src/screens/CompassScreen.tsx
@@ -198,7 +198,9 @@ export default function CompassScreen() {
                 <Text style={styles.rhythmTitle}>Rolling Rhythm</Text>
                 <Text style={styles.rhythmSubtitle}>Meaningful weeks, not perfect days.</Text>
               </View>
-              <Text style={styles.rhythmValue}>{trail.activeWeeks}/{trail.windowWeeks}</Text>
+              <Text style={styles.rhythmValue}>
+                {trail.activeWeeks}/{trail.windowWeeks}
+              </Text>
             </View>
             <View style={styles.rhythmSlots}>
               {Array.from({ length: trail.windowWeeks }, (_, index) => (

--- a/apps/mobile/src/screens/CompassScreen.tsx
+++ b/apps/mobile/src/screens/CompassScreen.tsx
@@ -10,6 +10,11 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import { adventureApi, type AdventureDashboard, type CompassPathway } from '../api/adventure';
+import {
+  deriveAdventureTrail,
+  TRAIL_PATHWAYS,
+  type TrailPathway,
+} from '../game/adventure-trail';
 import { colors } from '../theme/tokens';
 
 const pathwayIcon: Record<string, keyof typeof Ionicons.glyphMap> = {
@@ -21,6 +26,16 @@ const pathwayIcon: Record<string, keyof typeof Ionicons.glyphMap> = {
   CARE: 'shield-checkmark-outline',
   RECOVER: 'moon-outline',
   BOND: 'heart-outline',
+};
+
+const pathwayShortLabel: Record<TrailPathway, string> = {
+  MOVE: 'Move',
+  EXPLORE: 'Explore',
+  ENRICH: 'Enrich',
+  LEARN: 'Learn',
+  CONNECT: 'Connect',
+  RECOVER: 'Recover',
+  BOND: 'Bond',
 };
 
 function PathwayCard({ item }: { item: CompassPathway }) {
@@ -46,6 +61,29 @@ function PathwayCard({ item }: { item: CompassPathway }) {
         <View style={[styles.fill, { width: `${coverage * 100}%` }]} />
       </View>
       <Text style={styles.coverageText}>{Math.round(coverage * 100)}% recent pathway coverage</Text>
+    </View>
+  );
+}
+
+function DiscoveryStamp({
+  pathway,
+  discovered,
+}: {
+  pathway: TrailPathway;
+  discovered: boolean;
+}) {
+  return (
+    <View style={[styles.stamp, !discovered && styles.stampUndiscovered]}>
+      <View style={[styles.stampIcon, !discovered && styles.stampIconUndiscovered]}>
+        <Ionicons
+          name={discovered ? (pathwayIcon[pathway] ?? 'paw-outline') : 'lock-closed-outline'}
+          size={17}
+          color={discovered ? colors.primary[700] : colors.gray[500]}
+        />
+      </View>
+      <Text style={[styles.stampLabel, !discovered && styles.stampLabelUndiscovered]}>
+        {pathwayShortLabel[pathway]}
+      </Text>
     </View>
   );
 }
@@ -76,6 +114,8 @@ export default function CompassScreen() {
     }, [load])
   );
 
+  const trail = dashboard ? deriveAdventureTrail(dashboard) : null;
+
   if (loading && !dashboard) {
     return (
       <View style={styles.centered}>
@@ -102,6 +142,92 @@ export default function CompassScreen() {
         <View style={styles.noticeCard}>
           <Ionicons name="cloud-offline-outline" size={20} color={colors.gray[600]} />
           <Text style={styles.noticeText}>{error}</Text>
+        </View>
+      )}
+
+      {dashboard && trail && (
+        <View style={styles.trailCard}>
+          <View style={styles.trailHeader}>
+            <View style={styles.trailIcon}>
+              <Ionicons name="map-outline" size={22} color={colors.primary[700]} />
+            </View>
+            <View style={styles.trailHeaderCopy}>
+              <Text style={styles.eyebrow}>ADVENTURE TRAIL</Text>
+              <Text style={styles.trailTitle}>{trail.chapter.label}</Text>
+            </View>
+          </View>
+
+          <Text style={styles.trailDescription}>{trail.chapter.description}</Text>
+
+          <View style={styles.trailTrack}>
+            <View
+              style={[styles.trailFill, { width: `${Math.round(trail.chapterProgress * 100)}%` }]}
+            />
+          </View>
+          <View style={styles.trailProgressRow}>
+            <Text style={styles.trailProgressValue}>{dashboard.bondXp} Bond XP</Text>
+            <Text style={styles.trailProgressHint}>
+              {trail.nextChapter
+                ? `${trail.xpToNextChapter} to ${trail.nextChapter.label}`
+                : 'The trail keeps unfolding'}
+            </Text>
+          </View>
+          <Text style={styles.trailAuthorityCopy}>
+            Chapters are a playful view of server-earned Bond XP. They never unlock care or change
+            what Woof recommends.
+          </Text>
+
+          <View style={styles.discoveryHeader}>
+            <View>
+              <Text style={styles.discoveryTitle}>Discovery stamps</Text>
+              <Text style={styles.discoverySubtitle}>Different kinds of good days leave a mark.</Text>
+            </View>
+            <Text style={styles.discoveryCount}>
+              {trail.discoveryCount}/{trail.discoveryTotal}
+            </Text>
+          </View>
+          <View style={styles.stampsRow}>
+            {TRAIL_PATHWAYS.map((pathway) => (
+              <DiscoveryStamp
+                key={pathway}
+                pathway={pathway}
+                discovered={trail.discoveredPathways.includes(pathway)}
+              />
+            ))}
+          </View>
+          <Text style={styles.collectionBoundary}>
+            CARE stays visible in the Compass below, but it is intentionally outside this collection
+            game.
+          </Text>
+
+          <View style={styles.rhythmPanel}>
+            <View style={styles.rhythmHeader}>
+              <View>
+                <Text style={styles.rhythmTitle}>Rolling Rhythm</Text>
+                <Text style={styles.rhythmSubtitle}>Meaningful weeks, not perfect days.</Text>
+              </View>
+              <Text style={styles.rhythmValue}>
+                {trail.activeWeeks}/{trail.windowWeeks}
+              </Text>
+            </View>
+            <View style={styles.rhythmSlots}>
+              {Array.from({ length: trail.windowWeeks }, (_, index) => (
+                <View
+                  key={index}
+                  style={[styles.rhythmSlot, index < trail.activeWeeks && styles.rhythmSlotActive]}
+                >
+                  <Ionicons
+                    name={index < trail.activeWeeks ? 'paw' : 'paw-outline'}
+                    size={16}
+                    color={index < trail.activeWeeks ? colors.primary[700] : colors.gray[400]}
+                  />
+                </View>
+              ))}
+            </View>
+            <Text style={styles.rhythmBoundary}>
+              Missing a day never resets Rhythm. Recovery and listening can be real progress too.
+            </Text>
+          </View>
         </View>
       )}
 
@@ -175,6 +301,137 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   noticeText: { flex: 1, color: colors.text.secondary, fontSize: 14, lineHeight: 20 },
+  trailCard: {
+    marginTop: 20,
+    padding: 18,
+    borderRadius: 24,
+    backgroundColor: colors.primary[50],
+    borderWidth: 1,
+    borderColor: colors.primary[200],
+  },
+  trailHeader: { flexDirection: 'row', alignItems: 'center', gap: 11 },
+  trailIcon: {
+    width: 44,
+    height: 44,
+    borderRadius: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: colors.primary[100],
+  },
+  trailHeaderCopy: { flex: 1 },
+  trailTitle: { marginTop: 2, color: colors.text.primary, fontSize: 21, fontWeight: '800' },
+  trailDescription: {
+    marginTop: 12,
+    color: colors.gray[700],
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  trailTrack: {
+    marginTop: 16,
+    height: 9,
+    borderRadius: 999,
+    backgroundColor: '#ffffff',
+    overflow: 'hidden',
+  },
+  trailFill: { height: '100%', borderRadius: 999, backgroundColor: colors.primary[500] },
+  trailProgressRow: {
+    marginTop: 7,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  trailProgressValue: { color: colors.primary[800], fontSize: 12, fontWeight: '800' },
+  trailProgressHint: {
+    flex: 1,
+    color: colors.text.secondary,
+    fontSize: 11,
+    textAlign: 'right',
+  },
+  trailAuthorityCopy: {
+    marginTop: 10,
+    color: colors.text.secondary,
+    fontSize: 11,
+    lineHeight: 16,
+  },
+  discoveryHeader: {
+    marginTop: 20,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+    gap: 12,
+  },
+  discoveryTitle: { color: colors.text.primary, fontSize: 15, fontWeight: '800' },
+  discoverySubtitle: { marginTop: 2, color: colors.text.secondary, fontSize: 11 },
+  discoveryCount: { color: colors.primary[700], fontSize: 16, fontWeight: '800' },
+  stampsRow: { marginTop: 11, flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  stamp: {
+    width: 72,
+    paddingVertical: 10,
+    paddingHorizontal: 6,
+    borderRadius: 14,
+    alignItems: 'center',
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: colors.primary[100],
+  },
+  stampUndiscovered: { backgroundColor: colors.gray[50], borderColor: colors.gray[200] },
+  stampIcon: {
+    width: 31,
+    height: 31,
+    borderRadius: 11,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.primary[50],
+  },
+  stampIconUndiscovered: { backgroundColor: colors.gray[100] },
+  stampLabel: { marginTop: 6, color: colors.text.primary, fontSize: 10, fontWeight: '700' },
+  stampLabelUndiscovered: { color: colors.text.secondary },
+  collectionBoundary: {
+    marginTop: 9,
+    color: colors.text.secondary,
+    fontSize: 10,
+    lineHeight: 15,
+  },
+  rhythmPanel: {
+    marginTop: 18,
+    padding: 14,
+    borderRadius: 17,
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: colors.primary[100],
+  },
+  rhythmHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: 12,
+  },
+  rhythmTitle: { color: colors.text.primary, fontSize: 14, fontWeight: '800' },
+  rhythmSubtitle: { marginTop: 2, color: colors.text.secondary, fontSize: 11 },
+  rhythmValue: { color: colors.primary[700], fontSize: 16, fontWeight: '800' },
+  rhythmSlots: { marginTop: 11, flexDirection: 'row', gap: 7 },
+  rhythmSlot: {
+    width: 34,
+    height: 34,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.gray[50],
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+  },
+  rhythmSlotActive: {
+    backgroundColor: colors.primary[50],
+    borderColor: colors.primary[200],
+  },
+  rhythmBoundary: {
+    marginTop: 10,
+    color: colors.text.secondary,
+    fontSize: 10,
+    lineHeight: 15,
+  },
   summaryCard: {
     marginTop: 20,
     padding: 18,

--- a/apps/mobile/src/screens/CompassScreen.tsx
+++ b/apps/mobile/src/screens/CompassScreen.tsx
@@ -155,7 +155,7 @@ export default function CompassScreen() {
             />
           </View>
           <View style={styles.trailProgressRow}>
-            <Text style={styles.trailProgressValue}>{dashboard.bondXp} Bond XP</Text>
+            <Text style={styles.trailProgressValue}>{trail.trailXp} Trail XP</Text>
             <Text style={styles.trailProgressHint}>
               {trail.nextChapter
                 ? `${trail.xpToNextChapter} to ${trail.nextChapter.label}`
@@ -163,8 +163,8 @@ export default function CompassScreen() {
             </Text>
           </View>
           <Text style={styles.trailAuthorityCopy}>
-            Chapters are a playful view of server-earned Bond XP. They never unlock care or change
-            what Woof recommends.
+            Trail XP is a display-only sum of server-earned XP from seven non-care pathways. CARE
+            never advances chapters or changes recommendations.
           </Text>
 
           <View style={styles.discoveryHeader}>

--- a/docs/NATIVE_ADVENTURE_TRAIL_V1.md
+++ b/docs/NATIVE_ADVENTURE_TRAIL_V1.md
@@ -1,0 +1,121 @@
+# Native Adventure Trail v1
+
+## Purpose
+
+Adventure Trail makes Woof feel more playful without turning the dog into a scorecard.
+
+The real-world loop remains authoritative:
+
+```text
+notice -> choose -> do together -> read the response -> adapt -> remember
+```
+
+Adventure Trail is a presentation layer over that loop. It gives the human a longer arc to uncover while preserving the existing rule that recommendation truth, reward truth, health truth, and social competition are separate authorities.
+
+## Product contract
+
+Adventure Trail reads only fields already returned by the canonical Adventure dashboard:
+
+- server-earned Bond XP;
+- rolling Rhythm;
+- canonical pathway history exposed through the Pawprint Compass.
+
+It does not write CareEvents, RewardLedger rows, recommendation evidence, pet state, health state, or social score. The client cannot submit XP or award itself a chapter.
+
+Policy marker: `adventure-trail-presentation-v1`.
+
+## Chapters
+
+v1 contains six presentation-only relationship chapters:
+
+1. **First Pawprints** at 0 Bond XP;
+2. **Finding Rhythm** at 100 Bond XP;
+3. **Reading Each Other** at 250 Bond XP;
+4. **A Wider World** at 500 Bond XP;
+5. **The Familiar Trail** at 900 Bond XP;
+6. **Shared Language** at 1500 Bond XP.
+
+These thresholds are product pacing constants, not claims about dog quality, owner quality, training mastery, attachment, welfare, or clinical status. Reaching a chapter does not unlock care, increase recommendation authority, or make an action safer.
+
+The final chapter is intentionally open-ended. Woof should not create an infinite treadmill of escalating requirements simply to preserve engagement.
+
+## Discovery stamps
+
+Adventure Trail treats breadth as discovery rather than perfection.
+
+The collectible presentation pathways are:
+
+- `MOVE`;
+- `EXPLORE`;
+- `ENRICH`;
+- `LEARN`;
+- `CONNECT`;
+- `RECOVER`;
+- `BOND`.
+
+A stamp appears after the canonical Compass reports positive earned XP for that pathway. Repetition does not create additional stamps.
+
+`CARE` is intentionally excluded from the collection layer. Preventive or clinical behavior may remain visible in the normal Compass where appropriate, but health-related actions must not become a collectible obligation.
+
+Recovery and safe listening remain legitimate progress. A game that only lights up for exercise, exposure, or obedience would push the product toward exactly the wrong incentives.
+
+## Rhythm, not streaks
+
+The native Trail visualizes the existing rolling multi-week Rhythm count with paw markers.
+
+It does not create a daily streak, freeze, loss counter, missed-day warning, or reset penalty. Missing a day never erases progress. This preserves the existing Adventure contract that real life, recovery, illness, weather, travel, and lower-capacity days are not failures.
+
+## Authority boundaries
+
+Adventure Trail must never:
+
+- calculate or submit authoritative Bond XP;
+- alter Adventure ranking or recommendation evidence;
+- gate Today, Story, Health Lens, account controls, or any other product access;
+- add health, symptoms, medication, weight, veterinary spending, or CARE actions to the collection game;
+- rank dogs or owners by exercise volume, distance, repetitions, or physiological data;
+- use post count, reactions, followers, or popularity as Trail progress;
+- convert Social Adventure score into relationship truth;
+- punish missed days or require a perfect routine.
+
+The human gets a game-shaped sense of unfolding progress. The dog keeps the right to have an ordinary day.
+
+## Native surface
+
+Compass now leads with an **Adventure Trail** card containing:
+
+- the current chapter and chapter-to-chapter progress;
+- server-earned Bond XP context;
+- seven discovery stamps;
+- a clear CARE collection boundary;
+- rolling Rhythm paws with explicit anti-reset copy.
+
+The ordinary Compass remains below it and continues to show all canonical pathways as recent opportunity coverage, not a health score.
+
+## Qualification
+
+`Native Adventure Trail CI` verifies on the exact change:
+
+- the presentation policy is deterministic and read-only;
+- chapter thresholds remain ordered and start at zero;
+- the seven discovery pathways remain the intended set and exclude CARE;
+- the Trail derives from `dashboard.bondXp`, `dashboard.compass`, and `dashboard.rhythm`;
+- the client contains the explicit no-unlock, no-daily-reset, and CARE-boundary copy;
+- the touched TypeScript/TSX, workflow, and documentation are formatted;
+- the full native client type-checks;
+- native lint remains zero-warning.
+
+Existing repository workflows remain authoritative for broader mobile, security, Xcode, privacy, and dogOS contracts.
+
+## Next game slices
+
+Adventure Trail is deliberately the quiet meta-game, not the whole game design. The next high-value slices are:
+
+- **Expeditions:** bounded seasonal cooperative objectives where the community completes varied safe actions together rather than racing for volume;
+- **Friend quests:** opt-in challenge templates that are re-resolved against each recipient's eligibility instead of copying one dog's task to another;
+- **Skillcraft on native:** short Human Skill Arcade scenarios that teach timing, reinforcement, setup, and reading behavior without claiming professional proficiency;
+- **Story collectibles:** chapter art, memory constellations, and discovery cards derived from already-authorized Story moments rather than upload pressure;
+- **Companion progression:** petless Animal Ally and Foster/Caregiver paths with useful human-skill and community goals that never fabricate dog state;
+- **responsible adoption readiness:** partner-authorized shelter/foster opportunities and learning quests that make taking the step toward pet guardianship clearer without turning adoption into a reward unlock.
+
+The north star is not more taps. It is making useful dog-human life feel like a world that gradually reveals itself.

--- a/docs/NATIVE_ADVENTURE_TRAIL_V1.md
+++ b/docs/NATIVE_ADVENTURE_TRAIL_V1.md
@@ -16,28 +16,38 @@ Adventure Trail is a presentation layer over that loop. It gives the human a lon
 
 Adventure Trail reads only fields already returned by the canonical Adventure dashboard:
 
-- server-earned Bond XP;
+- server-earned pathway XP exposed by the Pawprint Compass;
 - rolling Rhythm;
-- canonical pathway history exposed through the Pawprint Compass.
+- canonical pathway history.
 
 It does not write CareEvents, RewardLedger rows, recommendation evidence, pet state, health state, or social score. The client cannot submit XP or award itself a chapter.
 
 Policy marker: `adventure-trail-presentation-v1`.
 
+### Trail XP is deliberately not a new reward authority
+
+`Trail XP` is a display-only sum of the server-earned pathway XP already present in the canonical Compass for seven game-eligible pathways. There is no Trail ledger and no Trail mutation endpoint.
+
+The eligible set is `MOVE`, `EXPLORE`, `ENRICH`, `LEARN`, `CONNECT`, `RECOVER`, and `BOND`.
+
+Total Bond XP can still appear elsewhere in Compass as existing relationship context, but Adventure Trail does not use total Bond XP to choose chapters. That distinction matters because canonical Bond XP can include CARE events. CARE contributes zero Trail XP and therefore cannot advance a chapter indirectly.
+
 ## Chapters
 
 v1 contains six presentation-only relationship chapters:
 
-1. **First Pawprints** at 0 Bond XP;
-2. **Finding Rhythm** at 100 Bond XP;
-3. **Reading Each Other** at 250 Bond XP;
-4. **A Wider World** at 500 Bond XP;
-5. **The Familiar Trail** at 900 Bond XP;
-6. **Shared Language** at 1500 Bond XP.
+1. **First Pawprints** at 0 Trail XP;
+2. **Finding Rhythm** at 100 Trail XP;
+3. **Reading Each Other** at 250 Trail XP;
+4. **A Wider World** at 500 Trail XP;
+5. **The Familiar Trail** at 900 Trail XP;
+6. **Shared Language** at 1500 Trail XP.
 
 These thresholds are product pacing constants, not claims about dog quality, owner quality, training mastery, attachment, welfare, or clinical status. Reaching a chapter does not unlock care, increase recommendation authority, or make an action safer.
 
 The final chapter is intentionally open-ended. Woof should not create an infinite treadmill of escalating requirements simply to preserve engagement.
+
+The current reward policy usually grants roughly low-tens of XP for one meaningful eligible event and caps both daily total and pathway volume. The chapter curve therefore gives an early reveal while making later chapters reflect a broader history rather than one high-volume day.
 
 ## Discovery stamps
 
@@ -55,7 +65,7 @@ The collectible presentation pathways are:
 
 A stamp appears after the canonical Compass reports positive earned XP for that pathway. Repetition does not create additional stamps.
 
-`CARE` is intentionally excluded from the collection layer. Preventive or clinical behavior may remain visible in the normal Compass where appropriate, but health-related actions must not become a collectible obligation.
+`CARE` is intentionally excluded from the collection layer and from Trail XP. Preventive or clinical behavior may remain visible in the normal Compass where appropriate, but health-related actions must not become a collectible obligation or an indirect chapter accelerator.
 
 Recovery and safe listening remain legitimate progress. A game that only lights up for exercise, exposure, or obedience would push the product toward exactly the wrong incentives.
 
@@ -70,6 +80,7 @@ It does not create a daily streak, freeze, loss counter, missed-day warning, or 
 Adventure Trail must never:
 
 - calculate or submit authoritative Bond XP;
+- let CARE contribute Trail XP or chapter progress;
 - alter Adventure ranking or recommendation evidence;
 - gate Today, Story, Health Lens, account controls, or any other product access;
 - add health, symptoms, medication, weight, veterinary spending, or CARE actions to the collection game;
@@ -85,12 +96,12 @@ The human gets a game-shaped sense of unfolding progress. The dog keeps the righ
 Compass now leads with an **Adventure Trail** card containing:
 
 - the current chapter and chapter-to-chapter progress;
-- server-earned Bond XP context;
+- display-only Trail XP derived from the seven game-eligible canonical pathway ledgers;
 - seven discovery stamps;
-- a clear CARE collection boundary;
+- an explicit statement that CARE never advances chapters;
 - rolling Rhythm paws with explicit anti-reset copy.
 
-The ordinary Compass remains below it and continues to show all canonical pathways as recent opportunity coverage, not a health score.
+The ordinary Compass remains below it and continues to show total Bond XP, Rhythm, and all canonical pathways as relationship context and recent opportunity coverage, not a health score.
 
 ## Qualification
 
@@ -99,8 +110,9 @@ The ordinary Compass remains below it and continues to show all canonical pathwa
 - the presentation policy is deterministic and read-only;
 - chapter thresholds remain ordered and start at zero;
 - the seven discovery pathways remain the intended set and exclude CARE;
-- the Trail derives from `dashboard.bondXp`, `dashboard.compass`, and `dashboard.rhythm`;
-- the client contains the explicit no-unlock, no-daily-reset, and CARE-boundary copy;
+- chapter progress derives from canonical per-pathway XP rather than total `dashboard.bondXp`;
+- the Trail still consumes canonical `dashboard.compass` and `dashboard.rhythm`;
+- the client contains the explicit no-unlock, no-daily-reset, no-CARE-progress, and collection-boundary copy;
 - the touched TypeScript/TSX, workflow, and documentation are formatted;
 - the full native client type-checks;
 - native lint remains zero-warning.


### PR DESCRIPTION
## Summary

Adds a native **Adventure Trail** meta-game on top of the already-qualified dogOS Adventure dashboard.

The goal is to make Woof feel more playful and worth returning to without turning the dog, health behavior, exercise volume, or missed days into a competition.

### Adventure Trail

- six deterministic relationship chapters;
- seven one-time discovery stamps for `MOVE`, `EXPLORE`, `ENRICH`, `LEARN`, `CONNECT`, `RECOVER`, and `BOND`;
- rolling Rhythm paw markers instead of a daily streak/reset mechanic;
- explicit UI copy that chapters never unlock care or change recommendation authority;
- final chapter stays open-ended rather than creating an infinite engagement treadmill.

### Trail XP boundary

A self-audit caught an important leak in the first draft: canonical total Bond XP can include CARE events, so using total Bond XP for chapters would have let wellness/clinical actions advance the game indirectly.

The repaired design introduces **Trail XP as presentation only**:

- it is the sum of server-earned per-pathway XP for exactly seven game-eligible pathways;
- `CARE` contributes zero Trail XP;
- there is no Trail ledger, mutation endpoint, or client-submitted reward;
- total Bond XP still appears in the ordinary Compass as existing relationship context, but it does not choose Trail chapters.

This makes the health boundary structural instead of cosmetic.

### Authority boundary

This tranche adds **presentation only**. It does not add a new server mutation, reward source, CareEvent, RewardLedger path, recommendation feature, health score, or social ranking authority.

The Trail consumes only canonical `GET /adventure/me` fields already owned by the server:

- per-pathway XP and history from `compass`;
- rolling `rhythm`.

The client cannot submit XP or award itself authoritative progression.

### Qualification

Adds `Native Adventure Trail CI`, which:

- freezes the seven intended game-eligible pathways and rejects CARE drift;
- verifies six ordered Trail XP chapter thresholds beginning at zero;
- requires derivation from canonical per-pathway XP;
- explicitly rejects `dashboard.bondXp` as chapter input so CARE cannot leak through total XP;
- rejects mutation/random-time markers in the Trail policy;
- requires explicit no-unlock, no-reset, no-CARE-progress, and collection-boundary copy;
- checks formatting for the touched product surfaces;
- type-checks the full native client;
- runs native lint with zero warnings.

The ordinary repository mobile, Xcode, privacy, security, Foundation, convergence, and CodeQL lanes remain authoritative and rerun where their path filters apply.

## Product direction

This is the quiet meta-game layer. Follow-on slices should build outward through cooperative seasonal Expeditions, friend challenges re-resolved through recipient eligibility, native Skillcraft/Human Skill Arcade, Story-derived collectibles, Companion/foster progression, and responsible adoption-readiness paths.

The design target is simple: **make useful dog-human life feel like a world that gradually reveals itself, without rewarding pressure.**

## Base

Created directly from qualified `main` at `ec2231be6694d59c28507308d20da0f0f6368d8a` after merged native First Adventure #134.

Keep draft until the exact final head passes its triggered workflow matrix.