### PR TITLE
Production promotion authority v1

### DIFF
--- a/.github/scripts/assert-operational-privacy-release.py
+++ b/.github/scripts/assert-operational-privacy-release.py
@@ -119,6 +119,7 @@ require(
     "Enforce deployed API release identity",
     "Verify deployed Web release and API integration",
     "Qualify live staging release and write receipt",
+    "RELEASE_RECEIPT_PATH: ${{ runner.temp }}/woof-staging-release-receipt.json",
     "qualify-live-release.mjs",
     "uses: actions/upload-artifact@v7",
     "name: staging-release-${{ github.sha }}",
@@ -128,9 +129,20 @@ require(
     ".github/workflows/deploy-production.yml",
     "workflow_dispatch:",
     "release_sha:",
+    "actions: read",
     "refs/heads/main",
     'if [[ ! "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]',
     'git merge-base --is-ancestor "${RELEASE_SHA}" refs/remotes/origin/main',
+    "Require exact successful staging release receipt",
+    "/actions/artifacts?name=${artifact_name}",
+    "artifact.workflow_run?.head_branch === 'main'",
+    "artifact.workflow_run?.head_sha === process.env.RELEASE_SHA",
+    "run.conclusion !== 'success'",
+    "run.path !== expectedPath",
+    "gh run download",
+    "receipt.environment !== 'staging'",
+    "receipt.releaseSha !== process.env.RELEASE_SHA",
+    "web-public-origin-provenance",
     "ref: ${{ inputs.release_sha }}",
     '--build-arg WOOF_RELEASE_SHA="${RELEASE_SHA}"',
     "NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ env.RELEASE_SHA }}",
@@ -139,6 +151,7 @@ require(
     "Enforce deployed API release identity",
     "Verify deployed Web release and API integration",
     "Qualify live production release and write receipt",
+    "RELEASE_RECEIPT_PATH: ${{ runner.temp }}/woof-production-release-receipt.json",
     "qualify-live-release.mjs",
     "uses: actions/upload-artifact@v7",
     "name: production-release-${{ env.RELEASE_SHA }}",
@@ -151,5 +164,5 @@ reject(
 )
 
 print(
-    "Operational privacy contract preserves exact release identity, explicit production promotion, stable public Web provenance, live receipts, Web/API provenance, and privacy-closed replay."
+    "Operational privacy contract preserves exact release identity, staging-evidence-gated production promotion, stable public Web provenance, live receipts, Web/API provenance, and privacy-closed replay."
 )

--- a/.github/scripts/assert-operational-privacy-release.py
+++ b/.github/scripts/assert-operational-privacy-release.py
@@ -96,7 +96,8 @@ require(
     "woof-live-release-qualification",
     "api-liveness",
     "api-readiness",
-    "web-release-provenance",
+    "web-deployment-provenance",
+    "web-public-origin-provenance",
     "cors-public-origin",
     "RELEASE_RECEIPT_PATH",
     "--self-test",
@@ -150,5 +151,5 @@ reject(
 )
 
 print(
-    "Operational privacy contract preserves exact release identity, explicit production promotion, live receipts, Web/API provenance, and privacy-closed replay."
+    "Operational privacy contract preserves exact release identity, explicit production promotion, stable public Web provenance, live receipts, Web/API provenance, and privacy-closed replay."
 )

--- a/.github/scripts/assert-operational-privacy-release.py
+++ b/.github/scripts/assert-operational-privacy-release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail closed when release identity or telemetry privacy authority drifts."""
+"""Fail closed when release identity, promotion authority, or telemetry privacy drifts."""
 
 from pathlib import Path
 
@@ -90,24 +90,65 @@ require(
     "EXPECTED_API_URL",
     "--self-test",
 )
+require(
+    ".github/scripts/qualify-live-release.mjs",
+    "qualifyLiveRelease",
+    "woof-live-release-qualification",
+    "api-liveness",
+    "api-readiness",
+    "web-release-provenance",
+    "cors-public-origin",
+    "RELEASE_RECEIPT_PATH",
+    "--self-test",
+)
 
 require(
     "infra/docker/Dockerfile.api",
     "ARG WOOF_RELEASE_SHA=unknown",
     "ENV WOOF_RELEASE_SHA=${WOOF_RELEASE_SHA}",
 )
-for path in [
-    ".github/workflows/deploy-production.yml",
-    ".github/workflows/deploy-staging.yml",
-]:
-    require(
-        path,
-        '--build-arg WOOF_RELEASE_SHA="${GITHUB_SHA}"',
-        "NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ github.sha }}",
-        "NEXT_PUBLIC_SENTRY_REPLAY_ENABLED: 'false'",
-        "Enforce deployed API release identity",
-        "Verify deployed Web release and API integration",
-        "verify-web-deployment-provenance.mjs",
-    )
 
-print("Operational privacy contract preserves exact release identity, Web/API provenance, and privacy-closed replay.")
+require(
+    ".github/workflows/deploy-staging.yml",
+    "branches: [main]",
+    '--build-arg WOOF_RELEASE_SHA="${GITHUB_SHA}"',
+    "NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ github.sha }}",
+    "NEXT_PUBLIC_SENTRY_REPLAY_ENABLED: 'false'",
+    "EXPECTED_WEB_ORIGIN: ${{ vars.WEB_ORIGIN }}",
+    "Enforce deployed API release identity",
+    "Verify deployed Web release and API integration",
+    "Qualify live staging release and write receipt",
+    "qualify-live-release.mjs",
+    "uses: actions/upload-artifact@v7",
+    "name: staging-release-${{ github.sha }}",
+)
+
+require(
+    ".github/workflows/deploy-production.yml",
+    "workflow_dispatch:",
+    "release_sha:",
+    "refs/heads/main",
+    'if [[ ! "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]',
+    'git merge-base --is-ancestor "${RELEASE_SHA}" refs/remotes/origin/main',
+    "ref: ${{ inputs.release_sha }}",
+    '--build-arg WOOF_RELEASE_SHA="${RELEASE_SHA}"',
+    "NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ env.RELEASE_SHA }}",
+    "NEXT_PUBLIC_SENTRY_REPLAY_ENABLED: 'false'",
+    "EXPECTED_WEB_ORIGIN: ${{ vars.WEB_ORIGIN }}",
+    "Enforce deployed API release identity",
+    "Verify deployed Web release and API integration",
+    "Qualify live production release and write receipt",
+    "qualify-live-release.mjs",
+    "uses: actions/upload-artifact@v7",
+    "name: production-release-${{ env.RELEASE_SHA }}",
+)
+reject(
+    ".github/workflows/deploy-production.yml",
+    "branches: [main]",
+    '--build-arg WOOF_RELEASE_SHA="${GITHUB_SHA}"',
+    "NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ github.sha }}",
+)
+
+print(
+    "Operational privacy contract preserves exact release identity, explicit production promotion, live receipts, Web/API provenance, and privacy-closed replay."
+)

--- a/.github/scripts/qualify-live-release.mjs
+++ b/.github/scripts/qualify-live-release.mjs
@@ -85,6 +85,35 @@ function verifyCors(response, expectedWebOrigin) {
   return { allowOrigin, allowCredentials: true };
 }
 
+async function verifyWebSurface({
+  fetchImpl,
+  url,
+  expectedRelease,
+  expectedApiUrl,
+  attempts,
+  delayMs,
+  label,
+}) {
+  const response = await fetchWithRetry(
+    fetchImpl,
+    url,
+    { headers: { Accept: 'text/html', 'Cache-Control': 'no-store' } },
+    attempts,
+    delayMs
+  );
+  const html = await response.text();
+  try {
+    return verifyWebDeploymentProvenance({
+      html,
+      expectedRelease,
+      expectedApiUrl,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${label} provenance failed: ${message}`);
+  }
+}
+
 export async function qualifyLiveRelease({
   environment,
   expectedRelease,
@@ -115,7 +144,10 @@ export async function qualifyLiveRelease({
   const apiUrl = httpsUrl(expectedApiUrl, 'Expected API URL');
   const deploymentUrl = httpsUrl(webDeploymentUrl, 'Web deployment URL');
   const publicWebUrl = httpsUrl(expectedWebOrigin, 'Expected Web origin');
-  if (publicWebUrl.pathname !== '/' || publicWebUrl.origin !== publicWebUrl.toString().replace(/\/$/, '')) {
+  if (
+    publicWebUrl.pathname !== '/' ||
+    publicWebUrl.origin !== publicWebUrl.toString().replace(/\/$/, '')
+  ) {
     throw new Error(`Expected Web origin must be an origin only, received '${expectedWebOrigin}'.`);
   }
 
@@ -161,20 +193,31 @@ export async function qualifyLiveRelease({
     );
   }
 
-  const demoUrl = new URL('/demo', deploymentUrl.origin);
-  const webResponse = await fetchWithRetry(
+  const deploymentDemoUrl = new URL('/demo', deploymentUrl.origin).toString();
+  const publicDemoUrl = new URL('/demo', webOrigin).toString();
+
+  const deploymentWeb = await verifyWebSurface({
     fetchImpl,
-    demoUrl.toString(),
-    { headers: { Accept: 'text/html', 'Cache-Control': 'no-store' } },
-    attempts,
-    delayMs
-  );
-  const html = await webResponse.text();
-  const web = verifyWebDeploymentProvenance({
-    html,
+    url: deploymentDemoUrl,
     expectedRelease: release,
     expectedApiUrl,
+    attempts,
+    delayMs,
+    label: 'Web deployment URL',
   });
+
+  const publicWeb =
+    deploymentUrl.origin === webOrigin
+      ? deploymentWeb
+      : await verifyWebSurface({
+          fetchImpl,
+          url: publicDemoUrl,
+          expectedRelease: release,
+          expectedApiUrl,
+          attempts,
+          delayMs,
+          label: 'Public Web origin',
+        });
 
   return {
     schemaVersion: 1,
@@ -192,15 +235,17 @@ export async function qualifyLiveRelease({
       deploymentUrl: deploymentUrl.origin,
       publicOrigin: webOrigin,
       route: '/demo',
-      release: web.release,
-      apiOrigin: web.apiOrigin,
+      deploymentRelease: deploymentWeb.release,
+      publicRelease: publicWeb.release,
+      apiOrigin: publicWeb.apiOrigin,
     },
     cors,
     checks: [
       'api-liveness',
       'api-readiness',
       'api-release-identity',
-      'web-release-provenance',
+      'web-deployment-provenance',
+      'web-public-origin-provenance',
       'web-api-origin',
       'cors-public-origin',
       'cors-credentials',
@@ -224,9 +269,14 @@ async function selfTest() {
     'access-control-allow-origin': webOrigin,
     'access-control-allow-credentials': 'true',
   };
-  const html = `<html><head><meta name="woof-release" content="${release}"><meta name="woof-api-origin" content="${api}"></head></html>`;
+  const goodHtml = `<html><head><meta name="woof-release" content="${release}"><meta name="woof-api-origin" content="${api}"></head></html>`;
 
-  const buildFetch = ({ liveRelease = release, readyStatus = 'ready', allowOrigin = webOrigin } = {}) =>
+  const buildFetch = ({
+    liveRelease = release,
+    readyStatus = 'ready',
+    allowOrigin = webOrigin,
+    publicRelease = release,
+  } = {}) =>
     async (url) => {
       if (url.endsWith('/ops/health/live')) {
         return response(
@@ -242,7 +292,10 @@ async function selfTest() {
         });
       }
       if (url === `${webDeployment}/demo`) {
-        return response(html, { contentType: 'text/html' });
+        return response(goodHtml, { contentType: 'text/html' });
+      }
+      if (url === `${webOrigin}/demo`) {
+        return response(goodHtml.replace(release, publicRelease), { contentType: 'text/html' });
       }
       return response({ error: 'not found' }, { status: 404 });
     };
@@ -259,7 +312,11 @@ async function selfTest() {
   };
 
   const receipt = await qualifyLiveRelease({ ...input, fetchImpl: buildFetch() });
-  if (receipt.releaseSha !== release || receipt.api.databaseStatus !== 'ready') {
+  if (
+    receipt.releaseSha !== release ||
+    receipt.api.databaseStatus !== 'ready' ||
+    receipt.web.publicRelease !== release
+  ) {
     throw new Error('Self-test failed to produce the expected qualification receipt.');
   }
 
@@ -267,6 +324,7 @@ async function selfTest() {
     ['wrong API release', buildFetch({ liveRelease: 'f'.repeat(40) })],
     ['database not ready', buildFetch({ readyStatus: 'not_ready' })],
     ['wrong CORS origin', buildFetch({ allowOrigin: 'https://wrong.example.com' })],
+    ['stale public Web alias', buildFetch({ publicRelease: 'f'.repeat(40) })],
   ]) {
     let rejected = false;
     try {

--- a/.github/scripts/qualify-live-release.mjs
+++ b/.github/scripts/qualify-live-release.mjs
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { verifyWebDeploymentProvenance } from './verify-web-deployment-provenance.mjs';
+
+const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const ALLOWED_ENVIRONMENTS = new Set(['staging', 'production']);
+
+function exactRelease(value) {
+  const normalized = value.trim().toLowerCase();
+  if (!GIT_SHA_PATTERN.test(normalized)) {
+    throw new Error(`Expected release must be one exact 40-hex Git SHA, received '${value}'.`);
+  }
+  return normalized;
+}
+
+function httpsUrl(value, label) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${label} is invalid: '${value}'.`);
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`${label} must use HTTPS, received '${value}'.`);
+  }
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+    throw new Error(`${label} must not contain credentials, query parameters, or fragments.`);
+  }
+  return parsed;
+}
+
+function apiEndpoint(apiUrl, suffix) {
+  const endpoint = new URL(apiUrl.toString());
+  endpoint.pathname = `${endpoint.pathname.replace(/\/$/, '')}${suffix}`;
+  return endpoint.toString();
+}
+
+async function sleep(ms) {
+  if (ms > 0) await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithRetry(fetchImpl, url, options, attempts, delayMs) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetchImpl(url, options);
+      if (response.ok) return response;
+      lastError = new Error(`${url} returned HTTP ${response.status}.`);
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+    }
+
+    if (attempt < attempts) await sleep(delayMs);
+  }
+  throw lastError ?? new Error(`Unable to fetch ${url}.`);
+}
+
+async function jsonResponse(response, label) {
+  try {
+    return await response.json();
+  } catch {
+    throw new Error(`${label} did not return valid JSON.`);
+  }
+}
+
+function verifyCors(response, expectedWebOrigin) {
+  const allowOrigin = response.headers.get('access-control-allow-origin');
+  const allowCredentials = response.headers.get('access-control-allow-credentials');
+
+  if (allowOrigin !== expectedWebOrigin) {
+    throw new Error(
+      `Production CORS mismatch: expected '${expectedWebOrigin}', received '${allowOrigin}'.`
+    );
+  }
+  if (allowCredentials !== 'true') {
+    throw new Error(
+      `Production CORS credentials mismatch: expected 'true', received '${allowCredentials}'.`
+    );
+  }
+
+  return { allowOrigin, allowCredentials: true };
+}
+
+export async function qualifyLiveRelease({
+  environment,
+  expectedRelease,
+  expectedApiUrl,
+  webDeploymentUrl,
+  expectedWebOrigin,
+  fetchImpl = globalThis.fetch,
+  attempts = 8,
+  delayMs = 3000,
+  now = () => new Date(),
+}) {
+  if (!ALLOWED_ENVIRONMENTS.has(environment)) {
+    throw new Error(
+      `Environment must be one of ${[...ALLOWED_ENVIRONMENTS].join(', ')}, received '${environment}'.`
+    );
+  }
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('A fetch implementation is required.');
+  }
+  if (!Number.isInteger(attempts) || attempts < 1 || attempts > 20) {
+    throw new Error(`Attempts must be an integer from 1 to 20, received '${attempts}'.`);
+  }
+  if (!Number.isInteger(delayMs) || delayMs < 0 || delayMs > 30000) {
+    throw new Error(`Retry delay must be an integer from 0 to 30000 ms, received '${delayMs}'.`);
+  }
+
+  const release = exactRelease(expectedRelease);
+  const apiUrl = httpsUrl(expectedApiUrl, 'Expected API URL');
+  const deploymentUrl = httpsUrl(webDeploymentUrl, 'Web deployment URL');
+  const publicWebUrl = httpsUrl(expectedWebOrigin, 'Expected Web origin');
+  if (publicWebUrl.pathname !== '/' || publicWebUrl.origin !== publicWebUrl.toString().replace(/\/$/, '')) {
+    throw new Error(`Expected Web origin must be an origin only, received '${expectedWebOrigin}'.`);
+  }
+
+  const webOrigin = publicWebUrl.origin;
+  const requestOptions = {
+    headers: {
+      Accept: 'application/json',
+      Origin: webOrigin,
+      'Cache-Control': 'no-store',
+    },
+  };
+
+  const liveResponse = await fetchWithRetry(
+    fetchImpl,
+    apiEndpoint(apiUrl, '/ops/health/live'),
+    requestOptions,
+    attempts,
+    delayMs
+  );
+  const cors = verifyCors(liveResponse, webOrigin);
+  const live = await jsonResponse(liveResponse, 'API liveness');
+  if (live.status !== 'live' || live.release !== release) {
+    throw new Error(
+      `API liveness mismatch: expected status=live release=${release}, received status=${live.status} release=${live.release}.`
+    );
+  }
+
+  const readyResponse = await fetchWithRetry(
+    fetchImpl,
+    apiEndpoint(apiUrl, '/ops/health/ready'),
+    requestOptions,
+    attempts,
+    delayMs
+  );
+  const ready = await jsonResponse(readyResponse, 'API readiness');
+  if (
+    ready.status !== 'ready' ||
+    ready.release !== release ||
+    ready.database?.status !== 'ready'
+  ) {
+    throw new Error(
+      `API readiness mismatch: expected ready database and release ${release}, received status=${ready.status} database=${ready.database?.status} release=${ready.release}.`
+    );
+  }
+
+  const demoUrl = new URL('/demo', deploymentUrl.origin);
+  const webResponse = await fetchWithRetry(
+    fetchImpl,
+    demoUrl.toString(),
+    { headers: { Accept: 'text/html', 'Cache-Control': 'no-store' } },
+    attempts,
+    delayMs
+  );
+  const html = await webResponse.text();
+  const web = verifyWebDeploymentProvenance({
+    html,
+    expectedRelease: release,
+    expectedApiUrl,
+  });
+
+  return {
+    schemaVersion: 1,
+    kind: 'woof-live-release-qualification',
+    environment,
+    qualifiedAt: now().toISOString(),
+    releaseSha: release,
+    api: {
+      baseUrl: expectedApiUrl,
+      liveStatus: live.status,
+      readyStatus: ready.status,
+      databaseStatus: ready.database.status,
+    },
+    web: {
+      deploymentUrl: deploymentUrl.origin,
+      publicOrigin: webOrigin,
+      route: '/demo',
+      release: web.release,
+      apiOrigin: web.apiOrigin,
+    },
+    cors,
+    checks: [
+      'api-liveness',
+      'api-readiness',
+      'api-release-identity',
+      'web-release-provenance',
+      'web-api-origin',
+      'cors-public-origin',
+      'cors-credentials',
+    ],
+  };
+}
+
+function response(body, { status = 200, headers = {}, contentType = 'application/json' } = {}) {
+  return new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+    status,
+    headers: { 'content-type': contentType, ...headers },
+  });
+}
+
+async function selfTest() {
+  const release = '0123456789abcdef0123456789abcdef01234567';
+  const api = 'https://api.example.com/api/v1';
+  const webDeployment = 'https://deployment.example.com';
+  const webOrigin = 'https://www.example.com';
+  const corsHeaders = {
+    'access-control-allow-origin': webOrigin,
+    'access-control-allow-credentials': 'true',
+  };
+  const html = `<html><head><meta name="woof-release" content="${release}"><meta name="woof-api-origin" content="${api}"></head></html>`;
+
+  const buildFetch = ({ liveRelease = release, readyStatus = 'ready', allowOrigin = webOrigin } = {}) =>
+    async (url) => {
+      if (url.endsWith('/ops/health/live')) {
+        return response(
+          { status: 'live', release: liveRelease },
+          { headers: { ...corsHeaders, 'access-control-allow-origin': allowOrigin } }
+        );
+      }
+      if (url.endsWith('/ops/health/ready')) {
+        return response({
+          status: readyStatus,
+          release,
+          database: { status: readyStatus === 'ready' ? 'ready' : 'unavailable' },
+        });
+      }
+      if (url === `${webDeployment}/demo`) {
+        return response(html, { contentType: 'text/html' });
+      }
+      return response({ error: 'not found' }, { status: 404 });
+    };
+
+  const input = {
+    environment: 'staging',
+    expectedRelease: release,
+    expectedApiUrl: api,
+    webDeploymentUrl: webDeployment,
+    expectedWebOrigin: webOrigin,
+    attempts: 1,
+    delayMs: 0,
+    now: () => new Date('2026-09-11T00:00:00.000Z'),
+  };
+
+  const receipt = await qualifyLiveRelease({ ...input, fetchImpl: buildFetch() });
+  if (receipt.releaseSha !== release || receipt.api.databaseStatus !== 'ready') {
+    throw new Error('Self-test failed to produce the expected qualification receipt.');
+  }
+
+  for (const [label, fetchImpl] of [
+    ['wrong API release', buildFetch({ liveRelease: 'f'.repeat(40) })],
+    ['database not ready', buildFetch({ readyStatus: 'not_ready' })],
+    ['wrong CORS origin', buildFetch({ allowOrigin: 'https://wrong.example.com' })],
+  ]) {
+    let rejected = false;
+    try {
+      await qualifyLiveRelease({ ...input, fetchImpl });
+    } catch {
+      rejected = true;
+    }
+    if (!rejected) throw new Error(`Self-test failed to reject ${label}.`);
+  }
+
+  let rejectedInsecure = false;
+  try {
+    await qualifyLiveRelease({
+      ...input,
+      expectedApiUrl: 'http://api.example.com/api/v1',
+      fetchImpl: buildFetch(),
+    });
+  } catch {
+    rejectedInsecure = true;
+  }
+  if (!rejectedInsecure) throw new Error('Self-test failed to reject insecure API URL.');
+
+  console.log('Live release qualification self-test passed.');
+}
+
+async function main() {
+  if (process.argv.includes('--self-test')) {
+    await selfTest();
+    return;
+  }
+
+  const receipt = await qualifyLiveRelease({
+    environment: process.env.WOOF_ENVIRONMENT ?? '',
+    expectedRelease: process.env.EXPECTED_RELEASE ?? '',
+    expectedApiUrl: process.env.EXPECTED_API_URL ?? '',
+    webDeploymentUrl: process.env.WEB_URL ?? '',
+    expectedWebOrigin: process.env.EXPECTED_WEB_ORIGIN ?? '',
+  });
+
+  const receiptPath = process.env.RELEASE_RECEIPT_PATH;
+  if (receiptPath) {
+    await mkdir(dirname(receiptPath), { recursive: true });
+    await writeFile(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+    console.log(`Wrote privacy-safe live release receipt to ${receiptPath}.`);
+  }
+
+  console.log(
+    `Qualified ${receipt.environment} release ${receipt.releaseSha} at ${receipt.web.publicOrigin}.`
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -151,7 +151,6 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
       EXPECTED_API_URL: https://woof-api-prod.fly.dev/api/v1
       EXPECTED_WEB_ORIGIN: ${{ vars.WEB_ORIGIN }}
-      RELEASE_RECEIPT_PATH: ${{ runner.temp }}/woof-production-release-receipt.json
     steps:
       - uses: actions/checkout@v7
         with:
@@ -214,13 +213,14 @@ jobs:
           WOOF_ENVIRONMENT: production
           WEB_URL: ${{ steps.deploy_web.outputs.url }}
           EXPECTED_RELEASE: ${{ env.RELEASE_SHA }}
+          RELEASE_RECEIPT_PATH: ${{ runner.temp }}/woof-production-release-receipt.json
         run: node .github/scripts/qualify-live-release.mjs
 
       - name: Retain production release receipt
         uses: actions/upload-artifact@v7
         with:
           name: production-release-${{ env.RELEASE_SHA }}
-          path: ${{ env.RELEASE_RECEIPT_PATH }}
+          path: ${{ runner.temp }}/woof-production-release-receipt.json
           if-no-files-found: error
           retention-days: 90
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: deploy-production
@@ -56,6 +57,131 @@ jobs:
           fi
 
           echo "Selected canonical main release ${RELEASE_SHA}."
+
+      - name: Require exact successful staging release receipt
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_name="staging-release-${RELEASE_SHA}"
+          artifacts_json="${RUNNER_TEMP}/staging-artifacts.json"
+          run_json="${RUNNER_TEMP}/staging-run.json"
+          receipt_dir="${RUNNER_TEMP}/staging-release-receipt"
+
+          gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "/repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${artifact_name}&per_page=100" \
+            > "${artifacts_json}"
+
+          artifact_meta=$(node - <<'NODE'
+          const fs = require('node:fs');
+          const data = JSON.parse(
+            fs.readFileSync(`${process.env.RUNNER_TEMP}/staging-artifacts.json`, 'utf8')
+          );
+          const expectedName = `staging-release-${process.env.RELEASE_SHA}`;
+          const candidates = (data.artifacts ?? [])
+            .filter(
+              (artifact) =>
+                artifact.name === expectedName &&
+                artifact.expired === false &&
+                artifact.size_in_bytes > 0 &&
+                artifact.workflow_run?.head_branch === 'main' &&
+                artifact.workflow_run?.head_sha === process.env.RELEASE_SHA
+            )
+            .sort((left, right) => new Date(right.created_at) - new Date(left.created_at));
+
+          if (candidates.length === 0) {
+            throw new Error(
+              `No non-expired staging receipt artifact exists for exact release ${process.env.RELEASE_SHA}.`
+            );
+          }
+
+          const artifact = candidates[0];
+          process.stdout.write(`${artifact.id}:${artifact.workflow_run.id}`);
+          NODE
+          )
+
+          artifact_id="${artifact_meta%%:*}"
+          staging_run_id="${artifact_meta##*:}"
+
+          gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${staging_run_id}" \
+            > "${run_json}"
+
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const run = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/staging-run.json`, 'utf8'));
+          const expected = process.env.RELEASE_SHA;
+          const expectedPath = '.github/workflows/deploy-staging.yml';
+
+          if (
+            run.conclusion !== 'success' ||
+            run.event !== 'push' ||
+            run.head_branch !== 'main' ||
+            run.head_sha !== expected ||
+            run.path !== expectedPath
+          ) {
+            throw new Error(
+              `Staging evidence mismatch: expected successful ${expectedPath} push on main at ${expected}; ` +
+                `received conclusion=${run.conclusion} event=${run.event} branch=${run.head_branch} ` +
+                `sha=${run.head_sha} path=${run.path}.`
+            );
+          }
+          NODE
+
+          rm -rf "${receipt_dir}"
+          gh run download "${staging_run_id}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --name "${artifact_name}" \
+            --dir "${receipt_dir}"
+
+          ARTIFACT_ID="${artifact_id}" STAGING_RUN_ID="${staging_run_id}" node - <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const receiptPath = path.join(
+            process.env.RUNNER_TEMP,
+            'staging-release-receipt',
+            'woof-staging-release-receipt.json'
+          );
+          if (!fs.existsSync(receiptPath)) {
+            throw new Error(`Staging receipt payload is missing at ${receiptPath}.`);
+          }
+
+          const receipt = JSON.parse(fs.readFileSync(receiptPath, 'utf8'));
+          const requiredChecks = new Set([
+            'api-liveness',
+            'api-readiness',
+            'api-release-identity',
+            'web-deployment-provenance',
+            'web-public-origin-provenance',
+            'web-api-origin',
+            'cors-public-origin',
+            'cors-credentials',
+          ]);
+          const actualChecks = new Set(receipt.checks ?? []);
+
+          if (
+            receipt.schemaVersion !== 1 ||
+            receipt.kind !== 'woof-live-release-qualification' ||
+            receipt.environment !== 'staging' ||
+            receipt.releaseSha !== process.env.RELEASE_SHA ||
+            receipt.api?.liveStatus !== 'live' ||
+            receipt.api?.readyStatus !== 'ready' ||
+            receipt.api?.databaseStatus !== 'ready' ||
+            receipt.web?.deploymentRelease !== process.env.RELEASE_SHA ||
+            receipt.web?.publicRelease !== process.env.RELEASE_SHA ||
+            receipt.cors?.allowCredentials !== true ||
+            [...requiredChecks].some((check) => !actualChecks.has(check))
+          ) {
+            throw new Error(
+              `Staging receipt failed promotion authority for ${process.env.RELEASE_SHA}.`
+            );
+          }
+
+          console.log(
+            `Accepted staging receipt artifact ${process.env.ARTIFACT_ID} from run ${process.env.STAGING_RUN_ID} for ${process.env.RELEASE_SHA}.`
+          );
+          NODE
 
   deploy-api-production:
     name: Deploy API to Production

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,9 +1,12 @@
 name: Deploy to Production
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Exact 40-hex main commit SHA already qualified in staging
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,16 +15,60 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+env:
+  RELEASE_SHA: ${{ inputs.release_sha }}
+
 jobs:
+  select-release:
+    name: Validate production release candidate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Require exact canonical-main release SHA
+        run: |
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error title=Non-canonical workflow source::Production promotion must be dispatched from main."
+            exit 1
+          fi
+          if [[ ! "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=Invalid release SHA::release_sha must be one exact lowercase 40-hex Git SHA."
+            exit 1
+          fi
+
+          git fetch --no-tags origin main
+          if ! git cat-file -e "${RELEASE_SHA}^{commit}" 2>/dev/null; then
+            echo "::error title=Unknown release SHA::${RELEASE_SHA} is not available in repository history."
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "${RELEASE_SHA}" refs/remotes/origin/main; then
+            echo "::error title=Release is outside canonical main::${RELEASE_SHA} is not an ancestor of origin/main."
+            exit 1
+          fi
+
+          resolved=$(git rev-parse "${RELEASE_SHA}^{commit}")
+          if [[ "${resolved}" != "${RELEASE_SHA}" ]]; then
+            echo "::error title=Release identity drift::Expected ${RELEASE_SHA}, resolved ${resolved}."
+            exit 1
+          fi
+
+          echo "Selected canonical main release ${RELEASE_SHA}."
+
   deploy-api-production:
     name: Deploy API to Production
     runs-on: ubuntu-latest
     environment: production
+    needs: select-release
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_sha }}
 
       - name: Validate production API deployment credentials
         run: |
@@ -41,7 +88,7 @@ jobs:
           --remote-only
           --app woof-api-prod
           --config apps/api/fly.toml
-          --build-arg WOOF_RELEASE_SHA="${GITHUB_SHA}"
+          --build-arg WOOF_RELEASE_SHA="${RELEASE_SHA}"
 
       - name: Capture liveness and readiness evidence
         id: release_bodies
@@ -65,7 +112,7 @@ jobs:
           READY_BODY: ${{ steps.release_bodies.outputs.ready }}
         run: |
           node - <<'NODE'
-          const expected = process.env.GITHUB_SHA;
+          const expected = process.env.RELEASE_SHA;
           for (const [name, raw] of Object.entries({ live: process.env.LIVE_BODY, ready: process.env.READY_BODY })) {
             const parsed = JSON.parse(raw);
             if (parsed.release !== expected) {
@@ -85,8 +132,8 @@ jobs:
             exit 0
           fi
 
-          payload=$(printf '{"text":"Woof production API deployment: %s (%s @ %.12s)"}' \
-            "${DEPLOYMENT_STATUS}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}")
+          payload=$(printf '{"text":"Woof production API deployment: %s (promoted %.12s)"}' \
+            "${DEPLOYMENT_STATUS}" "${RELEASE_SHA}")
           curl --fail --silent --show-error \
             -H 'Content-Type: application/json' \
             --data "${payload}" \
@@ -96,26 +143,34 @@ jobs:
     name: Deploy Web to Production
     runs-on: ubuntu-latest
     environment: production
-    needs: deploy-api-production
+    needs: [select-release, deploy-api-production]
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
       EXPECTED_API_URL: https://woof-api-prod.fly.dev/api/v1
+      EXPECTED_WEB_ORIGIN: ${{ vars.WEB_ORIGIN }}
+      RELEASE_RECEIPT_PATH: ${{ runner.temp }}/woof-production-release-receipt.json
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_sha }}
 
-      - name: Validate production Web deployment credentials
+      - name: Validate production Web deployment authority
         run: |
           missing=0
-          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID EXPECTED_WEB_ORIGIN; do
             if [[ -z "${!name}" ]]; then
-              echo "::error title=Missing production secret::${name} is not configured for the production environment."
+              echo "::error title=Missing production authority::${name} is not configured for the production environment."
               missing=1
             fi
           done
           if [[ "${missing}" -ne 0 ]]; then
+            exit 1
+          fi
+          if [[ ! "${EXPECTED_WEB_ORIGIN}" =~ ^https://[^/]+/?$ ]]; then
+            echo "::error title=Invalid production Web origin::WEB_ORIGIN must be one HTTPS origin without a path, query, or fragment."
             exit 1
           fi
 
@@ -131,7 +186,7 @@ jobs:
         working-directory: apps/web
         env:
           NEXT_PUBLIC_API_URL: ${{ env.EXPECTED_API_URL }}
-          NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ github.sha }}
+          NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ env.RELEASE_SHA }}
           NEXT_PUBLIC_SENTRY_REPLAY_ENABLED: 'false'
 
       - name: Deploy to Vercel
@@ -148,11 +203,26 @@ jobs:
       - name: Verify deployed Web release and API integration
         env:
           WEB_URL: ${{ steps.deploy_web.outputs.url }}
-          EXPECTED_RELEASE: ${{ github.sha }}
+          EXPECTED_RELEASE: ${{ env.RELEASE_SHA }}
         run: |
           html=$(curl --fail --silent --show-error --location --retry 8 --retry-all-errors --retry-delay 3 \
             "${WEB_URL}/demo")
           WEB_HTML="$html" node .github/scripts/verify-web-deployment-provenance.mjs
+
+      - name: Qualify live production release and write receipt
+        env:
+          WOOF_ENVIRONMENT: production
+          WEB_URL: ${{ steps.deploy_web.outputs.url }}
+          EXPECTED_RELEASE: ${{ env.RELEASE_SHA }}
+        run: node .github/scripts/qualify-live-release.mjs
+
+      - name: Retain production release receipt
+        uses: actions/upload-artifact@v7
+        with:
+          name: production-release-${{ env.RELEASE_SHA }}
+          path: ${{ env.RELEASE_RECEIPT_PATH }}
+          if-no-files-found: error
+          retention-days: 90
 
       - name: Notify production Web deployment when configured
         if: ${{ always() }}
@@ -165,8 +235,8 @@ jobs:
             exit 0
           fi
 
-          payload=$(printf '{"text":"Woof production Web deployment: %s (%s @ %.12s)"}' \
-            "${DEPLOYMENT_STATUS}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}")
+          payload=$(printf '{"text":"Woof production Web deployment: %s (promoted %.12s)"}' \
+            "${DEPLOYMENT_STATUS}" "${RELEASE_SHA}")
           curl --fail --silent --show-error \
             -H 'Content-Type: application/json' \
             --data "${payload}" \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -2,7 +2,7 @@ name: Deploy to Staging
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
 
 permissions:
   contents: read
@@ -82,19 +82,25 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       EXPECTED_API_URL: https://woof-api-staging.fly.dev/api/v1
+      EXPECTED_WEB_ORIGIN: ${{ vars.WEB_ORIGIN }}
+      RELEASE_RECEIPT_PATH: ${{ runner.temp }}/woof-staging-release-receipt.json
     steps:
       - uses: actions/checkout@v7
 
-      - name: Validate staging Web deployment credentials
+      - name: Validate staging Web deployment authority
         run: |
           missing=0
-          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID EXPECTED_WEB_ORIGIN; do
             if [[ -z "${!name}" ]]; then
-              echo "::error title=Missing staging secret::${name} is not configured for the staging environment."
+              echo "::error title=Missing staging authority::${name} is not configured for the staging environment."
               missing=1
             fi
           done
           if [[ "${missing}" -ne 0 ]]; then
+            exit 1
+          fi
+          if [[ ! "${EXPECTED_WEB_ORIGIN}" =~ ^https://[^/]+/?$ ]]; then
+            echo "::error title=Invalid staging Web origin::WEB_ORIGIN must be one HTTPS origin without a path, query, or fragment."
             exit 1
           fi
 
@@ -132,3 +138,18 @@ jobs:
           html=$(curl --fail --silent --show-error --location --retry 8 --retry-all-errors --retry-delay 3 \
             "${WEB_URL}/demo")
           WEB_HTML="$html" node .github/scripts/verify-web-deployment-provenance.mjs
+
+      - name: Qualify live staging release and write receipt
+        env:
+          WOOF_ENVIRONMENT: staging
+          WEB_URL: ${{ steps.deploy_web.outputs.url }}
+          EXPECTED_RELEASE: ${{ github.sha }}
+        run: node .github/scripts/qualify-live-release.mjs
+
+      - name: Retain staging release receipt
+        uses: actions/upload-artifact@v7
+        with:
+          name: staging-release-${{ github.sha }}
+          path: ${{ env.RELEASE_RECEIPT_PATH }}
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -83,7 +83,6 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       EXPECTED_API_URL: https://woof-api-staging.fly.dev/api/v1
       EXPECTED_WEB_ORIGIN: ${{ vars.WEB_ORIGIN }}
-      RELEASE_RECEIPT_PATH: ${{ runner.temp }}/woof-staging-release-receipt.json
     steps:
       - uses: actions/checkout@v7
 
@@ -144,12 +143,13 @@ jobs:
           WOOF_ENVIRONMENT: staging
           WEB_URL: ${{ steps.deploy_web.outputs.url }}
           EXPECTED_RELEASE: ${{ github.sha }}
+          RELEASE_RECEIPT_PATH: ${{ runner.temp }}/woof-staging-release-receipt.json
         run: node .github/scripts/qualify-live-release.mjs
 
       - name: Retain staging release receipt
         uses: actions/upload-artifact@v7
         with:
           name: staging-release-${{ github.sha }}
-          path: ${{ env.RELEASE_RECEIPT_PATH }}
+          path: ${{ runner.temp }}/woof-staging-release-receipt.json
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/dogos-operational-privacy-ci.yml
+++ b/.github/workflows/dogos-operational-privacy-ci.yml
@@ -18,6 +18,8 @@ on:
       - '.github/workflows/deploy-staging.yml'
       - '.github/scripts/assert-operational-privacy-release.py'
       - '.github/scripts/verify-web-deployment-provenance.mjs'
+      - '.github/scripts/qualify-live-release.mjs'
+      - 'docs/operations/PRODUCTION_PROMOTION_AUTHORITY_V1.md'
       - '.github/workflows/dogos-operational-privacy-ci.yml'
 
 permissions:
@@ -35,7 +37,7 @@ env:
 
 jobs:
   qualify:
-    name: Release identity + telemetry privacy + Web/API provenance qualification
+    name: Release identity + promotion authority + telemetry privacy + Web/API provenance
     runs-on: ubuntu-24.04
 
     steps:
@@ -72,9 +74,11 @@ jobs:
           apps/web/src/lib/observability/sentry-policy.ts
           apps/web/src/lib/observability/sentry-policy.test.ts
           .github/scripts/verify-web-deployment-provenance.mjs
+          .github/scripts/qualify-live-release.mjs
           .github/workflows/deploy-production.yml
           .github/workflows/deploy-staging.yml
           .github/workflows/dogos-operational-privacy-ci.yml
+          docs/operations/PRODUCTION_PROMOTION_AUTHORITY_V1.md
 
       - name: Lint API operational privacy surface
         run: >-
@@ -94,11 +98,13 @@ jobs:
           src/lib/observability/sentry-policy.ts
           src/lib/observability/sentry-policy.test.ts
 
-      - name: Validate source contracts and deployment verifier
+      - name: Validate source contracts and deployment verifiers
         run: |
           python -m py_compile .github/scripts/assert-operational-privacy-release.py
           node --check .github/scripts/verify-web-deployment-provenance.mjs
+          node --check .github/scripts/qualify-live-release.mjs
           node .github/scripts/verify-web-deployment-provenance.mjs --self-test
+          node .github/scripts/qualify-live-release.mjs --self-test
 
       - name: Enforce source contract
         run: python .github/scripts/assert-operational-privacy-release.py

--- a/docs/operations/PRODUCTION_PROMOTION_AUTHORITY_V1.md
+++ b/docs/operations/PRODUCTION_PROMOTION_AUTHORITY_V1.md
@@ -47,12 +47,12 @@ The workflow:
 - deploys the API with `WOOF_RELEASE_SHA` equal to the exact `github.sha`;
 - requires API liveness and database-backed readiness to report that same release;
 - builds Web with the same release identity and the canonical staging API URL;
-- verifies public Web provenance markers;
+- verifies both the transient Vercel deployment and the stable public Web origin expose that exact release and API provenance;
 - verifies the configured public Web origin is actually admitted by API CORS;
 - writes a privacy-safe `woof-live-release-qualification` receipt; and
 - retains that receipt as `staging-release-<sha>`.
 
-Staging therefore answers: **did the exact merged commit become a coherent live Web/API release?**
+Staging therefore answers: **did the exact merged commit become a coherent live Web/API release at the public staging boundary?**
 
 It does not prove production, device distribution, recovery, or user value.
 
@@ -90,7 +90,7 @@ Public environment variable:
 
 - `WEB_ORIGIN` — one stable HTTPS origin only, for example `https://staging.example.com` or `https://www.example.com`.
 
-`WEB_ORIGIN` is not inferred from a transient Vercel deployment URL. It represents the public origin that the API is expected to admit through CORS.
+`WEB_ORIGIN` is not inferred from a transient Vercel deployment URL. It represents the stable public alias that must expose the selected release and that the API must admit through CORS.
 
 Production should also use GitHub environment protection / reviewers where available. Repository code can require the `production` environment, but repository code cannot prove that an administrator configured reviewers or secret scope correctly.
 
@@ -103,8 +103,10 @@ It verifies:
 - API `/ops/health/live` returns `status=live` and the exact expected release;
 - API `/ops/health/ready` returns `status=ready`, database `status=ready`, and the same release;
 - the API admits the configured public Web origin through credentialed CORS;
-- the deployed Web `/demo` page exposes the exact release SHA; and
-- the deployed Web artifact points at the intended API base URL.
+- the transient Vercel deployment `/demo` page exposes the exact release SHA and intended API base URL; and
+- the stable public Web origin `/demo` page exposes the same exact release SHA and intended API base URL.
+
+This deliberately catches the case where deployment succeeds but the stable alias still points at an older artifact.
 
 The retained receipt contains only low-cardinality public operational facts:
 
@@ -112,7 +114,8 @@ The retained receipt contains only low-cardinality public operational facts:
 - qualification timestamp;
 - exact release SHA;
 - public API base URL;
-- public Web deployment/origin;
+- transient Web deployment origin;
+- stable public Web origin;
 - health status classes;
 - CORS authority result; and
 - names of checks performed.
@@ -140,11 +143,11 @@ Still required before public beta:
 
 1. Merge only a fully qualified release candidate to `main`.
 2. Confirm `Deploy to Staging` succeeds for that exact SHA.
-3. Inspect the retained `staging-release-<sha>` receipt.
-4. Resolve any staging or provider discrepancy before production promotion.
+3. Inspect the retained `staging-release-<sha>` receipt and confirm both deployment and stable public origins report the same SHA.
+4. Resolve any staging, alias, CORS, or provider discrepancy before production promotion.
 5. Dispatch `Deploy to Production` from `main` and paste the exact staged 40-hex SHA into `release_sha`.
 6. Complete any configured production-environment approval.
-7. Confirm API migration, liveness, readiness, Web provenance, CORS, and live qualification succeed.
+7. Confirm API migration, liveness, readiness, deployment provenance, stable-origin provenance, CORS, and live qualification succeed.
 8. Retain and inspect `production-release-<sha>`.
 9. Continue with authenticated live black-box and operational drills. Do not treat the receipt alone as full public-beta evidence.
 

--- a/docs/operations/PRODUCTION_PROMOTION_AUTHORITY_V1.md
+++ b/docs/operations/PRODUCTION_PROMOTION_AUTHORITY_V1.md
@@ -26,6 +26,9 @@ automatic staging deploy
 staging live-release receipt
     |
     v
+production verifies exact staging receipt + workflow run
+    |
+    v
 operator selects exact 40-hex main SHA
     |
     v
@@ -64,12 +67,15 @@ Before deployment, the workflow rejects the request unless:
 
 - the workflow itself was dispatched from `main`;
 - `release_sha` is one exact lowercase 40-hex Git SHA;
-- the commit exists in repository history; and
-- the commit is an ancestor of the current canonical `origin/main`.
+- the commit exists in repository history;
+- the commit is an ancestor of the current canonical `origin/main`;
+- a non-expired `staging-release-<sha>` artifact exists for that exact SHA and `main` branch;
+- the artifact came from a successful `push` run of `.github/workflows/deploy-staging.yml` at that exact SHA; and
+- the downloaded receipt itself reports staging, the exact release, live/ready/database-ready API state, exact transient + stable Web provenance, intended API origin, and credentialed CORS qualification.
 
 The API and Web jobs then check out that exact SHA. Release identity is derived from `release_sha`, never from the workflow-dispatch commit.
 
-This prevents a later `main` commit from silently becoming the deployed artifact merely because the operator intended to promote an older qualified release.
+This prevents a later `main` commit from silently becoming the deployed artifact and prevents an operator from promoting a canonical commit that never completed the staging live-release gate.
 
 ## Environment authority required outside the repository
 
@@ -93,6 +99,8 @@ Public environment variable:
 `WEB_ORIGIN` is not inferred from a transient Vercel deployment URL. It represents the stable public alias that must expose the selected release and that the API must admit through CORS.
 
 Production should also use GitHub environment protection / reviewers where available. Repository code can require the `production` environment, but repository code cannot prove that an administrator configured reviewers or secret scope correctly.
+
+The production workflow has read-only Actions permission in addition to repository-content read permission solely so it can authenticate the exact staging workflow run and download its retained receipt. It does not gain Actions write authority.
 
 ## Live qualification receipt
 
@@ -146,13 +154,14 @@ Still required before public beta:
 3. Inspect the retained `staging-release-<sha>` receipt and confirm both deployment and stable public origins report the same SHA.
 4. Resolve any staging, alias, CORS, or provider discrepancy before production promotion.
 5. Dispatch `Deploy to Production` from `main` and paste the exact staged 40-hex SHA into `release_sha`.
-6. Complete any configured production-environment approval.
-7. Confirm API migration, liveness, readiness, deployment provenance, stable-origin provenance, CORS, and live qualification succeed.
-8. Retain and inspect `production-release-<sha>`.
-9. Continue with authenticated live black-box and operational drills. Do not treat the receipt alone as full public-beta evidence.
+6. The workflow independently locates the exact staging artifact, verifies its successful staging workflow run, downloads it, and validates its contents before any production deploy job can start.
+7. Complete any configured production-environment approval.
+8. Confirm API migration, liveness, readiness, deployment provenance, stable-origin provenance, CORS, and live qualification succeed.
+9. Retain and inspect `production-release-<sha>`.
+10. Continue with authenticated live black-box and operational drills. Do not treat the receipt alone as full public-beta evidence.
 
 ## Rollback boundary
 
-A previous known-good `main` SHA can be deliberately re-promoted through the same production workflow because the selector accepts canonical `main` ancestors.
+A previous known-good `main` SHA can be deliberately re-promoted through the same production workflow because the selector accepts canonical `main` ancestors, but it still needs a valid retained staging receipt for that exact SHA.
 
 That is application rollback authority, not database rollback authority. Database migrations must remain forward-safe or use an explicitly rehearsed recovery procedure. Never infer that deploying an older application SHA reverses a migrated production schema.

--- a/docs/operations/PRODUCTION_PROMOTION_AUTHORITY_V1.md
+++ b/docs/operations/PRODUCTION_PROMOTION_AUTHORITY_V1.md
@@ -1,0 +1,155 @@
+# Production Promotion Authority v1
+
+Woof production deployment is a promotion decision, not a side effect of merging code.
+
+This contract separates four different statements:
+
+1. a commit exists on canonical `main`;
+2. that commit has repository qualification evidence;
+3. that commit has been deployed and qualified in staging;
+4. an operator deliberately promotes that exact commit to production.
+
+Green CI is not a production-deployment claim, and a production deployment is not a product-validation claim.
+
+## Canonical flow
+
+```text
+pull request
+    |
+    v
+qualified main commit
+    |
+    v
+automatic staging deploy
+    |
+    v
+staging live-release receipt
+    |
+    v
+operator selects exact 40-hex main SHA
+    |
+    v
+production environment approval / authority
+    |
+    v
+exact-SHA API + Web production deploy
+    |
+    v
+production live-release receipt
+```
+
+## Staging authority
+
+`.github/workflows/deploy-staging.yml` runs after a push to `main`.
+
+The workflow:
+
+- deploys the API with `WOOF_RELEASE_SHA` equal to the exact `github.sha`;
+- requires API liveness and database-backed readiness to report that same release;
+- builds Web with the same release identity and the canonical staging API URL;
+- verifies public Web provenance markers;
+- verifies the configured public Web origin is actually admitted by API CORS;
+- writes a privacy-safe `woof-live-release-qualification` receipt; and
+- retains that receipt as `staging-release-<sha>`.
+
+Staging therefore answers: **did the exact merged commit become a coherent live Web/API release?**
+
+It does not prove production, device distribution, recovery, or user value.
+
+## Production authority
+
+`.github/workflows/deploy-production.yml` has no `push` trigger. It is manually dispatched with one required `release_sha`.
+
+Before deployment, the workflow rejects the request unless:
+
+- the workflow itself was dispatched from `main`;
+- `release_sha` is one exact lowercase 40-hex Git SHA;
+- the commit exists in repository history; and
+- the commit is an ancestor of the current canonical `origin/main`.
+
+The API and Web jobs then check out that exact SHA. Release identity is derived from `release_sha`, never from the workflow-dispatch commit.
+
+This prevents a later `main` commit from silently becoming the deployed artifact merely because the operator intended to promote an older qualified release.
+
+## Environment authority required outside the repository
+
+Both `staging` and `production` GitHub environments require externally configured deployment authority.
+
+Secrets:
+
+- `FLY_API_TOKEN`
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
+
+Optional notification secret:
+
+- `SLACK_WEBHOOK`
+
+Public environment variable:
+
+- `WEB_ORIGIN` — one stable HTTPS origin only, for example `https://staging.example.com` or `https://www.example.com`.
+
+`WEB_ORIGIN` is not inferred from a transient Vercel deployment URL. It represents the public origin that the API is expected to admit through CORS.
+
+Production should also use GitHub environment protection / reviewers where available. Repository code can require the `production` environment, but repository code cannot prove that an administrator configured reviewers or secret scope correctly.
+
+## Live qualification receipt
+
+`.github/scripts/qualify-live-release.mjs` performs non-destructive black-box release checks against public endpoints.
+
+It verifies:
+
+- API `/ops/health/live` returns `status=live` and the exact expected release;
+- API `/ops/health/ready` returns `status=ready`, database `status=ready`, and the same release;
+- the API admits the configured public Web origin through credentialed CORS;
+- the deployed Web `/demo` page exposes the exact release SHA; and
+- the deployed Web artifact points at the intended API base URL.
+
+The retained receipt contains only low-cardinality public operational facts:
+
+- environment class;
+- qualification timestamp;
+- exact release SHA;
+- public API base URL;
+- public Web deployment/origin;
+- health status classes;
+- CORS authority result; and
+- names of checks performed.
+
+It intentionally excludes user IDs, pet IDs, household IDs, emails, tokens, request bodies, provider payloads, free-form notes, database rows, and raw response bodies.
+
+## What v1 does not yet prove
+
+This tranche deliberately does not pretend to solve the remaining launch gates.
+
+Still required before public beta:
+
+- repository ruleset / protected `main` configured administratively;
+- an actually successful staging deployment with retained receipt;
+- deliberate promotion of the same selected release to production;
+- authenticated synthetic black-box journeys against the live stack;
+- realtime revoke/block/logout authority checked live;
+- backup and restore rehearsal;
+- live error-monitoring and alert-routing drill;
+- physical iOS/TestFlight qualification and accessibility evidence;
+- structured coarse-region Pack authority; and
+- a real owner/advisor pilot.
+
+## Promotion procedure
+
+1. Merge only a fully qualified release candidate to `main`.
+2. Confirm `Deploy to Staging` succeeds for that exact SHA.
+3. Inspect the retained `staging-release-<sha>` receipt.
+4. Resolve any staging or provider discrepancy before production promotion.
+5. Dispatch `Deploy to Production` from `main` and paste the exact staged 40-hex SHA into `release_sha`.
+6. Complete any configured production-environment approval.
+7. Confirm API migration, liveness, readiness, Web provenance, CORS, and live qualification succeed.
+8. Retain and inspect `production-release-<sha>`.
+9. Continue with authenticated live black-box and operational drills. Do not treat the receipt alone as full public-beta evidence.
+
+## Rollback boundary
+
+A previous known-good `main` SHA can be deliberately re-promoted through the same production workflow because the selector accepts canonical `main` ancestors.
+
+That is application rollback authority, not database rollback authority. Database migrations must remain forward-safe or use an explicitly rehearsed recovery procedure. Never infer that deploying an older application SHA reverses a migrated production schema.


### PR DESCRIPTION
## Summary

Turn production deployment into an explicit release-promotion boundary instead of a side effect of merging to `main`.

- make `main` the automatic staging proving ground;
- remove the production `push` trigger;
- require one exact 40-hex canonical-main `release_sha` for production promotion;
- require a non-expired `staging-release-<sha>` artifact from a successful exact-SHA `Deploy to Staging` push run on `main` before any production deploy can start;
- download and validate the staging receipt itself before promotion;
- deploy API and Web from that exact selected checkout and bind release identity to it;
- verify both transient Vercel deployment provenance and the stable public Web alias;
- verify credentialed CORS from the configured public Web origin;
- retain privacy-safe staging and production release receipts;
- extend the existing operational privacy/release CI authority rather than adding a parallel qualification system;
- document the external GitHub environment/secrets/`WEB_ORIGIN` authority still required before the first live release.

## Claim boundary

This PR is repository qualification only. It does **not** claim that staging or production is live, that environment secrets/reviewers are configured, that backup/restore has been rehearsed, or that authenticated live-user journeys have passed.

## Follow-up after merge

1. configure protected `main` / ruleset administratively;
2. configure staging and production GitHub environments, deployment secrets, and stable `WEB_ORIGIN` values;
3. obtain the first exact-SHA staging receipt;
4. promote that same receipt-backed SHA deliberately to production;
5. run authenticated black-box, realtime revocation, observability/alert, and backup/restore drills.
