### PR TITLE
Clarify native scope across Story, Expedition, and Companion

### DIFF
--- a/.github/scripts/assert-expedition-field-journal.py
+++ b/.github/scripts/assert-expedition-field-journal.py
@@ -169,7 +169,11 @@ def main() -> None:
     ]:
         reject(journal_types, forbidden, "mobile Expedition Journal types")
 
-    require(mobile_api, "journal: () => apiClient.get<ExpeditionJournal>('/expeditions/journal')", "mobile Expedition API")
+    require(
+        mobile_api,
+        "journal: () => apiClient.get<ExpeditionJournal>('/expeditions/journal')",
+        "mobile Expedition API",
+    )
     require_count(mobile_api, "'/expeditions/journal'", 1, "mobile Expedition API")
     for forbidden in [
         "apiClient.post<ExpeditionJournal>",
@@ -179,20 +183,29 @@ def main() -> None:
     ]:
         reject(mobile_api, forbidden, "mobile Expedition API")
 
-    # Journal is an independently degradable read slice and is never reconstructed from
-    # current-world or Social Adventure state.
+    # Journal is independently degradable. Its failure cannot poison a healthy live world,
+    # and no current-world or Social Adventure state is used to reconstruct history.
     for marker in [
         "type ExpeditionJournal",
         "expeditionApi.journal()",
         "Promise.allSettled([",
-        "if (journalResult.value.scope === 'GLOBAL') setJournal(journalResult.value)",
-        "unavailable.push('field journal')",
-        "journal={journal}",
-        "Woof did not infer missing progress, membership, or journal history.",
+        "journalResult.status === 'fulfilled' && journalResult.value.scope === 'GLOBAL'",
+        "journalRef.current = journalResult.value",
+        "setJournalError(null)",
+        "journalError={journalError}",
+        "setWorldError(",
+        "setJournalError(",
+        "leave history blank rather than guess",
     ]:
         require(screen, marker, "native Expedition screen")
+    reject(screen, "unavailableWorld.push('field journal')", "native Expedition screen")
+    reject(screen, "unavailable.push('field journal')", "native Expedition screen")
 
-    require(world, "<ExpeditionFieldJournalView journal={props.journal} />", "native Expedition world")
+    require(
+        world,
+        "<ExpeditionFieldJournalView journal={props.journal} error={props.journalError} />",
+        "native Expedition world",
+    )
     require(world, "timeZone: 'UTC'", "native Expedition world")
 
     # The scrapbook only renders returned landmarks. There are no missing-slot placeholders,
@@ -205,8 +218,10 @@ def main() -> None:
         "Nothing is overdue and there is nothing to catch up on.",
         "older pages are not presented as non-participation.",
         "timeZone: 'UTC'",
+        "Your shared world is still available.",
+        "Showing your last verified pages.",
     ]:
