### PR TITLE
Make native dogOS relationship context explicit

### DIFF
--- a/.github/scripts/assert-native-adventure-trail.py
+++ b/.github/scripts/assert-native-adventure-trail.py
@@ -78,7 +78,8 @@ for forbidden in (
         raise SystemExit(f"Adventure Trail presentation policy must stay bounded/read-only: {forbidden}")
 
 for marker in (
-    "deriveAdventureTrail(dashboard)",
+    "deriveAdventureTrail(activeDashboard)",
+    "dashboard.pet.id === selectedPetId",
     "ADVENTURE TRAIL",
     "Trail XP",
     "Discovery stamps",

--- a/.github/scripts/assert-native-relationship-context.py
+++ b/.github/scripts/assert-native-relationship-context.py
@@ -51,24 +51,102 @@ require(
 # Relationship selection is presentation state only. The usable set must come from
 # authenticated household authority, and persisted IDs must be intersected with it.
 require(scope, "householdsApi.getMine()", "Relationship scope must load household authority")
-require(scope, "woof:selected-relationship-pet:v1:", "Relationship selection must be account-namespaced")
-require(scope, "pets.some((pet) => pet.id === candidate)", "Stored pet IDs must be intersected with fresh authorized pets")
-require(scope, "snapshot.pets.some((pet) => pet.id === petId)", "Interactive pet selection must reject IDs outside the authorized snapshot")
-require(scope, "SecureStore.setItemAsync", "Relationship preference should survive a normal app restart")
-require(scope, "Server household authority remains canonical", "Persistence failure must not become authorization authority")
-forbid(scope, r"petsApi\.", "Relationship scope must not fall back to the legacy owner-only pets client")
+require(
+    scope,
+    "woof:selected-relationship-pet:v1:",
+    "Relationship selection must be account-namespaced",
+)
+require(
+    scope,
+    "pets.some((pet) => pet.id === candidate)",
+    "Stored pet IDs must be intersected with fresh authorized pets",
+)
+require(
+    scope,
+    "snapshot.pets.some((pet) => pet.id === petId)",
+    "Interactive pet selection must reject IDs outside the authorized snapshot",
+)
+require(
+    scope,
+    "SecureStore.setItemAsync",
+    "Relationship preference should survive a normal app restart",
+)
+require(
+    scope,
+    "Server household authority remains canonical",
+    "Persistence failure must not become authorization authority",
+)
+forbid(
+    scope,
+    r"petsApi\.",
+    "Relationship scope must not fall back to the legacy owner-only pets client",
+)
+
+# Slow household reads and slow dog-specific dashboard reads must not overwrite a
+# newer account/pet choice.
+require(scope, "let loadGeneration = 0", "Relationship authority refresh needs a generation guard")
+require(
+    scope,
+    "generation !== loadGeneration",
+    "Stale household refreshes must be rejected before updating shared state",
+)
+require(
+    scope,
+    "loadGeneration += 1",
+    "An explicit pet choice must supersede an older household refresh",
+)
+require(today, "requestGenerationRef", "Today needs a stale-response generation guard")
+require(compass, "requestGenerationRef", "Compass needs a stale-response generation guard")
+require(
+    today,
+    "requestGeneration !== requestGenerationRef.current",
+    "Today must reject stale cross-pet dashboard responses",
+)
+require(
+    compass,
+    "requestGeneration !== requestGenerationRef.current",
+    "Compass must reject stale cross-pet dashboard responses",
+)
 
 # Pet-specific Adventure reads must always name the selected relationship.
-require(today, "adventureApi.getMine(selectedPetId)", "Today must request the explicitly selected pet")
-require(compass, "adventureApi.getMine(selectedPetId)", "Compass must request the explicitly selected pet")
-require(today, "dashboard.pet.id === selectedPetId", "Today must suppress stale cross-pet dashboards")
-require(compass, "dashboard.pet.id === selectedPetId", "Compass must suppress stale cross-pet dashboards")
+require(
+    today,
+    "adventureApi.getMine(selectedPetId)",
+    "Today must request the explicitly selected pet",
+)
+require(
+    compass,
+    "adventureApi.getMine(selectedPetId)",
+    "Compass must request the explicitly selected pet",
+)
+require(
+    today,
+    "dashboard.pet.id === selectedPetId",
+    "Today must suppress stale cross-pet dashboards",
+)
+require(
+    compass,
+    "dashboard.pet.id === selectedPetId",
+    "Compass must suppress stale cross-pet dashboards",
+)
 require(today, "<RelationshipScopeBar", "Today must expose relationship scope")
 require(compass, "<RelationshipScopeBar", "Compass must expose relationship scope")
 
 # Selection controls need a comfortable mobile target and explicit accessibility state.
-require(selector, "minHeight: 44", "Relationship selector controls must provide a 44pt minimum target")
-require(selector, "accessibilityState={{ selected }}", "Relationship selector must expose selected state")
-require(selector, "Each dog keeps a separate history.", "Multi-dog copy must make relationship separation explicit")
+require(
+    selector,
+    "minHeight: 44",
+    "Relationship selector controls must provide a 44pt minimum target",
+)
+require(
+    selector,
+    "accessibilityState={{ selected }}",
+    "Relationship selector must expose selected state",
+)
+require(
+    selector,
+    "Each dog keeps a separate history.",
+    "Multi-dog copy must make relationship separation explicit",
+)
 
 print("Native relationship context authority contract OK")

--- a/.github/scripts/assert-native-relationship-context.py
+++ b/.github/scripts/assert-native-relationship-context.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def require(source: str, needle: str, message: str) -> None:
+    if needle not in source:
+        raise SystemExit(message)
+
+
+def forbid(source: str, pattern: str, message: str) -> None:
+    if re.search(pattern, source, flags=re.MULTILINE | re.DOTALL):
+        raise SystemExit(message)
+
+
+care = read("apps/api/src/care-events/care-events.service.ts")
+compass = read("apps/mobile/src/screens/CompassScreen.tsx")
+today = read("apps/mobile/src/screens/TodayScreen.tsx")
+scope = read("apps/mobile/src/relationship/relationship-scope.ts")
+selector = read("apps/mobile/src/components/relationship/RelationshipScopeBar.tsx")
+
+# Cross-layer percentage contract. CareSummary owns a 0–100 opportunity percentage;
+# native must not reinterpret that value as a 0–1 fraction.
+require(
+    care,
+    "coverage: Math.min(100, recentDays * 25)",
+    "CareSummary must retain the canonical 0–100 pathway coverage scale",
+)
+require(
+    compass,
+    "Math.min(100, item.coverage)",
+    "Compass must clamp canonical coverage directly on the 0–100 scale",
+)
+forbid(
+    compass,
+    r"Math\.min\(\s*1\s*,\s*item\.coverage\s*\)",
+    "Compass must not collapse 0–100 pathway coverage onto a 0–1 scale",
+)
+require(
+    compass,
+    "width: `${coveragePercent}%`",
+    "Compass progress width must use the canonical percentage without multiplying again",
+)
+
+# Relationship selection is presentation state only. The usable set must come from
+# authenticated household authority, and persisted IDs must be intersected with it.
+require(scope, "householdsApi.getMine()", "Relationship scope must load household authority")
+require(scope, "woof:selected-relationship-pet:v1:", "Relationship selection must be account-namespaced")
+require(scope, "pets.some((pet) => pet.id === candidate)", "Stored pet IDs must be intersected with fresh authorized pets")
+require(scope, "snapshot.pets.some((pet) => pet.id === petId)", "Interactive pet selection must reject IDs outside the authorized snapshot")
+require(scope, "SecureStore.setItemAsync", "Relationship preference should survive a normal app restart")
+require(scope, "Server household authority remains canonical", "Persistence failure must not become authorization authority")
+forbid(scope, r"petsApi\.", "Relationship scope must not fall back to the legacy owner-only pets client")
+
+# Pet-specific Adventure reads must always name the selected relationship.
+require(today, "adventureApi.getMine(selectedPetId)", "Today must request the explicitly selected pet")
+require(compass, "adventureApi.getMine(selectedPetId)", "Compass must request the explicitly selected pet")
+require(today, "dashboard.pet.id === selectedPetId", "Today must suppress stale cross-pet dashboards")
+require(compass, "dashboard.pet.id === selectedPetId", "Compass must suppress stale cross-pet dashboards")
+require(today, "<RelationshipScopeBar", "Today must expose relationship scope")
+require(compass, "<RelationshipScopeBar", "Compass must expose relationship scope")
+
+# Selection controls need a comfortable mobile target and explicit accessibility state.
+require(selector, "minHeight: 44", "Relationship selector controls must provide a 44pt minimum target")
+require(selector, "accessibilityState={{ selected }}", "Relationship selector must expose selected state")
+require(selector, "Each dog keeps a separate history.", "Multi-dog copy must make relationship separation explicit")
+
+print("Native relationship context authority contract OK")

--- a/.github/workflows/native-relationship-context-ci.yml
+++ b/.github/workflows/native-relationship-context-ci.yml
@@ -1,0 +1,51 @@
+name: Native Relationship Context CI
+
+on:
+  pull_request:
+    paths:
+      - 'apps/api/src/care-events/care-events.service.ts'
+      - 'apps/mobile/src/api/households.ts'
+      - 'apps/mobile/src/components/relationship/**'
+      - 'apps/mobile/src/relationship/**'
+      - 'apps/mobile/src/screens/TodayScreen.tsx'
+      - 'apps/mobile/src/screens/CompassScreen.tsx'
+      - '.github/scripts/assert-native-relationship-context.py'
+      - '.github/workflows/native-relationship-context-ci.yml'
+      - 'docs/NATIVE_RELATIONSHIP_CONTEXT_V1.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  relationship-context:
+    name: Authorized multi-dog relationship context
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 8.15.1
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20.20.2
+          cache: pnpm
+      - name: Enforce relationship-context authority contract
+        run: python3 .github/scripts/assert-native-relationship-context.py
+      - name: Install from committed lockfile
+        run: pnpm install --frozen-lockfile
+      - name: Reject relationship-context formatting drift
+        run: |
+          pnpm exec prettier --check \
+            apps/mobile/src/relationship/relationship-scope.ts \
+            apps/mobile/src/components/relationship/RelationshipScopeBar.tsx \
+            apps/mobile/src/screens/TodayScreen.tsx \
+            apps/mobile/src/screens/CompassScreen.tsx \
+            .github/scripts/assert-native-relationship-context.py \
+            .github/workflows/native-relationship-context-ci.yml \
+            docs/NATIVE_RELATIONSHIP_CONTEXT_V1.md
+      - name: Type-check native client
+        run: pnpm --filter @woof/mobile type-check
+      - name: Lint native client
+        run: pnpm --filter @woof/mobile lint

--- a/.github/workflows/native-relationship-context-ci.yml
+++ b/.github/workflows/native-relationship-context-ci.yml
@@ -39,14 +39,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Reject relationship-context formatting drift
         run: |
-          pnpm exec prettier --write \
-            apps/mobile/src/relationship/relationship-scope.ts \
-            apps/mobile/src/components/relationship/RelationshipScopeBar.tsx \
-            apps/mobile/src/screens/TodayScreen.tsx \
-            apps/mobile/src/screens/CompassScreen.tsx \
-            .github/workflows/native-relationship-context-ci.yml \
-            docs/NATIVE_RELATIONSHIP_CONTEXT_V1.md
-          git diff --exit-code -- \
+          pnpm exec prettier --check \
             apps/mobile/src/relationship/relationship-scope.ts \
             apps/mobile/src/components/relationship/RelationshipScopeBar.tsx \
             apps/mobile/src/screens/TodayScreen.tsx \

--- a/.github/workflows/native-relationship-context-ci.yml
+++ b/.github/workflows/native-relationship-context-ci.yml
@@ -33,16 +33,24 @@ jobs:
           cache: pnpm
       - name: Enforce relationship-context authority contract
         run: python3 .github/scripts/assert-native-relationship-context.py
+      - name: Compile relationship-context sentry
+        run: python3 -m py_compile .github/scripts/assert-native-relationship-context.py
       - name: Install from committed lockfile
         run: pnpm install --frozen-lockfile
       - name: Reject relationship-context formatting drift
         run: |
-          pnpm exec prettier --check \
+          pnpm exec prettier --write \
             apps/mobile/src/relationship/relationship-scope.ts \
             apps/mobile/src/components/relationship/RelationshipScopeBar.tsx \
             apps/mobile/src/screens/TodayScreen.tsx \
             apps/mobile/src/screens/CompassScreen.tsx \
-            .github/scripts/assert-native-relationship-context.py \
+            .github/workflows/native-relationship-context-ci.yml \
+            docs/NATIVE_RELATIONSHIP_CONTEXT_V1.md
+          git diff --exit-code -- \
+            apps/mobile/src/relationship/relationship-scope.ts \
+            apps/mobile/src/components/relationship/RelationshipScopeBar.tsx \
+            apps/mobile/src/screens/TodayScreen.tsx \
+            apps/mobile/src/screens/CompassScreen.tsx \
             .github/workflows/native-relationship-context-ci.yml \
             docs/NATIVE_RELATIONSHIP_CONTEXT_V1.md
       - name: Type-check native client

--- a/apps/mobile/src/components/relationship/RelationshipScopeBar.tsx
+++ b/apps/mobile/src/components/relationship/RelationshipScopeBar.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRelationshipScope } from '../../relationship/relationship-scope';
+import { colors } from '../../theme/tokens';
+
+type Props = {
+  onBeforeSelect?: () => void;
+};
+
+export function RelationshipScopeBar({ onBeforeSelect }: Props) {
+  const { pets, selectedPetId, selectedPet, loading, error, selectPet } = useRelationshipScope();
+
+  if (loading && pets.length === 0) {
+    return (
+      <View style={styles.loadingCard} accessibilityRole="progressbar">
+        <ActivityIndicator size="small" color={colors.primary[600]} />
+        <Text style={styles.loadingText}>Checking which dog you’re with…</Text>
+      </View>
+    );
+  }
+
+  if (!selectedPet) {
+    return (
+      <View style={styles.unavailableCard} accessibilityRole={error ? 'alert' : undefined}>
+        <Ionicons name="paw-outline" size={18} color={colors.gray[600]} />
+        <Text style={styles.unavailableText}>
+          {error ?? 'No authorized dog relationship is available for this view.'}
+        </Text>
+      </View>
+    );
+  }
+
+  if (pets.length === 1) {
+    return (
+      <View
+        style={styles.singleCard}
+        accessible
+        accessibilityLabel={`Viewing your relationship with ${selectedPet.name}`}
+      >
+        <View style={styles.scopeIcon}>
+          <Ionicons name="paw" size={17} color={colors.primary[700]} />
+        </View>
+        <View style={styles.copy}>
+          <Text style={styles.eyebrow}>WITH</Text>
+          <Text style={styles.selectedName}>{selectedPet.name}</Text>
+        </View>
+        <Text style={styles.singleHint}>This view is just for this relationship.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.headingRow}>
+        <View>
+          <Text style={styles.eyebrow}>RELATIONSHIP</Text>
+          <Text style={styles.heading}>Who are you with?</Text>
+        </View>
+        <Text style={styles.headingHint}>Each dog keeps a separate history.</Text>
+      </View>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.chipRow}
+      >
+        {pets.map((pet) => {
+          const selected = pet.id === selectedPetId;
+          return (
+            <Pressable
+              key={pet.id}
+              accessibilityRole="button"
+              accessibilityState={{ selected }}
+              accessibilityLabel={`${selected ? 'Viewing' : 'View'} relationship with ${pet.name}`}
+              onPress={() => {
+                if (selected) return;
+                onBeforeSelect?.();
+                selectPet(pet.id);
+              }}
+              style={[styles.chip, selected && styles.chipSelected]}
+            >
+              <Ionicons
+                name={selected ? 'paw' : 'paw-outline'}
+                size={16}
+                color={selected ? colors.primary[800] : colors.gray[600]}
+              />
+              <Text style={[styles.chipText, selected && styles.chipTextSelected]}>{pet.name}</Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    marginTop: 16,
+    paddingVertical: 14,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: colors.gray[200],
+  },
+  headingRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+    gap: 12,
+  },
+  copy: { flex: 1 },
+  eyebrow: { color: colors.text.secondary, fontSize: 10, fontWeight: '800', letterSpacing: 1.2 },
+  heading: { marginTop: 3, color: colors.text.primary, fontSize: 15, fontWeight: '800' },
+  headingHint: {
+    flex: 1,
+    color: colors.text.secondary,
+    fontSize: 10,
+    lineHeight: 15,
+    textAlign: 'right',
+  },
+  chipRow: { gap: 8, paddingTop: 10, paddingRight: 18 },
+  chip: {
+    minHeight: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 7,
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: colors.gray[300],
+    backgroundColor: '#ffffff',
+  },
+  chipSelected: {
+    borderColor: colors.primary[300],
+    backgroundColor: colors.primary[100],
+  },
+  chipText: { color: colors.gray[700], fontSize: 13, fontWeight: '700' },
+  chipTextSelected: { color: colors.primary[900] },
+  singleCard: {
+    minHeight: 58,
+    marginTop: 16,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    borderRadius: 16,
+    backgroundColor: colors.primary[50],
+    borderWidth: 1,
+    borderColor: colors.primary[100],
+  },
+  scopeIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#ffffff',
+  },
+  selectedName: { marginTop: 1, color: colors.text.primary, fontSize: 15, fontWeight: '800' },
+  singleHint: {
+    maxWidth: 132,
+    color: colors.text.secondary,
+    fontSize: 10,
+    lineHeight: 14,
+    textAlign: 'right',
+  },
+  loadingCard: {
+    minHeight: 52,
+    marginTop: 16,
+    paddingHorizontal: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 9,
+    borderRadius: 15,
+    backgroundColor: colors.gray[50],
+  },
+  loadingText: { color: colors.text.secondary, fontSize: 12 },
+  unavailableCard: {
+    minHeight: 52,
+    marginTop: 16,
+    paddingHorizontal: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 9,
+    borderRadius: 15,
+    backgroundColor: colors.gray[50],
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+  },
+  unavailableText: { flex: 1, color: colors.text.secondary, fontSize: 12, lineHeight: 17 },
+});

--- a/apps/mobile/src/relationship/relationship-scope.ts
+++ b/apps/mobile/src/relationship/relationship-scope.ts
@@ -1,0 +1,173 @@
+import { useEffect, useSyncExternalStore } from 'react';
+import * as SecureStore from 'expo-secure-store';
+import { householdsApi, type HouseholdSnapshot } from '../api/households';
+import { useAuth } from '../contexts/AuthContext';
+
+const STORAGE_PREFIX = 'woof:selected-relationship-pet:v1:';
+
+export type RelationshipPet = {
+  id: string;
+  name: string;
+  species: string;
+  breed?: string | null;
+  avatarUrl?: string | null;
+  householdNames: string[];
+};
+
+type RelationshipSnapshot = {
+  userId: string | null;
+  pets: RelationshipPet[];
+  selectedPetId: string | null;
+  loading: boolean;
+  error: string | null;
+  initialized: boolean;
+};
+
+const EMPTY_SNAPSHOT: RelationshipSnapshot = {
+  userId: null,
+  pets: [],
+  selectedPetId: null,
+  loading: false,
+  error: null,
+  initialized: false,
+};
+
+let snapshot: RelationshipSnapshot = EMPTY_SNAPSHOT;
+let loadPromise: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+
+function emit(next: RelationshipSnapshot) {
+  snapshot = next;
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function storageKey(userId: string) {
+  return `${STORAGE_PREFIX}${userId}`;
+}
+
+function flattenAuthorizedPets(households: HouseholdSnapshot[]): RelationshipPet[] {
+  const pets = new Map<string, RelationshipPet>();
+
+  for (const household of households) {
+    for (const link of household.pets) {
+      const existing = pets.get(link.pet.id);
+      if (existing) {
+        if (!existing.householdNames.includes(household.name)) {
+          existing.householdNames.push(household.name);
+        }
+        continue;
+      }
+
+      pets.set(link.pet.id, {
+        id: link.pet.id,
+        name: link.pet.name,
+        species: link.pet.species,
+        breed: link.pet.breed,
+        avatarUrl: link.pet.avatarUrl,
+        householdNames: [household.name],
+      });
+    }
+  }
+
+  return [...pets.values()];
+}
+
+async function readStoredPetId(userId: string) {
+  try {
+    return await SecureStore.getItemAsync(storageKey(userId));
+  } catch {
+    return null;
+  }
+}
+
+async function persistSelectedPetId(userId: string, petId: string | null) {
+  try {
+    if (petId) await SecureStore.setItemAsync(storageKey(userId), petId);
+    else await SecureStore.deleteItemAsync(storageKey(userId));
+  } catch {
+    // Persistence is convenience only. Server household authority remains canonical.
+  }
+}
+
+async function loadAuthorizedRelationships(userId: string, force = false) {
+  if (!force && snapshot.initialized && snapshot.userId === userId) return;
+  if (loadPromise && snapshot.userId === userId) return loadPromise;
+
+  const previous = snapshot.userId === userId ? snapshot : EMPTY_SNAPSHOT;
+  emit({ ...previous, userId, loading: true, error: null });
+
+  loadPromise = (async () => {
+    try {
+      const households = await householdsApi.getMine();
+      const pets = flattenAuthorizedPets(households);
+      const storedPetId = await readStoredPetId(userId);
+      const previousPetId = previous.selectedPetId;
+      const selectedPetId =
+        [storedPetId, previousPetId].find(
+          (candidate): candidate is string =>
+            Boolean(candidate) && pets.some((pet) => pet.id === candidate)
+        ) ?? pets[0]?.id ?? null;
+
+      emit({
+        userId,
+        pets,
+        selectedPetId,
+        loading: false,
+        error: null,
+        initialized: true,
+      });
+
+      if (storedPetId !== selectedPetId) {
+        void persistSelectedPetId(userId, selectedPetId);
+      }
+    } catch {
+      emit({
+        ...previous,
+        userId,
+        loading: false,
+        error:
+          'Woof could not verify your dog relationships. Pet-specific views stay closed until household access can be checked.',
+        initialized: true,
+      });
+    } finally {
+      loadPromise = null;
+    }
+  })();
+
+  return loadPromise;
+}
+
+export function useRelationshipScope() {
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+  const current = useSyncExternalStore(subscribe, () => snapshot, () => snapshot);
+  const visible = current.userId === userId ? current : EMPTY_SNAPSHOT;
+
+  useEffect(() => {
+    if (userId) void loadAuthorizedRelationships(userId);
+  }, [userId]);
+
+  const selectPet = (petId: string) => {
+    if (!userId || snapshot.userId !== userId) return;
+    if (!snapshot.pets.some((pet) => pet.id === petId)) return;
+    if (snapshot.selectedPetId === petId) return;
+
+    emit({ ...snapshot, selectedPetId: petId, error: null });
+    void persistSelectedPetId(userId, petId);
+  };
+
+  return {
+    pets: visible.pets,
+    selectedPetId: visible.selectedPetId,
+    selectedPet: visible.pets.find((pet) => pet.id === visible.selectedPetId) ?? null,
+    loading: visible.loading || (Boolean(userId) && !visible.initialized),
+    error: visible.error,
+    selectPet,
+    refresh: () => (userId ? loadAuthorizedRelationships(userId, true) : Promise.resolve()),
+  };
+}

--- a/apps/mobile/src/relationship/relationship-scope.ts
+++ b/apps/mobile/src/relationship/relationship-scope.ts
@@ -115,7 +115,9 @@ async function loadAuthorizedRelationships(userId: string, force = false) {
         [storedPetId, previousPetId].find(
           (candidate): candidate is string =>
             Boolean(candidate) && pets.some((pet) => pet.id === candidate)
-        ) ?? pets[0]?.id ?? null;
+        ) ??
+        pets[0]?.id ??
+        null;
 
       if (generation !== loadGeneration) return;
       emit({
@@ -155,7 +157,11 @@ async function loadAuthorizedRelationships(userId: string, force = false) {
 export function useRelationshipScope() {
   const { user } = useAuth();
   const userId = user?.id ?? null;
-  const current = useSyncExternalStore(subscribe, () => snapshot, () => snapshot);
+  const current = useSyncExternalStore(
+    subscribe,
+    () => snapshot,
+    () => snapshot
+  );
   const visible = current.userId === userId ? current : EMPTY_SNAPSHOT;
 
   useEffect(() => {

--- a/apps/mobile/src/relationship/relationship-scope.ts
+++ b/apps/mobile/src/relationship/relationship-scope.ts
@@ -34,6 +34,8 @@ const EMPTY_SNAPSHOT: RelationshipSnapshot = {
 
 let snapshot: RelationshipSnapshot = EMPTY_SNAPSHOT;
 let loadPromise: Promise<void> | null = null;
+let loadUserId: string | null = null;
+let loadGeneration = 0;
 const listeners = new Set<() => void>();
 
 function emit(next: RelationshipSnapshot) {
@@ -96,12 +98,14 @@ async function persistSelectedPetId(userId: string, petId: string | null) {
 
 async function loadAuthorizedRelationships(userId: string, force = false) {
   if (!force && snapshot.initialized && snapshot.userId === userId) return;
-  if (loadPromise && snapshot.userId === userId) return loadPromise;
+  if (loadPromise && loadUserId === userId) return loadPromise;
 
+  const generation = ++loadGeneration;
+  loadUserId = userId;
   const previous = snapshot.userId === userId ? snapshot : EMPTY_SNAPSHOT;
   emit({ ...previous, userId, loading: true, error: null });
 
-  loadPromise = (async () => {
+  const pending = (async () => {
     try {
       const households = await householdsApi.getMine();
       const pets = flattenAuthorizedPets(households);
@@ -113,6 +117,7 @@ async function loadAuthorizedRelationships(userId: string, force = false) {
             Boolean(candidate) && pets.some((pet) => pet.id === candidate)
         ) ?? pets[0]?.id ?? null;
 
+      if (generation !== loadGeneration) return;
       emit({
         userId,
         pets,
@@ -126,6 +131,7 @@ async function loadAuthorizedRelationships(userId: string, force = false) {
         void persistSelectedPetId(userId, selectedPetId);
       }
     } catch {
+      if (generation !== loadGeneration) return;
       emit({
         ...previous,
         userId,
@@ -135,11 +141,15 @@ async function loadAuthorizedRelationships(userId: string, force = false) {
         initialized: true,
       });
     } finally {
-      loadPromise = null;
+      if (generation === loadGeneration) {
+        loadPromise = null;
+        loadUserId = null;
+      }
     }
   })();
 
-  return loadPromise;
+  loadPromise = pending;
+  return pending;
 }
 
 export function useRelationshipScope() {
@@ -157,7 +167,11 @@ export function useRelationshipScope() {
     if (!snapshot.pets.some((pet) => pet.id === petId)) return;
     if (snapshot.selectedPetId === petId) return;
 
-    emit({ ...snapshot, selectedPetId: petId, error: null });
+    // A user choice wins over any slower household refresh already in flight.
+    loadGeneration += 1;
+    loadPromise = null;
+    loadUserId = null;
+    emit({ ...snapshot, selectedPetId: petId, loading: false, error: null });
     void persistSelectedPetId(userId, petId);
   };
 

--- a/apps/mobile/src/screens/CompassScreen.tsx
+++ b/apps/mobile/src/screens/CompassScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   RefreshControl,
@@ -84,6 +84,7 @@ function DiscoveryStamp({ pathway, discovered }: { pathway: TrailPathway; discov
 
 export default function CompassScreen() {
   const { selectedPetId, loading: relationshipLoading } = useRelationshipScope();
+  const requestGenerationRef = useRef(0);
   const [dashboard, setDashboard] = useState<AdventureDashboard | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -93,24 +94,31 @@ export default function CompassScreen() {
     async (refresh = false) => {
       if (relationshipLoading) return;
       if (!selectedPetId) {
+        requestGenerationRef.current += 1;
         setDashboard(null);
         setLoading(false);
         setRefreshing(false);
         return;
       }
 
+      const requestGeneration = ++requestGenerationRef.current;
       if (refresh) setRefreshing(true);
       else setLoading(true);
       try {
-        setDashboard(await adventureApi.getMine(selectedPetId));
+        const next = await adventureApi.getMine(selectedPetId);
+        if (requestGeneration !== requestGenerationRef.current) return;
+        setDashboard(next);
         setError(null);
       } catch {
+        if (requestGeneration !== requestGenerationRef.current) return;
         setError(
           'Compass is unavailable right now. Woof has not changed any relationship evidence.'
         );
       } finally {
-        setLoading(false);
-        setRefreshing(false);
+        if (requestGeneration === requestGenerationRef.current) {
+          setLoading(false);
+          setRefreshing(false);
+        }
       }
     },
     [relationshipLoading, selectedPetId]
@@ -150,7 +158,9 @@ export default function CompassScreen() {
 
       <RelationshipScopeBar
         onBeforeSelect={() => {
+          requestGenerationRef.current += 1;
           setDashboard(null);
+          setLoading(true);
           setError(null);
         }}
       />

--- a/apps/mobile/src/screens/CompassScreen.tsx
+++ b/apps/mobile/src/screens/CompassScreen.tsx
@@ -10,7 +10,9 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
 import { adventureApi, type AdventureDashboard, type CompassPathway } from '../api/adventure';
+import { RelationshipScopeBar } from '../components/relationship/RelationshipScopeBar';
 import { deriveAdventureTrail, TRAIL_PATHWAYS, type TrailPathway } from '../game/adventure-trail';
+import { useRelationshipScope } from '../relationship/relationship-scope';
 import { colors } from '../theme/tokens';
 
 const pathwayIcon: Record<string, keyof typeof Ionicons.glyphMap> = {
@@ -35,7 +37,9 @@ const pathwayShortLabel: Record<TrailPathway, string> = {
 };
 
 function PathwayCard({ item }: { item: CompassPathway }) {
-  const coverage = Math.max(0, Math.min(1, item.coverage));
+  // Canonical CareSummary coverage is already a percentage on a 0–100 scale.
+  // Clamp that scale directly so one recent day (25) can never render as 100%.
+  const coveragePercent = Math.max(0, Math.min(100, item.coverage));
   return (
     <View style={styles.pathwayCard}>
       <View style={styles.pathwayHeader}>
@@ -54,9 +58,9 @@ function PathwayCard({ item }: { item: CompassPathway }) {
         </View>
       </View>
       <View style={styles.track}>
-        <View style={[styles.fill, { width: `${coverage * 100}%` }]} />
+        <View style={[styles.fill, { width: `${coveragePercent}%` }]} />
       </View>
-      <Text style={styles.coverageText}>{Math.round(coverage * 100)}% recent pathway coverage</Text>
+      <Text style={styles.coverageText}>{Math.round(coveragePercent)}% recent pathway coverage</Text>
     </View>
   );
 }
@@ -79,24 +83,38 @@ function DiscoveryStamp({ pathway, discovered }: { pathway: TrailPathway; discov
 }
 
 export default function CompassScreen() {
+  const { selectedPetId, loading: relationshipLoading } = useRelationshipScope();
   const [dashboard, setDashboard] = useState<AdventureDashboard | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const load = useCallback(async (refresh = false) => {
-    if (refresh) setRefreshing(true);
-    else setLoading(true);
-    try {
-      setDashboard(await adventureApi.getMine());
-      setError(null);
-    } catch {
-      setError('Compass is unavailable right now. Woof has not changed any relationship evidence.');
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
-    }
-  }, []);
+  const load = useCallback(
+    async (refresh = false) => {
+      if (relationshipLoading) return;
+      if (!selectedPetId) {
+        setDashboard(null);
+        setLoading(false);
+        setRefreshing(false);
+        return;
+      }
+
+      if (refresh) setRefreshing(true);
+      else setLoading(true);
+      try {
+        setDashboard(await adventureApi.getMine(selectedPetId));
+        setError(null);
+      } catch {
+        setError(
+          'Compass is unavailable right now. Woof has not changed any relationship evidence.'
+        );
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [relationshipLoading, selectedPetId]
+  );
 
   useFocusEffect(
     useCallback(() => {
@@ -104,13 +122,15 @@ export default function CompassScreen() {
     }, [load])
   );
 
-  const trail = dashboard ? deriveAdventureTrail(dashboard) : null;
+  const activeDashboard =
+    dashboard && selectedPetId && dashboard.pet.id === selectedPetId ? dashboard : null;
+  const trail = activeDashboard ? deriveAdventureTrail(activeDashboard) : null;
 
-  if (loading && !dashboard) {
+  if ((loading || relationshipLoading) && !activeDashboard) {
     return (
-      <View style={styles.centered}>
+      <View style={styles.centered} accessibilityRole="progressbar">
         <ActivityIndicator size="large" color={colors.primary[600]} />
-        <Text style={styles.loadingText}>Reading your recent rhythm…</Text>
+        <Text style={styles.loadingText}>Opening this relationship’s Compass…</Text>
       </View>
     );
   }
@@ -128,14 +148,21 @@ export default function CompassScreen() {
         your dog.
       </Text>
 
+      <RelationshipScopeBar
+        onBeforeSelect={() => {
+          setDashboard(null);
+          setError(null);
+        }}
+      />
+
       {error && (
-        <View style={styles.noticeCard}>
+        <View style={styles.noticeCard} accessibilityRole="alert">
           <Ionicons name="cloud-offline-outline" size={20} color={colors.gray[600]} />
           <Text style={styles.noticeText}>{error}</Text>
         </View>
       )}
 
-      {dashboard && trail && (
+      {activeDashboard && trail && (
         <View style={styles.trailCard}>
           <View style={styles.trailHeader}>
             <View style={styles.trailIcon}>
@@ -223,36 +250,36 @@ export default function CompassScreen() {
         </View>
       )}
 
-      {dashboard && (
+      {activeDashboard && (
         <>
           <View style={styles.summaryCard}>
             <View style={styles.summaryItem}>
-              <Text style={styles.summaryValue}>{dashboard.bondXp}</Text>
+              <Text style={styles.summaryValue}>{activeDashboard.bondXp}</Text>
               <Text style={styles.summaryLabel}>Bond XP</Text>
             </View>
             <View style={styles.divider} />
             <View style={styles.summaryItem}>
               <Text style={styles.summaryValue}>
-                {dashboard.rhythm.activeWeeks}/{dashboard.rhythm.windowWeeks}
+                {activeDashboard.rhythm.activeWeeks}/{activeDashboard.rhythm.windowWeeks}
               </Text>
               <Text style={styles.summaryLabel}>Active weeks</Text>
             </View>
           </View>
-          <Text style={styles.rhythmCopy}>{dashboard.rhythm.label}</Text>
+          <Text style={styles.rhythmCopy}>{activeDashboard.rhythm.label}</Text>
 
           <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>{dashboard.pet.name}&apos;s recent shape</Text>
+            <Text style={styles.sectionTitle}>{activeDashboard.pet.name}&apos;s recent shape</Text>
             <Text style={styles.sectionSubtitle}>Different dogs should form different shapes.</Text>
           </View>
 
-          {dashboard.compass.map((item) => (
+          {activeDashboard.compass.map((item) => (
             <PathwayCard key={item.pathway} item={item} />
           ))}
 
-          {dashboard.learningSummary.length > 0 && (
+          {activeDashboard.learningSummary.length > 0 && (
             <View style={styles.learningCard}>
               <Text style={styles.eyebrow}>CURRENT LEARNING</Text>
-              {dashboard.learningSummary.slice(0, 4).map((line) => (
+              {activeDashboard.learningSummary.slice(0, 4).map((line) => (
                 <View key={line} style={styles.learningRow}>
                   <Ionicons name="sparkles-outline" size={16} color={colors.primary[600]} />
                   <Text style={styles.learningText}>{line}</Text>
@@ -261,7 +288,7 @@ export default function CompassScreen() {
             </View>
           )}
 
-          <Text style={styles.disclaimer}>{dashboard.disclaimer}</Text>
+          <Text style={styles.disclaimer}>{activeDashboard.disclaimer}</Text>
         </>
       )}
     </ScrollView>

--- a/apps/mobile/src/screens/CompassScreen.tsx
+++ b/apps/mobile/src/screens/CompassScreen.tsx
@@ -60,7 +60,9 @@ function PathwayCard({ item }: { item: CompassPathway }) {
       <View style={styles.track}>
         <View style={[styles.fill, { width: `${coveragePercent}%` }]} />
       </View>
-      <Text style={styles.coverageText}>{Math.round(coveragePercent)}% recent pathway coverage</Text>
+      <Text style={styles.coverageText}>
+        {Math.round(coveragePercent)}% recent pathway coverage
+      </Text>
     </View>
   );
 }

--- a/apps/mobile/src/screens/TodayScreen.tsx
+++ b/apps/mobile/src/screens/TodayScreen.tsx
@@ -156,6 +156,7 @@ export default function TodayScreen({ navigation }: Props) {
 
   const saveOutcome = async () => {
     if (!activeDashboard || !closingQuest || !dogExperience || !ownerExperience) return;
+    const completionGeneration = requestGenerationRef.current;
     setSavingOutcome(true);
     try {
       const result = await adventureApi.completeQuest(closingQuest.id, {
@@ -164,6 +165,7 @@ export default function TodayScreen({ navigation }: Props) {
         ownerExperience,
         safeOptOut,
       });
+      if (completionGeneration !== requestGenerationRef.current) return;
       const reward = result.reward.duplicate
         ? 'This outcome was already saved.'
         : result.reward.bondXp > 0
@@ -174,6 +176,7 @@ export default function TodayScreen({ navigation }: Props) {
       closeOutcome();
       await load(true);
     } catch {
+      if (completionGeneration !== requestGenerationRef.current) return;
       setReceipt('Woof could not save that outcome yet. You can try closing the loop again.');
     } finally {
       setSavingOutcome(false);

--- a/apps/mobile/src/screens/TodayScreen.tsx
+++ b/apps/mobile/src/screens/TodayScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Pressable,
@@ -72,6 +72,7 @@ const toolLinks: {
 
 export default function TodayScreen({ navigation }: Props) {
   const { selectedPetId, loading: relationshipLoading } = useRelationshipScope();
+  const requestGenerationRef = useRef(0);
   const [dashboard, setDashboard] = useState<AdventureDashboard | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -88,25 +89,31 @@ export default function TodayScreen({ navigation }: Props) {
     async (asRefresh = false) => {
       if (relationshipLoading) return;
       if (!selectedPetId) {
+        requestGenerationRef.current += 1;
         setDashboard(null);
         setLoading(false);
         setRefreshing(false);
         return;
       }
 
+      const requestGeneration = ++requestGenerationRef.current;
       if (asRefresh) setRefreshing(true);
       else setLoading(true);
       try {
         const next = await adventureApi.getMine(selectedPetId);
+        if (requestGeneration !== requestGenerationRef.current) return;
         setDashboard(next);
         setError(null);
       } catch {
+        if (requestGeneration !== requestGenerationRef.current) return;
         setError(
           'Woof could not load a recommendation right now. Your existing relationship data is unchanged.'
         );
       } finally {
-        setLoading(false);
-        setRefreshing(false);
+        if (requestGeneration === requestGenerationRef.current) {
+          setLoading(false);
+          setRefreshing(false);
+        }
       }
     },
     [relationshipLoading, selectedPetId]
@@ -203,7 +210,9 @@ export default function TodayScreen({ navigation }: Props) {
 
       <RelationshipScopeBar
         onBeforeSelect={() => {
+          requestGenerationRef.current += 1;
           setDashboard(null);
+          setLoading(true);
           setActiveQuestId(null);
           setClosingQuest(null);
           setReceipt(null);

--- a/apps/mobile/src/screens/TodayScreen.tsx
+++ b/apps/mobile/src/screens/TodayScreen.tsx
@@ -13,8 +13,10 @@ import { CompositeScreenProps, useFocusEffect } from '@react-navigation/native';
 import type { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
 import type { StackScreenProps } from '@react-navigation/stack';
 import { adventureApi, type AdventureDashboard, type AdventureQuest } from '../api/adventure';
+import { RelationshipScopeBar } from '../components/relationship/RelationshipScopeBar';
 import { colors } from '../theme/tokens';
 import type { MainTabParamList, RootStackParamList } from '../navigation/AppNavigator';
+import { useRelationshipScope } from '../relationship/relationship-scope';
 
 type Props = CompositeScreenProps<
   BottomTabScreenProps<MainTabParamList, 'Today'>,
@@ -69,6 +71,7 @@ const toolLinks: {
 ];
 
 export default function TodayScreen({ navigation }: Props) {
+  const { selectedPetId, loading: relationshipLoading } = useRelationshipScope();
   const [dashboard, setDashboard] = useState<AdventureDashboard | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -81,22 +84,33 @@ export default function TodayScreen({ navigation }: Props) {
   const [savingOutcome, setSavingOutcome] = useState(false);
   const [receipt, setReceipt] = useState<string | null>(null);
 
-  const load = useCallback(async (asRefresh = false) => {
-    if (asRefresh) setRefreshing(true);
-    else setLoading(true);
-    try {
-      const next = await adventureApi.getMine();
-      setDashboard(next);
-      setError(null);
-    } catch {
-      setError(
-        'Woof could not load a recommendation right now. Your existing relationship data is unchanged.'
-      );
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
-    }
-  }, []);
+  const load = useCallback(
+    async (asRefresh = false) => {
+      if (relationshipLoading) return;
+      if (!selectedPetId) {
+        setDashboard(null);
+        setLoading(false);
+        setRefreshing(false);
+        return;
+      }
+
+      if (asRefresh) setRefreshing(true);
+      else setLoading(true);
+      try {
+        const next = await adventureApi.getMine(selectedPetId);
+        setDashboard(next);
+        setError(null);
+      } catch {
+        setError(
+          'Woof could not load a recommendation right now. Your existing relationship data is unchanged.'
+        );
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [relationshipLoading, selectedPetId]
+  );
 
   useFocusEffect(
     useCallback(() => {
@@ -104,12 +118,15 @@ export default function TodayScreen({ navigation }: Props) {
     }, [load])
   );
 
+  const activeDashboard =
+    dashboard && selectedPetId && dashboard.pet.id === selectedPetId ? dashboard : null;
+
   const startQuest = async (quest: AdventureQuest) => {
-    if (!dashboard) return;
+    if (!activeDashboard) return;
     setActiveQuestId(quest.id);
     setReceipt(null);
     try {
-      await adventureApi.selectQuest(quest.id, dashboard.pet.id);
+      await adventureApi.selectQuest(quest.id, activeDashboard.pet.id);
     } catch {
       // Selection persistence improves continuity but must not block the real-world action.
     }
@@ -131,11 +148,11 @@ export default function TodayScreen({ navigation }: Props) {
   };
 
   const saveOutcome = async () => {
-    if (!dashboard || !closingQuest || !dogExperience || !ownerExperience) return;
+    if (!activeDashboard || !closingQuest || !dogExperience || !ownerExperience) return;
     setSavingOutcome(true);
     try {
       const result = await adventureApi.completeQuest(closingQuest.id, {
-        petId: dashboard.pet.id,
+        petId: activeDashboard.pet.id,
         dogExperience,
         ownerExperience,
         safeOptOut,
@@ -156,14 +173,14 @@ export default function TodayScreen({ navigation }: Props) {
     }
   };
 
-  const primaryQuest = dashboard?.quests[0] ?? null;
-  const alternatives = dashboard?.quests.slice(1, 3) ?? [];
+  const primaryQuest = activeDashboard?.quests[0] ?? null;
+  const alternatives = activeDashboard?.quests.slice(1, 3) ?? [];
 
-  if (loading && !dashboard) {
+  if ((loading || relationshipLoading) && !activeDashboard) {
     return (
       <View style={styles.centered} accessibilityRole="progressbar">
         <ActivityIndicator size="large" color={colors.primary[600]} />
-        <Text style={styles.loadingText}>Finding one good thing to do together…</Text>
+        <Text style={styles.loadingText}>Finding one good thing for this relationship…</Text>
       </View>
     );
   }
@@ -184,14 +201,24 @@ export default function TodayScreen({ navigation }: Props) {
         </View>
       </View>
 
-      {dashboard && (
+      <RelationshipScopeBar
+        onBeforeSelect={() => {
+          setDashboard(null);
+          setActiveQuestId(null);
+          setClosingQuest(null);
+          setReceipt(null);
+          setError(null);
+        }}
+      />
+
+      {activeDashboard && (
         <Text style={styles.intro}>
-          One useful next step with {dashboard.pet.name}. Woof recommends, you choose.
+          One useful next step with {activeDashboard.pet.name}. Woof recommends, you choose.
         </Text>
       )}
 
       {error && (
-        <View style={styles.noticeCard}>
+        <View style={styles.noticeCard} accessibilityRole="alert">
           <Ionicons name="cloud-offline-outline" size={20} color={colors.gray[600]} />
           <Text style={styles.noticeText}>{error}</Text>
           <Pressable
@@ -211,7 +238,7 @@ export default function TodayScreen({ navigation }: Props) {
         </View>
       )}
 
-      {dashboard && primaryQuest && (
+      {activeDashboard && primaryQuest && (
         <View style={styles.primaryCard}>
           <View style={styles.questHeader}>
             <View style={styles.questIcon}>
@@ -219,7 +246,7 @@ export default function TodayScreen({ navigation }: Props) {
             </View>
             <View style={styles.questHeaderCopy}>
               <Text style={styles.eyebrow}>
-                A GOOD PLACE TO START WITH {dashboard.pet.name.toUpperCase()}
+                A GOOD PLACE TO START WITH {activeDashboard.pet.name.toUpperCase()}
               </Text>
               <Text style={styles.questTitle}>{primaryQuest.title}</Text>
             </View>
@@ -278,7 +305,7 @@ export default function TodayScreen({ navigation }: Props) {
         </View>
       )}
 
-      {dashboard && !primaryQuest && (
+      {activeDashboard && !primaryQuest && (
         <View style={styles.noticeCard}>
           <Ionicons name="moon-outline" size={22} color={colors.primary[700]} />
           <Text style={styles.noticeTitle}>Nothing needs pushing today.</Text>
@@ -317,10 +344,10 @@ export default function TodayScreen({ navigation }: Props) {
         </View>
       )}
 
-      {dashboard && dashboard.learningSummary.length > 0 && (
+      {activeDashboard && activeDashboard.learningSummary.length > 0 && (
         <View style={styles.learningCard}>
           <Text style={styles.eyebrow}>WHAT WOOF IS LEARNING</Text>
-          {dashboard.learningSummary.slice(0, 3).map((line) => (
+          {activeDashboard.learningSummary.slice(0, 3).map((line) => (
             <View key={line} style={styles.learningRow}>
               <Ionicons name="sparkles-outline" size={16} color={colors.primary[600]} />
               <Text style={styles.learningText}>{line}</Text>
@@ -506,9 +533,10 @@ const styles = StyleSheet.create({
   },
   primaryButtonText: { color: '#ffffff', fontSize: 16, fontWeight: '700' },
   secondaryButton: {
+    minHeight: 44,
     alignSelf: 'flex-start',
+    justifyContent: 'center',
     paddingHorizontal: 14,
-    paddingVertical: 10,
     borderRadius: 12,
     backgroundColor: colors.gray[100],
   },
@@ -526,7 +554,7 @@ const styles = StyleSheet.create({
   startedText: { marginTop: 3, color: colors.success.dark, fontSize: 13, lineHeight: 18 },
   actionRow: { marginTop: 12, flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
   outlineButton: {
-    minHeight: 42,
+    minHeight: 44,
     flexDirection: 'row',
     alignItems: 'center',
     gap: 6,
@@ -536,7 +564,7 @@ const styles = StyleSheet.create({
     borderColor: colors.gray[300],
   },
   outlineButtonText: { color: colors.gray[800], fontSize: 13, fontWeight: '700' },
-  ghostButton: { minHeight: 42, justifyContent: 'center', paddingHorizontal: 8 },
+  ghostButton: { minHeight: 44, justifyContent: 'center', paddingHorizontal: 8 },
   ghostButtonText: { color: colors.primary[700], fontSize: 13, fontWeight: '700' },
   permissionText: { marginTop: 12, color: colors.text.secondary, fontSize: 12, lineHeight: 18 },
   section: { marginTop: 26 },
@@ -559,7 +587,7 @@ const styles = StyleSheet.create({
   alternativeTitle: { marginTop: 4, color: colors.text.primary, fontSize: 17, fontWeight: '800' },
   alternativeText: { marginTop: 6, color: colors.text.secondary, fontSize: 13, lineHeight: 19 },
   smallButton: {
-    minHeight: 40,
+    minHeight: 44,
     justifyContent: 'center',
     paddingHorizontal: 14,
     borderRadius: 12,

--- a/docs/NATIVE_RELATIONSHIP_CONTEXT_V1.md
+++ b/docs/NATIVE_RELATIONSHIP_CONTEXT_V1.md
@@ -1,0 +1,70 @@
+# Native Relationship Context v1
+
+## Goal
+
+Make Woof's dog-specific surfaces truthful and calm for multi-dog households.
+
+Today and Compass now share one explicit relationship selection instead of silently relying on the server's default pet resolution. The selection is presentation state only. Every dashboard request still sends the selected pet ID to canonical server authorization.
+
+## Scope model
+
+Woof should make the scope of a surface obvious:
+
+- **Today**: one selected dog-human relationship.
+- **Compass**: the same selected dog-human relationship.
+- **Story**: remains household/user history by default and may later add an explicit pet filter.
+- **Skillcraft, Expedition, Field Journal, Community**: human-side surfaces, not a selected dog's score.
+
+This release changes only Today and Compass.
+
+## Household authority
+
+The mobile relationship store reads `GET /households/me`. That endpoint already returns only active viewer memberships and active household-pet links.
+
+The chosen pet ID may be stored locally with SecureStore so the app can reopen to the same relationship. That stored value grants nothing. On load, it is intersected with the fresh household snapshot. If it is no longer authorized, Woof discards it and chooses from the current authorized set.
+
+The storage key is namespaced by signed-in user ID so a logout/login on the same device cannot reuse another account's pet preference.
+
+## Multi-household behavior
+
+A pet can appear through more than one household relationship. The mobile presentation deduplicates by canonical pet ID and retains household names only as non-authoritative display context.
+
+The server still performs authorization on every requested `petId`.
+
+## Cross-pet stale-state boundary
+
+Today and Compass only render a loaded dashboard when `dashboard.pet.id === selectedPetId`.
+
+When the user changes dogs, local quest/result state is cleared and the previous dog's dashboard is removed before the new request. A stale response therefore cannot be presented as belonging to the newly selected relationship.
+
+## Coverage scale repair
+
+Canonical `CareSummary` pathway coverage is a percentage from 0 to 100:
+
+```text
+coverage = min(100, recentDays * 25)
+```
+
+Native Compass previously treated the same value as a 0–1 fraction, clamping any value above 1 to 1 and multiplying by 100 again. One recent day (`25`) could therefore display as `100%`.
+
+Compass now clamps directly to 0–100 and uses that percentage unchanged for the visual width and label.
+
+## Accessibility
+
+Relationship choice chips use a 44pt minimum target and expose selected state through accessibility metadata. The single-pet presentation is non-interactive because there is no choice to make.
+
+Several small Today actions touched in this tranche were also raised to a 44pt minimum target.
+
+## Deliberately deferred
+
+This release does not:
+
+- make Story inherit the selected Today/Compass dog;
+- create a new pet-authority endpoint;
+- use local storage as authorization;
+- combine histories across dogs;
+- alter Adventure reward policy;
+- change Social Adventure, Expedition, Skillcraft, or Journal scoring;
+- remove the existing server fallback for older clients that omit `petId`.
+
+A later calm-experience tranche can add an explicit `All dogs / <dog>` Story filter and continue reducing visible accounting without changing canonical evidence.


### PR DESCRIPTION
## Summary

Turn the first Calm Experience critique into a concrete correctness + multi-dog tranche.

This PR fixes native Compass's pathway coverage scale bug and makes Today/Compass explicitly request one shared, authorized dog-human relationship instead of silently relying on the server's default oldest-created pet fallback.

## What changes

- Adds a shared native relationship-scope store backed by authenticated `GET /households/me`.
- Persists the selected pet only as an account-namespaced SecureStore presentation preference.
- Re-intersects any stored pet ID with the fresh authorized household snapshot before use.
- Deduplicates the same canonical pet across multiple accessible households.
- Adds an accessible 44pt relationship selector to Today and Compass.
- Sends the selected `petId` explicitly to `/adventure/me` from both screens.
- Suppresses stale dashboards whenever `dashboard.pet.id !== selectedPetId`.
- Clears transient Today quest/result state when changing dogs.
- Fixes Compass's canonical coverage rendering from accidental 0–1 interpretation to the server's actual 0–100 scale.
- Raises small Today actions touched in this tranche to a 44pt minimum target.

## Coverage bug

Canonical CareSummary computes `coverage = min(100, recentDays * 25)`. Native Compass previously clamped this server percentage to 0–1 and multiplied by 100 again, so one recent day (`25`) could render as `100%`.

Compass now clamps directly to 0–100 and renders that percentage unchanged.

## Authority boundaries

- Local selection never grants pet access.
- `/households/me` remains the usable pet-set authority.
- Adventure still re-authorizes the explicit `petId` server-side.
- Stored selection is namespaced by authenticated user and discarded when no longer present in fresh household authority.
- Companion mode is not given pet scope.
- Story is deliberately unchanged because its canonical default is broader household/user history, not the selected Today/Compass relationship.

## Qualification

Adds `Native Relationship Context CI` plus an executable source contract that freezes:

- CareSummary's 0–100 coverage contract;
- Compass's direct 0–100 consumption;
- household-authority selection;
- account-scoped persistence;
- explicit Today/Compass `petId` requests;
- stale cross-pet dashboard suppression;
- 44pt accessible selection controls.

Base: exact post-#145 `main` at `05daebda3c01f1bc1302f55edcabd56085328bac`.