### PR TITLE
Bring server-authoritative Skillcraft to native Woof

### DIFF
--- a/.github/scripts/assert-native-skillcraft.py
+++ b/.github/scripts/assert-native-skillcraft.py
@@ -71,8 +71,16 @@ for marker in (
     "reactions do not increase your rank.",
     "A game is not training authority.",
     "onPress={() => void shareResult()}",
+    "Share publicly",
+    'accessibilityLabel="Share this human skill moment publicly"',
+    "const totalChallenges = catalog?.challenges.length ?? 0;",
+    "{catalog && (",
+    "Choose a fresh round",
 ):
     require(screen, marker, f"Native Skillcraft UI boundary missing: {marker}")
+
+if "catalog?.challenges.length ?? 4" in screen:
+    raise SystemExit("Unavailable Skillcraft authority must not render as fabricated 0/4 progress")
 
 if screen.count("socialAdventureApi.shareSkillAttempt") != 1:
     raise SystemExit("Skillcraft sharing must remain one explicit post-completion action")

--- a/.github/scripts/assert-native-skillcraft.py
+++ b/.github/scripts/assert-native-skillcraft.py
@@ -30,6 +30,10 @@ def require(source: str, marker: str, message: str) -> None:
         raise SystemExit(message)
 
 
+def normalized(source: str) -> str:
+    return re.sub(r"\s+", " ", source).strip()
+
+
 challenge_match = re.search(
     r"export const HUMAN_SKILL_CHALLENGES = \[(.*?)\] as const;",
     server_policy,
@@ -63,6 +67,15 @@ for marker in (
     "socialAdventureApi.startArcadeAttempt",
     "socialAdventureApi.completeArcadeAttempt",
     "socialAdventureApi.shareSkillAttempt",
+    "onPress={() => void shareResult()}",
+    'accessibilityLabel="Share this human skill moment publicly"',
+    "const totalChallenges = catalog?.challenges.length ?? 0;",
+    "{catalog && (",
+):
+    require(screen, marker, f"Native Skillcraft UI contract missing: {marker}")
+
+screen_copy = normalized(screen)
+for marker in (
     "Breadth counts once. Grinding does not.",
     "Practice scores stay personal feedback.",
     "retries and higher scores add no rank.",
@@ -70,14 +83,10 @@ for marker in (
     "Sharing is optional and publishes this human practice moment only.",
     "reactions do not increase your rank.",
     "A game is not training authority.",
-    "onPress={() => void shareResult()}",
     "Share publicly",
-    'accessibilityLabel="Share this human skill moment publicly"',
-    "const totalChallenges = catalog?.challenges.length ?? 0;",
-    "{catalog && (",
     "Choose a fresh round",
 ):
-    require(screen, marker, f"Native Skillcraft UI boundary missing: {marker}")
+    require(screen_copy, marker, f"Native Skillcraft UI boundary missing: {marker}")
 
 if "catalog?.challenges.length ?? 4" in screen:
     raise SystemExit("Unavailable Skillcraft authority must not render as fabricated 0/4 progress")
@@ -135,6 +144,6 @@ for marker in (
     "Pet relationships still control pet authority.",
     "the human gets the game; the dog keeps the right to have an ordinary day.",
 ):
-    require(doc.lower(), marker.lower(), f"Native Skillcraft documentation boundary missing: {marker}")
+    require(normalized(doc).lower(), marker.lower(), f"Native Skillcraft documentation boundary missing: {marker}")
 
 print("Native Skillcraft source contract passed")

--- a/.github/scripts/assert-native-skillcraft.py
+++ b/.github/scripts/assert-native-skillcraft.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[2]
+MOBILE_API = ROOT / "apps/mobile/src/api/social-adventure.ts"
+SCREEN = ROOT / "apps/mobile/src/screens/SkillcraftScreen.tsx"
+NAV = ROOT / "apps/mobile/src/navigation/AppNavigator.tsx"
+COMPANION = ROOT / "apps/mobile/src/screens/CompanionHomeScreen.tsx"
+FEED = ROOT / "apps/mobile/src/screens/FeedScreen.tsx"
+SERVER_POLICY = ROOT / "apps/api/src/social-adventure/social-adventure.policy.ts"
+SERVER_ARCADE = ROOT / "apps/api/src/social-adventure/social-adventure.arcade.ts"
+SERVER_SERVICE = ROOT / "apps/api/src/social-adventure/social-adventure.service.ts"
+DOC = ROOT / "docs/NATIVE_SKILLCRAFT_V1.md"
+
+mobile_api = MOBILE_API.read_text()
+screen = SCREEN.read_text()
+nav = NAV.read_text()
+companion = COMPANION.read_text()
+feed = FEED.read_text()
+server_policy = SERVER_POLICY.read_text()
+server_arcade = SERVER_ARCADE.read_text()
+server_service = SERVER_SERVICE.read_text()
+doc = DOC.read_text()
+
+
+def require(source: str, marker: str, message: str) -> None:
+    if marker not in source:
+        raise SystemExit(message)
+
+
+challenge_match = re.search(
+    r"export const HUMAN_SKILL_CHALLENGES = \[(.*?)\] as const;",
+    server_policy,
+    re.DOTALL,
+)
+if challenge_match is None:
+    raise SystemExit("Unable to parse server Human Skill challenge authority")
+
+challenges = re.findall(r"'([A-Z_]+)'", challenge_match.group(1))
+expected_challenges = [
+    "MAKE_IT_EASIER",
+    "CATCH_THE_GOOD",
+    "PAIRING_LAB",
+    "MARKER_TIMING",
+]
+if challenges != expected_challenges:
+    raise SystemExit(f"Human Skill challenge set drifted: {challenges!r}")
+
+for marker in (
+    "'/social-adventure/arcade'",
+    "`/social-adventure/arcade/${challengeKey}/attempts`",
+    "`/social-adventure/arcade/attempts/${attemptId}/complete`",
+    "'/social-adventure/shares'",
+    "sourceType: 'HUMAN_SKILL_ATTEMPT'",
+    "visibility: 'PUBLIC'",
+):
+    require(mobile_api, marker, f"Native Skillcraft API contract missing: {marker}")
+
+for marker in (
+    "socialAdventureApi.arcade()",
+    "socialAdventureApi.startArcadeAttempt",
+    "socialAdventureApi.completeArcadeAttempt",
+    "socialAdventureApi.shareSkillAttempt",
+    "Breadth counts once. Grinding does not.",
+    "Practice scores stay personal feedback.",
+    "retries and higher scores add no rank.",
+    "The dog does not have to perform for you to play.",
+    "Sharing is optional and publishes this human practice moment only.",
+    "reactions do not increase your rank.",
+    "A game is not training authority.",
+    "onPress={() => void shareResult()}",
+):
+    require(screen, marker, f"Native Skillcraft UI boundary missing: {marker}")
+
+if screen.count("socialAdventureApi.shareSkillAttempt") != 1:
+    raise SystemExit("Skillcraft sharing must remain one explicit post-completion action")
+
+for forbidden in (
+    "correctOptionId",
+    "scoreArcadeResponse",
+    "quieter_context",
+    "mark_settle",
+    "sound_then_good",
+    "../api/adventure",
+    "../api/pets",
+    "../api/activities",
+    "../api/daily-signals",
+    "careEvent",
+    "petId",
+):
+    if forbidden in screen or forbidden in mobile_api:
+        raise SystemExit(f"Native Skillcraft crossed an authority boundary: {forbidden}")
+
+for marker in (
+    "correctOptionId",
+    "scoreArcadeResponse",
+    "quieter_context",
+    "mark_settle",
+    "sound_then_good",
+):
+    require(server_arcade, marker, f"Server Arcade scoring authority missing: {marker}")
+
+for marker in (
+    "async getArcade(userId: string)",
+    "async startHumanSkillAttempt(userId: string, challengeKey: string)",
+    "async completeHumanSkillAttempt(",
+    "private async getBestHumanSkillScores(userId: string)",
+    "const season = currentUtcSeason();",
+    "completed_at >= ${season.startsAt}",
+    "completed_at < ${season.endsAt}",
+):
+    require(server_service, marker, f"Server Skillcraft authority missing: {marker}")
+
+if nav.count('name="Skillcraft"') != 2:
+    raise SystemExit("Skillcraft must remain registered in both Guardian and Companion navigators")
+require(nav, "Skillcraft: undefined;", "Skillcraft route type is missing")
+require(companion, "route: 'Skillcraft'", "Companion mode must expose pet-independent Skillcraft")
+require(feed, "navigation.navigate('Skillcraft')", "Community must link into Skillcraft")
+
+for marker in (
+    "A dog does not need to perform for the human to practice.",
+    "weekly breadth, not grind",
+    "replaying the same room does not add another breadth unit",
+    "automatically share a result",
+    "Pet relationships still control pet authority.",
+    "the human gets the game; the dog keeps the right to have an ordinary day.",
+):
+    require(doc.lower(), marker.lower(), f"Native Skillcraft documentation boundary missing: {marker}")
+
+print("Native Skillcraft source contract passed")

--- a/.github/workflows/native-skillcraft-ci.yml
+++ b/.github/workflows/native-skillcraft-ci.yml
@@ -68,16 +68,14 @@ jobs:
       - name: Enforce native Skillcraft source contract
         run: python3 .github/scripts/assert-native-skillcraft.py
 
-      - name: Check native Skillcraft formatting
+      - name: Print canonical Skillcraft formatting diff
         run: |
-          pnpm exec prettier --check \
+          pnpm exec prettier --write \
             apps/mobile/src/api/social-adventure.ts \
-            apps/mobile/src/screens/SkillcraftScreen.tsx \
-            apps/mobile/src/screens/CompanionHomeScreen.tsx \
-            apps/mobile/src/screens/FeedScreen.tsx \
-            apps/mobile/src/navigation/AppNavigator.tsx \
-            .github/workflows/native-skillcraft-ci.yml \
-            docs/NATIVE_SKILLCRAFT_V1.md
+            apps/mobile/src/screens/SkillcraftScreen.tsx
+          git diff --exit-code -- \
+            apps/mobile/src/api/social-adventure.ts \
+            apps/mobile/src/screens/SkillcraftScreen.tsx
 
       - name: Re-run server Human Skill policy tests
         run: pnpm --filter @woof/api test -- social-adventure.arcade.spec.ts social-adventure.policy.spec.ts --runInBand

--- a/.github/workflows/native-skillcraft-ci.yml
+++ b/.github/workflows/native-skillcraft-ci.yml
@@ -1,0 +1,89 @@
+name: Native Skillcraft CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/mobile/src/api/social-adventure.ts'
+      - 'apps/mobile/src/screens/SkillcraftScreen.tsx'
+      - 'apps/mobile/src/screens/CompanionHomeScreen.tsx'
+      - 'apps/mobile/src/screens/FeedScreen.tsx'
+      - 'apps/mobile/src/navigation/AppNavigator.tsx'
+      - 'apps/api/src/social-adventure/social-adventure.arcade.ts'
+      - 'apps/api/src/social-adventure/social-adventure.arcade.spec.ts'
+      - 'apps/api/src/social-adventure/social-adventure.policy.ts'
+      - 'apps/api/src/social-adventure/social-adventure.policy.spec.ts'
+      - 'apps/api/src/social-adventure/social-adventure.service.ts'
+      - '.github/scripts/assert-native-skillcraft.py'
+      - '.github/workflows/native-skillcraft-ci.yml'
+      - 'docs/NATIVE_SKILLCRAFT_V1.md'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mobile/src/api/social-adventure.ts'
+      - 'apps/mobile/src/screens/SkillcraftScreen.tsx'
+      - 'apps/mobile/src/screens/CompanionHomeScreen.tsx'
+      - 'apps/mobile/src/screens/FeedScreen.tsx'
+      - 'apps/mobile/src/navigation/AppNavigator.tsx'
+      - 'apps/api/src/social-adventure/social-adventure.arcade.ts'
+      - 'apps/api/src/social-adventure/social-adventure.arcade.spec.ts'
+      - 'apps/api/src/social-adventure/social-adventure.policy.ts'
+      - 'apps/api/src/social-adventure/social-adventure.policy.spec.ts'
+      - 'apps/api/src/social-adventure/social-adventure.service.ts'
+      - '.github/scripts/assert-native-skillcraft.py'
+      - '.github/workflows/native-skillcraft-ci.yml'
+      - 'docs/NATIVE_SKILLCRAFT_V1.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-skillcraft-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  qualify:
+    name: Native human-skill game authority
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from committed lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Enforce native Skillcraft source contract
+        run: python3 .github/scripts/assert-native-skillcraft.py
+
+      - name: Check native Skillcraft formatting
+        run: |
+          pnpm exec prettier --check \
+            apps/mobile/src/api/social-adventure.ts \
+            apps/mobile/src/screens/SkillcraftScreen.tsx \
+            apps/mobile/src/screens/CompanionHomeScreen.tsx \
+            apps/mobile/src/screens/FeedScreen.tsx \
+            apps/mobile/src/navigation/AppNavigator.tsx \
+            .github/workflows/native-skillcraft-ci.yml \
+            docs/NATIVE_SKILLCRAFT_V1.md
+
+      - name: Re-run server Human Skill policy tests
+        run: pnpm --filter @woof/api test -- social-adventure.arcade.spec.ts social-adventure.policy.spec.ts --runInBand
+
+      - name: Type-check native client
+        run: pnpm --filter @woof/mobile type-check
+
+      - name: Lint native client
+        run: pnpm --filter @woof/mobile lint

--- a/.github/workflows/native-skillcraft-ci.yml
+++ b/.github/workflows/native-skillcraft-ci.yml
@@ -68,14 +68,16 @@ jobs:
       - name: Enforce native Skillcraft source contract
         run: python3 .github/scripts/assert-native-skillcraft.py
 
-      - name: Print canonical Skillcraft formatting diff
+      - name: Check native Skillcraft formatting
         run: |
-          pnpm exec prettier --write \
+          pnpm exec prettier --check \
             apps/mobile/src/api/social-adventure.ts \
-            apps/mobile/src/screens/SkillcraftScreen.tsx
-          git diff --exit-code -- \
-            apps/mobile/src/api/social-adventure.ts \
-            apps/mobile/src/screens/SkillcraftScreen.tsx
+            apps/mobile/src/screens/SkillcraftScreen.tsx \
+            apps/mobile/src/screens/CompanionHomeScreen.tsx \
+            apps/mobile/src/screens/FeedScreen.tsx \
+            apps/mobile/src/navigation/AppNavigator.tsx \
+            .github/workflows/native-skillcraft-ci.yml \
+            docs/NATIVE_SKILLCRAFT_V1.md
 
       - name: Re-run server Human Skill policy tests
         run: pnpm --filter @woof/api test -- social-adventure.arcade.spec.ts social-adventure.policy.spec.ts --runInBand

--- a/apps/mobile/src/api/social-adventure.ts
+++ b/apps/mobile/src/api/social-adventure.ts
@@ -1,10 +1,7 @@
 import apiClient from './client';
 
 export type ArcadeChallengeKey =
-  | 'MAKE_IT_EASIER'
-  | 'CATCH_THE_GOOD'
-  | 'PAIRING_LAB'
-  | 'MARKER_TIMING';
+  'MAKE_IT_EASIER' | 'CATCH_THE_GOOD' | 'PAIRING_LAB' | 'MARKER_TIMING';
 
 export type ArcadeOption = {
   id: string;

--- a/apps/mobile/src/api/social-adventure.ts
+++ b/apps/mobile/src/api/social-adventure.ts
@@ -1,0 +1,79 @@
+import apiClient from './client';
+
+export type ArcadeChallengeKey =
+  | 'MAKE_IT_EASIER'
+  | 'CATCH_THE_GOOD'
+  | 'PAIRING_LAB'
+  | 'MARKER_TIMING';
+
+export type ArcadeOption = {
+  id: string;
+  label: string;
+};
+
+export type ArcadeScenario = {
+  challengeKey: ArcadeChallengeKey;
+  challengeVersion: string;
+  scenarioKey: string;
+  title: string;
+  skill: string;
+  prompt: string;
+  options?: ArcadeOption[];
+  timing?: {
+    durationMs: number;
+    targetAtMs: number;
+    targetLabel: string;
+  };
+  bestScore: number | null;
+};
+
+export type ArcadeCatalog = {
+  challengeVersion: string;
+  challenges: ArcadeScenario[];
+  scoring: string;
+};
+
+export type ArcadeAttempt = {
+  attemptId: string;
+  issuedAt: string;
+  expiresAt: string;
+  scenario: Omit<ArcadeScenario, 'bestScore'>;
+};
+
+export type ArcadeReceipt = {
+  attemptId: string;
+  challengeKey: ArcadeChallengeKey;
+  challengeVersion: string;
+  score: number;
+  correct: boolean;
+  timingErrorMs?: number;
+  explanation: string;
+  completedAt: string;
+};
+
+export type SocialAdventureShare = {
+  shareId: string;
+  postId: string;
+  headline: string;
+  summary: string;
+  visibility: string;
+};
+
+export const socialAdventureApi = {
+  arcade: () => apiClient.get<ArcadeCatalog>('/social-adventure/arcade'),
+
+  startArcadeAttempt: (challengeKey: ArcadeChallengeKey) =>
+    apiClient.post<ArcadeAttempt>(`/social-adventure/arcade/${challengeKey}/attempts`, {}),
+
+  completeArcadeAttempt: (attemptId: string, response: Record<string, unknown>) =>
+    apiClient.post<ArcadeReceipt>(`/social-adventure/arcade/attempts/${attemptId}/complete`, {
+      response,
+    }),
+
+  shareSkillAttempt: (attemptId: string) =>
+    apiClient.post<SocialAdventureShare>('/social-adventure/shares', {
+      sourceType: 'HUMAN_SKILL_ATTEMPT',
+      sourceId: attemptId,
+      visibility: 'PUBLIC',
+    }),
+};

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -32,6 +32,7 @@ import PetsListScreen from '../screens/PetsListScreen';
 import GoalsScreen from '../screens/GoalsScreen';
 import MediaLibraryScreen from '../screens/MediaLibraryScreen';
 import ProfileScreen from '../screens/ProfileScreen';
+import SkillcraftScreen from '../screens/SkillcraftScreen';
 
 export type RootStackParamList = {
   Login: undefined;
@@ -46,6 +47,7 @@ export type RootStackParamList = {
   Goals: undefined;
   Library: undefined;
   Profile: undefined;
+  Skillcraft: undefined;
 };
 
 export type MainTabParamList = {
@@ -157,6 +159,11 @@ function GuardianNavigator() {
           options={{ ...secondaryScreenOptions, title: 'Map' }}
         />
         <Stack.Screen
+          name="Skillcraft"
+          component={SkillcraftScreen}
+          options={{ ...secondaryScreenOptions, title: 'Skillcraft' }}
+        />
+        <Stack.Screen
           name="Profile"
           component={ProfileScreen}
           options={{ ...secondaryScreenOptions, title: 'You' }}
@@ -187,6 +194,11 @@ function CompanionNavigator({ onResolved }: { onResolved: (state: CompanionState
           name="Map"
           component={MapScreen}
           options={{ ...secondaryScreenOptions, title: 'Map' }}
+        />
+        <Stack.Screen
+          name="Skillcraft"
+          component={SkillcraftScreen}
+          options={{ ...secondaryScreenOptions, title: 'Skillcraft' }}
         />
         <Stack.Screen
           name="Profile"

--- a/apps/mobile/src/screens/CompanionHomeScreen.tsx
+++ b/apps/mobile/src/screens/CompanionHomeScreen.tsx
@@ -11,11 +11,17 @@ type Props = StackScreenProps<RootStackParamList, 'CompanionHome'> & {
 };
 
 const links: {
-  route: 'CommunityStandalone' | 'Events' | 'Profile';
+  route: 'Skillcraft' | 'CommunityStandalone' | 'Events' | 'Profile';
   title: string;
   description: string;
   icon: keyof typeof Ionicons.glyphMap;
 }[] = [
+  {
+    route: 'Skillcraft',
+    title: 'Skillcraft',
+    description: 'Practice setup, observation, pairing, and timing without inventing a pet.',
+    icon: 'game-controller-outline',
+  },
   {
     route: 'CommunityStandalone',
     title: 'Community',
@@ -62,7 +68,8 @@ export default function CompanionHomeScreen({ navigation, onResolved }: Props) {
       <Text style={styles.title}>You do not need to invent a dog to belong here.</Text>
       <Text style={styles.intro}>
         Woof keeps pet-specific Today, Compass, and Story closed until the server can verify a real
-        owned or authorized relationship. You can still explore people, events, and your account.
+        owned or authorized relationship. You can still practice human skills, explore people and
+        events, and manage your account.
       </Text>
 
       <View style={styles.truthCard}>

--- a/apps/mobile/src/screens/FeedScreen.tsx
+++ b/apps/mobile/src/screens/FeedScreen.tsx
@@ -154,10 +154,18 @@ export default function FeedScreen({ navigation }: Props) {
             <Text style={styles.eyebrow}>PEOPLE AROUND YOUR DOG LIFE</Text>
             <Text style={styles.headerTitle}>Community</Text>
             <Text style={styles.headerSubtitle}>
-              Real friends, local plans, and shared moments. Community should help you get back to
-              life together, not keep you scrolling.
+              Real friends, local plans, shared moments, and human-skill practice. Community should
+              help you get back to life together, not keep you scrolling.
             </Text>
             <View style={styles.quickLinks}>
+              <Pressable
+                style={styles.quickLink}
+                onPress={() => navigation.navigate('Skillcraft')}
+                accessibilityRole="button"
+              >
+                <Ionicons name="game-controller-outline" size={18} color={colors.primary[700]} />
+                <Text style={styles.quickLinkText}>Skillcraft</Text>
+              </Pressable>
               <Pressable
                 style={styles.quickLink}
                 onPress={() => navigation.navigate('Events')}
@@ -188,8 +196,8 @@ export default function FeedScreen({ navigation }: Props) {
             <Ionicons name="people-outline" size={44} color={colors.primary[500]} />
             <Text style={styles.emptyText}>A quieter community is okay.</Text>
             <Text style={styles.emptySubtext}>
-              Woof can still be useful through Today, Story, and your real relationship even when
-              there is nothing new to browse.
+              Woof can still be useful through Today, Story, Skillcraft, and your real relationship
+              even when there is nothing new to browse.
             </Text>
           </View>
         }
@@ -212,7 +220,7 @@ const styles = StyleSheet.create({
   eyebrow: { color: colors.text.secondary, fontSize: 10, fontWeight: '700', letterSpacing: 1.4 },
   headerTitle: { marginTop: 3, fontSize: 32, fontWeight: '800', color: colors.text.primary },
   headerSubtitle: { marginTop: 7, fontSize: 14, lineHeight: 20, color: colors.text.secondary },
-  quickLinks: { marginTop: 14, flexDirection: 'row', gap: 8 },
+  quickLinks: { marginTop: 14, flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
   quickLink: {
     minHeight: 42,
     paddingHorizontal: 13,

--- a/apps/mobile/src/screens/SkillcraftScreen.tsx
+++ b/apps/mobile/src/screens/SkillcraftScreen.tsx
@@ -1,0 +1,754 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useFocusEffect } from '@react-navigation/native';
+import type { StackScreenProps } from '@react-navigation/stack';
+import {
+  socialAdventureApi,
+  type ArcadeAttempt,
+  type ArcadeCatalog,
+  type ArcadeChallengeKey,
+  type ArcadeReceipt,
+  type ArcadeScenario,
+} from '../api/social-adventure';
+import type { RootStackParamList } from '../navigation/AppNavigator';
+import { colors } from '../theme/tokens';
+
+type Props = StackScreenProps<RootStackParamList, 'Skillcraft'>;
+
+type ShareState = 'idle' | 'pending' | 'shared' | 'error';
+
+const challengeIcon: Record<ArcadeChallengeKey, keyof typeof Ionicons.glyphMap> = {
+  MAKE_IT_EASIER: 'options-outline',
+  CATCH_THE_GOOD: 'sparkles-outline',
+  PAIRING_LAB: 'link-outline',
+  MARKER_TIMING: 'timer-outline',
+};
+
+const challengeRoom: Record<ArcadeChallengeKey, string> = {
+  MAKE_IT_EASIER: 'Setup Lab',
+  CATCH_THE_GOOD: 'Observation Room',
+  PAIRING_LAB: 'Association Studio',
+  MARKER_TIMING: 'Timing Deck',
+};
+
+function clampPercent(value: number) {
+  return Math.max(0, Math.min(100, value));
+}
+
+export default function SkillcraftScreen({ navigation }: Props) {
+  const [catalog, setCatalog] = useState<ArcadeCatalog | null>(null);
+  const [attempt, setAttempt] = useState<ArcadeAttempt | null>(null);
+  const [receipt, setReceipt] = useState<ArcadeReceipt | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [startingKey, setStartingKey] = useState<ArcadeChallengeKey | null>(null);
+  const [completing, setCompleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [shareState, setShareState] = useState<ShareState>('idle');
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [timingExpired, setTimingExpired] = useState(false);
+  const timingStartRef = useRef<number | null>(null);
+
+  const loadCatalog = useCallback(async (refresh = false) => {
+    if (refresh) setRefreshing(true);
+    else setLoading(true);
+    try {
+      setCatalog(await socialAdventureApi.arcade());
+      setError(null);
+    } catch {
+      setError('Skillcraft is unavailable right now. No practice result or social score changed.');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      void loadCatalog();
+    }, [loadCatalog])
+  );
+
+  useEffect(() => {
+    const timing = attempt?.scenario.timing;
+    if (!timing || receipt || timingExpired || timingStartRef.current === null) return;
+
+    const timer = setInterval(() => {
+      if (timingStartRef.current === null) return;
+      const elapsed = Math.max(0, Date.now() - timingStartRef.current);
+      const bounded = Math.min(timing.durationMs, elapsed);
+      setElapsedMs(bounded);
+      if (bounded >= timing.durationMs) setTimingExpired(true);
+    }, 40);
+
+    return () => clearInterval(timer);
+  }, [attempt, receipt, timingExpired]);
+
+  const startRound = async (challenge: ArcadeScenario) => {
+    if (startingKey || completing) return;
+    setStartingKey(challenge.challengeKey);
+    setError(null);
+    setShareState('idle');
+    try {
+      const nextAttempt = await socialAdventureApi.startArcadeAttempt(challenge.challengeKey);
+      setAttempt(nextAttempt);
+      setReceipt(null);
+      setElapsedMs(0);
+      setTimingExpired(false);
+      timingStartRef.current = nextAttempt.scenario.timing ? Date.now() : null;
+    } catch {
+      setError('That Skillcraft round could not start. Nothing was scored.');
+    } finally {
+      setStartingKey(null);
+    }
+  };
+
+  const completeRound = async (response: Record<string, unknown>) => {
+    if (!attempt || completing || receipt) return;
+    setCompleting(true);
+    setError(null);
+    try {
+      const nextReceipt = await socialAdventureApi.completeArcadeAttempt(attempt.attemptId, response);
+      setReceipt(nextReceipt);
+      timingStartRef.current = null;
+      void socialAdventureApi
+        .arcade()
+        .then((nextCatalog) => setCatalog(nextCatalog))
+        .catch(() => undefined);
+    } catch {
+      setError('Woof could not score that practice round. Start a fresh round before trying again.');
+    } finally {
+      setCompleting(false);
+    }
+  };
+
+  const markTiming = () => {
+    if (!attempt?.scenario.timing || timingStartRef.current === null || timingExpired) return;
+    const tapMs = Math.max(0, Date.now() - timingStartRef.current);
+    void completeRound({ tapMs });
+  };
+
+  const resetRound = () => {
+    setAttempt(null);
+    setReceipt(null);
+    setElapsedMs(0);
+    setTimingExpired(false);
+    setShareState('idle');
+    timingStartRef.current = null;
+    setError(null);
+  };
+
+  const shareResult = async () => {
+    if (!receipt || shareState === 'pending' || shareState === 'shared') return;
+    setShareState('pending');
+    try {
+      await socialAdventureApi.shareSkillAttempt(receipt.attemptId);
+      setShareState('shared');
+    } catch {
+      setShareState('error');
+    }
+  };
+
+  const completedThisWeek = catalog?.challenges.filter((challenge) => challenge.bestScore !== null).length ?? 0;
+  const totalChallenges = catalog?.challenges.length ?? 4;
+  const breadthProgress = clampPercent((completedThisWeek / Math.max(1, totalChallenges)) * 100);
+  const timing = attempt?.scenario.timing;
+  const timingProgress = timing ? clampPercent((elapsedMs / timing.durationMs) * 100) : 0;
+
+  if (loading && !catalog) {
+    return (
+      <View style={styles.centered} accessibilityRole="progressbar">
+        <ActivityIndicator size="large" color={colors.primary[600]} />
+        <Text style={styles.loadingText}>Opening Skillcraft…</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.screen}
+      contentContainerStyle={styles.content}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={() => void loadCatalog(true)} />
+      }
+    >
+      <View style={styles.hero}>
+        <View style={styles.heroIcon}>
+          <Ionicons name="game-controller-outline" size={24} color={colors.primary[700]} />
+        </View>
+        <Text style={styles.eyebrow}>HUMAN SKILL ARCADE</Text>
+        <Text style={styles.title}>Skillcraft</Text>
+        <Text style={styles.subtitle}>
+          Practice the human mechanics behind better dog days: setup, observation, positive
+          association, and timing. The dog does not have to perform for you to play.
+        </Text>
+
+        <View style={styles.weekPanel}>
+          <View style={styles.weekHeader}>
+            <View>
+              <Text style={styles.weekTitle}>This week&apos;s rooms</Text>
+              <Text style={styles.weekSubtitle}>Breadth counts once. Grinding does not.</Text>
+            </View>
+            <Text style={styles.weekCount}>
+              {completedThisWeek}/{totalChallenges}
+            </Text>
+          </View>
+          <View
+            style={styles.progressTrack}
+            accessibilityRole="progressbar"
+            accessibilityValue={{ min: 0, max: 100, now: Math.round(breadthProgress) }}
+          >
+            <View style={[styles.progressFill, { width: `${breadthProgress}%` }]} />
+          </View>
+          <Text style={styles.weekBoundary}>
+            Practice scores stay personal feedback. Completing each different room once in the
+            weekly season contributes one fixed breadth unit; retries and higher scores add no rank.
+          </Text>
+        </View>
+      </View>
+
+      {error && (
+        <View style={styles.errorCard} accessibilityRole="alert">
+          <Ionicons name="alert-circle-outline" size={19} color={colors.error.dark} />
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      )}
+
+      {!attempt && catalog && (
+        <View style={styles.challengeList}>
+          {catalog.challenges.map((challenge) => {
+            const practiced = challenge.bestScore !== null;
+            const starting = startingKey === challenge.challengeKey;
+            return (
+              <View key={challenge.challengeKey} style={styles.challengeCard}>
+                <View style={styles.challengeHeader}>
+                  <View style={styles.challengeIcon}>
+                    <Ionicons
+                      name={challengeIcon[challenge.challengeKey]}
+                      size={21}
+                      color={colors.primary[700]}
+                    />
+                  </View>
+                  <View style={styles.challengeCopy}>
+                    <Text style={styles.roomLabel}>{challengeRoom[challenge.challengeKey]}</Text>
+                    <Text style={styles.challengeTitle}>{challenge.title}</Text>
+                    <Text style={styles.skillLabel}>{challenge.skill}</Text>
+                  </View>
+                  <View style={[styles.badge, practiced && styles.badgePracticed]}>
+                    <Ionicons
+                      name={practiced ? 'checkmark-circle' : 'sparkles-outline'}
+                      size={13}
+                      color={practiced ? colors.success.dark : colors.primary[700]}
+                    />
+                    <Text style={[styles.badgeText, practiced && styles.badgeTextPracticed]}>
+                      {practiced ? 'Explored' : 'New'}
+                    </Text>
+                  </View>
+                </View>
+
+                <Text style={styles.challengePrompt}>{challenge.prompt}</Text>
+                {practiced && (
+                  <Text style={styles.personalBest}>Personal practice best: {challenge.bestScore}/100</Text>
+                )}
+
+                <Pressable
+                  accessibilityRole="button"
+                  disabled={startingKey !== null}
+                  style={[styles.playButton, startingKey !== null && styles.disabled]}
+                  onPress={() => void startRound(challenge)}
+                >
+                  {starting ? (
+                    <ActivityIndicator color="#ffffff" />
+                  ) : (
+                    <>
+                      <Ionicons name="play" size={16} color="#ffffff" />
+                      <Text style={styles.playButtonText}>{practiced ? 'Practice again' : 'Play room'}</Text>
+                    </>
+                  )}
+                </Pressable>
+              </View>
+            );
+          })}
+
+          <Text style={styles.scoringCopy}>{catalog.scoring}</Text>
+        </View>
+      )}
+
+      {attempt && (
+        <View style={styles.roundCard}>
+          <View style={styles.roundHeader}>
+            <View style={styles.roundIcon}>
+              <Ionicons
+                name={challengeIcon[attempt.scenario.challengeKey]}
+                size={22}
+                color="#ffffff"
+              />
+            </View>
+            <View style={styles.roundCopy}>
+              <Text style={styles.roundEyebrow}>{attempt.scenario.skill}</Text>
+              <Text style={styles.roundTitle}>{attempt.scenario.title}</Text>
+            </View>
+          </View>
+
+          <Text style={styles.roundPrompt}>{attempt.scenario.prompt}</Text>
+
+          {!receipt && attempt.scenario.options && (
+            <View style={styles.optionsList}>
+              {attempt.scenario.options.map((option) => (
+                <Pressable
+                  key={option.id}
+                  accessibilityRole="button"
+                  disabled={completing}
+                  style={[styles.optionButton, completing && styles.disabled]}
+                  onPress={() => void completeRound({ optionId: option.id })}
+                >
+                  <Text style={styles.optionText}>{option.label}</Text>
+                  <Ionicons name="chevron-forward" size={17} color={colors.gray[400]} />
+                </Pressable>
+              ))}
+            </View>
+          )}
+
+          {!receipt && timing && (
+            <View style={styles.timingPanel}>
+              <View style={styles.timingTitleRow}>
+                <Ionicons name="timer-outline" size={18} color={colors.primary[700]} />
+                <Text style={styles.timingTitle}>Watch the behavior track</Text>
+              </View>
+              <View
+                style={styles.timingTrack}
+                accessibilityRole="progressbar"
+                accessibilityValue={{ min: 0, max: 100, now: Math.round(timingProgress) }}
+              >
+                <View style={[styles.timingFill, { width: `${timingProgress}%` }]} />
+              </View>
+              <View style={styles.timingCue}>
+                <Text style={styles.timingCueText}>
+                  {timingExpired
+                    ? 'Round ended. Start fresh for another timing attempt.'
+                    : elapsedMs < timing.targetAtMs - 700
+                      ? 'Approaching the mat…'
+                      : elapsedMs < timing.targetAtMs
+                        ? 'Almost there…'
+                        : elapsedMs < timing.targetAtMs + 350
+                          ? `Target: ${timing.targetLabel}`
+                          : 'Behavior moved on'}
+                </Text>
+              </View>
+              <Pressable
+                accessibilityRole="button"
+                disabled={completing || timingExpired}
+                style={[
+                  styles.markButton,
+                  (completing || timingExpired) && styles.disabled,
+                ]}
+                onPress={markTiming}
+              >
+                {completing ? (
+                  <ActivityIndicator color="#ffffff" />
+                ) : (
+                  <Text style={styles.markButtonText}>Mark now</Text>
+                )}
+              </Pressable>
+              <Text style={styles.timingBoundary}>
+                Device timing is a teaching exercise. Milliseconds never determine public rank or
+                professional proficiency.
+              </Text>
+            </View>
+          )}
+
+          {completing && !timing && (
+            <View style={styles.scoringRow} accessibilityRole="progressbar">
+              <ActivityIndicator color={colors.primary[600]} />
+              <Text style={styles.scoringText}>Scoring this practice round…</Text>
+            </View>
+          )}
+
+          {receipt && (
+            <View style={styles.receiptCard}>
+              <View style={styles.receiptHeader}>
+                <View style={styles.receiptIcon}>
+                  <Ionicons
+                    name={receipt.correct ? 'checkmark' : 'bulb-outline'}
+                    size={20}
+                    color={colors.primary[700]}
+                  />
+                </View>
+                <View style={styles.receiptCopy}>
+                  <Text style={styles.receiptEyebrow}>PRACTICE RESULT</Text>
+                  <Text style={styles.receiptScore}>{receipt.score}/100</Text>
+                  <Text style={styles.receiptLabel}>
+                    {receipt.correct ? 'Good read' : 'Useful miss — review the pattern'}
+                  </Text>
+                </View>
+              </View>
+
+              {receipt.timingErrorMs !== undefined && (
+                <Text style={styles.timingResult}>
+                  {receipt.timingErrorMs} ms from the practice target
+                </Text>
+              )}
+              <Text style={styles.receiptExplanation}>{receipt.explanation}</Text>
+
+              <View style={styles.receiptActions}>
+                <Pressable accessibilityRole="button" style={styles.playButton} onPress={resetRound}>
+                  <Ionicons name="game-controller-outline" size={17} color="#ffffff" />
+                  <Text style={styles.playButtonText}>Another room</Text>
+                </Pressable>
+                <Pressable
+                  accessibilityRole="button"
+                  disabled={shareState === 'pending' || shareState === 'shared'}
+                  style={[
+                    styles.shareButton,
+                    (shareState === 'pending' || shareState === 'shared') && styles.disabled,
+                  ]}
+                  onPress={() => void shareResult()}
+                >
+                  {shareState === 'pending' ? (
+                    <ActivityIndicator color={colors.primary[700]} />
+                  ) : (
+                    <>
+                      <Ionicons
+                        name={shareState === 'shared' ? 'checkmark-circle' : 'share-social-outline'}
+                        size={17}
+                        color={colors.primary[700]}
+                      />
+                      <Text style={styles.shareButtonText}>
+                        {shareState === 'shared' ? 'Shared publicly' : 'Share skill moment'}
+                      </Text>
+                    </>
+                  )}
+                </Pressable>
+              </View>
+
+              {shareState === 'error' && (
+                <Text style={styles.shareError} accessibilityRole="alert">
+                  That result was not shared. Your practice receipt is still saved.
+                </Text>
+              )}
+              <Text style={styles.shareBoundary}>
+                Sharing is optional and publishes this human practice moment only. It does not post
+                a pet score or private dog history, and reactions do not increase your rank.
+              </Text>
+            </View>
+          )}
+
+          {!receipt && !completing && (
+            <Pressable accessibilityRole="button" style={styles.leaveButton} onPress={resetRound}>
+              <Text style={styles.leaveButtonText}>{timingExpired ? 'Start a fresh round' : 'Leave round'}</Text>
+            </Pressable>
+          )}
+        </View>
+      )}
+
+      <View style={styles.safetyCard}>
+        <Ionicons name="shield-checkmark-outline" size={21} color={colors.primary[700]} />
+        <View style={styles.safetyCopy}>
+          <Text style={styles.safetyTitle}>A game is not training authority.</Text>
+          <Text style={styles.safetyText}>
+            Skillcraft teaches general reward-based mechanics. Significant fear, aggression, pain,
+            or sudden behavior change should not become a DIY exposure level; use qualified
+            professional or veterinary help when appropriate.
+          </Text>
+        </View>
+      </View>
+
+      <Pressable accessibilityRole="button" style={styles.backLink} onPress={() => navigation.goBack()}>
+        <Ionicons name="arrow-back" size={16} color={colors.gray[600]} />
+        <Text style={styles.backLinkText}>Back to Woof</Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: colors.background.paper },
+  content: { padding: 18, paddingBottom: 44 },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.background.paper,
+    padding: 24,
+  },
+  loadingText: { marginTop: 12, color: colors.text.secondary },
+  hero: {
+    padding: 20,
+    borderRadius: 26,
+    backgroundColor: colors.primary[50],
+    borderWidth: 1,
+    borderColor: colors.primary[200],
+  },
+  heroIcon: {
+    width: 48,
+    height: 48,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: colors.primary[100],
+    marginBottom: 16,
+  },
+  eyebrow: {
+    color: colors.primary[700],
+    fontSize: 10,
+    fontWeight: '800',
+    letterSpacing: 1.4,
+  },
+  title: { marginTop: 3, color: colors.text.primary, fontSize: 34, fontWeight: '800' },
+  subtitle: { marginTop: 8, color: colors.gray[700], fontSize: 14, lineHeight: 21 },
+  weekPanel: {
+    marginTop: 18,
+    padding: 15,
+    borderRadius: 18,
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: colors.primary[100],
+  },
+  weekHeader: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  weekTitle: { color: colors.text.primary, fontSize: 14, fontWeight: '800' },
+  weekSubtitle: { marginTop: 2, color: colors.text.secondary, fontSize: 11 },
+  weekCount: { color: colors.primary[700], fontSize: 18, fontWeight: '900' },
+  progressTrack: {
+    marginTop: 12,
+    height: 9,
+    borderRadius: 999,
+    overflow: 'hidden',
+    backgroundColor: colors.gray[100],
+  },
+  progressFill: { height: '100%', borderRadius: 999, backgroundColor: colors.primary[500] },
+  weekBoundary: { marginTop: 10, color: colors.text.secondary, fontSize: 10, lineHeight: 15 },
+  errorCard: {
+    marginTop: 14,
+    padding: 13,
+    borderRadius: 14,
+    flexDirection: 'row',
+    gap: 8,
+    backgroundColor: colors.error.light,
+  },
+  errorText: { flex: 1, color: colors.error.dark, fontSize: 12, lineHeight: 18 },
+  challengeList: { marginTop: 18, gap: 12 },
+  challengeCard: {
+    padding: 17,
+    borderRadius: 21,
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+  },
+  challengeHeader: { flexDirection: 'row', alignItems: 'flex-start', gap: 10 },
+  challengeIcon: {
+    width: 43,
+    height: 43,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.primary[50],
+  },
+  challengeCopy: { flex: 1 },
+  roomLabel: {
+    color: colors.primary[700],
+    fontSize: 9,
+    fontWeight: '800',
+    letterSpacing: 1.1,
+  },
+  challengeTitle: { marginTop: 2, color: colors.text.primary, fontSize: 17, fontWeight: '800' },
+  skillLabel: { marginTop: 2, color: colors.text.secondary, fontSize: 11 },
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 5,
+    borderRadius: 999,
+    backgroundColor: colors.primary[50],
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  badgePracticed: { backgroundColor: colors.success.light },
+  badgeText: { color: colors.primary[700], fontSize: 9, fontWeight: '800' },
+  badgeTextPracticed: { color: colors.success.dark },
+  challengePrompt: { marginTop: 13, color: colors.gray[700], fontSize: 13, lineHeight: 19 },
+  personalBest: { marginTop: 8, color: colors.text.secondary, fontSize: 10, fontWeight: '700' },
+  playButton: {
+    minHeight: 46,
+    marginTop: 14,
+    paddingHorizontal: 15,
+    borderRadius: 13,
+    backgroundColor: colors.primary[600],
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 7,
+  },
+  playButtonText: { color: '#ffffff', fontSize: 13, fontWeight: '800' },
+  disabled: { opacity: 0.5 },
+  scoringCopy: { color: colors.text.secondary, fontSize: 10, lineHeight: 16, paddingHorizontal: 4 },
+  roundCard: {
+    marginTop: 18,
+    padding: 18,
+    borderRadius: 23,
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+  },
+  roundHeader: { flexDirection: 'row', alignItems: 'center', gap: 11 },
+  roundIcon: {
+    width: 45,
+    height: 45,
+    borderRadius: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.primary[600],
+  },
+  roundCopy: { flex: 1 },
+  roundEyebrow: {
+    color: colors.primary[700],
+    fontSize: 9,
+    fontWeight: '800',
+    letterSpacing: 1,
+  },
+  roundTitle: { marginTop: 2, color: colors.text.primary, fontSize: 20, fontWeight: '800' },
+  roundPrompt: { marginTop: 17, color: colors.gray[800], fontSize: 15, lineHeight: 22 },
+  optionsList: { marginTop: 16, gap: 9 },
+  optionButton: {
+    minHeight: 58,
+    padding: 14,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    backgroundColor: colors.gray[50],
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  optionText: { flex: 1, color: colors.gray[800], fontSize: 13, lineHeight: 19, fontWeight: '600' },
+  timingPanel: {
+    marginTop: 17,
+    padding: 15,
+    borderRadius: 18,
+    backgroundColor: colors.primary[50],
+    borderWidth: 1,
+    borderColor: colors.primary[100],
+  },
+  timingTitleRow: { flexDirection: 'row', alignItems: 'center', gap: 7 },
+  timingTitle: { color: colors.text.primary, fontSize: 13, fontWeight: '800' },
+  timingTrack: {
+    marginTop: 14,
+    height: 11,
+    borderRadius: 999,
+    overflow: 'hidden',
+    backgroundColor: '#ffffff',
+  },
+  timingFill: { height: '100%', borderRadius: 999, backgroundColor: colors.primary[500] },
+  timingCue: {
+    minHeight: 54,
+    marginTop: 12,
+    borderRadius: 13,
+    borderWidth: 1,
+    borderColor: colors.primary[100],
+    backgroundColor: '#ffffff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 10,
+  },
+  timingCueText: { color: colors.gray[700], fontSize: 12, lineHeight: 17, textAlign: 'center' },
+  markButton: {
+    minHeight: 52,
+    marginTop: 12,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.primary[600],
+  },
+  markButtonText: { color: '#ffffff', fontSize: 14, fontWeight: '900' },
+  timingBoundary: { marginTop: 10, color: colors.text.secondary, fontSize: 10, lineHeight: 15 },
+  scoringRow: {
+    marginTop: 18,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  scoringText: { color: colors.text.secondary, fontSize: 12 },
+  receiptCard: {
+    marginTop: 18,
+    padding: 16,
+    borderRadius: 19,
+    backgroundColor: colors.primary[50],
+    borderWidth: 1,
+    borderColor: colors.primary[100],
+  },
+  receiptHeader: { flexDirection: 'row', alignItems: 'center', gap: 11 },
+  receiptIcon: {
+    width: 43,
+    height: 43,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#ffffff',
+  },
+  receiptCopy: { flex: 1 },
+  receiptEyebrow: {
+    color: colors.primary[700],
+    fontSize: 9,
+    fontWeight: '800',
+    letterSpacing: 1.1,
+  },
+  receiptScore: { marginTop: 1, color: colors.primary[800], fontSize: 29, fontWeight: '900' },
+  receiptLabel: { color: colors.text.secondary, fontSize: 10, fontWeight: '700' },
+  timingResult: { marginTop: 12, color: colors.primary[800], fontSize: 11, fontWeight: '800' },
+  receiptExplanation: { marginTop: 12, color: colors.gray[700], fontSize: 13, lineHeight: 19 },
+  receiptActions: { marginTop: 2 },
+  shareButton: {
+    minHeight: 44,
+    marginTop: 8,
+    paddingHorizontal: 13,
+    borderRadius: 13,
+    borderWidth: 1,
+    borderColor: colors.primary[200],
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 7,
+    backgroundColor: '#ffffff',
+  },
+  shareButtonText: { color: colors.primary[800], fontSize: 12, fontWeight: '800' },
+  shareError: { marginTop: 9, color: colors.error.dark, fontSize: 10, lineHeight: 15 },
+  shareBoundary: { marginTop: 10, color: colors.text.secondary, fontSize: 10, lineHeight: 15 },
+  leaveButton: { alignSelf: 'center', paddingVertical: 13, paddingHorizontal: 20, marginTop: 10 },
+  leaveButtonText: { color: colors.gray[600], fontSize: 12, fontWeight: '700' },
+  safetyCard: {
+    marginTop: 18,
+    padding: 16,
+    borderRadius: 19,
+    flexDirection: 'row',
+    gap: 10,
+    backgroundColor: colors.gray[100],
+  },
+  safetyCopy: { flex: 1 },
+  safetyTitle: { color: colors.text.primary, fontSize: 13, fontWeight: '800' },
+  safetyText: { marginTop: 4, color: colors.text.secondary, fontSize: 11, lineHeight: 17 },
+  backLink: {
+    alignSelf: 'center',
+    marginTop: 14,
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  backLinkText: { color: colors.gray[600], fontSize: 12, fontWeight: '700' },
+});

--- a/apps/mobile/src/screens/SkillcraftScreen.tsx
+++ b/apps/mobile/src/screens/SkillcraftScreen.tsx
@@ -117,7 +117,10 @@ export default function SkillcraftScreen({ navigation }: Props) {
     setCompleting(true);
     setError(null);
     try {
-      const nextReceipt = await socialAdventureApi.completeArcadeAttempt(attempt.attemptId, response);
+      const nextReceipt = await socialAdventureApi.completeArcadeAttempt(
+        attempt.attemptId,
+        response
+      );
       setReceipt(nextReceipt);
       timingStartRef.current = null;
       void socialAdventureApi
@@ -125,7 +128,9 @@ export default function SkillcraftScreen({ navigation }: Props) {
         .then((nextCatalog) => setCatalog(nextCatalog))
         .catch(() => undefined);
     } catch {
-      setError('Woof could not score that practice round. Start a fresh round before trying again.');
+      setError(
+        'Woof could not score that practice round. Start a fresh round before trying again.'
+      );
     } finally {
       setCompleting(false);
     }
@@ -158,8 +163,9 @@ export default function SkillcraftScreen({ navigation }: Props) {
     }
   };
 
-  const completedThisWeek = catalog?.challenges.filter((challenge) => challenge.bestScore !== null).length ?? 0;
-  const totalChallenges = catalog?.challenges.length ?? 4;
+  const completedThisWeek =
+    catalog?.challenges.filter((challenge) => challenge.bestScore !== null).length ?? 0;
+  const totalChallenges = catalog?.challenges.length ?? 0;
   const breadthProgress = clampPercent((completedThisWeek / Math.max(1, totalChallenges)) * 100);
   const timing = attempt?.scenario.timing;
   const timingProgress = timing ? clampPercent((elapsedMs / timing.durationMs) * 100) : 0;
@@ -192,28 +198,31 @@ export default function SkillcraftScreen({ navigation }: Props) {
           association, and timing. The dog does not have to perform for you to play.
         </Text>
 
-        <View style={styles.weekPanel}>
-          <View style={styles.weekHeader}>
-            <View>
-              <Text style={styles.weekTitle}>This week&apos;s rooms</Text>
-              <Text style={styles.weekSubtitle}>Breadth counts once. Grinding does not.</Text>
+        {catalog && (
+          <View style={styles.weekPanel}>
+            <View style={styles.weekHeader}>
+              <View>
+                <Text style={styles.weekTitle}>This week&apos;s rooms</Text>
+                <Text style={styles.weekSubtitle}>Breadth counts once. Grinding does not.</Text>
+              </View>
+              <Text style={styles.weekCount}>
+                {completedThisWeek}/{totalChallenges}
+              </Text>
             </View>
-            <Text style={styles.weekCount}>
-              {completedThisWeek}/{totalChallenges}
+            <View
+              style={styles.progressTrack}
+              accessibilityRole="progressbar"
+              accessibilityValue={{ min: 0, max: 100, now: Math.round(breadthProgress) }}
+            >
+              <View style={[styles.progressFill, { width: `${breadthProgress}%` }]} />
+            </View>
+            <Text style={styles.weekBoundary}>
+              Practice scores stay personal feedback. Completing each different room once in the
+              weekly season contributes one fixed breadth unit; retries and higher scores add no
+              rank.
             </Text>
           </View>
-          <View
-            style={styles.progressTrack}
-            accessibilityRole="progressbar"
-            accessibilityValue={{ min: 0, max: 100, now: Math.round(breadthProgress) }}
-          >
-            <View style={[styles.progressFill, { width: `${breadthProgress}%` }]} />
-          </View>
-          <Text style={styles.weekBoundary}>
-            Practice scores stay personal feedback. Completing each different room once in the
-            weekly season contributes one fixed breadth unit; retries and higher scores add no rank.
-          </Text>
-        </View>
+        )}
       </View>
 
       {error && (
@@ -257,7 +266,9 @@ export default function SkillcraftScreen({ navigation }: Props) {
 
                 <Text style={styles.challengePrompt}>{challenge.prompt}</Text>
                 {practiced && (
-                  <Text style={styles.personalBest}>Personal practice best: {challenge.bestScore}/100</Text>
+                  <Text style={styles.personalBest}>
+                    Personal practice best: {challenge.bestScore}/100
+                  </Text>
                 )}
 
                 <Pressable
@@ -271,7 +282,9 @@ export default function SkillcraftScreen({ navigation }: Props) {
                   ) : (
                     <>
                       <Ionicons name="play" size={16} color="#ffffff" />
-                      <Text style={styles.playButtonText}>{practiced ? 'Practice again' : 'Play room'}</Text>
+                      <Text style={styles.playButtonText}>
+                        {practiced ? 'Practice again' : 'Play room'}
+                      </Text>
                     </>
                   )}
                 </Pressable>
@@ -334,7 +347,7 @@ export default function SkillcraftScreen({ navigation }: Props) {
               <View style={styles.timingCue}>
                 <Text style={styles.timingCueText}>
                   {timingExpired
-                    ? 'Round ended. Start fresh for another timing attempt.'
+                    ? 'Round ended. Choose a fresh timing attempt.'
                     : elapsedMs < timing.targetAtMs - 700
                       ? 'Approaching the mat…'
                       : elapsedMs < timing.targetAtMs
@@ -347,10 +360,7 @@ export default function SkillcraftScreen({ navigation }: Props) {
               <Pressable
                 accessibilityRole="button"
                 disabled={completing || timingExpired}
-                style={[
-                  styles.markButton,
-                  (completing || timingExpired) && styles.disabled,
-                ]}
+                style={[styles.markButton, (completing || timingExpired) && styles.disabled]}
                 onPress={markTiming}
               >
                 {completing ? (
@@ -400,12 +410,17 @@ export default function SkillcraftScreen({ navigation }: Props) {
               <Text style={styles.receiptExplanation}>{receipt.explanation}</Text>
 
               <View style={styles.receiptActions}>
-                <Pressable accessibilityRole="button" style={styles.playButton} onPress={resetRound}>
+                <Pressable
+                  accessibilityRole="button"
+                  style={styles.playButton}
+                  onPress={resetRound}
+                >
                   <Ionicons name="game-controller-outline" size={17} color="#ffffff" />
                   <Text style={styles.playButtonText}>Another room</Text>
                 </Pressable>
                 <Pressable
                   accessibilityRole="button"
+                  accessibilityLabel="Share this human skill moment publicly"
                   disabled={shareState === 'pending' || shareState === 'shared'}
                   style={[
                     styles.shareButton,
@@ -423,7 +438,7 @@ export default function SkillcraftScreen({ navigation }: Props) {
                         color={colors.primary[700]}
                       />
                       <Text style={styles.shareButtonText}>
-                        {shareState === 'shared' ? 'Shared publicly' : 'Share skill moment'}
+                        {shareState === 'shared' ? 'Shared publicly' : 'Share publicly'}
                       </Text>
                     </>
                   )}
@@ -444,7 +459,9 @@ export default function SkillcraftScreen({ navigation }: Props) {
 
           {!receipt && !completing && (
             <Pressable accessibilityRole="button" style={styles.leaveButton} onPress={resetRound}>
-              <Text style={styles.leaveButtonText}>{timingExpired ? 'Start a fresh round' : 'Leave round'}</Text>
+              <Text style={styles.leaveButtonText}>
+                {timingExpired ? 'Choose a fresh round' : 'Leave round'}
+              </Text>
             </Pressable>
           )}
         </View>
@@ -462,7 +479,11 @@ export default function SkillcraftScreen({ navigation }: Props) {
         </View>
       </View>
 
-      <Pressable accessibilityRole="button" style={styles.backLink} onPress={() => navigation.goBack()}>
+      <Pressable
+        accessibilityRole="button"
+        style={styles.backLink}
+        onPress={() => navigation.goBack()}
+      >
         <Ionicons name="arrow-back" size={16} color={colors.gray[600]} />
         <Text style={styles.backLinkText}>Back to Woof</Text>
       </Pressable>

--- a/docs/NATIVE_SKILLCRAFT_V1.md
+++ b/docs/NATIVE_SKILLCRAFT_V1.md
@@ -1,0 +1,163 @@
+# Native Skillcraft v1
+
+## Purpose
+
+Skillcraft brings the existing server-authoritative Human Skill Arcade into native Woof.
+
+The game is intentionally aimed at the human side of the relationship:
+
+```text
+notice -> choose a setup -> time the useful moment -> learn from feedback -> try again
+```
+
+A dog does not need to perform for the human to practice. Petless Companion users and Pet Guardian users receive the same Skillcraft surface and the same server-authored game rules.
+
+## Product contract
+
+Native Skillcraft is a client for the existing `social-adventure` authority. It does not invent questions, correct answers, score formulas, weekly seasons, league points, or proficiency claims.
+
+The client uses:
+
+- `GET /social-adventure/arcade` for the public challenge catalog and weekly practice state;
+- `POST /social-adventure/arcade/:challengeKey/attempts` for a server-issued attempt;
+- `POST /social-adventure/arcade/attempts/:attemptId/complete` for server scoring;
+- `POST /social-adventure/shares` only after an explicit user action to share a completed Human Skill attempt.
+
+The server remains authoritative for challenge version, scenario identity, attempt expiry, scoring, correctness, timing error, explanations, and the Social Adventure breadth model.
+
+## Four rooms
+
+v1 exposes the four server-owned Human Skill challenges already qualified by dogOS Social Adventure:
+
+1. **Make It Easier** — difficulty and setup selection;
+2. **Catch the Good** — noticing useful behavior worth reinforcing;
+3. **Pairing Lab** — positive association ordering and timing;
+4. **Marker Timing** — temporal precision practice.
+
+Native code does not contain correct option IDs or a duplicate score formula.
+
+## Weekly breadth, not grind
+
+The catalog's `bestScore` is scoped by the server to the current UTC weekly season.
+
+Native Skillcraft turns that into a simple room counter:
+
+```text
+rooms explored this week / 4
+```
+
+A room is explored when the server reports a current-season practice result for that challenge.
+
+The important asymmetry is deliberate:
+
+- completing a distinct room can contribute one fixed Human Skill breadth unit to Social Adventure;
+- replaying the same room does not add another breadth unit;
+- raising a personal score does not increase public rank;
+- millisecond timing magnitude does not increase public rank;
+- posting, reactions, comments, or popularity do not increase public rank.
+
+The 0–100 result remains useful personal feedback. It is not evidence of professional training proficiency.
+
+## Timing game
+
+Marker Timing uses the server-issued public timing scenario.
+
+The native client measures the user's tap relative to the local round start and sends only `tapMs` as the challenge response. The server decides the practice score and timing error.
+
+The native client may animate the public behavior track and describe the current cue window, but it must not reproduce the server score formula or turn timing precision into competitive authority.
+
+If the local display reaches the end of the playable window before a tap, the client stops the round and asks for a fresh attempt. It does not manufacture an outcome.
+
+## Sharing
+
+Sharing is always optional and post-completion.
+
+Native Skillcraft can publish a completed Human Skill attempt only when the user presses **Share skill moment**. The request uses:
+
+- `sourceType = HUMAN_SKILL_ATTEMPT`;
+- the server-owned attempt ID;
+- explicit `PUBLIC` visibility.
+
+The server resolves what is safe to publish from the authorized attempt. The client does not copy private dog history into the share payload.
+
+A shared practice result is social expression, not recommendation evidence. Likes, comments, reactions, follower count, and posting frequency do not add Skillcraft or Social Adventure rank.
+
+## Companion boundary
+
+Skillcraft is pet-independent by design.
+
+`COMPANION_TODAY` users can open the same native Skillcraft route as `PET_TODAY` users without receiving pet-only Today, Compass, Story, CareEvent, Health, or household authority.
+
+The route therefore belongs in both authenticated native navigators, but Skillcraft itself does not import pet, Adventure, CareEvent, Health, or household mutation APIs.
+
+Account mode still controls presentation. Pet relationships still control pet authority.
+
+## Safety boundary
+
+Skillcraft teaches general reward-based mechanics. It must never imply that an Arcade score authorizes a user to handle significant fear, aggression, pain, sudden behavior change, or other cases that may require qualified trainer, behavior, or veterinary support.
+
+The game must not:
+
+- rank a dog;
+- award Bond XP;
+- create or modify pet state;
+- create CareEvents or recommendation evidence;
+- unlock care or health access;
+- claim professional proficiency;
+- reward repeated attempts with more public points;
+- reward higher practice scores with more public points;
+- automatically share a result;
+- make social reactions part of the score.
+
+## Native surfaces
+
+### Skillcraft
+
+The native screen provides:
+
+- a four-room weekly breadth panel;
+- server-authored challenge cards;
+- server-issued rounds;
+- multiple-choice interaction for three rooms;
+- a local timing track for Marker Timing;
+- server-scored receipts and explanations;
+- personal practice-best context;
+- an explicit optional share action;
+- an explicit professional-support boundary.
+
+### Companion Home
+
+Skillcraft is the first useful pet-independent action shown in Companion mode.
+
+### Community
+
+Community links to Skillcraft so guardians can move from social browsing into human-skill practice rather than making scrolling the engagement destination.
+
+## Qualification
+
+`Native Skillcraft CI` cross-checks native and server source contracts. It must fail if:
+
+- the four Human Skill challenge keys drift unexpectedly;
+- the native API stops using the existing server-authoritative Arcade endpoints;
+- correct answer IDs or the server score formula are copied into native code;
+- Skillcraft gains pet/Adventure/CareEvent/Health mutation authority;
+- weekly breadth, no-grind, optional-sharing, or safety-boundary copy disappears;
+- the route is removed from either Pet Guardian or Companion native navigation;
+- Companion Home or Community loses its Skillcraft entry point;
+- touched source or documentation is not formatted;
+- the full native client fails type-check or lint.
+
+Existing Social Adventure, Companion, mobile convergence, security, Xcode, root CI, and CodeQL lanes remain broader authorities.
+
+## What comes next
+
+Skillcraft makes Woof more game-like without needing another currency. The next game releases should build on that restraint:
+
+- cooperative **Expeditions** with varied eligible contributions instead of volume races;
+- Story-derived collectible art that never pressures uploads;
+- friend challenges that are re-resolved against the recipient's eligibility rather than copying one dog's task;
+- cosmetic Trail/camp evolution from already-earned discovery, never care compliance;
+- richer trainer- and shelter-reviewed Human Skill scenarios;
+- Companion learning paths that make fostering, volunteering, and responsible guardianship easier to understand without pretending Woof grants placement eligibility.
+
+The design target remains: **the human gets the game; the dog keeps the right to have an ordinary day.**

--- a/docs/NATIVE_SKILLCRAFT_V1.md
+++ b/docs/NATIVE_SKILLCRAFT_V1.md
@@ -48,6 +48,8 @@ rooms explored this week / 4
 
 A room is explored when the server reports a current-season practice result for that challenge.
 
+If the Arcade catalog is unavailable, native does not render an invented `0/4`. Unknown server state stays unknown until authority is restored.
+
 The important asymmetry is deliberate:
 
 - completing a distinct room can contribute one fixed Human Skill breadth unit to Social Adventure;
@@ -66,13 +68,13 @@ The native client measures the user's tap relative to the local round start and 
 
 The native client may animate the public behavior track and describe the current cue window, but it must not reproduce the server score formula or turn timing precision into competitive authority.
 
-If the local display reaches the end of the playable window before a tap, the client stops the round and asks for a fresh attempt. It does not manufacture an outcome.
+If the local display reaches the end of the playable window before a tap, the client stops the round and asks the user to choose a fresh attempt. It does not manufacture an outcome.
 
 ## Sharing
 
 Sharing is always optional and post-completion.
 
-Native Skillcraft can publish a completed Human Skill attempt only when the user presses **Share skill moment**. The request uses:
+Native Skillcraft can publish a completed Human Skill attempt only when the user presses **Share publicly**. The public scope is visible at the decision point before the mutation. The request uses:
 
 - `sourceType = HUMAN_SKILL_ATTEMPT`;
 - the server-owned attempt ID;
@@ -115,14 +117,14 @@ The game must not:
 
 The native screen provides:
 
-- a four-room weekly breadth panel;
+- a four-room weekly breadth panel only when canonical catalog state is available;
 - server-authored challenge cards;
 - server-issued rounds;
 - multiple-choice interaction for three rooms;
 - a local timing track for Marker Timing;
 - server-scored receipts and explanations;
 - personal practice-best context;
-- an explicit optional share action;
+- an explicit optional public share action;
 - an explicit professional-support boundary.
 
 ### Companion Home
@@ -141,6 +143,8 @@ Community links to Skillcraft so guardians can move from social browsing into hu
 - the native API stops using the existing server-authoritative Arcade endpoints;
 - correct answer IDs or the server score formula are copied into native code;
 - Skillcraft gains pet/Adventure/CareEvent/Health mutation authority;
+- unavailable catalog state is presented as fabricated zero progress;
+- public sharing is not disclosed before the share mutation;
 - weekly breadth, no-grind, optional-sharing, or safety-boundary copy disappears;
 - the route is removed from either Pet Guardian or Companion native navigation;
 - Companion Home or Community loses its Skillcraft entry point;


### PR DESCRIPTION
## Summary

Brings the already-qualified dogOS **Human Skill Arcade** into native Woof as **Skillcraft**.

This is the next game layer after #135's Adventure Trail: the app becomes more fun by giving the human short practice games, while dog performance, health behavior, repetition volume, and social popularity remain outside the game authority.

## Native Skillcraft

Adds one shared pet-independent native route with four server-owned rooms:

- **Make It Easier** / Setup Lab;
- **Catch the Good** / Observation Room;
- **Pairing Lab** / Association Studio;
- **Marker Timing** / Timing Deck.

The client fetches the public catalog, requests a server-issued attempt, submits only the user's response, and renders the server-scored receipt/explanation. Correct answer IDs and the score formula remain server-only.

Marker Timing animates the server-issued public timing scenario locally and submits `tapMs`; the server remains authoritative for score, correctness, and timing error. If the local round window ends before a tap, native stops the round and returns the user to choose a fresh server-issued attempt instead of manufacturing a result.

## Gamification boundary

Skillcraft shows **rooms explored this week / 4** only when the canonical current-season catalog is available.

- a distinct room can contribute one fixed Human Skill breadth unit;
- retries do not add another unit;
- higher personal scores do not add rank;
- millisecond precision does not add rank;
- shares/reactions/comments/popularity do not add rank;
- unavailable catalog authority remains unknown rather than being rendered as a fabricated `0/4`.

The 0–100 score remains personal practice feedback, not professional proficiency evidence.

## Sharing

A completed Human Skill attempt can be shared only after the user explicitly presses **Share publicly**. The public scope is disclosed before the mutation. Native submits the server-owned attempt ID with `sourceType = HUMAN_SKILL_ATTEMPT` and explicit `PUBLIC` visibility. No pet score or private dog-history payload is authored by the client.

## Companion + Guardian convergence

Skillcraft is registered in both authenticated native navigators.

- Companion Home now leads with Skillcraft as a useful pet-independent action.
- Guardian Community links into the same Skillcraft route.
- Skillcraft itself imports no pet, Adventure, CareEvent, Daily Signals, Health, or household mutation API.

This preserves the Companion rule: account mode controls presentation; pet relationships control pet authority.

## Qualification

Adds `Native Skillcraft CI`, which cross-checks native and server source authority and then:

- freezes the four server Human Skill challenge keys;
- requires the canonical Arcade/start/complete/share endpoints;
- rejects copied answer IDs and client-side score logic;
- rejects pet/Adventure/CareEvent/Daily Signals authority inside Skillcraft;
- rejects fabricated zero progress when the server catalog is unavailable;
- requires public visibility to be disclosed before sharing;
- requires weekly breadth/no-grind/optional-sharing/safety copy;
- requires Skillcraft in both Guardian and Companion navigators;
- requires Companion Home and Community entry points;
- re-runs the server `social-adventure.arcade` and `social-adventure.policy` specs;
- checks touched formatting;
- type-checks the full native client;
- lints native with zero warnings.

Existing root CI, Social Adventure, Companion, mobile convergence, Security, CodeQL, native artifact, and Xcode lanes remain broader authorities where triggered.

## Self-audit repairs

The first focused run passed the source-authority contract and failed only formatting. Before simply formatting it, a manual product audit caught three truth/UX issues and repaired them:

1. missing catalog authority could have displayed as `0/4` weekly progress;
2. the public share request was not explicit enough at the button before the tap;
3. an expired timing round said “start fresh” even though the action actually returns to room selection.

Those cases are now frozen into the source contract so they cannot silently regress.

## Production note

#135 merged to exact `main` SHA `cbd8c5fdd1103fdf36146ae1de109533f551c7c7`. Its production deployment workflow is still correctly fail-closed under #77 because the GitHub production environment does not provide `FLY_API_TOKEN`; no deploy command ran. This PR does not weaken or bypass that launch blocker.

## Base

Created directly from merged #135 boundary `cbd8c5fdd1103fdf36146ae1de109533f551c7c7`.

Keep draft until the exact final head passes its triggered matrix.