-        require(journal_view, marker, "native Expedition Field Journal")
+        require(journal_view + screen, marker, "native Expedition Field Journal")
 
     for forbidden in [
         "entry.landmarks.length",

--- a/.github/scripts/assert-native-expedition-world.py
+++ b/.github/scripts/assert-native-expedition-world.py
@@ -89,16 +89,22 @@ def main() -> None:
         reject(mobile_api, forbidden, "native Expedition API")
 
     # Pack reads remain downstream of a server-confirmed joined Pack and identity-bound response.
+    # Whole-screen refreshes and Pack requests are generation-bound so stale network results cannot
+    # replace a newer scope or erase an independently surfaced Pack error.
     for marker in [
         "expeditionApi.global()",
         "socialAdventureApi.packs()",
         "pack.id === packId && pack.joined",
         "expeditionApi.pack(joinedPack.id)",
         "response.scope !== 'PACK' || response.pack?.id !== joinedPack.id",
+        "loadRequestRef",
+        "loadRequestId !== loadRequestRef.current",
         "packRequestRef",
         "requestId !== packRequestRef.current",
-        "selectedScopeRef",
+        "selectedScopeRef.current !== joinedPack.id",
         "Promise.allSettled([",
+        "packLoadResult?.status === 'error'",
+        "setWorldError(packLoadResult.message)",
         "Woof will only open Expedition views for Packs you have joined.",
         "setWorldError(",
         "setJournalError(",
@@ -161,7 +167,11 @@ def main() -> None:
     # Community is a portal to cooperative play, not a hidden embedding in league arithmetic.
     require(feed, "onOpenExpedition={() => navigation.navigate('Expedition')}", "native Community screen")
     require(community, "onOpenExpedition: () => void", "native Community presentation")
-    require(community, 'label="Expedition" onPress={props.onOpenExpedition}', "native Community presentation")
+    require(
+        community,
+        'label="Expedition" onPress={props.onOpenExpedition}',
+        "native Community presentation",
+    )
 
     # Both guardian and Companion stacks expose the same human-side Expedition surface.
     require(nav, "Expedition: undefined", "native navigation")

--- a/.github/scripts/assert-native-expedition-world.py
+++ b/.github/scripts/assert-native-expedition-world.py
@@ -65,8 +65,8 @@ def main() -> None:
     server_service = SERVER_SERVICE.read_text()
     doc = DOC.read_text()
 
-    # Native live Expedition has exactly two projection read paths and no contribution
-    # mutation surface. Historical Journal reads are governed by their own stricter contract.
+    # Native live Expedition has exactly two projection read paths and no contribution mutation.
+    # Journal history is governed by its own stricter contract.
     for marker in [
         "'/expeditions/global'",
         "`/expeditions/packs/${packId}`",
@@ -88,7 +88,7 @@ def main() -> None:
     ]:
         reject(mobile_api, forbidden, "native Expedition API")
 
-    # Pack reads must be downstream of a server-confirmed joined Pack and identity-bound response.
+    # Pack reads remain downstream of a server-confirmed joined Pack and identity-bound response.
     for marker in [
         "expeditionApi.global()",
         "socialAdventureApi.packs()",
@@ -99,8 +99,9 @@ def main() -> None:
         "requestId !== packRequestRef.current",
         "selectedScopeRef",
         "Promise.allSettled([",
-        "Woof will only open Expedition views for Packs the server says you joined.",
-        "Woof did not infer missing progress, membership, or journal history.",
+        "Woof will only open Expedition views for Packs you have joined.",
+        "setWorldError(",
+        "setJournalError(",
     ]:
         require(screen, marker, "native Expedition screen")
 
@@ -116,12 +117,11 @@ def main() -> None:
     ]:
         reject(screen, forbidden, "native Expedition screen")
 
-    # The renderer may display each numeric authority field, but may not repeatedly consume it
-    # to create shadow geometry, unlocks, or local scoring. myContribution gets one additional
-    # binary use for the explicitly documented Your-mark treatment.
-    require_count(world, "objective.total", 1, "native Expedition world")
+    # Native presentation deliberately hides repeatable contribution volume. The server retains
+    # totals for calibration, but the world may only show communal presence and a binary personal mark.
+    reject(world, "objective.total", "native Expedition world")
     require_count(world, "objective.contributors", 1, "native Expedition world")
-    require_count(world, "objective.myContribution", 2, "native Expedition world")
+    require_count(world, "objective.myContribution", 1, "native Expedition world")
     require(world, "objective.myContribution > 0", "native Expedition world")
 
     for marker in [
@@ -129,11 +129,12 @@ def main() -> None:
         "Resting Hollow",
         "Signal Observatory",
         "objective.status === 'CALIBRATING'",
-        "Calibrating, no completion target yet.",
+        "This landmark is open. There is no finish line to chase.",
         "No completion bar. This shared scene is not a checklist.",
-        "Landmarks always exist. Counts show server-issued evidence, not unlock levels.",
+        "Every landmark is here from the beginning. Presence matters more than repetition.",
         "The world is the game. Your dog is not.",
-        "CARE, health state, distance, duration, intensity, missed days, likes, rankings",
+        "It never asks",
+        "minHeight: 44",
     ]:
         require(world, marker, "native Expedition world")
 

--- a/.github/scripts/assert-native-first-adventure.py
+++ b/.github/scripts/assert-native-first-adventure.py
@@ -109,10 +109,11 @@ for question_id in question_ids:
 require(companion_home, "You can belong here before you have a dog.", "petless Companion framing")
 require(companion_home, "CommunityStandalone", "petless Community route")
 require(companion_home, "Dog-specific spaces stay private", "human-language pet privacy boundary")
+require(companion_home, "does not invent a", "mode/authority separation prefix")
 require(
     companion_home,
-    "does not invent a\n            pet relationship or unlock pet-specific Today, Compass, or Story.",
-    "mode/authority separation",
+    "pet relationship or unlock pet-specific Today, Compass, or Story.",
+    "mode/authority separation boundary",
 )
 
 print("native First Adventure authority contract: PASS")

--- a/.github/scripts/assert-native-first-adventure.py
+++ b/.github/scripts/assert-native-first-adventure.py
@@ -5,7 +5,6 @@ This verifies authority boundaries and Web/native ontology parity. Runtime,
 typing, lint, and native-build qualification belong to the workflows that
 invoke or accompany this contract.
 """
-
 from pathlib import Path
 import re
 
@@ -107,8 +106,13 @@ for question_id in question_ids:
     require(web_questions, question_id, f"web question id {question_id}")
 
 # Petless Companion mode is a truthful first-class route, not a broken pet Today.
-require(companion_home, "You do not need to invent a dog", "petless Companion framing")
+require(companion_home, "You can belong here before you have a dog.", "petless Companion framing")
 require(companion_home, "CommunityStandalone", "petless Community route")
-require(companion_home, "Presentation is not authority", "mode/authority separation")
+require(companion_home, "Dog-specific spaces stay private", "human-language pet privacy boundary")
+require(
+    companion_home,
+    "does not invent a\n            pet relationship or unlock pet-specific Today, Compass, or Story.",
+    "mode/authority separation",
+)
 
 print("native First Adventure authority contract: PASS")

--- a/.github/scripts/assert-native-first-adventure.py
+++ b/.github/scripts/assert-native-first-adventure.py
@@ -109,10 +109,10 @@ for question_id in question_ids:
 require(companion_home, "You can belong here before you have a dog.", "petless Companion framing")
 require(companion_home, "CommunityStandalone", "petless Community route")
 require(companion_home, "Dog-specific spaces stay private", "human-language pet privacy boundary")
-require(companion_home, "does not invent a", "mode/authority separation prefix")
+companion_home_compact = " ".join(companion_home.split())
 require(
-    companion_home,
-    "pet relationship or unlock pet-specific Today, Compass, or Story.",
+    companion_home_compact,
+    "Companion mode gives you human-side places to learn and participate. It does not invent a pet relationship or unlock pet-specific Today, Compass, or Story.",
     "mode/authority separation boundary",
 )
 

--- a/.github/scripts/assert-native-scope-clarity.py
+++ b/.github/scripts/assert-native-scope-clarity.py
@@ -103,12 +103,16 @@ def main() -> None:
     ]:
         reject(story, forbidden, "Story scope")
 
-    # Failure to discover filter options cannot erase or block the all-dogs Story authority.
+    # Optional filter discovery may fail without blocking canonical Story, but stale pet-specific
+    # filter state or stale same-scope Story data must not remain visible after authority reads fail.
+    require(story, "setFilterPets([]);", "Story filter degradation")
     require(
         story,
-        "Dog filters are unavailable. All-dogs Story still uses server-authorized history.",
+        "Dog filters are unavailable. Story is using the server-authorized all-dogs view.",
         "Story filter degradation",
     )
+    require_count(story, "setDashboard(null);", 2, "Story fail-closed data presentation")
+    require_count(story, "setDashboardScope(null);", 2, "Story fail-closed data presentation")
     require(story, "setFilterError", "Story filter degradation")
     require(story, "setError('Story is unavailable right now.", "Story data degradation")
 

--- a/.github/scripts/assert-native-scope-clarity.py
+++ b/.github/scripts/assert-native-scope-clarity.py
@@ -73,7 +73,11 @@ def main() -> None:
     # Story owns its own truthful scope: ALL is canonical default, pet filters are authorized
     # through household reads, and Today/Compass relationship preference is not inherited.
     require(story_api, "petId?: string", "Story API")
-    require(households_api, "getMine: () => apiClient.get<HouseholdSnapshot[]>('/households/me')", "household API")
+    require(
+        households_api,
+        "getMine: () => apiClient.get<HouseholdSnapshot[]>('/households/me')",
+        "household API",
+    )
     for marker in [
         "type StoryScope = 'ALL' | string",
         "useState<StoryScope>('ALL')",
@@ -100,14 +104,25 @@ def main() -> None:
         reject(story, forbidden, "Story scope")
 
     # Failure to discover filter options cannot erase or block the all-dogs Story authority.
-    require(story, "Dog filters are unavailable. All-dogs Story still uses server-authorized history.", "Story filter degradation")
+    require(
+        story,
+        "Dog filters are unavailable. All-dogs Story still uses server-authorized history.",
+        "Story filter degradation",
+    )
     require(story, "setFilterError", "Story filter degradation")
     require(story, "setError('Story is unavailable right now.", "Story data degradation")
 
-    # Field Journal is independently degradable from the live Expedition world.
+    # Field Journal is independently degradable from the live Expedition world. Refresh and Pack
+    # requests are generation-bound so an older network result cannot erase a newer truth.
     for marker in [
         "const [worldError, setWorldError]",
         "const [journalError, setJournalError]",
+        "loadRequestRef",
+        "loadRequestId !== loadRequestRef.current",
+        "packRequestRef",
+        "selectedScopeRef.current !== joinedPack.id",
+        "packLoadResult?.status === 'error'",
+        "setWorldError(packLoadResult.message)",
         "journalRef.current",
         "journalError={journalError}",
         "Your shared world is still available",

--- a/.github/scripts/assert-native-scope-clarity.py
+++ b/.github/scripts/assert-native-scope-clarity.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Fail closed if native scope clarity drifts across Companion, Story, or Expedition."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+COMPANION = ROOT / "apps/mobile/src/screens/CompanionHomeScreen.tsx"
+STORY = ROOT / "apps/mobile/src/screens/StoryScreen.tsx"
+STORY_API = ROOT / "apps/mobile/src/api/story.ts"
+HOUSEHOLDS_API = ROOT / "apps/mobile/src/api/households.ts"
+EXPEDITION = ROOT / "apps/mobile/src/screens/ExpeditionScreen.tsx"
+WORLD = ROOT / "apps/mobile/src/components/community/ExpeditionWorldView.tsx"
+JOURNAL = ROOT / "apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx"
+DOC = ROOT / "docs/NATIVE_SCOPE_CLARITY_V1.md"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def require(text: str, marker: str, label: str) -> None:
+    if marker not in text:
+        fail(f"{label} missing required marker: {marker}")
+
+
+def reject(text: str, marker: str, label: str) -> None:
+    if marker in text:
+        fail(f"{label} contains forbidden marker: {marker}")
+
+
+def require_count(text: str, marker: str, expected: int, label: str) -> None:
+    actual = text.count(marker)
+    if actual != expected:
+        fail(f"{label} expected {expected} occurrences of {marker!r}, found {actual}")
+
+
+def main() -> None:
+    for path in [COMPANION, STORY, STORY_API, HOUSEHOLDS_API, EXPEDITION, WORLD, JOURNAL, DOC]:
+        if not path.is_file():
+            fail(f"missing scope clarity file: {path.relative_to(ROOT)}")
+
+    companion = COMPANION.read_text()
+    story = STORY.read_text()
+    story_api = STORY_API.read_text()
+    households_api = HOUSEHOLDS_API.read_text()
+    expedition = EXPEDITION.read_text()
+    world = WORLD.read_text()
+    journal = JOURNAL.read_text()
+    doc = DOC.read_text()
+
+    # Companion is a first-class human-side starting point, never a synthetic pet scope.
+    for marker in [
+        "You can belong here before you have a dog.",
+        "Dog-specific spaces stay private",
+        "route: 'Expedition'",
+        "route: 'Skillcraft'",
+        "route: 'Packs'",
+        "route: 'CommunityStandalone'",
+        "pet relationship or unlock pet-specific Today, Compass, or Story.",
+    ]:
+        require(companion, marker, "Companion Home")
+    for forbidden in [
+        "adventureApi",
+        "storyApi",
+        "petsApi",
+        "householdsApi",
+        "useRelationshipScope",
+        "selectedPetId",
+    ]:
+        reject(companion, forbidden, "Companion Home")
+
+    # Story owns its own truthful scope: ALL is canonical default, pet filters are authorized
+    # through household reads, and Today/Compass relationship preference is not inherited.
+    require(story_api, "petId?: string", "Story API")
+    require(households_api, "getMine: () => apiClient.get<HouseholdSnapshot[]>('/households/me')", "household API")
+    for marker in [
+        "type StoryScope = 'ALL' | string",
+        "useState<StoryScope>('ALL')",
+        "householdsApi.getMine()",
+        "scope === 'ALL' ? {} : { petId: scope }",
+        "storyRequestRef",
+        "requestId !== storyRequestRef.current",
+        "scope !== selectedScopeRef.current",
+        "dashboardScope === selectedScope",
+        "All dogs",
+        "All dogs is one authorized household view.",
+        "accessibilityState={{ selected }}",
+        "minHeight: 44",
+    ]:
+        require(story, marker, "Story scope")
+    for forbidden in [
+        "useRelationshipScope",
+        "relationship-scope",
+        "storyApi.post",
+        "storyApi.put",
+        "storyApi.patch",
+        "storyApi.delete",
+    ]:
+        reject(story, forbidden, "Story scope")
+
+    # Failure to discover filter options cannot erase or block the all-dogs Story authority.
+    require(story, "Dog filters are unavailable. All-dogs Story still uses server-authorized history.", "Story filter degradation")
+    require(story, "setFilterError", "Story filter degradation")
+    require(story, "setError('Story is unavailable right now.", "Story data degradation")
+
+    # Field Journal is independently degradable from the live Expedition world.
+    for marker in [
+        "const [worldError, setWorldError]",
+        "const [journalError, setJournalError]",
+        "journalRef.current",
+        "journalError={journalError}",
+        "Your shared world is still available",
+    ]:
+        require(expedition, marker, "Expedition failure isolation")
+    reject(expedition, "unavailableWorld.push('field journal')", "Expedition failure isolation")
+    reject(expedition, "unavailable.push('field journal')", "Expedition failure isolation")
+    require(journal, "error?: string | null", "Field Journal failure presentation")
+    require(journal, "Showing your last verified pages.", "Field Journal stale-history presentation")
+    require(journal, "leave history blank rather than guess", "Field Journal fail-closed presentation")
+
+    # The cooperative world keeps server calibration fields in the API but does not advertise
+    # repeatable volume. Personal presence is binary and communal count is descriptive only.
+    reject(world, "objective.total", "Expedition calm presentation")
+    require_count(world, "objective.myContribution", 1, "Expedition calm presentation")
+    require(world, "objective.myContribution > 0", "Expedition calm presentation")
+    require_count(world, "objective.contributors", 1, "Expedition calm presentation")
+    require(world, "There is no finish line to chase.", "Expedition calm presentation")
+    require(world, "Presence matters more than repetition.", "Expedition calm presentation")
+    require(world, "minHeight: 44", "Expedition scope accessibility")
+
+    # The documentation must make all three scope classes explicit.
+    for marker in [
+        "Today + Compass",
+        "Story",
+        "Skillcraft + Expedition + Field Journal + Community",
+        "human-side",
+        "Local selection never grants authority",
+        "Personal Expedition repetition is binary presence",
+        "Journal failure does not poison the live world",
+        "44pt",
+    ]:
+        require(doc, marker, "scope clarity documentation")
+
+    print("Native scope clarity contract OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/assert-native-scope-clarity.py
+++ b/.github/scripts/assert-native-scope-clarity.py
@@ -131,7 +131,7 @@ def main() -> None:
     reject(expedition, "unavailableWorld.push('field journal')", "Expedition failure isolation")
     reject(expedition, "unavailable.push('field journal')", "Expedition failure isolation")
     require(journal, "error?: string | null", "Field Journal failure presentation")
-    require(journal, "Showing your last verified pages.", "Field Journal stale-history presentation")
+    require(expedition, "Showing your last verified pages.", "Field Journal stale-history authority")
     require(journal, "leave history blank rather than guess", "Field Journal fail-closed presentation")
 
     # The cooperative world keeps server calibration fields in the API but does not advertise

--- a/.github/workflows/native-scope-clarity-ci.yml
+++ b/.github/workflows/native-scope-clarity-ci.yml
@@ -54,9 +54,10 @@ jobs:
             .github/scripts/assert-expedition-field-journal.py
       - name: Install from committed lockfile
         run: pnpm install --frozen-lockfile
-      - name: Reject scope-clarity formatting drift
+      - name: Produce canonical scope-clarity formatting
+        id: formatting
         run: |
-          pnpm exec prettier --check \
+          pnpm exec prettier --write \
             apps/mobile/src/screens/CompanionHomeScreen.tsx \
             apps/mobile/src/screens/StoryScreen.tsx \
             apps/mobile/src/screens/ExpeditionScreen.tsx \
@@ -65,7 +66,50 @@ jobs:
             .github/workflows/native-scope-clarity-ci.yml \
             docs/NATIVE_SCOPE_CLARITY_V1.md \
             docs/NATIVE_EXPEDITION_WORLD_V1.md
+          if git diff --quiet -- \
+            apps/mobile/src/screens/CompanionHomeScreen.tsx \
+            apps/mobile/src/screens/StoryScreen.tsx \
+            apps/mobile/src/screens/ExpeditionScreen.tsx \
+            apps/mobile/src/components/community/ExpeditionWorldView.tsx \
+            apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx \
+            .github/workflows/native-scope-clarity-ci.yml \
+            docs/NATIVE_SCOPE_CLARITY_V1.md \
+            docs/NATIVE_EXPEDITION_WORLD_V1.md
+          then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            git diff -- \
+              apps/mobile/src/screens/CompanionHomeScreen.tsx \
+              apps/mobile/src/screens/StoryScreen.tsx \
+              apps/mobile/src/screens/ExpeditionScreen.tsx \
+              apps/mobile/src/components/community/ExpeditionWorldView.tsx \
+              apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx \
+              .github/workflows/native-scope-clarity-ci.yml \
+              docs/NATIVE_SCOPE_CLARITY_V1.md \
+              docs/NATIVE_EXPEDITION_WORLD_V1.md | head -c 60000
+          fi
+      - name: Upload canonical scope-clarity Prettier output
+        if: steps.formatting.outputs.drift == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: native-scope-clarity-prettier-output-${{ github.run_id }}
+          retention-days: 1
+          path: |
+            apps/mobile/src/screens/CompanionHomeScreen.tsx
+            apps/mobile/src/screens/StoryScreen.tsx
+            apps/mobile/src/screens/ExpeditionScreen.tsx
+            apps/mobile/src/components/community/ExpeditionWorldView.tsx
+            apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx
+            .github/workflows/native-scope-clarity-ci.yml
+            docs/NATIVE_SCOPE_CLARITY_V1.md
+            docs/NATIVE_EXPEDITION_WORLD_V1.md
       - name: Type-check native client
         run: pnpm --filter @woof/mobile type-check
       - name: Lint native client
         run: pnpm --filter @woof/mobile lint
+      - name: Reject uncommitted canonical formatting
+        if: steps.formatting.outputs.drift == 'true'
+        run: |
+          echo "Native scope-clarity files differ from canonical Prettier output."
+          exit 1

--- a/.github/workflows/native-scope-clarity-ci.yml
+++ b/.github/workflows/native-scope-clarity-ci.yml
@@ -1,0 +1,71 @@
+name: Native Scope Clarity CI
+
+on:
+  pull_request:
+    paths:
+      - 'apps/mobile/src/api/households.ts'
+      - 'apps/mobile/src/api/story.ts'
+      - 'apps/mobile/src/api/expeditions.ts'
+      - 'apps/mobile/src/screens/CompanionHomeScreen.tsx'
+      - 'apps/mobile/src/screens/StoryScreen.tsx'
+      - 'apps/mobile/src/screens/ExpeditionScreen.tsx'
+      - 'apps/mobile/src/components/community/ExpeditionWorldView.tsx'
+      - 'apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx'
+      - '.github/scripts/assert-native-scope-clarity.py'
+      - '.github/scripts/assert-native-first-adventure.py'
+      - '.github/scripts/assert-native-expedition-world.py'
+      - '.github/scripts/assert-expedition-field-journal.py'
+      - '.github/workflows/native-scope-clarity-ci.yml'
+      - 'docs/NATIVE_SCOPE_CLARITY_V1.md'
+      - 'docs/NATIVE_EXPEDITION_WORLD_V1.md'
+      - 'docs/NATIVE_EXPEDITION_FIELD_JOURNAL_V1.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scope-clarity:
+    name: Truthful native scope and failure isolation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 8.15.1
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20.20.2
+          cache: pnpm
+      - name: Enforce native scope clarity contract
+        run: python3 .github/scripts/assert-native-scope-clarity.py
+      - name: Re-run adjacent authority contracts
+        run: |
+          python3 .github/scripts/assert-native-first-adventure.py
+          python3 .github/scripts/assert-native-expedition-world.py
+          python3 .github/scripts/assert-expedition-field-journal.py
+      - name: Compile authority sentries
+        run: |
+          python3 -m py_compile \
+            .github/scripts/assert-native-scope-clarity.py \
+            .github/scripts/assert-native-first-adventure.py \
+            .github/scripts/assert-native-expedition-world.py \
+            .github/scripts/assert-expedition-field-journal.py
+      - name: Install from committed lockfile
+        run: pnpm install --frozen-lockfile
+      - name: Reject scope-clarity formatting drift
+        run: |
+          pnpm exec prettier --check \
+            apps/mobile/src/screens/CompanionHomeScreen.tsx \
+            apps/mobile/src/screens/StoryScreen.tsx \
+            apps/mobile/src/screens/ExpeditionScreen.tsx \
+            apps/mobile/src/components/community/ExpeditionWorldView.tsx \
+            apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx \
+            .github/workflows/native-scope-clarity-ci.yml \
+            docs/NATIVE_SCOPE_CLARITY_V1.md \
+            docs/NATIVE_EXPEDITION_WORLD_V1.md
+      - name: Type-check native client
+        run: pnpm --filter @woof/mobile type-check
+      - name: Lint native client
+        run: pnpm --filter @woof/mobile lint

--- a/apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx
+++ b/apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx
@@ -10,6 +10,7 @@ import { colors } from '../../theme/tokens';
 
 type Props = {
   journal: ExpeditionJournal | null;
+  error?: string | null;
 };
 
 type JournalLandmark = {
@@ -25,7 +26,7 @@ const JOURNAL_LANDMARKS: Record<ExpeditionObjectiveKey, JournalLandmark> = {
 
 function formatWeek(startsAt: string) {
   const date = new Date(startsAt);
-  if (!Number.isFinite(date.getTime())) return 'Server-recorded week';
+  if (!Number.isFinite(date.getTime())) return 'Recorded week';
   const formatter = new Intl.DateTimeFormat(undefined, {
     month: 'short',
     day: 'numeric',
@@ -43,9 +44,7 @@ function FieldNote({ entry }: { entry: ExpeditionJournalEntry }) {
           <Ionicons name="paw-outline" size={15} color={colors.primary[700]} />
         </View>
         <View style={styles.noteHeading}>
-          <Text style={styles.noteState}>
-            {entry.state === 'ACTIVE' ? 'THIS WEEK' : 'FIELD NOTE'}
-          </Text>
+          <Text style={styles.noteState}>{entry.state === 'ACTIVE' ? 'THIS WEEK' : 'FIELD NOTE'}</Text>
           <Text style={styles.noteDate}>{formatWeek(entry.season.startsAt)}</Text>
         </View>
       </View>
@@ -67,14 +66,14 @@ function FieldNote({ entry }: { entry: ExpeditionJournalEntry }) {
 
       <Text style={styles.noteFoot}>
         {entry.state === 'ACTIVE'
-          ? 'This page reflects server-issued receipts so far. There is nothing you need to fill.'
+          ? 'This page reflects verified moments so far. There is nothing you need to fill.'
           : 'This page records what happened. Blank space is part of the memory.'}
       </Text>
     </View>
   );
 }
 
-export function ExpeditionFieldJournalView({ journal }: Props) {
+export function ExpeditionFieldJournalView({ journal, error }: Props) {
   return (
     <View style={styles.section}>
       <Text style={styles.eyebrow}>FIELD JOURNAL</Text>
@@ -84,12 +83,21 @@ export function ExpeditionFieldJournalView({ journal }: Props) {
         moment does not make a bigger stamp, and a page is never graded for being full.
       </Text>
 
+      {error && journal && (
+        <View style={styles.noticeCard} accessibilityRole="alert">
+          <Ionicons name="cloud-offline-outline" size={18} color={colors.gray[600]} />
+          <Text style={styles.noticeText}>{error}</Text>
+        </View>
+      )}
+
       {!journal ? (
-        <View style={styles.quietCard}>
+        <View style={styles.quietCard} accessibilityRole={error ? 'alert' : undefined}>
           <Ionicons name="book-outline" size={23} color={colors.gray[500]} />
-          <Text style={styles.quietTitle}>Journal history is unavailable.</Text>
+          <Text style={styles.quietTitle}>{error ? 'Field notes could not refresh.' : 'No field notes yet.'}</Text>
           <Text style={styles.quietBody}>
-            Woof will not rebuild field notes from local activity, league score, or guessed history.
+            {error
+              ? 'Your shared world is still available. Woof will leave history blank rather than guess.'
+              : 'Nothing is overdue and there is nothing to catch up on. A page appears only from verified Expedition moments.'}
           </Text>
         </View>
       ) : journal.entries.length === 0 ? (
@@ -97,8 +105,8 @@ export function ExpeditionFieldJournalView({ journal }: Props) {
           <Ionicons name="leaf-outline" size={23} color={colors.primary[600]} />
           <Text style={styles.quietTitle}>No field notes yet.</Text>
           <Text style={styles.quietBody}>
-            Nothing is overdue and there is nothing to catch up on. A page appears only from
-            server-issued Expedition receipts.
+            Nothing is overdue and there is nothing to catch up on. A page appears only from verified
+            Expedition moments.
           </Text>
         </View>
       ) : (
@@ -128,6 +136,18 @@ const styles = StyleSheet.create({
   eyebrow: { color: colors.gray[500], fontSize: 10, fontWeight: '800', letterSpacing: 1.2 },
   title: { marginTop: 4, color: colors.gray[900], fontSize: 20, fontWeight: '900' },
   body: { marginTop: 6, color: colors.gray[600], fontSize: 12, lineHeight: 18 },
+  noticeCard: {
+    marginTop: 12,
+    padding: 12,
+    borderRadius: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: colors.gray[50],
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+  },
+  noticeText: { flex: 1, color: colors.gray[600], fontSize: 11, lineHeight: 17 },
   notesRow: { gap: 11, paddingTop: 12, paddingRight: 18 },
   noteCard: {
     width: 286,

--- a/apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx
+++ b/apps/mobile/src/components/community/ExpeditionFieldJournalView.tsx
@@ -44,7 +44,9 @@ function FieldNote({ entry }: { entry: ExpeditionJournalEntry }) {
           <Ionicons name="paw-outline" size={15} color={colors.primary[700]} />
         </View>
         <View style={styles.noteHeading}>
-          <Text style={styles.noteState}>{entry.state === 'ACTIVE' ? 'THIS WEEK' : 'FIELD NOTE'}</Text>
+          <Text style={styles.noteState}>
+            {entry.state === 'ACTIVE' ? 'THIS WEEK' : 'FIELD NOTE'}
+          </Text>
           <Text style={styles.noteDate}>{formatWeek(entry.season.startsAt)}</Text>
         </View>
       </View>
@@ -93,7 +95,9 @@ export function ExpeditionFieldJournalView({ journal, error }: Props) {
       {!journal ? (
         <View style={styles.quietCard} accessibilityRole={error ? 'alert' : undefined}>
           <Ionicons name="book-outline" size={23} color={colors.gray[500]} />
-          <Text style={styles.quietTitle}>{error ? 'Field notes could not refresh.' : 'No field notes yet.'}</Text>
+          <Text style={styles.quietTitle}>
+            {error ? 'Field notes could not refresh.' : 'No field notes yet.'}
+          </Text>
           <Text style={styles.quietBody}>
             {error
               ? 'Your shared world is still available. Woof will leave history blank rather than guess.'
@@ -105,8 +109,8 @@ export function ExpeditionFieldJournalView({ journal, error }: Props) {
           <Ionicons name="leaf-outline" size={23} color={colors.primary[600]} />
           <Text style={styles.quietTitle}>No field notes yet.</Text>
           <Text style={styles.quietBody}>
-            Nothing is overdue and there is nothing to catch up on. A page appears only from verified
-            Expedition moments.
+            Nothing is overdue and there is nothing to catch up on. A page appears only from
+            verified Expedition moments.
           </Text>
         </View>
       ) : (

--- a/apps/mobile/src/components/community/ExpeditionWorldView.tsx
+++ b/apps/mobile/src/components/community/ExpeditionWorldView.tsx
@@ -22,6 +22,7 @@ type Props = {
   globalProjection: ExpeditionProjection | null;
   packProjection: ExpeditionProjection | null;
   journal: ExpeditionJournal | null;
+  journalError: string | null;
   joinedPacks: SocialPack[];
   selectedScope: 'GLOBAL' | string;
   packLoading: boolean;
@@ -66,7 +67,7 @@ function formatSeason(start: string, end: string) {
   const startsAt = new Date(start);
   const endsAt = new Date(end);
   if (!Number.isFinite(startsAt.getTime()) || !Number.isFinite(endsAt.getTime())) {
-    return 'Server-defined weekly season';
+    return 'Weekly Expedition';
   }
   const formatter = new Intl.DateTimeFormat(undefined, {
     month: 'short',
@@ -74,6 +75,12 @@ function formatSeason(start: string, end: string) {
     timeZone: 'UTC',
   });
   return `${formatter.format(startsAt)} – ${formatter.format(endsAt)}`;
+}
+
+function contributorPresence(count: number) {
+  if (count <= 0) return 'This landmark is quiet so far this week.';
+  if (count === 1) return '1 person has left a mark here this week.';
+  return `${count} people have left a mark here this week.`;
 }
 
 function ScopeChip({
@@ -119,9 +126,7 @@ function Landmark({
         <View style={styles.landmarkHeading}>
           <View style={styles.flex}>
             <Text style={styles.placeName}>{spec.place}</Text>
-            <Text style={styles.objectiveTitle}>
-              {objective?.title ?? 'Server objective unavailable'}
-            </Text>
+            <Text style={styles.objectiveTitle}>{objective?.title ?? 'Landmark unavailable'}</Text>
           </View>
           {participated && (
             <View style={styles.myMark}>
@@ -135,32 +140,19 @@ function Landmark({
 
         {objective ? (
           <>
-            <View style={styles.countRow}>
-              <View style={styles.countCell}>
-                <Text style={styles.countValue}>{objective.total}</Text>
-                <Text style={styles.countLabel}>shared marks</Text>
-              </View>
-              <View style={styles.countCell}>
-                <Text style={styles.countValue}>{objective.contributors}</Text>
-                <Text style={styles.countLabel}>contributors</Text>
-              </View>
-              <View style={styles.countCell}>
-                <Text style={styles.countValue}>{objective.myContribution}</Text>
-                <Text style={styles.countLabel}>yours</Text>
-              </View>
-            </View>
-            <View style={styles.calibrationNote}>
-              <Ionicons name="flask-outline" size={15} color={colors.primary[700]} />
-              <Text style={styles.calibrationText}>
+            <Text style={styles.presenceText}>{contributorPresence(objective.contributors)}</Text>
+            <View style={styles.openNote}>
+              <Ionicons name="leaf-outline" size={15} color={colors.primary[700]} />
+              <Text style={styles.openText}>
                 {objective.status === 'CALIBRATING'
-                  ? 'Calibrating, no completion target yet.'
-                  : 'Server authority has not supplied a supported target state.'}
+                  ? 'This landmark is open. There is no finish line to chase.'
+                  : 'This landmark stays open without a chaseable target.'}
               </Text>
             </View>
           </>
         ) : (
           <Text style={styles.unavailableText}>
-            Woof will not estimate this landmark from another score or local activity history.
+            Woof will leave this landmark quiet rather than guess from another score or local history.
           </Text>
         )}
       </View>
@@ -182,8 +174,7 @@ export function ExpeditionWorldView(props: Props) {
         <Text style={styles.eyebrow}>WEEKLY EXPEDITION</Text>
         <Text style={styles.heroTitle}>Build a shared world, not a bigger score.</Text>
         <Text style={styles.heroBody}>
-          Useful variety leaves marks across the landscape. The scene is playful; what counts stays
-          bounded and server-authored.
+          Useful variety leaves marks across the landscape. There is no finish line to chase.
         </Text>
 
         <View style={styles.worldScene} accessible accessibilityLabel="Shared Expedition landscape">
@@ -238,9 +229,7 @@ export function ExpeditionWorldView(props: Props) {
           ))}
         </ScrollView>
         {props.joinedPacks.length === 0 && (
-          <Text style={styles.scopeHint}>
-            No joined Pack is shown. Woof does not infer local membership from your location.
-          </Text>
+          <Text style={styles.scopeHint}>Join a Pack to see its shared Expedition here.</Text>
         )}
       </View>
 
@@ -254,14 +243,14 @@ export function ExpeditionWorldView(props: Props) {
       {props.selectedScope !== 'GLOBAL' && props.packLoading ? (
         <View style={styles.loadingCard} accessibilityRole="progressbar">
           <ActivityIndicator color={colors.primary[600]} />
-          <Text style={styles.loadingText}>Reading this Pack’s server-issued world…</Text>
+          <Text style={styles.loadingText}>Opening this Pack’s shared world…</Text>
         </View>
       ) : projection ? (
         <View style={styles.landmarksSection}>
           <Text style={styles.sectionLabel}>LANDMARKS</Text>
-          <Text style={styles.sectionTitle}>A landscape with three kinds of contribution</Text>
+          <Text style={styles.sectionTitle}>Three ways to leave the world a little richer</Text>
           <Text style={styles.sectionBody}>
-            Landmarks always exist. Counts show server-issued evidence, not unlock levels.
+            Every landmark is here from the beginning. Presence matters more than repetition.
           </Text>
           {LANDMARKS.map((spec) => (
             <Landmark
@@ -278,13 +267,13 @@ export function ExpeditionWorldView(props: Props) {
           <Ionicons name="shield-outline" size={24} color={colors.gray[600]} />
           <Text style={styles.unavailableTitle}>This Expedition view is unavailable.</Text>
           <Text style={styles.unavailableText}>
-            Woof will not reconstruct shared progress from cached activity, league score, or local
-            guesses.
+            Woof will leave the shared world blank rather than reconstruct it from another score or
+            local guesses.
           </Text>
         </View>
       )}
 
-      <ExpeditionFieldJournalView journal={props.journal} />
+      <ExpeditionFieldJournalView journal={props.journal} error={props.journalError} />
 
       <View style={styles.boundaryCard}>
         <View style={styles.boundaryIcon}>
@@ -293,13 +282,10 @@ export function ExpeditionWorldView(props: Props) {
         <View style={styles.flex}>
           <Text style={styles.boundaryTitle}>The world is the game. Your dog is not.</Text>
           <Text style={styles.boundaryBody}>
-            CARE, health state, distance, duration, intensity, missed days, likes, rankings, and
-            repeated grinding add no Expedition progress. Recovery can count because listening can
-            be the useful choice.
+            The world responds to useful variety, including recovery and listening. It never asks
+            you to optimize health, distance, duration, missed days, likes, or rank.
           </Text>
-          <Text style={styles.noMeter}>
-            No completion bar. This shared scene is not a checklist.
-          </Text>
+          <Text style={styles.noMeter}>No completion bar. This shared scene is not a checklist.</Text>
         </View>
       </View>
 
@@ -406,8 +392,9 @@ const styles = StyleSheet.create({
   sectionLabel: { color: colors.gray[500], fontSize: 10, fontWeight: '800', letterSpacing: 1.2 },
   scopeRow: { gap: 8, paddingTop: 9, paddingRight: 18 },
   scopeChip: {
+    minHeight: 44,
+    justifyContent: 'center',
     paddingHorizontal: 13,
-    paddingVertical: 9,
     borderRadius: 999,
     borderWidth: 1,
     borderColor: colors.gray[200],
@@ -464,11 +451,8 @@ const styles = StyleSheet.create({
   },
   myMarkText: { color: colors.primary[800], fontSize: 9, fontWeight: '800' },
   atmosphere: { marginTop: 7, color: colors.gray[600], fontSize: 11, lineHeight: 17 },
-  countRow: { marginTop: 11, flexDirection: 'row', gap: 7 },
-  countCell: { flex: 1, padding: 8, borderRadius: 11, backgroundColor: colors.gray[50] },
-  countValue: { color: colors.gray[900], fontSize: 17, fontWeight: '900' },
-  countLabel: { marginTop: 1, color: colors.gray[500], fontSize: 8 },
-  calibrationNote: {
+  presenceText: { marginTop: 10, color: colors.gray[700], fontSize: 11, fontWeight: '700' },
+  openNote: {
     marginTop: 9,
     flexDirection: 'row',
     alignItems: 'center',
@@ -477,7 +461,7 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     backgroundColor: colors.primary[50],
   },
-  calibrationText: {
+  openText: {
     flex: 1,
     color: colors.primary[800],
     fontSize: 10,

--- a/apps/mobile/src/components/community/ExpeditionWorldView.tsx
+++ b/apps/mobile/src/components/community/ExpeditionWorldView.tsx
@@ -152,7 +152,8 @@ function Landmark({
           </>
         ) : (
           <Text style={styles.unavailableText}>
-            Woof will leave this landmark quiet rather than guess from another score or local history.
+            Woof will leave this landmark quiet rather than guess from another score or local
+            history.
           </Text>
         )}
       </View>
@@ -285,7 +286,9 @@ export function ExpeditionWorldView(props: Props) {
             The world responds to useful variety, including recovery and listening. It never asks
             you to optimize health, distance, duration, missed days, likes, or rank.
           </Text>
-          <Text style={styles.noMeter}>No completion bar. This shared scene is not a checklist.</Text>
+          <Text style={styles.noMeter}>
+            No completion bar. This shared scene is not a checklist.
+          </Text>
         </View>
       </View>
 

--- a/apps/mobile/src/screens/CompanionHomeScreen.tsx
+++ b/apps/mobile/src/screens/CompanionHomeScreen.tsx
@@ -19,7 +19,8 @@ const links: {
   {
     route: 'Expedition',
     title: 'Shared Expedition',
-    description: 'Step into the cooperative world. Human-side participation does not require a dog.',
+    description:
+      'Step into the cooperative world. Human-side participation does not require a dog.',
     icon: 'map-outline',
   },
   {
@@ -31,7 +32,8 @@ const links: {
   {
     route: 'Packs',
     title: 'Packs',
-    description: 'Find small communities to learn and explore with, without borrowing pet authority.',
+    description:
+      'Find small communities to learn and explore with, without borrowing pet authority.',
     icon: 'people-circle-outline',
   },
   {
@@ -80,7 +82,8 @@ export default function CompanionHomeScreen({ navigation, onResolved }: Props) {
       <Text style={styles.title}>You can belong here before you have a dog.</Text>
       <Text style={styles.intro}>
         Explore the shared world, practice useful human skills, and meet people. Dog-specific Today,
-        Compass, and Story open only when Woof can verify a real relationship you are allowed to see.
+        Compass, and Story open only when Woof can verify a real relationship you are allowed to
+        see.
       </Text>
 
       <View style={styles.truthCard}>
@@ -88,14 +91,16 @@ export default function CompanionHomeScreen({ navigation, onResolved }: Props) {
         <View style={styles.truthCopy}>
           <Text style={styles.truthTitle}>Dog-specific spaces stay private</Text>
           <Text style={styles.truthText}>
-            Companion mode gives you human-side places to learn and participate. It does not invent a
-            pet relationship or unlock pet-specific Today, Compass, or Story.
+            Companion mode gives you human-side places to learn and participate. It does not invent
+            a pet relationship or unlock pet-specific Today, Compass, or Story.
           </Text>
         </View>
       </View>
 
       <Text style={styles.sectionTitle}>Start anywhere</Text>
-      <Text style={styles.sectionIntro}>These paths are useful with or without a dog of your own.</Text>
+      <Text style={styles.sectionIntro}>
+        These paths are useful with or without a dog of your own.
+      </Text>
       <View style={styles.linkList}>
         {links.map((link) => (
           <Pressable
@@ -184,7 +189,13 @@ const styles = StyleSheet.create({
     fontWeight: '800',
     marginTop: 30,
   },
-  sectionIntro: { marginTop: 4, marginBottom: 12, color: colors.gray[600], fontSize: 12, lineHeight: 18 },
+  sectionIntro: {
+    marginTop: 4,
+    marginBottom: 12,
+    color: colors.gray[600],
+    fontSize: 12,
+    lineHeight: 18,
+  },
   linkList: { gap: 10 },
   linkCard: {
     minHeight: 88,

--- a/apps/mobile/src/screens/CompanionHomeScreen.tsx
+++ b/apps/mobile/src/screens/CompanionHomeScreen.tsx
@@ -11,21 +11,33 @@ type Props = StackScreenProps<RootStackParamList, 'CompanionHome'> & {
 };
 
 const links: {
-  route: 'Skillcraft' | 'CommunityStandalone' | 'Events' | 'Profile';
+  route: 'Expedition' | 'Skillcraft' | 'Packs' | 'CommunityStandalone' | 'Events' | 'Profile';
   title: string;
   description: string;
   icon: keyof typeof Ionicons.glyphMap;
 }[] = [
   {
+    route: 'Expedition',
+    title: 'Shared Expedition',
+    description: 'Step into the cooperative world. Human-side participation does not require a dog.',
+    icon: 'map-outline',
+  },
+  {
     route: 'Skillcraft',
     title: 'Skillcraft',
-    description: 'Practice setup, observation, pairing, and timing without inventing a pet.',
+    description: 'Practice observation, setup, pairing, and timing before a real dog is involved.',
     icon: 'game-controller-outline',
+  },
+  {
+    route: 'Packs',
+    title: 'Packs',
+    description: 'Find small communities to learn and explore with, without borrowing pet authority.',
+    icon: 'people-circle-outline',
   },
   {
     route: 'CommunityStandalone',
     title: 'Community',
-    description: 'See what people and dogs around Woof are sharing.',
+    description: 'See shared moments, local plans, and people across Woof.',
     icon: 'people-outline',
   },
   {
@@ -65,25 +77,25 @@ export default function CompanionHomeScreen({ navigation, onResolved }: Props) {
         <Ionicons name="heart-outline" size={25} color={colors.primary[700]} />
       </View>
       <Text style={styles.eyebrow}>COMPANION MODE</Text>
-      <Text style={styles.title}>You do not need to invent a dog to belong here.</Text>
+      <Text style={styles.title}>You can belong here before you have a dog.</Text>
       <Text style={styles.intro}>
-        Woof keeps pet-specific Today, Compass, and Story closed until the server can verify a real
-        owned or authorized relationship. You can still practice human skills, explore people and
-        events, and manage your account.
+        Explore the shared world, practice useful human skills, and meet people. Dog-specific Today,
+        Compass, and Story open only when Woof can verify a real relationship you are allowed to see.
       </Text>
 
       <View style={styles.truthCard}>
         <Ionicons name="shield-checkmark-outline" size={21} color={colors.success.dark} />
         <View style={styles.truthCopy}>
-          <Text style={styles.truthTitle}>Presentation is not authority</Text>
+          <Text style={styles.truthTitle}>Dog-specific spaces stay private</Text>
           <Text style={styles.truthText}>
-            Companion mode changes what Woof shows you. It never grants access to somebody else’s
-            dog or manufactures relationship history.
+            Companion mode gives you human-side places to learn and participate. It does not invent a
+            pet relationship or unlock pet-specific Today, Compass, or Story.
           </Text>
         </View>
       </View>
 
-      <Text style={styles.sectionTitle}>Useful without a pet</Text>
+      <Text style={styles.sectionTitle}>Start anywhere</Text>
+      <Text style={styles.sectionIntro}>These paths are useful with or without a dog of your own.</Text>
       <View style={styles.linkList}>
         {links.map((link) => (
           <Pressable
@@ -171,8 +183,8 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: '800',
     marginTop: 30,
-    marginBottom: 12,
   },
+  sectionIntro: { marginTop: 4, marginBottom: 12, color: colors.gray[600], fontSize: 12, lineHeight: 18 },
   linkList: { gap: 10 },
   linkCard: {
     minHeight: 88,
@@ -185,8 +197,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   linkIcon: {
-    width: 43,
-    height: 43,
+    width: 44,
+    height: 44,
     borderRadius: 14,
     alignItems: 'center',
     justifyContent: 'center',

--- a/apps/mobile/src/screens/ExpeditionScreen.tsx
+++ b/apps/mobile/src/screens/ExpeditionScreen.tsx
@@ -25,7 +25,8 @@ export default function ExpeditionScreen({ navigation }: Props) {
   const [loading, setLoading] = useState(true);
   const [packLoading, setPackLoading] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [worldError, setWorldError] = useState<string | null>(null);
+  const [journalError, setJournalError] = useState<string | null>(null);
   const packRequestRef = useRef(0);
   const selectedScopeRef = useRef<SelectedScope>('GLOBAL');
 
@@ -54,16 +55,15 @@ export default function ExpeditionScreen({ navigation }: Props) {
         if (requestId !== packRequestRef.current) return;
         if (response.scope !== 'PACK' || response.pack?.id !== joinedPack.id) {
           setPackProjection(null);
-          setError('That Pack Expedition did not match the server-confirmed Pack, so Woof hid it.');
+          setWorldError('That Pack Expedition did not match the Pack you opened, so Woof hid it.');
           return;
         }
         setPackProjection(response);
+        setWorldError(null);
       } catch {
         if (requestId !== packRequestRef.current) return;
         setPackProjection(null);
-        setError(
-          'That Pack Expedition is unavailable. Woof will not estimate shared progress from local activity or league data.'
-        );
+        setWorldError('That Pack Expedition is unavailable. Woof will leave the shared world blank rather than guess.');
       } finally {
         if (requestId === packRequestRef.current) setPackLoading(false);
       }
@@ -82,13 +82,13 @@ export default function ExpeditionScreen({ navigation }: Props) {
         expeditionApi.journal(),
       ]);
 
-      const unavailable: string[] = [];
+      const unavailableWorld: string[] = [];
 
       if (globalResult.status === 'fulfilled') {
         if (globalResult.value.scope === 'GLOBAL') setGlobalProjection(globalResult.value);
-        else unavailable.push('global Expedition');
+        else unavailableWorld.push('shared Expedition');
       } else {
-        unavailable.push('global Expedition');
+        unavailableWorld.push('shared Expedition');
       }
 
       if (packsResult.status === 'fulfilled') {
@@ -107,26 +107,30 @@ export default function ExpeditionScreen({ navigation }: Props) {
           }
         }
       } else {
-        unavailable.push('Pack membership');
+        unavailableWorld.push('Pack list');
       }
 
-      if (journalResult.status === 'fulfilled') {
-        if (journalResult.value.scope === 'GLOBAL') setJournal(journalResult.value);
-        else unavailable.push('field journal');
+      if (journalResult.status === 'fulfilled' && journalResult.value.scope === 'GLOBAL') {
+        setJournal(journalResult.value);
+        setJournalError(null);
       } else {
-        unavailable.push('field journal');
+        setJournalError(
+          journal
+            ? 'Could not refresh field notes. Showing your last verified pages.'
+            : 'Field notes could not refresh. Your shared world is still available; Woof will leave history blank rather than guess.'
+        );
       }
 
-      if (unavailable.length === 0) setError(null);
+      if (unavailableWorld.length === 0) setWorldError(null);
       else
-        setError(
-          `${unavailable.join(' and ')} could not refresh. Previously loaded server projections remain visible where available; Woof did not infer missing progress, membership, or journal history.`
+        setWorldError(
+          `${unavailableWorld.join(' and ')} could not refresh. Previously loaded shared-world data stays visible where available; Woof will not invent the missing view.`
         );
 
       setLoading(false);
       setRefreshing(false);
     },
-    [applySelectedScope, loadPackProjection]
+    [applySelectedScope, journal, loadPackProjection]
   );
 
   useFocusEffect(
@@ -139,7 +143,7 @@ export default function ExpeditionScreen({ navigation }: Props) {
     packRequestRef.current += 1;
     setPackProjection(null);
     setPackLoading(false);
-    setError(null);
+    setWorldError(null);
     applySelectedScope('GLOBAL');
   }, [applySelectedScope]);
 
@@ -147,10 +151,10 @@ export default function ExpeditionScreen({ navigation }: Props) {
     (packId: string) => {
       const joinedPack = catalog?.packs.find((pack) => pack.id === packId && pack.joined);
       if (!joinedPack) {
-        setError('Woof will only open Expedition views for Packs the server says you joined.');
+        setWorldError('Woof will only open Expedition views for Packs you have joined.');
         return;
       }
-      setError(null);
+      setWorldError(null);
       setPackProjection(null);
       applySelectedScope(joinedPack.id);
       void loadPackProjection(joinedPack.id, catalog);
@@ -172,11 +176,12 @@ export default function ExpeditionScreen({ navigation }: Props) {
       globalProjection={globalProjection}
       packProjection={packProjection}
       journal={journal}
+      journalError={journalError}
       joinedPacks={joinedPacks}
       selectedScope={selectedScope}
       packLoading={packLoading}
       refreshing={refreshing}
-      error={error}
+      error={worldError}
       onRefresh={() => void load(true)}
       onSelectGlobal={selectGlobal}
       onSelectPack={selectPack}

--- a/apps/mobile/src/screens/ExpeditionScreen.tsx
+++ b/apps/mobile/src/screens/ExpeditionScreen.tsx
@@ -16,6 +16,11 @@ type Props = StackScreenProps<RootStackParamList, 'Expedition'>;
 
 type SelectedScope = 'GLOBAL' | string;
 
+type PackLoadResult =
+  | { status: 'ok' }
+  | { status: 'stale' }
+  | { status: 'error'; message: string };
+
 export default function ExpeditionScreen({ navigation }: Props) {
   const [globalProjection, setGlobalProjection] = useState<ExpeditionProjection | null>(null);
   const [packProjection, setPackProjection] = useState<ExpeditionProjection | null>(null);
@@ -27,6 +32,7 @@ export default function ExpeditionScreen({ navigation }: Props) {
   const [refreshing, setRefreshing] = useState(false);
   const [worldError, setWorldError] = useState<string | null>(null);
   const [journalError, setJournalError] = useState<string | null>(null);
+  const loadRequestRef = useRef(0);
   const packRequestRef = useRef(0);
   const selectedScopeRef = useRef<SelectedScope>('GLOBAL');
   const journalRef = useRef<ExpeditionJournal | null>(null);
@@ -39,34 +45,45 @@ export default function ExpeditionScreen({ navigation }: Props) {
   }, []);
 
   const loadPackProjection = useCallback(
-    async (packId: string, packs: PacksCatalog | null) => {
+    async (packId: string, packs: PacksCatalog | null): Promise<PackLoadResult> => {
       const joinedPack = packs?.packs.find((pack) => pack.id === packId && pack.joined);
       if (!joinedPack) {
         packRequestRef.current += 1;
         setPackProjection(null);
         setPackLoading(false);
         applySelectedScope('GLOBAL');
-        return;
+        return {
+          status: 'error',
+          message: 'Woof will only open Expedition views for Packs you have joined.',
+        };
       }
 
       const requestId = ++packRequestRef.current;
       setPackLoading(true);
       try {
         const response = await expeditionApi.pack(joinedPack.id);
-        if (requestId !== packRequestRef.current) return;
+        if (requestId !== packRequestRef.current || selectedScopeRef.current !== joinedPack.id) {
+          return { status: 'stale' };
+        }
         if (response.scope !== 'PACK' || response.pack?.id !== joinedPack.id) {
           setPackProjection(null);
-          setWorldError('That Pack Expedition did not match the Pack you opened, so Woof hid it.');
-          return;
+          return {
+            status: 'error',
+            message: 'That Pack Expedition did not match the Pack you opened, so Woof hid it.',
+          };
         }
         setPackProjection(response);
-        setWorldError(null);
+        return { status: 'ok' };
       } catch {
-        if (requestId !== packRequestRef.current) return;
+        if (requestId !== packRequestRef.current || selectedScopeRef.current !== joinedPack.id) {
+          return { status: 'stale' };
+        }
         setPackProjection(null);
-        setWorldError(
-          'That Pack Expedition is unavailable. Woof will leave the shared world blank rather than guess.'
-        );
+        return {
+          status: 'error',
+          message:
+            'That Pack Expedition is unavailable. Woof will leave the shared world blank rather than guess.',
+        };
       } finally {
         if (requestId === packRequestRef.current) setPackLoading(false);
       }
@@ -76,6 +93,7 @@ export default function ExpeditionScreen({ navigation }: Props) {
 
   const load = useCallback(
     async (refresh = false) => {
+      const loadRequestId = ++loadRequestRef.current;
       if (refresh) setRefreshing(true);
       else setLoading(true);
 
@@ -85,7 +103,10 @@ export default function ExpeditionScreen({ navigation }: Props) {
         expeditionApi.journal(),
       ]);
 
+      if (loadRequestId !== loadRequestRef.current) return;
+
       const unavailableWorld: string[] = [];
+      let packLoadResult: PackLoadResult | null = null;
 
       if (globalResult.status === 'fulfilled') {
         if (globalResult.value.scope === 'GLOBAL') setGlobalProjection(globalResult.value);
@@ -101,7 +122,7 @@ export default function ExpeditionScreen({ navigation }: Props) {
           const stillJoined = packsResult.value.packs.some(
             (pack) => pack.id === currentScope && pack.joined
           );
-          if (stillJoined) await loadPackProjection(currentScope, packsResult.value);
+          if (stillJoined) packLoadResult = await loadPackProjection(currentScope, packsResult.value);
           else {
             packRequestRef.current += 1;
             setPackProjection(null);
@@ -112,6 +133,8 @@ export default function ExpeditionScreen({ navigation }: Props) {
       } else {
         unavailableWorld.push('Pack list');
       }
+
+      if (loadRequestId !== loadRequestRef.current) return;
 
       if (journalResult.status === 'fulfilled' && journalResult.value.scope === 'GLOBAL') {
         journalRef.current = journalResult.value;
@@ -125,11 +148,15 @@ export default function ExpeditionScreen({ navigation }: Props) {
         );
       }
 
-      if (unavailableWorld.length === 0) setWorldError(null);
-      else
+      if (packLoadResult?.status === 'error') {
+        setWorldError(packLoadResult.message);
+      } else if (unavailableWorld.length === 0) {
+        setWorldError(null);
+      } else {
         setWorldError(
           `${unavailableWorld.join(' and ')} could not refresh. Previously loaded shared-world data stays visible where available; Woof will not invent the missing view.`
         );
+      }
 
       setLoading(false);
       setRefreshing(false);
@@ -140,6 +167,10 @@ export default function ExpeditionScreen({ navigation }: Props) {
   useFocusEffect(
     useCallback(() => {
       void load();
+      return () => {
+        loadRequestRef.current += 1;
+        packRequestRef.current += 1;
+      };
     }, [load])
   );
 
@@ -161,7 +192,10 @@ export default function ExpeditionScreen({ navigation }: Props) {
       setWorldError(null);
       setPackProjection(null);
       applySelectedScope(joinedPack.id);
-      void loadPackProjection(joinedPack.id, catalog);
+      void loadPackProjection(joinedPack.id, catalog).then((result) => {
+        if (result.status === 'stale' || selectedScopeRef.current !== joinedPack.id) return;
+        setWorldError(result.status === 'error' ? result.message : null);
+      });
     },
     [applySelectedScope, catalog, loadPackProjection]
   );

--- a/apps/mobile/src/screens/ExpeditionScreen.tsx
+++ b/apps/mobile/src/screens/ExpeditionScreen.tsx
@@ -16,10 +16,7 @@ type Props = StackScreenProps<RootStackParamList, 'Expedition'>;
 
 type SelectedScope = 'GLOBAL' | string;
 
-type PackLoadResult =
-  | { status: 'ok' }
-  | { status: 'stale' }
-  | { status: 'error'; message: string };
+type PackLoadResult = { status: 'ok' } | { status: 'stale' } | { status: 'error'; message: string };
 
 export default function ExpeditionScreen({ navigation }: Props) {
   const [globalProjection, setGlobalProjection] = useState<ExpeditionProjection | null>(null);
@@ -122,7 +119,8 @@ export default function ExpeditionScreen({ navigation }: Props) {
           const stillJoined = packsResult.value.packs.some(
             (pack) => pack.id === currentScope && pack.joined
           );
-          if (stillJoined) packLoadResult = await loadPackProjection(currentScope, packsResult.value);
+          if (stillJoined)
+            packLoadResult = await loadPackProjection(currentScope, packsResult.value);
           else {
             packRequestRef.current += 1;
             setPackProjection(null);

--- a/apps/mobile/src/screens/ExpeditionScreen.tsx
+++ b/apps/mobile/src/screens/ExpeditionScreen.tsx
@@ -29,6 +29,7 @@ export default function ExpeditionScreen({ navigation }: Props) {
   const [journalError, setJournalError] = useState<string | null>(null);
   const packRequestRef = useRef(0);
   const selectedScopeRef = useRef<SelectedScope>('GLOBAL');
+  const journalRef = useRef<ExpeditionJournal | null>(null);
 
   const joinedPacks = useMemo(() => catalog?.packs.filter((pack) => pack.joined) ?? [], [catalog]);
 
@@ -63,7 +64,9 @@ export default function ExpeditionScreen({ navigation }: Props) {
       } catch {
         if (requestId !== packRequestRef.current) return;
         setPackProjection(null);
-        setWorldError('That Pack Expedition is unavailable. Woof will leave the shared world blank rather than guess.');
+        setWorldError(
+          'That Pack Expedition is unavailable. Woof will leave the shared world blank rather than guess.'
+        );
       } finally {
         if (requestId === packRequestRef.current) setPackLoading(false);
       }
@@ -111,11 +114,12 @@ export default function ExpeditionScreen({ navigation }: Props) {
       }
 
       if (journalResult.status === 'fulfilled' && journalResult.value.scope === 'GLOBAL') {
+        journalRef.current = journalResult.value;
         setJournal(journalResult.value);
         setJournalError(null);
       } else {
         setJournalError(
-          journal
+          journalRef.current
             ? 'Could not refresh field notes. Showing your last verified pages.'
             : 'Field notes could not refresh. Your shared world is still available; Woof will leave history blank rather than guess.'
         );
@@ -130,7 +134,7 @@ export default function ExpeditionScreen({ navigation }: Props) {
       setLoading(false);
       setRefreshing(false);
     },
-    [applySelectedScope, journal, loadPackProjection]
+    [applySelectedScope, loadPackProjection]
   );
 
   useFocusEffect(

--- a/apps/mobile/src/screens/StoryScreen.tsx
+++ b/apps/mobile/src/screens/StoryScreen.tsx
@@ -39,7 +39,9 @@ function iconForMoment(moment: StoryMoment): keyof typeof Ionicons.glyphMap {
   return 'paw-outline';
 }
 
-function uniqueStoryPets(households: Awaited<ReturnType<typeof householdsApi.getMine>>): StoryPet[] {
+function uniqueStoryPets(
+  households: Awaited<ReturnType<typeof householdsApi.getMine>>
+): StoryPet[] {
   const pets = new Map<string, StoryPet>();
   for (const household of households) {
     for (const link of household.pets) {
@@ -104,7 +106,9 @@ export default function StoryScreen() {
       }
     } catch {
       if (requestId !== filterRequestRef.current) return;
-      setFilterError('Dog filters are unavailable. All-dogs Story still uses server-authorized history.');
+      setFilterError(
+        'Dog filters are unavailable. All-dogs Story still uses server-authorized history.'
+      );
     } finally {
       if (requestId === filterRequestRef.current) setFilterLoading(false);
     }
@@ -154,7 +158,9 @@ export default function StoryScreen() {
     <ScrollView
       style={styles.screen}
       contentContainerStyle={styles.content}
-      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={() => void loadStory(true)} />}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={() => void loadStory(true)} />
+      }
     >
       <Text style={styles.eyebrow}>RELATIONSHIP MEMORY</Text>
       <Text style={styles.title}>Story</Text>
@@ -174,14 +180,23 @@ export default function StoryScreen() {
           </View>
           {filterLoading && <ActivityIndicator size="small" color={colors.primary[600]} />}
         </View>
-        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.scopeRow}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.scopeRow}
+        >
           <Pressable
             accessibilityRole="button"
             accessibilityState={{ selected: selectedScope === 'ALL' }}
             style={[styles.scopeChip, selectedScope === 'ALL' && styles.scopeChipSelected]}
             onPress={() => chooseScope('ALL')}
           >
-            <Text style={[styles.scopeChipText, selectedScope === 'ALL' && styles.scopeChipTextSelected]}>
+            <Text
+              style={[
+                styles.scopeChipText,
+                selectedScope === 'ALL' && styles.scopeChipTextSelected,
+              ]}
+            >
               All dogs
             </Text>
           </Pressable>
@@ -196,13 +211,16 @@ export default function StoryScreen() {
                 style={[styles.scopeChip, selected && styles.scopeChipSelected]}
                 onPress={() => chooseScope(pet.id)}
               >
-                <Text style={[styles.scopeChipText, selected && styles.scopeChipTextSelected]}>{pet.name}</Text>
+                <Text style={[styles.scopeChipText, selected && styles.scopeChipTextSelected]}>
+                  {pet.name}
+                </Text>
               </Pressable>
             );
           })}
         </ScrollView>
         <Text style={styles.scopeHint}>
-          All dogs is one authorized household view. Choosing a dog narrows Story without changing Today or Compass.
+          All dogs is one authorized household view. Choosing a dog narrows Story without changing
+          Today or Compass.
         </Text>
         {filterError && <Text style={styles.filterError}>{filterError}</Text>}
       </View>
@@ -260,14 +278,17 @@ export default function StoryScreen() {
 
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>What you have lived</Text>
-            <Text style={styles.sectionSubtitle}>Recent moments from activity, care, and memories.</Text>
+            <Text style={styles.sectionSubtitle}>
+              Recent moments from activity, care, and memories.
+            </Text>
 
             {moments.length === 0 ? (
               <View style={styles.emptyCard}>
                 <Ionicons name="paw-outline" size={28} color={colors.primary[600]} />
                 <Text style={styles.emptyTitle}>This Story view is just beginning.</Text>
                 <Text style={styles.emptyText}>
-                  Nothing is missing or overdue. Woof will keep useful moments without turning everyday life into homework.
+                  Nothing is missing or overdue. Woof will keep useful moments without turning
+                  everyday life into homework.
                 </Text>
               </View>
             ) : (
@@ -298,7 +319,9 @@ export default function StoryScreen() {
           </View>
 
           <Text style={styles.coverageNote}>
-            Story coverage: {activeDashboard.stats.coverage.toLowerCase()}. Woof may intentionally show a bounded recent history rather than pretending this is every moment you have shared.
+            Story coverage: {activeDashboard.stats.coverage.toLowerCase()}. Woof may intentionally
+            show a bounded recent history rather than pretending this is every moment you have
+            shared.
           </Text>
         </>
       ) : null}
@@ -328,7 +351,12 @@ const styles = StyleSheet.create({
     borderColor: colors.gray[200],
   },
   scopeHeadingRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
-  scopeEyebrow: { color: colors.text.secondary, fontSize: 9, fontWeight: '800', letterSpacing: 1.2 },
+  scopeEyebrow: {
+    color: colors.text.secondary,
+    fontSize: 9,
+    fontWeight: '800',
+    letterSpacing: 1.2,
+  },
   scopeTitle: { marginTop: 2, color: colors.text.primary, fontSize: 16, fontWeight: '800' },
   scopeRow: { gap: 8, paddingTop: 10, paddingRight: 18 },
   scopeChip: {

--- a/apps/mobile/src/screens/StoryScreen.tsx
+++ b/apps/mobile/src/screens/StoryScreen.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
+  Pressable,
   RefreshControl,
   ScrollView,
   StyleSheet,
@@ -9,8 +10,16 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect } from '@react-navigation/native';
+import { householdsApi } from '../api/households';
 import { storyApi, type StoryDashboard, type StoryMoment } from '../api/story';
 import { colors } from '../theme/tokens';
+
+type StoryScope = 'ALL' | string;
+
+type StoryPet = {
+  id: string;
+  name: string;
+};
 
 function formatDate(value: string) {
   const date = new Date(value);
@@ -30,43 +39,111 @@ function iconForMoment(moment: StoryMoment): keyof typeof Ionicons.glyphMap {
   return 'paw-outline';
 }
 
+function uniqueStoryPets(households: Awaited<ReturnType<typeof householdsApi.getMine>>): StoryPet[] {
+  const pets = new Map<string, StoryPet>();
+  for (const household of households) {
+    for (const link of household.pets) {
+      if (!pets.has(link.pet.id)) pets.set(link.pet.id, { id: link.pet.id, name: link.pet.name });
+    }
+  }
+  return [...pets.values()];
+}
+
 export default function StoryScreen() {
   const [dashboard, setDashboard] = useState<StoryDashboard | null>(null);
+  const [dashboardScope, setDashboardScope] = useState<StoryScope | null>(null);
+  const [filterPets, setFilterPets] = useState<StoryPet[]>([]);
+  const [selectedScope, setSelectedScopeState] = useState<StoryScope>('ALL');
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [filterLoading, setFilterLoading] = useState(true);
+  const [filterError, setFilterError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const selectedScopeRef = useRef<StoryScope>('ALL');
+  const storyRequestRef = useRef(0);
+  const filterRequestRef = useRef(0);
 
-  const load = useCallback(async (refresh = false) => {
+  const setSelectedScope = useCallback((scope: StoryScope) => {
+    selectedScopeRef.current = scope;
+    setSelectedScopeState(scope);
+  }, []);
+
+  const loadStory = useCallback(async (refresh = false, scope = selectedScopeRef.current) => {
+    const requestId = ++storyRequestRef.current;
     if (refresh) setRefreshing(true);
     else setLoading(true);
     try {
-      setDashboard(await storyApi.get({ limit: 36 }));
+      const next = await storyApi.get({ limit: 36, ...(scope === 'ALL' ? {} : { petId: scope }) });
+      if (requestId !== storyRequestRef.current || scope !== selectedScopeRef.current) return;
+      setDashboard(next);
+      setDashboardScope(scope);
       setError(null);
     } catch {
+      if (requestId !== storyRequestRef.current || scope !== selectedScopeRef.current) return;
       setError('Story is unavailable right now. Your existing memories remain unchanged.');
     } finally {
-      setLoading(false);
-      setRefreshing(false);
+      if (requestId === storyRequestRef.current && scope === selectedScopeRef.current) {
+        setLoading(false);
+        setRefreshing(false);
+      }
     }
   }, []);
 
+  const loadFilters = useCallback(async () => {
+    const requestId = ++filterRequestRef.current;
+    setFilterLoading(true);
+    try {
+      const pets = uniqueStoryPets(await householdsApi.getMine());
+      if (requestId !== filterRequestRef.current) return;
+      setFilterPets(pets);
+      setFilterError(null);
+      const currentScope = selectedScopeRef.current;
+      if (currentScope !== 'ALL' && !pets.some((pet) => pet.id === currentScope)) {
+        setSelectedScope('ALL');
+        void loadStory(false, 'ALL');
+      }
+    } catch {
+      if (requestId !== filterRequestRef.current) return;
+      setFilterError('Dog filters are unavailable. All-dogs Story still uses server-authorized history.');
+    } finally {
+      if (requestId === filterRequestRef.current) setFilterLoading(false);
+    }
+  }, [loadStory, setSelectedScope]);
+
   useFocusEffect(
     useCallback(() => {
-      void load();
-    }, [load])
+      void loadStory();
+      void loadFilters();
+      return () => {
+        storyRequestRef.current += 1;
+        filterRequestRef.current += 1;
+      };
+    }, [loadFilters, loadStory])
   );
 
+  const chooseScope = useCallback(
+    (scope: StoryScope) => {
+      if (scope === selectedScopeRef.current) return;
+      if (scope !== 'ALL' && !filterPets.some((pet) => pet.id === scope)) return;
+      setSelectedScope(scope);
+      setError(null);
+      void loadStory(false, scope);
+    },
+    [filterPets, loadStory, setSelectedScope]
+  );
+
+  const activeDashboard = dashboard && dashboardScope === selectedScope ? dashboard : null;
   const moments = useMemo(
     () =>
-      [...(dashboard?.moments ?? [])].sort(
+      [...(activeDashboard?.moments ?? [])].sort(
         (a, b) => new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime()
       ),
-    [dashboard]
+    [activeDashboard]
   );
 
   if (loading && !dashboard) {
     return (
-      <View style={styles.centered}>
+      <View style={styles.centered} accessibilityRole="progressbar">
         <ActivityIndicator size="large" color={colors.primary[600]} />
         <Text style={styles.loadingText}>Gathering the moments that matter…</Text>
       </View>
@@ -77,7 +154,7 @@ export default function StoryScreen() {
     <ScrollView
       style={styles.screen}
       contentContainerStyle={styles.content}
-      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={() => void load(true)} />}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={() => void loadStory(true)} />}
     >
       <Text style={styles.eyebrow}>RELATIONSHIP MEMORY</Text>
       <Text style={styles.title}>Story</Text>
@@ -85,31 +162,81 @@ export default function StoryScreen() {
         A record of what you have actually lived together, not a feed you need to keep filling.
       </Text>
 
+      <View style={styles.scopeSection}>
+        <View style={styles.scopeHeadingRow}>
+          <View>
+            <Text style={styles.scopeEyebrow}>SHOWING</Text>
+            <Text style={styles.scopeTitle}>
+              {selectedScope === 'ALL'
+                ? 'All your dogs'
+                : (filterPets.find((pet) => pet.id === selectedScope)?.name ?? 'One dog')}
+            </Text>
+          </View>
+          {filterLoading && <ActivityIndicator size="small" color={colors.primary[600]} />}
+        </View>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.scopeRow}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityState={{ selected: selectedScope === 'ALL' }}
+            style={[styles.scopeChip, selectedScope === 'ALL' && styles.scopeChipSelected]}
+            onPress={() => chooseScope('ALL')}
+          >
+            <Text style={[styles.scopeChipText, selectedScope === 'ALL' && styles.scopeChipTextSelected]}>
+              All dogs
+            </Text>
+          </Pressable>
+          {filterPets.map((pet) => {
+            const selected = pet.id === selectedScope;
+            return (
+              <Pressable
+                key={pet.id}
+                accessibilityRole="button"
+                accessibilityState={{ selected }}
+                accessibilityLabel={`${selected ? 'Showing' : 'Show'} Story for ${pet.name}`}
+                style={[styles.scopeChip, selected && styles.scopeChipSelected]}
+                onPress={() => chooseScope(pet.id)}
+              >
+                <Text style={[styles.scopeChipText, selected && styles.scopeChipTextSelected]}>{pet.name}</Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+        <Text style={styles.scopeHint}>
+          All dogs is one authorized household view. Choosing a dog narrows Story without changing Today or Compass.
+        </Text>
+        {filterError && <Text style={styles.filterError}>{filterError}</Text>}
+      </View>
+
       {error && (
-        <View style={styles.noticeCard}>
+        <View style={styles.noticeCard} accessibilityRole="alert">
           <Ionicons name="cloud-offline-outline" size={20} color={colors.gray[600]} />
           <Text style={styles.noticeText}>{error}</Text>
         </View>
       )}
 
-      {dashboard && (
+      {loading && !activeDashboard ? (
+        <View style={styles.scopeLoadingCard} accessibilityRole="progressbar">
+          <ActivityIndicator size="small" color={colors.primary[600]} />
+          <Text style={styles.scopeLoadingText}>Opening this Story view…</Text>
+        </View>
+      ) : activeDashboard ? (
         <>
           <View style={styles.statsCard}>
             <View style={styles.stat}>
-              <Text style={styles.statValue}>{dashboard.stats.activities}</Text>
+              <Text style={styles.statValue}>{activeDashboard.stats.activities}</Text>
               <Text style={styles.statLabel}>Activities</Text>
             </View>
             <View style={styles.stat}>
-              <Text style={styles.statValue}>{dashboard.stats.memories}</Text>
+              <Text style={styles.statValue}>{activeDashboard.stats.memories}</Text>
               <Text style={styles.statLabel}>Memories</Text>
             </View>
             <View style={styles.stat}>
-              <Text style={styles.statValue}>{dashboard.stats.namedPlaces}</Text>
+              <Text style={styles.statValue}>{activeDashboard.stats.namedPlaces}</Text>
               <Text style={styles.statLabel}>Places</Text>
             </View>
           </View>
 
-          {dashboard.milestones.length > 0 && (
+          {activeDashboard.milestones.length > 0 && (
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>Milestones</Text>
               <ScrollView
@@ -117,7 +244,7 @@ export default function StoryScreen() {
                 showsHorizontalScrollIndicator={false}
                 contentContainerStyle={styles.milestonesRow}
               >
-                {dashboard.milestones.slice(0, 8).map((milestone) => (
+                {activeDashboard.milestones.slice(0, 8).map((milestone) => (
                   <View key={milestone.id} style={styles.milestoneCard}>
                     <View style={styles.milestoneIcon}>
                       <Ionicons name="sparkles-outline" size={20} color={colors.primary[700]} />
@@ -133,17 +260,14 @@ export default function StoryScreen() {
 
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>What you have lived</Text>
-            <Text style={styles.sectionSubtitle}>
-              Recent moments from activity, care, and memories.
-            </Text>
+            <Text style={styles.sectionSubtitle}>Recent moments from activity, care, and memories.</Text>
 
             {moments.length === 0 ? (
               <View style={styles.emptyCard}>
                 <Ionicons name="paw-outline" size={28} color={colors.primary[600]} />
-                <Text style={styles.emptyTitle}>Your story is just beginning.</Text>
+                <Text style={styles.emptyTitle}>This Story view is just beginning.</Text>
                 <Text style={styles.emptyText}>
-                  Complete a shared activity or add a memory. Woof will keep the useful parts
-                  without turning everyday life into homework.
+                  Nothing is missing or overdue. Woof will keep useful moments without turning everyday life into homework.
                 </Text>
               </View>
             ) : (
@@ -174,11 +298,10 @@ export default function StoryScreen() {
           </View>
 
           <Text style={styles.coverageNote}>
-            Story coverage: {dashboard.stats.coverage.toLowerCase()}. Woof may intentionally show a
-            bounded recent history rather than pretending this is every moment you have shared.
+            Story coverage: {activeDashboard.stats.coverage.toLowerCase()}. Woof may intentionally show a bounded recent history rather than pretending this is every moment you have shared.
           </Text>
         </>
-      )}
+      ) : null}
     </ScrollView>
   );
 }
@@ -197,6 +320,31 @@ const styles = StyleSheet.create({
   eyebrow: { color: colors.text.secondary, fontSize: 10, fontWeight: '700', letterSpacing: 1.5 },
   title: { marginTop: 3, color: colors.text.primary, fontSize: 34, fontWeight: '800' },
   subtitle: { marginTop: 8, color: colors.text.secondary, fontSize: 15, lineHeight: 22 },
+  scopeSection: {
+    marginTop: 18,
+    paddingVertical: 14,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: colors.gray[200],
+  },
+  scopeHeadingRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  scopeEyebrow: { color: colors.text.secondary, fontSize: 9, fontWeight: '800', letterSpacing: 1.2 },
+  scopeTitle: { marginTop: 2, color: colors.text.primary, fontSize: 16, fontWeight: '800' },
+  scopeRow: { gap: 8, paddingTop: 10, paddingRight: 18 },
+  scopeChip: {
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: colors.gray[300],
+    backgroundColor: '#ffffff',
+  },
+  scopeChipSelected: { borderColor: colors.primary[300], backgroundColor: colors.primary[100] },
+  scopeChipText: { color: colors.gray[700], fontSize: 13, fontWeight: '700' },
+  scopeChipTextSelected: { color: colors.primary[900] },
+  scopeHint: { marginTop: 8, color: colors.text.secondary, fontSize: 11, lineHeight: 17 },
+  filterError: { marginTop: 6, color: colors.text.secondary, fontSize: 10, lineHeight: 15 },
   noticeCard: {
     marginTop: 18,
     padding: 16,
@@ -208,6 +356,18 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   noticeText: { flex: 1, color: colors.text.secondary, fontSize: 14, lineHeight: 20 },
+  scopeLoadingCard: {
+    minHeight: 84,
+    marginTop: 18,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+  },
+  scopeLoadingText: { color: colors.text.secondary, fontSize: 12 },
   statsCard: {
     marginTop: 20,
     paddingVertical: 18,

--- a/apps/mobile/src/screens/StoryScreen.tsx
+++ b/apps/mobile/src/screens/StoryScreen.tsx
@@ -82,6 +82,8 @@ export default function StoryScreen() {
       setError(null);
     } catch {
       if (requestId !== storyRequestRef.current || scope !== selectedScopeRef.current) return;
+      setDashboard(null);
+      setDashboardScope(null);
       setError('Story is unavailable right now. Your existing memories remain unchanged.');
     } finally {
       if (requestId === storyRequestRef.current && scope === selectedScopeRef.current) {
@@ -106,8 +108,17 @@ export default function StoryScreen() {
       }
     } catch {
       if (requestId !== filterRequestRef.current) return;
+      setFilterPets([]);
+      const currentScope = selectedScopeRef.current;
+      if (currentScope !== 'ALL') {
+        setSelectedScope('ALL');
+        setDashboard(null);
+        setDashboardScope(null);
+        setError(null);
+        void loadStory(false, 'ALL');
+      }
       setFilterError(
-        'Dog filters are unavailable. All-dogs Story still uses server-authorized history.'
+        'Dog filters are unavailable. Story is using the server-authorized all-dogs view.'
       );
     } finally {
       if (requestId === filterRequestRef.current) setFilterLoading(false);

--- a/docs/NATIVE_EXPEDITION_WORLD_V1.md
+++ b/docs/NATIVE_EXPEDITION_WORLD_V1.md
@@ -27,9 +27,9 @@ Those place names, icons, hills, and other scenery are presentation. They do not
 
 Expedition Authority v1 deliberately returns `target: null` and `status: CALIBRATING` for the canonical projection.
 
-Native therefore does **not** invent a fallback target, percentage, completion bar, level threshold, unlock threshold, or aggregate "three of three" meter. Every landmark exists from the beginning. The surface shows the server's bounded contribution total, contributor count, and the viewer's contribution as descriptive evidence only.
+Native therefore does **not** invent a fallback target, percentage, completion bar, level threshold, unlock threshold, or aggregate "three of three" meter. Every landmark exists from the beginning.
 
-A viewer with `myContribution > 0` may see a small **Your mark** treatment. This is binary presentation that a server-issued contribution exists. It is not a proficiency claim, completion claim, reward multiplier, or hidden score.
+The server continues to retain bounded contribution totals for calibration and policy evaluation, but the native world intentionally does **not** display `objective.total` or the viewer's numeric contribution. Communal contributor count may appear once as social presence, never as a threshold. A viewer with `myContribution > 0` may see a small **Your mark** treatment. This is binary presentation that a server-issued contribution exists. It is not a proficiency claim, completion claim, reward multiplier, or hidden score.
 
 The scene geometry is intentionally static with respect to totals. Contribution counts do not enlarge landmarks, brighten the sky, unlock terrain, increase opacity, or otherwise encode an unofficial target.
 
@@ -59,9 +59,11 @@ Recovery remains visible because choosing decompression or stopping can be the u
 
 ## Failure behavior
 
-Global projection, Pack membership, and Pack projection reads fail independently.
+Global projection, Pack membership, Pack projection, and Field Journal reads fail independently.
 
-When authority is unavailable, native shows the last server-confirmed state where appropriate and explicit unavailable copy. It does not reconstruct missing Expedition state from Adventure Trail XP, Social Adventure score, Story, raw activity history, cached route metrics, or client arithmetic.
+A Field Journal refresh failure cannot make a healthy live Expedition look broken. If verified journal pages were already loaded, native may keep showing those pages with a stale-history notice. If no verified journal exists, it leaves the history blank rather than reconstructing it.
+
+When live-world authority is unavailable, native shows the last server-confirmed state where appropriate and explicit unavailable copy. It does not reconstruct missing Expedition state from Adventure Trail XP, Social Adventure score, Story, raw activity history, cached route metrics, or client arithmetic.
 
 ## Relationship to Social Adventure
 
@@ -92,8 +94,8 @@ A later server-authorized archive can turn past seasons into Story artifacts onc
 1. the mobile Expedition API is GET-only;
 2. Global and Pack projections remain server-authored;
 3. Pack requests require a server-confirmed joined Pack and response-Pack identity check;
-4. `CALIBRATING` renders as **no target yet** rather than a client meter;
-5. server totals are displayed but not transformed into progress geometry or completion arithmetic;
+4. `CALIBRATING` renders as no finish line rather than a client meter;
+5. native does not consume `objective.total`, consumes `myContribution` only as binary presence, and allows contributor count only as communal context;
 6. Community links to Expedition;
 7. both guardian and Companion navigation graphs expose the same Expedition screen;
 8. full native type-check and lint stay green;

--- a/docs/NATIVE_SCOPE_CLARITY_V1.md
+++ b/docs/NATIVE_SCOPE_CLARITY_V1.md
@@ -1,0 +1,105 @@
+# Native Scope Clarity v1
+
+## Purpose
+
+Native Woof now has several useful surfaces that intentionally operate at different scopes. This tranche makes those boundaries visible in the product and executable in CI so convenience cannot quietly become authority.
+
+The design goal is not to add more warnings. It is to make the default behavior truthful enough that the user rarely needs one.
+
+## Three scope classes
+
+### Today + Compass
+
+Today + Compass are relationship-scoped dog surfaces.
+
+- Their selected dog must come from fresh authenticated household authority.
+- The selected pet is only a presentation preference. Local selection never grants authority.
+- The client sends the selected `petId` explicitly to the canonical Adventure read.
+- A response for another pet is hidden rather than relabeled.
+- Changing dogs clears transient cross-dog presentation state instead of carrying it forward.
+
+This is the narrowest scope in the native shell because the user is asking about one concrete dog-human relationship.
+
+### Story
+
+Story has a different truthful default.
+
+The canonical all-dogs Story is the signed-in human's authorized household history returned by `GET /story` without a client-selected pet filter. It is not the currently selected Today + Compass relationship and it does not inherit that preference.
+
+A user may narrow Story to one dog. Filter options are discovered from authenticated `GET /households/me`, and the selected `petId` is still re-authorized by the Story service. A local chip therefore narrows a server-authorized view; it does not create access.
+
+Network behavior is intentionally asymmetric:
+
+- failure to discover optional dog filters does not erase or block the canonical all-dogs Story;
+- an old Story response cannot replace a newer selected scope;
+- a response is rendered only for the scope that requested it;
+- failed scoped reads leave that scope unavailable rather than borrowing another dog's Story.
+
+Story remains a read model over canonical source history. This tranche does not add Story mutation authority.
+
+### Skillcraft + Expedition + Field Journal + Community
+
+Skillcraft + Expedition + Field Journal + Community are human-side surfaces. They are useful before a person has a dog and do not require synthetic pet scope.
+
+Companion mode can therefore enter these spaces directly. Presentation mode does not manufacture a pet relationship or unlock pet-specific Today, Compass, or Story.
+
+Expedition has two live cooperative scopes:
+
+- Global, read from canonical Global Expedition authority;
+- a joined Pack, read only after the server catalog confirms `joined: true` and the returned Pack identity matches the requested Pack.
+
+The Field Journal is personal Global history over immutable Expedition receipts. It is not Pack history and it is not reconstructed from the live world, Social Adventure score, Story, route history, or client arithmetic.
+
+## Calm cooperative presentation
+
+The server retains bounded Expedition totals for calibration, but native presentation deliberately does not advertise repeatable personal volume.
+
+Personal Expedition repetition is binary presence. A person either has a server-issued mark for a landmark or does not. Repeating the same qualifying category does not make a larger personal mark in the world or Field Journal.
+
+Communal contributor counts are descriptive context, not a target. There is no client completion percentage, fallback target, progress bar, unlock threshold, rarity ladder, or finish-line arithmetic while authority remains `CALIBRATING`.
+
+Every landmark exists from the beginning. The world can become visually richer without turning a dog's health, mileage, duration, missed days, popularity, or repetition volume into game pressure.
+
+## Independent failure domains
+
+Native reads should preserve the smallest truthful unit of successful authority.
+
+- Story filter discovery can fail while the all-dogs Story remains usable.
+- Global Expedition, Pack catalog, and a selected Pack projection are request-bound so stale responses cannot win after a newer refresh or scope change.
+- A Pack response must identify the Pack that was requested before display.
+- Journal failure does not poison the live world.
+- When a previously verified Journal exists, a refresh failure may continue showing those verified pages with stale-state copy.
+- When no verified Journal exists, history remains blank rather than being guessed from current Expedition data.
+
+The UI may preserve previously loaded server-confirmed data after a transient read failure, but it must describe that state honestly and never synthesize missing authority.
+
+## Petless Companion experience
+
+A person in Companion mode can belong in Woof before they have a dog. The native home therefore leads with human-side places to learn, participate, and meet people rather than presenting an empty or broken pet dashboard.
+
+If their situation changes, switching presentation mode still creates no pet access. Canonical onboarding must resolve a real relationship before dog-specific surfaces open.
+
+## Accessibility and interaction
+
+Scope selectors are real buttons with selected accessibility state, not decorative labels. Touched native scope controls keep at least a 44pt interactive height so the clearer authority model is also practical to use.
+
+## Permanent sentry
+
+`assert-native-scope-clarity.py` fails closed if the product drifts across these boundaries. It is intentionally cross-cutting and runs alongside the more specific First Adventure, Native Expedition World, and Expedition Field Journal contracts.
+
+The dedicated CI lane also compiles all four sentries, installs from the committed lockfile, rejects formatting drift, type-checks the complete mobile client, and lints mobile with zero warnings.
+
+## Non-claims
+
+This tranche does not claim:
+
+- that a local selection grants authorization;
+- that Story's all-dogs view means lifetime-complete history;
+- that Companion mode creates or implies a pet relationship;
+- that Expedition contributor counts are calibrated goals;
+- that Field Journal is a completion system or Story persistence;
+- offline authority;
+- physical-device or TestFlight qualification;
+- production deployment or pilot evidence.
+
+Those remain separate authorities and release gates.


### PR DESCRIPTION
## Summary

Make native scope legible without adding another layer of counters or warning copy.

This tranche separates three intentionally different scope classes:

- **Today + Compass** remain one explicitly selected, server-authorized dog-human relationship.
- **Story** owns its own canonical all-dogs household-history default and can narrow to one authorized dog without inheriting the Today/Compass preference.
- **Skillcraft + Expedition + Field Journal + Community** remain human-side surfaces that are useful without synthetic pet scope.

It also simplifies Expedition presentation so server calibration data does not become a repeat-volume treadmill, and improves the petless Companion starting experience.

## Product changes

### Story

- defaults to canonical `GET /story` without `petId`;
- discovers optional dog filters only from authenticated `/households/me`;
- sends an explicit `petId` only when the user narrows Story;
- ignores stale responses after scope changes;
- never renders a dashboard for a different selected scope;
- fails closed rather than retaining stale same-scope Story after a failed authority read;
- clears stale dog-filter choices if household authority discovery fails and returns to canonical all-dogs scope;
- keeps canonical all-dogs Story usable when optional filter discovery fails;
- does not inherit the Today/Compass relationship-selection preference.

The server continues to re-authorize any explicit Story `petId` through household authority.

### Expedition

- removes repeatable personal-volume presentation from the native world;
- keeps `myContribution` binary as **Your mark**;
- keeps communal contributor presence descriptive rather than target-shaped;
- preserves the no-meter/no-fallback-target boundary while server authority is `CALIBRATING`;
- isolates Field Journal refresh failure from the live Expedition world;
- preserves previously verified Journal pages on transient refresh failure;
- leaves Journal history blank rather than reconstructing it when no verified history is available.

A release self-audit also found and repaired a network race: a failed Pack projection could previously set a truthful error and then have the outer refresh immediately clear it. Pack loads now return an explicit success/stale/error result, whole-screen and Pack reads are generation-bound, and old responses cannot overwrite a newer selected scope.

### Companion

Petless Companion becomes a useful first-class starting surface rather than an empty dog dashboard. It links directly to human-side Expedition, Skillcraft, Packs, Community, Events, and account controls while explicitly preserving the rule that presentation mode does not create pet authority.

## Authority boundary

- Local selection never grants pet access.
- Story pet filters are presentation narrowing over server authorization.
- Companion mode never fabricates a pet relationship.
- Expedition remains GET-only on native.
- Field Journal remains personal, Global-only receipt history.
- No Story mutation, Expedition contribution mutation, client score, completion percentage, fallback target, rarity, streak, or unlock threshold is introduced.

## Qualification

Adds `Native Scope Clarity CI`, `NATIVE_SCOPE_CLARITY_V1.md`, and `assert-native-scope-clarity.py`.

The lane deliberately reruns the modified adjacent contracts:

- Native First Adventure;
- Native Expedition World;
- Expedition Field Journal.

It also compiles all four sentries, installs from the committed lockfile, canonical-formats the touched native surfaces, type-checks the full native client, and lints native with zero warnings.

During qualification, two sentry defects were repaired without weakening authority: the Field Journal stale-history assertion was moved to its actual authority owner, and the First Adventure Companion boundary became whitespace-normalized while requiring the complete semantic sentence.

## Exact-head evidence

Qualified head: `5514829f0bf10b51e6d71201113ee11d6276c1ba`.
Qualified base: `main@92372e4d11dac2e4164794f662c8e2505a93375a`.

**13/13 fresh pull-request workflows passed on that exact head:**

- CI;
- iOS CocoaPods + Xcode Qualification CI;
- iOS Native Artifact Audit CI;
- Native Scope Clarity CI;
- Native First Adventure CI;
- Native Expedition World CI;
- Expedition Field Journal CI;
- Native Skillcraft CI;
- dogOS Mobile Convergence CI;
- dogOS Foundation CI;
- dogOS Security Baseline CI;
- CI Action Runtime Qualification;
- CodeQL.

The Xcode lane resolved CocoaPods, generated and inventoried the production-shaped native workspace, compiled the unsigned **Release iOS Simulator** app successfully, audited the resolved Pods and built app bundle, and uploaded its evidence artifact.

Root CI passed static quality gates, backend tests, browser smoke/accessibility/visual contracts, and API/Web production builds.

At promotion time the PR head remained unchanged, GitHub reported it mergeable, and `main` remained exactly the qualified base SHA. No older-head evidence is being substituted for the final matrix.

This is repository/CI qualification. It does not claim signed-device, TestFlight, production deployment, or pilot evidence.