### PR TITLE
Add receipt-backed Expedition Field Journal

### DIFF
--- a/.github/scripts/assert-expedition-field-journal.py
+++ b/.github/scripts/assert-expedition-field-journal.py
@@ -200,7 +200,7 @@ def main() -> None:
     # page fullness calculations, or local transformations into achievement semantics.
     for marker in [
         "entry.landmarks.map((landmark)",
-        "Repeating a moment does not make a bigger stamp",
+        "does not make a bigger stamp",
         "There is nothing you need to fill.",
         "Blank space is part of the memory.",
         "Nothing is overdue and there is nothing to catch up on.",

--- a/.github/scripts/assert-expedition-field-journal.py
+++ b/.github/scripts/assert-expedition-field-journal.py
@@ -147,8 +147,7 @@ def main() -> None:
 
     for marker in [
         "state: 'ACTIVE' | 'PAST'",
-        "landmarks: Array<",
-        "key: ExpeditionObjectiveKey",
+        "landmarks: {\n    key: ExpeditionObjectiveKey;\n    title: string;\n  }[];",
         "kind: 'RECENT_PARTICIPATED_SEASONS'",
         "maxSeasons: number",
         "scope: 'GLOBAL'",

--- a/.github/scripts/assert-expedition-field-journal.py
+++ b/.github/scripts/assert-expedition-field-journal.py
@@ -203,7 +203,7 @@ def main() -> None:
         "There is nothing you need to fill.",
         "Blank space is part of the memory.",
         "Nothing is overdue and there is nothing to catch up on.",
-        "Missing older pages are not presented as non-participation.",
+        "older pages are not presented as non-participation.",
         "timeZone: 'UTC'",
     ]:
         require(journal_view, marker, "native Expedition Field Journal")

--- a/.github/scripts/assert-expedition-field-journal.py
+++ b/.github/scripts/assert-expedition-field-journal.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Fail closed if Expedition Field Journal drifts into an achievement or score system."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+SERVICE = ROOT / "apps/api/src/expeditions/expedition-journal.service.ts"
+CONTROLLER = ROOT / "apps/api/src/expeditions/expeditions.controller.ts"
+MODULE = ROOT / "apps/api/src/expeditions/expeditions.module.ts"
+INTEGRATION = ROOT / "apps/api/src/expeditions/expedition-journal.integration.spec.ts"
+MOBILE_API = ROOT / "apps/mobile/src/api/expeditions.ts"
+SCREEN = ROOT / "apps/mobile/src/screens/ExpeditionScreen.tsx"
+WORLD = ROOT / "apps/mobile/src/components/community/ExpeditionWorldView.tsx"
+JOURNAL_VIEW = ROOT / "apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx"
+MIGRATION = (
+    ROOT
+    / "packages/database/prisma/migrations/20260909181500_add_expedition_authority_v1/migration.sql"
+)
+DOC = ROOT / "docs/NATIVE_EXPEDITION_FIELD_JOURNAL_V1.md"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def require(text: str, marker: str, label: str) -> None:
+    if marker not in text:
+        fail(f"{label} missing required marker: {marker}")
+
+
+def reject(text: str, marker: str, label: str) -> None:
+    if marker in text:
+        fail(f"{label} contains forbidden marker: {marker}")
+
+
+def require_count(text: str, marker: str, expected: int, label: str) -> None:
+    actual = text.count(marker)
+    if actual != expected:
+        fail(f"{label} expected {expected} occurrences of {marker!r}, found {actual}")
+
+
+def main() -> None:
+    required = [
+        SERVICE,
+        CONTROLLER,
+        MODULE,
+        INTEGRATION,
+        MOBILE_API,
+        SCREEN,
+        WORLD,
+        JOURNAL_VIEW,
+        MIGRATION,
+        DOC,
+    ]
+    for path in required:
+        if not path.is_file():
+            fail(f"missing required Expedition Journal file: {path.relative_to(ROOT)}")
+
+    service = SERVICE.read_text()
+    controller = CONTROLLER.read_text()
+    module = MODULE.read_text()
+    integration = INTEGRATION.read_text()
+    mobile_api = MOBILE_API.read_text()
+    screen = SCREEN.read_text()
+    world = WORLD.read_text()
+    journal_view = JOURNAL_VIEW.read_text()
+    migration = MIGRATION.read_text()
+    doc = DOC.read_text()
+
+    # The Journal is a read projection over canonical receipt authority. The existing
+    # Expedition service remains the only current-season materializer.
+    for marker in [
+        "JOURNAL_MAX_PARTICIPATED_SEASONS = 26",
+        "await this.expeditions.getGlobal(userId)",
+        "receipt.expedition_key = ${EXPEDITION_KEY}",
+        "receipt.expedition_version = ${EXPEDITION_VERSION}",
+        "receipt.policy_version = ${EXPEDITION_POLICY_VERSION}",
+        "receipt.scope = 'GLOBAL'",
+        "receipt.pack_id IS NULL",
+        "receipt.user_id = ${userId}",
+        "receipt.season_key <= ${current.key}",
+        "GROUP BY receipt.season_key, receipt.objective_key",
+        "LIMIT ${JOURNAL_MAX_PARTICIPATED_SEASONS}",
+        "startsAt.getUTCDay() !== 1",
+        "landmarks.add(objective.key)",
+        "landmarks: EXPEDITION_OBJECTIVES.filter",
+        "kind: 'RECENT_PARTICIPATED_SEASONS' as const",
+        "'landmark-presence-not-volume'",
+        "'no-completion-or-rarity'",
+        "'no-rank-or-streak'",
+    ]:
+        require(service, marker, "server Expedition Journal")
+
+    for forbidden in [
+        "INSERT INTO",
+        "UPDATE dogos_social",
+        "DELETE FROM",
+        "scope = 'PACK'",
+        "pack_id = ${",
+        "leaderboard",
+        "socialAdventure",
+        "score:",
+        "rank:",
+        "target:",
+        "rarity:",
+        "completed:",
+        "streak:",
+    ]:
+        reject(service, forbidden, "server Expedition Journal")
+
+    # Route is authenticated by the existing controller guard and GET-only.
+    require(controller, "@UseGuards(JwtAuthGuard)", "Expedition controller")
+    require(controller, "@Get('journal')", "Expedition controller")
+    require(controller, "return this.journal.getMine(req.user.sub)", "Expedition controller")
+    require_count(controller, "@Get('journal')", 1, "Expedition controller")
+    for marker in ["@Post('journal')", "@Put('journal')", "@Patch('journal')", "@Delete('journal')"]:
+        reject(controller, marker, "Expedition controller")
+
+    require(module, "providers: [ExpeditionsService, ExpeditionJournalService]", "Expedition module")
+
+    # The integration contract intentionally injects hostile historical rows and proves
+    # volume, another user, Pack scope, future weeks, and non-Monday weeks do not leak.
+    for marker in [
+        "insertCareEvent(userId, evidenceAt, 0)",
+        "insertCareEvent(userId, new Date(evidenceAt.getTime() + 1000), 1)",
+        "userId: otherUserId",
+        "scope: 'PACK'",
+        "suffix: 'future'",
+        "suffix: 'non-monday'",
+        "maxSeasons: 26",
+        "{ key: 'SNIFF_EXPLORE', title: 'Sniff & Explore' }",
+        "{ key: 'READ_THE_ROOM', title: 'Read the Room' }",
+        "{ key: 'RECOVERY_COUNTS', title: 'Recovery Counts' }",
+        "expect(Object.keys(current ?? {}).sort()).toEqual(['landmarks', 'season', 'state'])",
+        "expect(Object.keys(current?.landmarks[0] ?? {}).sort()).toEqual(['key', 'title'])",
+    ]:
+        require(integration, marker, "Expedition Journal integration test")
+
+    # Mobile history type is deliberately narrow. The journal has no count, score, rank,
+    # target, completion, or Pack fields that presentation could repurpose later.
+    journal_type_start = mobile_api.find("export type ExpeditionJournalEntry")
+    journal_type_end = mobile_api.find("export const expeditionApi")
+    if journal_type_start < 0 or journal_type_end <= journal_type_start:
+        fail("mobile Expedition Journal types are missing or malformed")
+    journal_types = mobile_api[journal_type_start:journal_type_end]
+
+    for marker in [
+        "state: 'ACTIVE' | 'PAST'",
+        "landmarks: Array<",
+        "key: ExpeditionObjectiveKey",
+        "kind: 'RECENT_PARTICIPATED_SEASONS'",
+        "maxSeasons: number",
+        "scope: 'GLOBAL'",
+    ]:
+        require(journal_types, marker, "mobile Expedition Journal types")
+
+    for forbidden in [
+        "count:",
+        "total:",
+        "contributors:",
+        "myContribution:",
+        "score:",
+        "rank:",
+        "target:",
+        "rarity:",
+        "completed:",
+        "streak:",
+        "pack:",
+    ]:
+        reject(journal_types, forbidden, "mobile Expedition Journal types")
+
+    require(mobile_api, "journal: () => apiClient.get<ExpeditionJournal>('/expeditions/journal')", "mobile Expedition API")
+    require_count(mobile_api, "'/expeditions/journal'", 1, "mobile Expedition API")
+    for forbidden in [
+        "apiClient.post<ExpeditionJournal>",
+        "apiClient.put<ExpeditionJournal>",
+        "apiClient.patch<ExpeditionJournal>",
+        "apiClient.delete<ExpeditionJournal>",
+    ]:
+        reject(mobile_api, forbidden, "mobile Expedition API")
+
+    # Journal is an independently degradable read slice and is never reconstructed from
+    # current-world or Social Adventure state.
+    for marker in [
+        "type ExpeditionJournal",
+        "expeditionApi.journal()",
+        "Promise.allSettled([",
+        "if (journalResult.value.scope === 'GLOBAL') setJournal(journalResult.value)",
+        "unavailable.push('field journal')",
+        "journal={journal}",
+        "Woof did not infer missing progress, membership, or journal history.",
+    ]:
+        require(screen, marker, "native Expedition screen")
+
+    require(world, "<ExpeditionFieldJournalView journal={props.journal} />", "native Expedition world")
+    require(world, "timeZone: 'UTC'", "native Expedition world")
+
+    # The scrapbook only renders returned landmarks. There are no missing-slot placeholders,
+    # page fullness calculations, or local transformations into achievement semantics.
+    for marker in [
+        "entry.landmarks.map((landmark)",
+        "Repeating a moment does not make a bigger stamp",
+        "There is nothing you need to fill.",
+        "Blank space is part of the memory.",
+        "Nothing is overdue and there is nothing to catch up on.",
+        "Missing older pages are not presented as non-participation.",
+        "timeZone: 'UTC'",
+    ]:
+        require(journal_view, marker, "native Expedition Field Journal")
+
+    for forbidden in [
+        "entry.landmarks.length",
+        "journal.entries.length /",
+        "landmarks.length /",
+        "Math.min(",
+        "Math.max(",
+        "* 100",
+        "ProgressBar",
+        "percentComplete",
+        "completionRate",
+        "unlockThreshold",
+        "rarityLevel",
+        ".score",
+        ".rank",
+        ".target",
+        ".completed",
+        ".streak",
+        "missingLandmarks",
+        "emptyStamp",
+        "lockedStamp",
+    ]:
+        reject(journal_view, forbidden, "native Expedition Field Journal")
+
+    require_count(journal_view, "journal.coverage.maxSeasons", 1, "native Expedition Field Journal")
+
+    # Existing receipt persistence remains immutable and indexed for user-season reads.
+    for marker in [
+        "CREATE INDEX IF NOT EXISTS expedition_receipt_user_season_idx",
+        "ON dogos_social.expedition_receipts (user_id, season_key, authorized_at DESC, id)",
+        "CREATE TRIGGER expedition_receipts_immutable_after_issue",
+        "RAISE EXCEPTION 'expedition contribution receipts are immutable'",
+    ]:
+        require(migration, marker, "Expedition receipt migration")
+
+    for marker in [
+        "A field note says **this happened**.",
+        "Presence, never volume",
+        "It does not render empty slots for the other landmarks.",
+        "No state called `COMPLETE`, `FAILED`, `MISSED`",
+        "Field Journal v1 is personal and Global-only.",
+        "26 most recent participated seasons",
+        "missing older pages are not presented as non-participation",
+        "Season dates are formatted in UTC",
+        "Field Journal v1 is **not** Story persistence",
+        "how do we make real weeks worth remembering?",
+    ]:
+        require(doc, marker, "Expedition Field Journal documentation")
+
+    print("Expedition Field Journal authority contract OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/assert-native-expedition-world.py
+++ b/.github/scripts/assert-native-expedition-world.py
@@ -65,7 +65,8 @@ def main() -> None:
     server_service = SERVER_SERVICE.read_text()
     doc = DOC.read_text()
 
-    # Native Expedition has exactly two read paths and no contribution mutation surface.
+    # Native live Expedition has exactly two projection read paths and no contribution
+    # mutation surface. Historical Journal reads are governed by their own stricter contract.
     for marker in [
         "'/expeditions/global'",
         "`/expeditions/packs/${packId}`",
@@ -99,7 +100,7 @@ def main() -> None:
         "selectedScopeRef",
         "Promise.allSettled([",
         "Woof will only open Expedition views for Packs the server says you joined.",
-        "Woof did not infer missing progress or membership.",
+        "Woof did not infer missing progress, membership, or journal history.",
     ]:
         require(screen, marker, "native Expedition screen")
 

--- a/.github/workflows/expedition-field-journal-ci.yml
+++ b/.github/workflows/expedition-field-journal-ci.yml
@@ -1,0 +1,124 @@
+name: Expedition Field Journal CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/api/src/expeditions/**'
+      - 'apps/mobile/src/api/expeditions.ts'
+      - 'apps/mobile/src/screens/ExpeditionScreen.tsx'
+      - 'apps/mobile/src/components/community/ExpeditionWorldView.tsx'
+      - 'apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx'
+      - 'packages/database/prisma/migrations/20260909181500_add_expedition_authority_v1/**'
+      - '.github/scripts/assert-expedition-field-journal.py'
+      - '.github/workflows/expedition-field-journal-ci.yml'
+      - 'docs/NATIVE_EXPEDITION_FIELD_JOURNAL_V1.md'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/api/src/expeditions/**'
+      - 'apps/mobile/src/api/expeditions.ts'
+      - 'apps/mobile/src/screens/ExpeditionScreen.tsx'
+      - 'apps/mobile/src/components/community/ExpeditionWorldView.tsx'
+      - 'apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx'
+      - 'packages/database/prisma/migrations/20260909181500_add_expedition_authority_v1/**'
+      - '.github/scripts/assert-expedition-field-journal.py'
+      - '.github/workflows/expedition-field-journal-ci.yml'
+      - 'docs/NATIVE_EXPEDITION_FIELD_JOURNAL_V1.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: expedition-field-journal-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  qualify:
+    name: Receipt-backed memory authority
+    runs-on: ubuntu-24.04
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+      NODE_ENV: test
+      ML_SERVICE_ENABLED: 'false'
+      ENABLE_ADVENTURE_SYSTEM: 'true'
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Enforce Expedition Journal source contract
+        run: python3 .github/scripts/assert-expedition-field-journal.py
+
+      - name: Install from committed lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Apply canonical migrations
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Check Expedition Journal formatting
+        run: |
+          pnpm exec prettier --check \
+            apps/api/src/expeditions/expedition-journal.service.ts \
+            apps/api/src/expeditions/expedition-journal.integration.spec.ts \
+            apps/api/src/expeditions/expeditions.controller.ts \
+            apps/api/src/expeditions/expeditions.module.ts \
+            apps/mobile/src/api/expeditions.ts \
+            apps/mobile/src/screens/ExpeditionScreen.tsx \
+            apps/mobile/src/components/community/ExpeditionWorldView.tsx \
+            apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx \
+            .github/workflows/expedition-field-journal-ci.yml \
+            docs/NATIVE_EXPEDITION_FIELD_JOURNAL_V1.md
+
+      - name: Run Journal and Expedition policy integration contracts
+        run: >-
+          pnpm --filter @woof/api exec jest
+          src/expeditions/expedition-journal.integration.spec.ts
+          src/expeditions/expeditions.policy.spec.ts
+          --runInBand
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Lint Journal API surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/expeditions/expedition-journal.service.ts
+          src/expeditions/expedition-journal.integration.spec.ts
+          src/expeditions/expeditions.controller.ts
+          src/expeditions/expeditions.module.ts
+
+      - name: Type-check native client
+        run: pnpm --filter @woof/mobile type-check
+
+      - name: Lint native client
+        run: pnpm --filter @woof/mobile lint

--- a/.github/workflows/expedition-field-journal-ci.yml
+++ b/.github/workflows/expedition-field-journal-ci.yml
@@ -85,9 +85,20 @@ jobs:
       - name: Apply canonical migrations
         run: pnpm --filter @woof/database db:migrate:deploy
 
-      - name: Check Expedition Journal formatting
+      - name: Reject Expedition Journal formatting drift
         run: |
-          pnpm exec prettier --check \
+          pnpm exec prettier --write \
+            apps/api/src/expeditions/expedition-journal.service.ts \
+            apps/api/src/expeditions/expedition-journal.integration.spec.ts \
+            apps/api/src/expeditions/expeditions.controller.ts \
+            apps/api/src/expeditions/expeditions.module.ts \
+            apps/mobile/src/api/expeditions.ts \
+            apps/mobile/src/screens/ExpeditionScreen.tsx \
+            apps/mobile/src/components/community/ExpeditionWorldView.tsx \
+            apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx \
+            .github/workflows/expedition-field-journal-ci.yml \
+            docs/NATIVE_EXPEDITION_FIELD_JOURNAL_V1.md
+          git diff --exit-code -- \
             apps/api/src/expeditions/expedition-journal.service.ts \
             apps/api/src/expeditions/expedition-journal.integration.spec.ts \
             apps/api/src/expeditions/expeditions.controller.ts \

--- a/apps/api/src/expeditions/expedition-journal.integration.spec.ts
+++ b/apps/api/src/expeditions/expedition-journal.integration.spec.ts
@@ -250,13 +250,19 @@ describe('ExpeditionJournalService integration', () => {
 
     const previous = result.entries[1];
     expect(previous?.state).toBe('PAST');
-    expect(previous?.landmarks).toEqual([
-      { key: 'RECOVERY_COUNTS', title: 'Recovery Counts' },
-    ]);
+    expect(previous?.landmarks).toEqual([{ key: 'RECOVERY_COUNTS', title: 'Recovery Counts' }]);
 
     expect(Object.keys(current ?? {}).sort()).toEqual(['landmarks', 'season', 'state']);
     expect(Object.keys(current?.landmarks[0] ?? {}).sort()).toEqual(['key', 'title']);
-    expect(result.entries.some((entry) => entry.season.key.includes(futureStart.toISOString().slice(0, 10)))).toBe(false);
-    expect(result.entries.some((entry) => entry.season.key.includes(malformedStart.toISOString().slice(0, 10)))).toBe(false);
+    expect(
+      result.entries.some((entry) =>
+        entry.season.key.includes(futureStart.toISOString().slice(0, 10))
+      )
+    ).toBe(false);
+    expect(
+      result.entries.some((entry) =>
+        entry.season.key.includes(malformedStart.toISOString().slice(0, 10))
+      )
+    ).toBe(false);
   });
 });

--- a/apps/api/src/expeditions/expedition-journal.integration.spec.ts
+++ b/apps/api/src/expeditions/expedition-journal.integration.spec.ts
@@ -1,0 +1,262 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+import { PackAccessService } from '../social-adventure/pack-access.service';
+import { ExpeditionJournalService } from './expedition-journal.service';
+import { currentExpeditionSeason } from './expeditions.policy';
+import { ExpeditionsService } from './expeditions.service';
+
+describe('ExpeditionJournalService integration', () => {
+  const prisma = new PrismaService();
+  const packAccess = new PackAccessService(prisma);
+  const expeditions = new ExpeditionsService(prisma, packAccess);
+  const journal = new ExpeditionJournalService(prisma, expeditions);
+  const usersToDelete: string[] = [];
+  const packsToDelete: string[] = [];
+
+  beforeAll(async () => {
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    for (const packId of packsToDelete) {
+      await prisma.$executeRaw(Prisma.sql`DELETE FROM dogos_social.packs WHERE id = ${packId}`);
+    }
+    if (usersToDelete.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: usersToDelete } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  async function createUser(label: string) {
+    const suffix = randomUUID().slice(0, 8);
+    const user = await prisma.user.create({
+      data: {
+        handle: `journal-${label}-${suffix}`,
+        email: `journal-${label}-${suffix}@example.test`,
+      },
+      select: { id: true },
+    });
+    usersToDelete.push(user.id);
+    return user.id;
+  }
+
+  async function insertCareEvent(userId: string, occurredAt: Date, index: number) {
+    const id = randomUUID();
+    await prisma.$executeRaw(Prisma.sql`
+      INSERT INTO public.care_events (
+        id,
+        user_id,
+        pet_id,
+        event_type,
+        pathway,
+        occurred_at,
+        source,
+        evidence_confidence,
+        dedupe_key,
+        visibility
+      ) VALUES (
+        ${id},
+        ${userId},
+        NULL,
+        'QUEST_EXPLORE',
+        'EXPLORE',
+        ${occurredAt},
+        'QUEST_ENGINE',
+        0.8,
+        ${`journal-test:${userId}:EXPLORE:${index}:${id}`},
+        'PRIVATE'
+      )
+    `);
+  }
+
+  async function insertHumanSkill(userId: string, completedAt: Date) {
+    const id = randomUUID();
+    await prisma.$executeRaw(Prisma.sql`
+      INSERT INTO dogos_social.human_skill_attempts (
+        id,
+        user_id,
+        challenge_key,
+        challenge_version,
+        scenario_key,
+        issued_at,
+        expires_at,
+        completed_at,
+        response,
+        score,
+        receipt
+      ) VALUES (
+        ${id},
+        ${userId},
+        'MAKE_IT_EASIER',
+        'human-skill-arcade-v1',
+        'journal-make-it-easier',
+        ${new Date(completedAt.getTime() - 60_000)},
+        ${new Date(completedAt.getTime() + 9 * 60_000)},
+        ${completedAt},
+        '{"test":true}'::jsonb,
+        100,
+        '{"score":100,"test":true}'::jsonb
+      )
+    `);
+  }
+
+  async function insertReceipt(input: {
+    userId: string;
+    seasonKey: string;
+    scope: 'GLOBAL' | 'PACK';
+    packId?: string | null;
+    objectiveKey: 'SNIFF_EXPLORE' | 'RECOVERY_COUNTS' | 'READ_THE_ROOM';
+    categoryKey: string;
+    sourceType?: 'CARE_EVENT' | 'HUMAN_SKILL_ATTEMPT';
+    pathway?: 'EXPLORE' | 'ENRICH' | 'RECOVER' | null;
+    suffix: string;
+  }) {
+    const sourceType = input.sourceType ?? 'CARE_EVENT';
+    const sourceId = `journal-source-${input.suffix}-${randomUUID()}`;
+    const identity = `${input.userId}|${input.seasonKey}|${input.scope}|${input.objectiveKey}|${sourceId}`;
+    const fingerprint = createHash('sha256').update(identity).digest('hex');
+    await prisma.$executeRaw(Prisma.sql`
+      INSERT INTO dogos_social.expedition_receipts (
+        id,
+        expedition_key,
+        expedition_version,
+        season_key,
+        policy_version,
+        scope,
+        pack_id,
+        user_id,
+        source_type,
+        source_id,
+        objective_key,
+        category_key,
+        pathway,
+        source_fingerprint,
+        evidence_at
+      ) VALUES (
+        ${`exp:${fingerprint}`},
+        'shared-world',
+        'v1',
+        ${input.seasonKey},
+        'expedition-authority-v1',
+        ${input.scope},
+        ${input.packId ?? null},
+        ${input.userId},
+        ${sourceType},
+        ${sourceId},
+        ${input.objectiveKey},
+        ${input.categoryKey},
+        ${input.pathway ?? null},
+        ${fingerprint},
+        NOW()
+      )
+    `);
+  }
+
+  it('projects personal Global landmark presence without volume, Pack, future, or malformed-season leakage', async () => {
+    const userId = await createUser('owner');
+    const otherUserId = await createUser('other');
+    const season = currentExpeditionSeason();
+    const evidenceAt = new Date(season.startsAt.getTime() + 6 * 60 * 60 * 1000);
+
+    await insertCareEvent(userId, evidenceAt, 0);
+    await insertCareEvent(userId, new Date(evidenceAt.getTime() + 1000), 1);
+    await insertHumanSkill(userId, new Date(evidenceAt.getTime() + 2000));
+
+    const previousStart = new Date(season.startsAt.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const previousKey = `week:${previousStart.toISOString().slice(0, 10)}`;
+    await insertReceipt({
+      userId,
+      seasonKey: previousKey,
+      scope: 'GLOBAL',
+      objectiveKey: 'RECOVERY_COUNTS',
+      categoryKey: 'RECOVER',
+      pathway: 'RECOVER',
+      suffix: 'previous-recovery',
+    });
+    await insertReceipt({
+      userId: otherUserId,
+      seasonKey: previousKey,
+      scope: 'GLOBAL',
+      objectiveKey: 'READ_THE_ROOM',
+      categoryKey: 'MARKER_TIMING',
+      sourceType: 'HUMAN_SKILL_ATTEMPT',
+      pathway: null,
+      suffix: 'other-user-skill',
+    });
+
+    const packId = randomUUID();
+    packsToDelete.push(packId);
+    await prisma.$executeRaw(Prisma.sql`
+      INSERT INTO dogos_social.packs (
+        id, owner_user_id, name, slug, scope, region_key, visibility, created_at
+      ) VALUES (
+        ${packId},
+        ${userId},
+        'Journal Test Pack',
+        ${`journal-test-${packId}`},
+        'LOCAL',
+        'test-region',
+        'PUBLIC',
+        ${season.startsAt}
+      )
+    `);
+    await insertReceipt({
+      userId,
+      seasonKey: previousKey,
+      scope: 'PACK',
+      packId,
+      objectiveKey: 'SNIFF_EXPLORE',
+      categoryKey: 'EXPLORE',
+      pathway: 'EXPLORE',
+      suffix: 'pack-only',
+    });
+
+    const futureStart = new Date(season.startsAt.getTime() + 7 * 24 * 60 * 60 * 1000);
+    await insertReceipt({
+      userId,
+      seasonKey: `week:${futureStart.toISOString().slice(0, 10)}`,
+      scope: 'GLOBAL',
+      objectiveKey: 'SNIFF_EXPLORE',
+      categoryKey: 'EXPLORE',
+      pathway: 'EXPLORE',
+      suffix: 'future',
+    });
+
+    const malformedStart = new Date(season.startsAt.getTime() - 5 * 24 * 60 * 60 * 1000);
+    await insertReceipt({
+      userId,
+      seasonKey: `week:${malformedStart.toISOString().slice(0, 10)}`,
+      scope: 'GLOBAL',
+      objectiveKey: 'READ_THE_ROOM',
+      categoryKey: 'PAIRING_LAB',
+      sourceType: 'HUMAN_SKILL_ATTEMPT',
+      pathway: null,
+      suffix: 'non-monday',
+    });
+
+    const result = await journal.getMine(userId);
+
+    expect(result.scope).toBe('GLOBAL');
+    expect(result.coverage).toEqual({ kind: 'RECENT_PARTICIPATED_SEASONS', maxSeasons: 26 });
+    expect(result.entries.map((entry) => entry.season.key)).toEqual([season.key, previousKey]);
+
+    const current = result.entries[0];
+    expect(current?.state).toBe('ACTIVE');
+    expect(current?.landmarks).toEqual([
+      { key: 'SNIFF_EXPLORE', title: 'Sniff & Explore' },
+      { key: 'READ_THE_ROOM', title: 'Read the Room' },
+    ]);
+
+    const previous = result.entries[1];
+    expect(previous?.state).toBe('PAST');
+    expect(previous?.landmarks).toEqual([
+      { key: 'RECOVERY_COUNTS', title: 'Recovery Counts' },
+    ]);
+
+    expect(Object.keys(current ?? {}).sort()).toEqual(['landmarks', 'season', 'state']);
+    expect(Object.keys(current?.landmarks[0] ?? {}).sort()).toEqual(['key', 'title']);
+    expect(result.entries.some((entry) => entry.season.key.includes(futureStart.toISOString().slice(0, 10)))).toBe(false);
+    expect(result.entries.some((entry) => entry.season.key.includes(malformedStart.toISOString().slice(0, 10)))).toBe(false);
+  });
+});

--- a/apps/api/src/expeditions/expedition-journal.service.ts
+++ b/apps/api/src/expeditions/expedition-journal.service.ts
@@ -1,0 +1,141 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+import {
+  currentExpeditionSeason,
+  EXPEDITION_KEY,
+  EXPEDITION_OBJECTIVES,
+  EXPEDITION_POLICY_VERSION,
+  EXPEDITION_VERSION,
+  type ExpeditionObjectiveKey,
+} from './expeditions.policy';
+import { ExpeditionsService } from './expeditions.service';
+
+const JOURNAL_MAX_PARTICIPATED_SEASONS = 26;
+
+type JournalRow = {
+  seasonKey: string;
+  objectiveKey: string;
+};
+
+type JournalSeason = {
+  key: string;
+  startsAt: Date;
+  endsAt: Date;
+};
+
+@Injectable()
+export class ExpeditionJournalService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly expeditions: ExpeditionsService
+  ) {}
+
+  async getMine(userId: string) {
+    // Keep the current page self-contained. The canonical Expedition service is
+    // the only writer of current-season receipts; its inserts are idempotent.
+    await this.expeditions.getGlobal(userId);
+
+    const current = currentExpeditionSeason();
+    const rows = await this.prisma.$queryRaw<JournalRow[]>(Prisma.sql`
+      WITH recent_seasons AS (
+        SELECT receipt.season_key
+        FROM dogos_social.expedition_receipts receipt
+        WHERE receipt.expedition_key = ${EXPEDITION_KEY}
+          AND receipt.expedition_version = ${EXPEDITION_VERSION}
+          AND receipt.policy_version = ${EXPEDITION_POLICY_VERSION}
+          AND receipt.scope = 'GLOBAL'
+          AND receipt.pack_id IS NULL
+          AND receipt.user_id = ${userId}
+          AND receipt.season_key ~ '^week:[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+          AND receipt.season_key <= ${current.key}
+        GROUP BY receipt.season_key
+        ORDER BY receipt.season_key DESC
+        LIMIT ${JOURNAL_MAX_PARTICIPATED_SEASONS}
+      )
+      SELECT
+        receipt.season_key AS "seasonKey",
+        receipt.objective_key AS "objectiveKey"
+      FROM dogos_social.expedition_receipts receipt
+      JOIN recent_seasons season ON season.season_key = receipt.season_key
+      WHERE receipt.expedition_key = ${EXPEDITION_KEY}
+        AND receipt.expedition_version = ${EXPEDITION_VERSION}
+        AND receipt.policy_version = ${EXPEDITION_POLICY_VERSION}
+        AND receipt.scope = 'GLOBAL'
+        AND receipt.pack_id IS NULL
+        AND receipt.user_id = ${userId}
+      GROUP BY receipt.season_key, receipt.objective_key
+      ORDER BY receipt.season_key DESC, receipt.objective_key ASC
+    `);
+
+    const seasons = new Map<string, Set<ExpeditionObjectiveKey>>();
+    for (const row of rows) {
+      const season = this.parseSeason(row.seasonKey);
+      const objective = EXPEDITION_OBJECTIVES.find((candidate) => candidate.key === row.objectiveKey);
+      if (!season || !objective || season.startsAt > current.startsAt) continue;
+      const landmarks = seasons.get(season.key) ?? new Set<ExpeditionObjectiveKey>();
+      landmarks.add(objective.key);
+      seasons.set(season.key, landmarks);
+    }
+
+    const entries = [...seasons.entries()]
+      .map(([seasonKey, landmarkKeys]) => {
+        const season = this.parseSeason(seasonKey);
+        if (!season) return null;
+        return {
+          season: {
+            key: season.key,
+            startsAt: season.startsAt.toISOString(),
+            endsAt: season.endsAt.toISOString(),
+          },
+          state: season.key === current.key ? ('ACTIVE' as const) : ('PAST' as const),
+          landmarks: EXPEDITION_OBJECTIVES.filter((objective) => landmarkKeys.has(objective.key)).map(
+            (objective) => ({ key: objective.key, title: objective.title })
+          ),
+        };
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+      .sort((a, b) => b.season.key.localeCompare(a.season.key));
+
+    return {
+      expeditionKey: EXPEDITION_KEY,
+      expeditionVersion: EXPEDITION_VERSION,
+      policyVersion: EXPEDITION_POLICY_VERSION,
+      scope: 'GLOBAL' as const,
+      generatedAt: new Date().toISOString(),
+      coverage: {
+        kind: 'RECENT_PARTICIPATED_SEASONS' as const,
+        maxSeasons: JOURNAL_MAX_PARTICIPATED_SEASONS,
+      },
+      entries,
+      principles: [
+        'personal-global-receipts-only',
+        'landmark-presence-not-volume',
+        'no-completion-or-rarity',
+        'no-rank-or-streak',
+      ],
+      disclaimer:
+        'Field notes are a bounded memory projection of server-issued Expedition receipts, not an achievement, behavior, health, or pet-performance score.',
+    };
+  }
+
+  private parseSeason(key: string): JournalSeason | null {
+    const match = /^week:(\d{4}-\d{2}-\d{2})$/.exec(key);
+    if (!match) return null;
+
+    const startsAt = new Date(`${match[1]}T00:00:00.000Z`);
+    if (
+      !Number.isFinite(startsAt.getTime()) ||
+      startsAt.toISOString().slice(0, 10) !== match[1] ||
+      startsAt.getUTCDay() !== 1
+    ) {
+      return null;
+    }
+
+    return {
+      key,
+      startsAt,
+      endsAt: new Date(startsAt.getTime() + 7 * 24 * 60 * 60 * 1000),
+    };
+  }
+}

--- a/apps/api/src/expeditions/expedition-journal.service.ts
+++ b/apps/api/src/expeditions/expedition-journal.service.ts
@@ -71,7 +71,9 @@ export class ExpeditionJournalService {
     const seasons = new Map<string, Set<ExpeditionObjectiveKey>>();
     for (const row of rows) {
       const season = this.parseSeason(row.seasonKey);
-      const objective = EXPEDITION_OBJECTIVES.find((candidate) => candidate.key === row.objectiveKey);
+      const objective = EXPEDITION_OBJECTIVES.find(
+        (candidate) => candidate.key === row.objectiveKey
+      );
       if (!season || !objective || season.startsAt > current.startsAt) continue;
       const landmarks = seasons.get(season.key) ?? new Set<ExpeditionObjectiveKey>();
       landmarks.add(objective.key);
@@ -89,9 +91,9 @@ export class ExpeditionJournalService {
             endsAt: season.endsAt.toISOString(),
           },
           state: season.key === current.key ? ('ACTIVE' as const) : ('PAST' as const),
-          landmarks: EXPEDITION_OBJECTIVES.filter((objective) => landmarkKeys.has(objective.key)).map(
-            (objective) => ({ key: objective.key, title: objective.title })
-          ),
+          landmarks: EXPEDITION_OBJECTIVES.filter((objective) =>
+            landmarkKeys.has(objective.key)
+          ).map((objective) => ({ key: objective.key, title: objective.title })),
         };
       })
       .filter((entry): entry is NonNullable<typeof entry> => entry !== null)

--- a/apps/api/src/expeditions/expeditions.controller.ts
+++ b/apps/api/src/expeditions/expeditions.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Param, Request, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import type { AuthenticatedRequest } from '../auth/authenticated-request';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ExpeditionJournalService } from './expedition-journal.service';
 import { ExpeditionsService } from './expeditions.service';
 
 @ApiTags('expeditions')
@@ -9,12 +10,21 @@ import { ExpeditionsService } from './expeditions.service';
 @UseGuards(JwtAuthGuard)
 @Controller('expeditions')
 export class ExpeditionsController {
-  constructor(private readonly expeditions: ExpeditionsService) {}
+  constructor(
+    private readonly expeditions: ExpeditionsService,
+    private readonly journal: ExpeditionJournalService
+  ) {}
 
   @Get('global')
   @ApiOperation({ summary: 'Get receipt-backed Global Expedition progress' })
   getGlobal(@Request() req: AuthenticatedRequest) {
     return this.expeditions.getGlobal(req.user.sub);
+  }
+
+  @Get('journal')
+  @ApiOperation({ summary: 'Get the signed-in human’s receipt-backed Expedition field journal' })
+  getJournal(@Request() req: AuthenticatedRequest) {
+    return this.journal.getMine(req.user.sub);
   }
 
   @Get('packs/:packId')

--- a/apps/api/src/expeditions/expeditions.module.ts
+++ b/apps/api/src/expeditions/expeditions.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { SocialAdventureModule } from '../social-adventure/social-adventure.module';
+import { ExpeditionJournalService } from './expedition-journal.service';
 import { ExpeditionsController } from './expeditions.controller';
 import { ExpeditionsService } from './expeditions.service';
 
 @Module({
   imports: [SocialAdventureModule],
   controllers: [ExpeditionsController],
-  providers: [ExpeditionsService],
+  providers: [ExpeditionsService, ExpeditionJournalService],
   exports: [ExpeditionsService],
 })
 export class ExpeditionsModule {}

--- a/apps/mobile/src/api/expeditions.ts
+++ b/apps/mobile/src/api/expeditions.ts
@@ -41,7 +41,36 @@ export type ExpeditionProjection = {
   principles: string[];
 };
 
+export type ExpeditionJournalEntry = {
+  season: {
+    key: string;
+    startsAt: string;
+    endsAt: string;
+  };
+  state: 'ACTIVE' | 'PAST';
+  landmarks: Array<{
+    key: ExpeditionObjectiveKey;
+    title: string;
+  }>;
+};
+
+export type ExpeditionJournal = {
+  expeditionKey: string;
+  expeditionVersion: string;
+  policyVersion: string;
+  scope: 'GLOBAL';
+  generatedAt: string;
+  coverage: {
+    kind: 'RECENT_PARTICIPATED_SEASONS';
+    maxSeasons: number;
+  };
+  entries: ExpeditionJournalEntry[];
+  principles: string[];
+  disclaimer: string;
+};
+
 export const expeditionApi = {
   global: () => apiClient.get<ExpeditionProjection>('/expeditions/global'),
+  journal: () => apiClient.get<ExpeditionJournal>('/expeditions/journal'),
   pack: (packId: string) => apiClient.get<ExpeditionProjection>(`/expeditions/packs/${packId}`),
 };

--- a/apps/mobile/src/api/expeditions.ts
+++ b/apps/mobile/src/api/expeditions.ts
@@ -48,10 +48,10 @@ export type ExpeditionJournalEntry = {
     endsAt: string;
   };
   state: 'ACTIVE' | 'PAST';
-  landmarks: Array<{
+  landmarks: {
     key: ExpeditionObjectiveKey;
     title: string;
-  }>;
+  }[];
 };
 
 export type ExpeditionJournal = {

--- a/apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx
+++ b/apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx
@@ -43,7 +43,9 @@ function FieldNote({ entry }: { entry: ExpeditionJournalEntry }) {
           <Ionicons name="paw-outline" size={15} color={colors.primary[700]} />
         </View>
         <View style={styles.noteHeading}>
-          <Text style={styles.noteState}>{entry.state === 'ACTIVE' ? 'THIS WEEK' : 'FIELD NOTE'}</Text>
+          <Text style={styles.noteState}>
+            {entry.state === 'ACTIVE' ? 'THIS WEEK' : 'FIELD NOTE'}
+          </Text>
           <Text style={styles.noteDate}>{formatWeek(entry.season.startsAt)}</Text>
         </View>
       </View>

--- a/apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx
+++ b/apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { Ionicons } from '@expo/vector-icons';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import type {
+  ExpeditionJournal,
+  ExpeditionJournalEntry,
+  ExpeditionObjectiveKey,
+} from '../../api/expeditions';
+import { colors } from '../../theme/tokens';
+
+type Props = {
+  journal: ExpeditionJournal | null;
+};
+
+type JournalLandmark = {
+  place: string;
+  icon: keyof typeof Ionicons.glyphMap;
+};
+
+const JOURNAL_LANDMARKS: Record<ExpeditionObjectiveKey, JournalLandmark> = {
+  SNIFF_EXPLORE: { place: 'Wandering Grove', icon: 'leaf-outline' },
+  RECOVERY_COUNTS: { place: 'Resting Hollow', icon: 'moon-outline' },
+  READ_THE_ROOM: { place: 'Signal Observatory', icon: 'bulb-outline' },
+};
+
+function formatWeek(startsAt: string) {
+  const date = new Date(startsAt);
+  if (!Number.isFinite(date.getTime())) return 'Server-recorded week';
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+  return `Week of ${formatter.format(date)}`;
+}
+
+function FieldNote({ entry }: { entry: ExpeditionJournalEntry }) {
+  return (
+    <View style={styles.noteCard}>
+      <View style={styles.noteHeader}>
+        <View style={styles.postmark}>
+          <Ionicons name="paw-outline" size={15} color={colors.primary[700]} />
+        </View>
+        <View style={styles.noteHeading}>
+          <Text style={styles.noteState}>{entry.state === 'ACTIVE' ? 'THIS WEEK' : 'FIELD NOTE'}</Text>
+          <Text style={styles.noteDate}>{formatWeek(entry.season.startsAt)}</Text>
+        </View>
+      </View>
+
+      <View style={styles.stamps}>
+        {entry.landmarks.map((landmark) => {
+          const spec = JOURNAL_LANDMARKS[landmark.key];
+          return (
+            <View key={landmark.key} style={styles.stamp}>
+              <Ionicons name={spec.icon} size={18} color={colors.primary[700]} />
+              <View style={styles.stampCopy}>
+                <Text style={styles.stampPlace}>{spec.place}</Text>
+                <Text style={styles.stampTitle}>{landmark.title}</Text>
+              </View>
+            </View>
+          );
+        })}
+      </View>
+
+      <Text style={styles.noteFoot}>
+        {entry.state === 'ACTIVE'
+          ? 'This page reflects server-issued receipts so far. There is nothing you need to fill.'
+          : 'This page records what happened. Blank space is part of the memory.'}
+      </Text>
+    </View>
+  );
+}
+
+export function ExpeditionFieldJournalView({ journal }: Props) {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.eyebrow}>FIELD JOURNAL</Text>
+      <Text style={styles.title}>Pages from worlds you helped inhabit</Text>
+      <Text style={styles.body}>
+        A field note remembers which kinds of Expedition moments actually occurred. Repeating a
+        moment does not make a bigger stamp, and a page is never graded for being full.
+      </Text>
+
+      {!journal ? (
+        <View style={styles.quietCard}>
+          <Ionicons name="book-outline" size={23} color={colors.gray[500]} />
+          <Text style={styles.quietTitle}>Journal history is unavailable.</Text>
+          <Text style={styles.quietBody}>
+            Woof will not rebuild field notes from local activity, league score, or guessed history.
+          </Text>
+        </View>
+      ) : journal.entries.length === 0 ? (
+        <View style={styles.quietCard}>
+          <Ionicons name="leaf-outline" size={23} color={colors.primary[600]} />
+          <Text style={styles.quietTitle}>No field notes yet.</Text>
+          <Text style={styles.quietBody}>
+            Nothing is overdue and there is nothing to catch up on. A page appears only from
+            server-issued Expedition receipts.
+          </Text>
+        </View>
+      ) : (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.notesRow}
+        >
+          {journal.entries.map((entry) => (
+            <FieldNote key={entry.season.key} entry={entry} />
+          ))}
+        </ScrollView>
+      )}
+
+      {journal && (
+        <Text style={styles.coverage}>
+          Recent journal coverage: up to {journal.coverage.maxSeasons} participated weeks. Missing
+          older pages are not presented as non-participation.
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: { marginTop: 26 },
+  eyebrow: { color: colors.gray[500], fontSize: 10, fontWeight: '800', letterSpacing: 1.2 },
+  title: { marginTop: 4, color: colors.gray[900], fontSize: 20, fontWeight: '900' },
+  body: { marginTop: 6, color: colors.gray[600], fontSize: 12, lineHeight: 18 },
+  notesRow: { gap: 11, paddingTop: 12, paddingRight: 18 },
+  noteCard: {
+    width: 286,
+    minHeight: 214,
+    padding: 16,
+    borderRadius: 20,
+    backgroundColor: '#fffdf7',
+    borderWidth: 1,
+    borderColor: '#eee7d7',
+  },
+  noteHeader: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  postmark: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: colors.primary[200],
+    backgroundColor: colors.primary[50],
+  },
+  noteHeading: { flex: 1 },
+  noteState: { color: colors.primary[700], fontSize: 9, fontWeight: '900', letterSpacing: 1.1 },
+  noteDate: { marginTop: 2, color: colors.gray[900], fontSize: 15, fontWeight: '800' },
+  stamps: { marginTop: 15, gap: 8 },
+  stamp: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 9,
+    padding: 10,
+    borderRadius: 13,
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+  },
+  stampCopy: { flex: 1 },
+  stampPlace: { color: colors.gray[900], fontSize: 12, fontWeight: '800' },
+  stampTitle: { marginTop: 1, color: colors.gray[500], fontSize: 10 },
+  noteFoot: { marginTop: 14, color: colors.gray[500], fontSize: 10, lineHeight: 15 },
+  quietCard: {
+    marginTop: 12,
+    padding: 18,
+    borderRadius: 18,
+    alignItems: 'center',
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+  },
+  quietTitle: { marginTop: 8, color: colors.gray[900], fontSize: 14, fontWeight: '800' },
+  quietBody: {
+    marginTop: 5,
+    color: colors.gray[600],
+    fontSize: 11,
+    lineHeight: 17,
+    textAlign: 'center',
+  },
+  coverage: { marginTop: 9, color: colors.gray[500], fontSize: 10, lineHeight: 15 },
+});

--- a/apps/mobile/src/components/community/ExpeditionWorldView.tsx
+++ b/apps/mobile/src/components/community/ExpeditionWorldView.tsx
@@ -9,13 +9,19 @@ import {
   View,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import type { ExpeditionObjective, ExpeditionProjection } from '../../api/expeditions';
+import type {
+  ExpeditionJournal,
+  ExpeditionObjective,
+  ExpeditionProjection,
+} from '../../api/expeditions';
 import type { SocialPack } from '../../api/social-adventure';
 import { colors } from '../../theme/tokens';
+import { ExpeditionFieldJournalView } from './ExpeditionFieldJournalView';
 
 type Props = {
   globalProjection: ExpeditionProjection | null;
   packProjection: ExpeditionProjection | null;
+  journal: ExpeditionJournal | null;
   joinedPacks: SocialPack[];
   selectedScope: 'GLOBAL' | string;
   packLoading: boolean;
@@ -62,7 +68,11 @@ function formatSeason(start: string, end: string) {
   if (!Number.isFinite(startsAt.getTime()) || !Number.isFinite(endsAt.getTime())) {
     return 'Server-defined weekly season';
   }
-  const formatter = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
   return `${formatter.format(startsAt)} – ${formatter.format(endsAt)}`;
 }
 
@@ -273,6 +283,8 @@ export function ExpeditionWorldView(props: Props) {
           </Text>
         </View>
       )}
+
+      <ExpeditionFieldJournalView journal={props.journal} />
 
       <View style={styles.boundaryCard}>
         <View style={styles.boundaryIcon}>

--- a/apps/mobile/src/screens/ExpeditionScreen.tsx
+++ b/apps/mobile/src/screens/ExpeditionScreen.tsx
@@ -2,7 +2,11 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import type { StackScreenProps } from '@react-navigation/stack';
-import { expeditionApi, type ExpeditionProjection } from '../api/expeditions';
+import {
+  expeditionApi,
+  type ExpeditionJournal,
+  type ExpeditionProjection,
+} from '../api/expeditions';
 import { socialAdventureApi, type PacksCatalog } from '../api/social-adventure';
 import { ExpeditionWorldView } from '../components/community/ExpeditionWorldView';
 import type { RootStackParamList } from '../navigation/AppNavigator';
@@ -15,6 +19,7 @@ type SelectedScope = 'GLOBAL' | string;
 export default function ExpeditionScreen({ navigation }: Props) {
   const [globalProjection, setGlobalProjection] = useState<ExpeditionProjection | null>(null);
   const [packProjection, setPackProjection] = useState<ExpeditionProjection | null>(null);
+  const [journal, setJournal] = useState<ExpeditionJournal | null>(null);
   const [catalog, setCatalog] = useState<PacksCatalog | null>(null);
   const [selectedScope, setSelectedScope] = useState<SelectedScope>('GLOBAL');
   const [loading, setLoading] = useState(true);
@@ -71,9 +76,10 @@ export default function ExpeditionScreen({ navigation }: Props) {
       if (refresh) setRefreshing(true);
       else setLoading(true);
 
-      const [globalResult, packsResult] = await Promise.allSettled([
+      const [globalResult, packsResult, journalResult] = await Promise.allSettled([
         expeditionApi.global(),
         socialAdventureApi.packs(),
+        expeditionApi.journal(),
       ]);
 
       const unavailable: string[] = [];
@@ -104,10 +110,17 @@ export default function ExpeditionScreen({ navigation }: Props) {
         unavailable.push('Pack membership');
       }
 
+      if (journalResult.status === 'fulfilled') {
+        if (journalResult.value.scope === 'GLOBAL') setJournal(journalResult.value);
+        else unavailable.push('field journal');
+      } else {
+        unavailable.push('field journal');
+      }
+
       if (unavailable.length === 0) setError(null);
       else
         setError(
-          `${unavailable.join(' and ')} could not refresh. Previously loaded server projections remain visible where available; Woof did not infer missing progress or membership.`
+          `${unavailable.join(' and ')} could not refresh. Previously loaded server projections remain visible where available; Woof did not infer missing progress, membership, or journal history.`
         );
 
       setLoading(false);
@@ -158,6 +171,7 @@ export default function ExpeditionScreen({ navigation }: Props) {
     <ExpeditionWorldView
       globalProjection={globalProjection}
       packProjection={packProjection}
+      journal={journal}
       joinedPacks={joinedPacks}
       selectedScope={selectedScope}
       packLoading={packLoading}

--- a/docs/NATIVE_EXPEDITION_FIELD_JOURNAL_V1.md
+++ b/docs/NATIVE_EXPEDITION_FIELD_JOURNAL_V1.md
@@ -1,0 +1,148 @@
+# Native Expedition Field Journal v1
+
+## Purpose
+
+The Expedition Field Journal makes Woof more collectible without creating another reward economy.
+
+A field note says **this happened**. It does not say **do more**, **finish the set**, or **beat somebody else**.
+
+The journal is a personal memory projection over the same immutable Expedition receipts that already power the cooperative world. It does not mint badges, award points, create streaks, or write a second archive.
+
+## Canonical authority
+
+The journal reads only:
+
+- the signed-in user's own receipts;
+- `GLOBAL` Expedition scope;
+- the current `EXPEDITION_KEY`, `EXPEDITION_VERSION`, and `EXPEDITION_POLICY_VERSION`;
+- canonical Expedition objective keys already accepted by the server.
+
+`GET /api/v1/expeditions/journal` is read-only.
+
+Before reading journal history, the journal service asks the canonical `ExpeditionsService` to materialize the current Global season. That existing materialization is idempotent and remains the only writer. The journal never inserts, updates, claims, completes, or awards anything.
+
+No new database table or migration is required. The existing immutable `dogos_social.expedition_receipts` table is the evidence source.
+
+## Presence, never volume
+
+For a given season, repeated authorized receipts for one objective collapse to one journal landmark.
+
+Two bounded `EXPLORE` receipts therefore create the same **Wandering Grove** stamp as one receipt. The journal response intentionally omits receipt count, contribution count, score, rank, target, rarity, and completion fields.
+
+The three possible journal landmarks remain:
+
+- `SNIFF_EXPLORE` → **Wandering Grove**
+- `RECOVERY_COUNTS` → **Resting Hollow**
+- `READ_THE_ROOM` → **Signal Observatory**
+
+The UI renders only landmarks that actually occurred. It does not render empty slots for the other landmarks. Empty slots would turn a memory page into a checklist.
+
+A page with only **Resting Hollow** is not less complete than a page with several kinds of moments. It simply records a different week.
+
+## Active and past pages
+
+A journal entry can be:
+
+- `ACTIVE` for the current Monday-UTC Expedition season;
+- `PAST` for an earlier valid Monday-UTC season.
+
+`ACTIVE` does not mean incomplete. The native copy explicitly says the page reflects server-issued receipts so far and that there is nothing the user needs to fill.
+
+`PAST` does not mean completed. The page simply records the landmark kinds that had authorized evidence in that season.
+
+No state called `COMPLETE`, `FAILED`, `MISSED`, or equivalent belongs in the journal.
+
+## Historical validation
+
+Storage is not treated as presentation authority by itself.
+
+Journal projection accepts only normalized `week:YYYY-MM-DD` keys that parse to real Monday UTC dates and are not after the current Expedition season. A malformed, non-Monday, or future receipt must not surface as a journal page.
+
+This validation is useful even though canonical Expedition writers already create valid season keys. Historical projections should fail closed if storage is ever repaired, imported, or manually altered.
+
+## Privacy and scope
+
+Field Journal v1 is personal and Global-only.
+
+It does not expose another user's receipts, community totals, contributor counts, Global rank, Pack rank, or Pack history. Pack receipts stay out of the personal Global journal even when the viewer currently belongs to that Pack.
+
+Pack history is deliberately deferred. Historical Pack membership changes, ownership transfer, and local-community privacy deserve their own authority contract rather than being inferred from current membership.
+
+## Bounded coverage
+
+The first journal returns up to the **26 most recent participated seasons** under the current Expedition authority version.
+
+This is intentionally described as recent coverage, not complete lifetime history. A user with more than 26 participated seasons may have older valid receipts that are not returned.
+
+Native copy must say that missing older pages are not presented as non-participation.
+
+The API returns the coverage contract explicitly:
+
+- `kind: RECENT_PARTICIPATED_SEASONS`
+- `maxSeasons: 26`
+
+The client does not infer a lifetime participation count from the number of returned pages.
+
+## Native presentation
+
+The journal lives inside the Expedition surface so both Guardian and Companion modes receive the same human-side history.
+
+Each field note is postcard-like rather than achievement-like:
+
+- week label;
+- one stamp per landmark that actually occurred;
+- no empty stamp placeholders;
+- no page score;
+- no progress meter;
+- no rarity color;
+- no completion burst;
+- no reward claim button.
+
+Season dates are formatted in UTC so the Monday-UTC authority does not appear as Sunday on clients west of UTC.
+
+The current live Expedition world may show server-authored communal totals. Historical journal pages do not. The present can say **we are here together**; the past only says **you were here**.
+
+## Failure behavior
+
+Current Global Expedition, Pack catalog, Pack projection, and Journal are independent read slices.
+
+A Journal failure does not erase a healthy current-world projection. A current-world failure does not authorize the client to rebuild journal history from Adventure Trail XP, Social Adventure score, Story, route data, local caches, or raw activity records.
+
+No local fallback journal is permitted.
+
+## Companion mode
+
+Companion users can accumulate legitimate journal history through human-side Expedition evidence such as eligible Human Skill breadth. Woof does not synthesize dog-specific Adventure stamps for them.
+
+This keeps the journal useful before pet ownership without making acquiring a pet an unlock condition or reward.
+
+## Relationship to Story
+
+Field Journal v1 is **not** Story persistence and does not create Story moments or milestones.
+
+That separation is useful. Expedition history is human-side cooperative evidence, while Story remains relationship memory tied to authorized pet context. A later product tranche may create an explicit guardian-side Story link or server-authored seasonal artifact, but it must not silently reinterpret Journal participation as a pet achievement.
+
+## Qualification contract
+
+`Expedition Field Journal CI` must prove that:
+
+1. Journal is a GET-only authenticated projection;
+2. current-season receipts are materialized only through canonical `ExpeditionsService` authority;
+3. only the viewer's current-policy Global receipts enter Journal history;
+4. Pack receipts and other users' receipts do not enter the journal;
+5. future, malformed, and non-Monday season keys do not surface;
+6. repeated receipts collapse to one landmark presence per objective per season;
+7. the response contains no contribution counts, scores, ranks, targets, rarity, or completion state;
+8. native pages render only returned landmarks and no empty completion slots;
+9. native copy explicitly rejects catch-up and fill-the-page pressure;
+10. coverage is clearly bounded to recent participated seasons;
+11. UTC season formatting is preserved;
+12. API and mobile type-check/lint remain green alongside the existing Expedition integration contracts.
+
+## Future visual evolution
+
+The journal can become more delightful without becoming more coercive.
+
+Safe future directions include server-authored seasonal paper textures, weather motifs, non-scarce illustrated postcards, or short narrative captions derived from the objective mix. Those cosmetics should not encode rarity, comparative status, health, pet performance, or hidden completion thresholds.
+
+The useful design question is not **how do we make people fill every page?** It is **how do we make real weeks worth remembering?**


### PR DESCRIPTION
## Summary

Add a personal Expedition **Field Journal** that turns existing immutable Global Expedition receipts into recent, postcard-like memory pages without creating another points economy.

This tranche makes Woof more collectible while preserving the core boundary: a field note says **this happened**, not **fill the set** or **do more**.

## Product shape

- One journal page per participated Monday-UTC Expedition season.
- Pages show only landmarks where the signed-in human has at least one authorized Global receipt:
  - **Wandering Grove** for `SNIFF_EXPLORE`
  - **Resting Hollow** for `RECOVERY_COUNTS`
  - **Signal Observatory** for `READ_THE_ROOM`
- Repeated receipts for the same objective collapse to one stamp.
- Missing landmarks render as nothing, not empty slots.
- Current-season pages are `ACTIVE`, but explicitly say there is nothing to fill.
- Past pages are memories, not completed achievements.
- Journal lives inside Expedition so Guardian and Companion modes share the same human-side history.

## Authority boundary

- Adds authenticated GET-only `/expeditions/journal`.
- No new database table or migration.
- Current receipts are materialized only through canonical `ExpeditionsService.getGlobal()` authority.
- History reads only the viewer's own `GLOBAL`, `pack_id IS NULL`, current key/version/policy receipts.
- Validates normalized Monday-UTC season keys and excludes future/non-Monday/malformed pages.
- Returns at most the 26 most recent participated seasons and exposes that bounded coverage explicitly.
- Journal entry types contain no contribution count, community total, rank, score, target, rarity, completion, streak, or Pack field.
- No Story moment/milestone mutation is introduced.

## Adversarial qualification

The new PostgreSQL integration test deliberately injects:

- repeated current EXPLORE evidence;
- another user's receipt;
- a Pack-scoped receipt;
- a future-season receipt;
- a validly-shaped non-Monday historical receipt.

The expected journal exposes only the viewer's valid Global landmark presence. Repetition remains one stamp.

## Repository contracts

Adds `Expedition Field Journal CI` and `assert-expedition-field-journal.py`. The source guard rejects Journal mutation paths, Pack-history sourcing, score/rank/target/completion/rarity/streak fields, landmark-count arithmetic, empty/locked stamp placeholders, and local fallback history. It also requires UTC rendering and the existing immutable receipt/index authority.

The existing Native Expedition World contract remains in force independently.

## Deliberately deferred

No lifetime-history claim, Pack journal, rarity system, badge minting, completion rewards, Story persistence, seasonal loot, or calibrated community target is added here.

Base: exact post-merge-qualified `main` at `83941a419eced84946507d787ad42b5f88735472`.