### PR TITLE
Harden exact-SHA staging and production promotion authority

### DIFF
--- a/.github/scripts/assert-operational-privacy-release.py
+++ b/.github/scripts/assert-operational-privacy-release.py
@@ -90,6 +90,16 @@ require(
     "EXPECTED_API_URL",
     "--self-test",
 )
+require(
+    ".github/scripts/write-release-receipt.mjs",
+    "SHA_PATTERN",
+    "buildReleaseReceipt",
+    "production receipt requires successful exact-SHA staging qualification",
+    "apiReleaseIdentityVerified: true",
+    "webReleaseIdentityVerified: true",
+    "webApiOriginVerified: true",
+    "--self-test",
+)
 
 require(
     "infra/docker/Dockerfile.api",
@@ -102,12 +112,14 @@ for path in [
 ]:
     require(
         path,
-        '--build-arg WOOF_RELEASE_SHA="${GITHUB_SHA}"',
-        "NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ github.sha }}",
+        '--build-arg WOOF_RELEASE_SHA="${RELEASE_SHA}"',
+        "NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ env.RELEASE_SHA }}",
         "NEXT_PUBLIC_SENTRY_REPLAY_ENABLED: 'false'",
         "Enforce deployed API release identity",
         "Verify deployed Web release and API integration",
         "verify-web-deployment-provenance.mjs",
+        "write-release-receipt.mjs",
+        "actions/upload-artifact@v7",
     )
 
-print("Operational privacy contract preserves exact release identity, Web/API provenance, and privacy-closed replay.")
+print("Operational privacy contract preserves exact release identity, Web/API provenance, and privacy-safe release receipts.")

--- a/.github/scripts/assert-release-promotion-authority.py
+++ b/.github/scripts/assert-release-promotion-authority.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Qualify staging and production promotion authority without deployment credentials."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+STAGING = ROOT / ".github/workflows/deploy-staging.yml"
+PRODUCTION = ROOT / ".github/workflows/deploy-production.yml"
+RECEIPT = ROOT / ".github/scripts/write-release-receipt.mjs"
+
+
+def read(path: Path) -> str:
+    if not path.is_file():
+        raise SystemExit(f"required release authority source missing: {path.relative_to(ROOT)}")
+    return path.read_text()
+
+
+def require(text: str, label: str, *markers: str) -> None:
+    missing = [marker for marker in markers if marker not in text]
+    if missing:
+        raise SystemExit(f"{label}: missing required release-authority markers: {missing}")
+
+
+def reject(text: str, label: str, *markers: str) -> None:
+    present = [marker for marker in markers if marker in text]
+    if present:
+        raise SystemExit(f"{label}: forbidden release-authority markers present: {present}")
+
+
+staging = read(STAGING)
+production = read(PRODUCTION)
+receipt = read(RECEIPT)
+
+require(
+    staging,
+    "deploy-staging.yml",
+    "branches: [main]",
+    "workflow_dispatch:",
+    "release_sha:",
+    "Validate Staging Release Candidate",
+    "git merge-base --is-ancestor \"${RELEASE_SHA}\" origin/main",
+    "ref: ${{ env.RELEASE_SHA }}",
+    '--build-arg WOOF_RELEASE_SHA="${RELEASE_SHA}"',
+    "NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ env.RELEASE_SHA }}",
+    "Retain Staging Release Receipt",
+    "staging-release-${{ env.RELEASE_SHA }}",
+    "retention-days: 30",
+)
+reject(staging, "deploy-staging.yml", "branches: [develop]")
+
+require(
+    production,
+    "deploy-production.yml",
+    "workflow_dispatch:",
+    "release_sha:",
+    "required: true",
+    "actions: read",
+    "Validate Production Release Candidate",
+    "git merge-base --is-ancestor \"${RELEASE_SHA}\" origin/main",
+    "Verify exact staging qualification",
+    "actions/workflows/deploy-staging.yml/runs",
+    '.conclusion == "success"',
+    "ref: ${{ env.RELEASE_SHA }}",
+    '--build-arg WOOF_RELEASE_SHA="${RELEASE_SHA}"',
+    "NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ env.RELEASE_SHA }}",
+    "environment: production",
+    "Retain Production Release Receipt",
+    "production-release-${{ env.RELEASE_SHA }}",
+    "retention-days: 90",
+)
+reject(
+    production,
+    "deploy-production.yml",
+    "\n  push:\n",
+    "branches: [main]",
+    'WOOF_RELEASE_SHA="${GITHUB_SHA}"',
+    "NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ github.sha }}",
+)
+
+require(
+    receipt,
+    "write-release-receipt.mjs",
+    "SHA_PATTERN",
+    "ALLOWED_ENVIRONMENTS",
+    "mainAncestryVerified: true",
+    "apiReleaseIdentityVerified: true",
+    "webReleaseIdentityVerified: true",
+    "webApiOriginVerified: true",
+    "production receipt requires successful exact-SHA staging qualification",
+    "--self-test",
+)
+reject(receipt, "write-release-receipt.mjs", "process.env.FLY_API_TOKEN", "process.env.VERCEL_TOKEN")
+
+print(
+    "Release promotion authority is explicit: main stages automatically, production is manual exact-SHA promotion, "
+    "successful staging is required, and privacy-safe receipts are retained."
+)

--- a/.github/scripts/assert-release-promotion-authority.py
+++ b/.github/scripts/assert-release-promotion-authority.py
@@ -36,7 +36,7 @@ require(
     "deploy-staging.yml",
     "branches: [main]",
     "workflow_dispatch:",
-    "release_sha:",
+    "REQUESTED_SHA: ${{ github.sha }}",
     "Validate Staging Release Candidate",
     "git merge-base --is-ancestor \"${RELEASE_SHA}\" origin/main",
     "ref: ${{ env.RELEASE_SHA }}",

--- a/.github/scripts/write-release-receipt.mjs
+++ b/.github/scripts/write-release-receipt.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const ALLOWED_ENVIRONMENTS = new Set(['staging', 'production']);
+
+function requireValue(name, value) {
+  if (!value || !value.trim()) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function requireHttpsUrl(name, value) {
+  const raw = requireValue(name, value);
+  const parsed = new URL(raw);
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`${name} must use https`);
+  }
+  parsed.username = '';
+  parsed.password = '';
+  parsed.search = '';
+  parsed.hash = '';
+  return parsed.toString().replace(/\/$/, '');
+}
+
+export function buildReleaseReceipt(env) {
+  const releaseEnvironment = requireValue('RELEASE_ENVIRONMENT', env.RELEASE_ENVIRONMENT);
+  if (!ALLOWED_ENVIRONMENTS.has(releaseEnvironment)) {
+    throw new Error(`unsupported RELEASE_ENVIRONMENT: ${releaseEnvironment}`);
+  }
+
+  const releaseSha = requireValue('RELEASE_SHA', env.RELEASE_SHA);
+  if (!SHA_PATTERN.test(releaseSha)) {
+    throw new Error('RELEASE_SHA must be an exact lowercase 40-character Git SHA');
+  }
+
+  const repository = requireValue('GITHUB_REPOSITORY', env.GITHUB_REPOSITORY);
+  const workflow = requireValue('GITHUB_WORKFLOW', env.GITHUB_WORKFLOW);
+  const runId = requireValue('GITHUB_RUN_ID', env.GITHUB_RUN_ID);
+  const runAttempt = requireValue('GITHUB_RUN_ATTEMPT', env.GITHUB_RUN_ATTEMPT);
+  const apiUrl = requireHttpsUrl('API_URL', env.API_URL);
+  const webUrl = requireHttpsUrl('WEB_URL', env.WEB_URL);
+  const stagingWorkflowVerified = env.STAGING_WORKFLOW_VERIFIED === 'true';
+
+  if (releaseEnvironment === 'production' && !stagingWorkflowVerified) {
+    throw new Error('production receipt requires successful exact-SHA staging qualification');
+  }
+
+  return {
+    schemaVersion: 1,
+    environment: releaseEnvironment,
+    releaseSha,
+    repository,
+    workflow,
+    runId,
+    runAttempt,
+    apiUrl,
+    webUrl,
+    evidence: {
+      mainAncestryVerified: true,
+      apiReleaseIdentityVerified: true,
+      webReleaseIdentityVerified: true,
+      webApiOriginVerified: true,
+      stagingWorkflowVerified,
+    },
+  };
+}
+
+function selfTest() {
+  const base = {
+    RELEASE_ENVIRONMENT: 'staging',
+    RELEASE_SHA: 'a'.repeat(40),
+    GITHUB_REPOSITORY: 'example/woof',
+    GITHUB_WORKFLOW: 'Deploy to Staging',
+    GITHUB_RUN_ID: '123',
+    GITHUB_RUN_ATTEMPT: '1',
+    API_URL: 'https://api.example.test/api/v1',
+    WEB_URL: 'https://web.example.test',
+    STAGING_WORKFLOW_VERIFIED: 'false',
+  };
+
+  const staging = buildReleaseReceipt(base);
+  if (staging.releaseSha !== base.RELEASE_SHA || staging.evidence.stagingWorkflowVerified) {
+    throw new Error('staging receipt self-test failed');
+  }
+
+  const production = buildReleaseReceipt({
+    ...base,
+    RELEASE_ENVIRONMENT: 'production',
+    GITHUB_WORKFLOW: 'Deploy to Production',
+    STAGING_WORKFLOW_VERIFIED: 'true',
+  });
+  if (!production.evidence.stagingWorkflowVerified) {
+    throw new Error('production receipt self-test failed');
+  }
+
+  let rejected = false;
+  try {
+    buildReleaseReceipt({ ...base, RELEASE_SHA: 'main' });
+  } catch {
+    rejected = true;
+  }
+  if (!rejected) {
+    throw new Error('non-SHA release identity was accepted');
+  }
+
+  rejected = false;
+  try {
+    buildReleaseReceipt({
+      ...base,
+      RELEASE_ENVIRONMENT: 'production',
+      STAGING_WORKFLOW_VERIFIED: 'false',
+    });
+  } catch {
+    rejected = true;
+  }
+  if (!rejected) {
+    throw new Error('production receipt without staging qualification was accepted');
+  }
+
+  console.log('release receipt self-test passed');
+}
+
+if (process.argv.includes('--self-test')) {
+  selfTest();
+} else {
+  const receiptPath = requireValue('RELEASE_RECEIPT_PATH', process.env.RELEASE_RECEIPT_PATH);
+  const receipt = buildReleaseReceipt(process.env);
+  fs.mkdirSync(path.dirname(receiptPath), { recursive: true });
+  fs.writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, { mode: 0o600 });
+  console.log(`wrote release receipt for ${receipt.environment} ${receipt.releaseSha}`);
+}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,11 +1,16 @@
 name: Deploy to Production
+run-name: Promote ${{ inputs.release_sha }} to production
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Exact 40-character main commit SHA already qualified in staging
+        required: true
+        type: string
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -13,15 +18,72 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate-release-candidate:
+    name: Validate Production Release Candidate
+    runs-on: ubuntu-latest
+    outputs:
+      release_sha: ${{ steps.candidate.outputs.sha }}
+    steps:
+      - name: Validate exact requested SHA
+        id: candidate
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          if [[ ! "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=Invalid release SHA::Production promotion requires an exact lowercase 40-character Git SHA."
+            exit 1
+          fi
+          echo "sha=${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.candidate.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Require candidate to be on main
+        env:
+          RELEASE_SHA: ${{ steps.candidate.outputs.sha }}
+        run: |
+          git fetch origin main --no-tags --prune
+          actual=$(git rev-parse HEAD)
+          if [[ "${actual}" != "${RELEASE_SHA}" ]]; then
+            echo "::error title=Checkout mismatch::Expected ${RELEASE_SHA}, checked out ${actual}."
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "${RELEASE_SHA}" origin/main; then
+            echo "::error title=Untrusted production candidate::${RELEASE_SHA} is not reachable from origin/main."
+            exit 1
+          fi
+
+      - name: Verify exact staging qualification
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ steps.candidate.outputs.sha }}
+        run: |
+          count=$(gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/deploy-staging.yml/runs" \
+            -f head_sha="${RELEASE_SHA}" \
+            -f per_page=20 \
+            --jq '[.workflow_runs[] | select(.head_sha == "'"${RELEASE_SHA}"'" and .conclusion == "success")] | length')
+          if [[ "${count}" -lt 1 ]]; then
+            echo "::error title=Missing staging qualification::No successful Deploy to Staging workflow was found for ${RELEASE_SHA}."
+            exit 1
+          fi
+          echo "Found ${count} successful staging qualification run(s) for ${RELEASE_SHA}."
+
   deploy-api-production:
     name: Deploy API to Production
     runs-on: ubuntu-latest
     environment: production
+    needs: validate-release-candidate
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+      RELEASE_SHA: ${{ needs.validate-release-candidate.outputs.release_sha }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_SHA }}
 
       - name: Validate production API deployment credentials
         run: |
@@ -41,7 +103,7 @@ jobs:
           --remote-only
           --app woof-api-prod
           --config apps/api/fly.toml
-          --build-arg WOOF_RELEASE_SHA="${GITHUB_SHA}"
+          --build-arg WOOF_RELEASE_SHA="${RELEASE_SHA}"
 
       - name: Capture liveness and readiness evidence
         id: release_bodies
@@ -65,7 +127,7 @@ jobs:
           READY_BODY: ${{ steps.release_bodies.outputs.ready }}
         run: |
           node - <<'NODE'
-          const expected = process.env.GITHUB_SHA;
+          const expected = process.env.RELEASE_SHA;
           for (const [name, raw] of Object.entries({ live: process.env.LIVE_BODY, ready: process.env.READY_BODY })) {
             const parsed = JSON.parse(raw);
             if (parsed.release !== expected) {
@@ -85,8 +147,8 @@ jobs:
             exit 0
           fi
 
-          payload=$(printf '{"text":"Woof production API deployment: %s (%s @ %.12s)"}' \
-            "${DEPLOYMENT_STATUS}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}")
+          payload=$(printf '{"text":"Woof production API deployment: %s (%.12s)"}' \
+            "${DEPLOYMENT_STATUS}" "${RELEASE_SHA}")
           curl --fail --silent --show-error \
             -H 'Content-Type: application/json' \
             --data "${payload}" \
@@ -96,15 +158,20 @@ jobs:
     name: Deploy Web to Production
     runs-on: ubuntu-latest
     environment: production
-    needs: deploy-api-production
+    needs: [validate-release-candidate, deploy-api-production]
+    outputs:
+      deployment_url: ${{ steps.deploy_web.outputs.url }}
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
       EXPECTED_API_URL: https://woof-api-prod.fly.dev/api/v1
+      RELEASE_SHA: ${{ needs.validate-release-candidate.outputs.release_sha }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_SHA }}
 
       - name: Validate production Web deployment credentials
         run: |
@@ -131,7 +198,7 @@ jobs:
         working-directory: apps/web
         env:
           NEXT_PUBLIC_API_URL: ${{ env.EXPECTED_API_URL }}
-          NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ github.sha }}
+          NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ env.RELEASE_SHA }}
           NEXT_PUBLIC_SENTRY_REPLAY_ENABLED: 'false'
 
       - name: Deploy to Vercel
@@ -148,7 +215,7 @@ jobs:
       - name: Verify deployed Web release and API integration
         env:
           WEB_URL: ${{ steps.deploy_web.outputs.url }}
-          EXPECTED_RELEASE: ${{ github.sha }}
+          EXPECTED_RELEASE: ${{ env.RELEASE_SHA }}
         run: |
           html=$(curl --fail --silent --show-error --location --retry 8 --retry-all-errors --retry-delay 3 \
             "${WEB_URL}/demo")
@@ -165,9 +232,37 @@ jobs:
             exit 0
           fi
 
-          payload=$(printf '{"text":"Woof production Web deployment: %s (%s @ %.12s)"}' \
-            "${DEPLOYMENT_STATUS}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}")
+          payload=$(printf '{"text":"Woof production Web deployment: %s (%.12s)"}' \
+            "${DEPLOYMENT_STATUS}" "${RELEASE_SHA}")
           curl --fail --silent --show-error \
             -H 'Content-Type: application/json' \
             --data "${payload}" \
             "${SLACK_WEBHOOK_URL}"
+
+  retain-production-release-receipt:
+    name: Retain Production Release Receipt
+    runs-on: ubuntu-latest
+    needs: [validate-release-candidate, deploy-api-production, deploy-web-production]
+    env:
+      RELEASE_SHA: ${{ needs.validate-release-candidate.outputs.release_sha }}
+      WEB_URL: ${{ needs.deploy-web-production.outputs.deployment_url }}
+      API_URL: https://woof-api-prod.fly.dev/api/v1
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_SHA }}
+
+      - name: Write privacy-safe production release receipt
+        env:
+          RELEASE_ENVIRONMENT: production
+          RELEASE_RECEIPT_PATH: .release-evidence/production-release-receipt.json
+          STAGING_WORKFLOW_VERIFIED: 'true'
+        run: node .github/scripts/write-release-receipt.mjs
+
+      - name: Retain production release receipt
+        uses: actions/upload-artifact@v7
+        with:
+          name: production-release-${{ env.RELEASE_SHA }}
+          path: .release-evidence/production-release-receipt.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,8 +1,15 @@
 name: Deploy to Staging
+run-name: Stage ${{ github.event_name == 'workflow_dispatch' && inputs.release_sha || github.sha }}
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Optional exact 40-character main commit SHA to stage
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -12,14 +19,55 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate-release-candidate:
+    name: Validate Staging Release Candidate
+    runs-on: ubuntu-latest
+    outputs:
+      release_sha: ${{ steps.candidate.outputs.sha }}
+    steps:
+      - name: Resolve exact release candidate
+        id: candidate
+        env:
+          REQUESTED_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.release_sha || github.sha }}
+        run: |
+          if [[ ! "${REQUESTED_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=Invalid release SHA::Expected an exact lowercase 40-character Git SHA, received '${REQUESTED_SHA}'."
+            exit 1
+          fi
+          echo "sha=${REQUESTED_SHA}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.candidate.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Require candidate to be on main
+        env:
+          RELEASE_SHA: ${{ steps.candidate.outputs.sha }}
+        run: |
+          git fetch origin main --no-tags --prune
+          actual=$(git rev-parse HEAD)
+          if [[ "${actual}" != "${RELEASE_SHA}" ]]; then
+            echo "::error title=Checkout mismatch::Expected ${RELEASE_SHA}, checked out ${actual}."
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "${RELEASE_SHA}" origin/main; then
+            echo "::error title=Untrusted staging candidate::${RELEASE_SHA} is not reachable from origin/main."
+            exit 1
+          fi
+
   deploy-api-staging:
     name: Deploy API to Staging
     runs-on: ubuntu-latest
     environment: staging
+    needs: validate-release-candidate
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      RELEASE_SHA: ${{ needs.validate-release-candidate.outputs.release_sha }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_SHA }}
 
       - name: Validate staging API deployment credentials
         run: |
@@ -39,7 +87,7 @@ jobs:
           --remote-only
           --app woof-api-staging
           --config apps/api/fly.toml
-          --build-arg WOOF_RELEASE_SHA="${GITHUB_SHA}"
+          --build-arg WOOF_RELEASE_SHA="${RELEASE_SHA}"
 
       - name: Capture liveness and readiness evidence
         id: release_bodies
@@ -63,7 +111,7 @@ jobs:
           READY_BODY: ${{ steps.release_bodies.outputs.ready }}
         run: |
           node - <<'NODE'
-          const expected = process.env.GITHUB_SHA;
+          const expected = process.env.RELEASE_SHA;
           for (const [name, raw] of Object.entries({ live: process.env.LIVE_BODY, ready: process.env.READY_BODY })) {
             const parsed = JSON.parse(raw);
             if (parsed.release !== expected) {
@@ -76,14 +124,19 @@ jobs:
     name: Deploy Web to Staging
     runs-on: ubuntu-latest
     environment: staging
-    needs: deploy-api-staging
+    needs: [validate-release-candidate, deploy-api-staging]
+    outputs:
+      deployment_url: ${{ steps.deploy_web.outputs.url }}
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       EXPECTED_API_URL: https://woof-api-staging.fly.dev/api/v1
+      RELEASE_SHA: ${{ needs.validate-release-candidate.outputs.release_sha }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_SHA }}
 
       - name: Validate staging Web deployment credentials
         run: |
@@ -110,7 +163,7 @@ jobs:
         working-directory: apps/web
         env:
           NEXT_PUBLIC_API_URL: ${{ env.EXPECTED_API_URL }}
-          NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ github.sha }}
+          NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ env.RELEASE_SHA }}
           NEXT_PUBLIC_SENTRY_REPLAY_ENABLED: 'false'
 
       - name: Deploy to Vercel
@@ -127,8 +180,36 @@ jobs:
       - name: Verify deployed Web release and API integration
         env:
           WEB_URL: ${{ steps.deploy_web.outputs.url }}
-          EXPECTED_RELEASE: ${{ github.sha }}
+          EXPECTED_RELEASE: ${{ env.RELEASE_SHA }}
         run: |
           html=$(curl --fail --silent --show-error --location --retry 8 --retry-all-errors --retry-delay 3 \
             "${WEB_URL}/demo")
           WEB_HTML="$html" node .github/scripts/verify-web-deployment-provenance.mjs
+
+  retain-staging-release-receipt:
+    name: Retain Staging Release Receipt
+    runs-on: ubuntu-latest
+    needs: [validate-release-candidate, deploy-api-staging, deploy-web-staging]
+    env:
+      RELEASE_SHA: ${{ needs.validate-release-candidate.outputs.release_sha }}
+      WEB_URL: ${{ needs.deploy-web-staging.outputs.deployment_url }}
+      API_URL: https://woof-api-staging.fly.dev/api/v1
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.RELEASE_SHA }}
+
+      - name: Write privacy-safe staging release receipt
+        env:
+          RELEASE_ENVIRONMENT: staging
+          RELEASE_RECEIPT_PATH: .release-evidence/staging-release-receipt.json
+          STAGING_WORKFLOW_VERIFIED: 'false'
+        run: node .github/scripts/write-release-receipt.mjs
+
+      - name: Retain staging release receipt
+        uses: actions/upload-artifact@v7
+        with:
+          name: staging-release-${{ env.RELEASE_SHA }}
+          path: .release-evidence/staging-release-receipt.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,15 +1,10 @@
 name: Deploy to Staging
-run-name: Stage ${{ github.event_name == 'workflow_dispatch' && inputs.release_sha || github.sha }}
+run-name: Stage ${{ github.sha }}
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
-    inputs:
-      release_sha:
-        description: Optional exact 40-character main commit SHA to stage
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -28,7 +23,7 @@ jobs:
       - name: Resolve exact release candidate
         id: candidate
         env:
-          REQUESTED_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.release_sha || github.sha }}
+          REQUESTED_SHA: ${{ github.sha }}
         run: |
           if [[ ! "${REQUESTED_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error title=Invalid release SHA::Expected an exact lowercase 40-character Git SHA, received '${REQUESTED_SHA}'."

--- a/.github/workflows/release-promotion-authority-ci.yml
+++ b/.github/workflows/release-promotion-authority-ci.yml
@@ -1,0 +1,49 @@
+name: Release Promotion Authority CI
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/deploy-staging.yml'
+      - '.github/workflows/deploy-production.yml'
+      - '.github/workflows/release-promotion-authority-ci.yml'
+      - '.github/workflows/dogos-operational-privacy-ci.yml'
+      - '.github/scripts/assert-release-promotion-authority.py'
+      - '.github/scripts/assert-operational-privacy-release.py'
+      - '.github/scripts/write-release-receipt.mjs'
+      - '.github/scripts/verify-web-deployment-provenance.mjs'
+      - 'docs/operations/RELEASE_PROMOTION_AUTHORITY_V1.md'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/deploy-staging.yml'
+      - '.github/workflows/deploy-production.yml'
+      - '.github/workflows/release-promotion-authority-ci.yml'
+      - '.github/workflows/dogos-operational-privacy-ci.yml'
+      - '.github/scripts/assert-release-promotion-authority.py'
+      - '.github/scripts/assert-operational-privacy-release.py'
+      - '.github/scripts/write-release-receipt.mjs'
+      - '.github/scripts/verify-web-deployment-provenance.mjs'
+      - 'docs/operations/RELEASE_PROMOTION_AUTHORITY_V1.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-promotion-authority:
+    name: Release Promotion Authority
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Qualify staging and production promotion contract
+        run: python3 .github/scripts/assert-release-promotion-authority.py
+
+      - name: Exercise privacy-safe release receipt writer
+        run: node .github/scripts/write-release-receipt.mjs --self-test
+
+      - name: Exercise Web deployment provenance verifier
+        run: node .github/scripts/verify-web-deployment-provenance.mjs --self-test
+
+      - name: Re-qualify operational privacy and release identity
+        run: python3 .github/scripts/assert-operational-privacy-release.py

--- a/docs/operations/RELEASE_PROMOTION_AUTHORITY_V1.md
+++ b/docs/operations/RELEASE_PROMOTION_AUTHORITY_V1.md
@@ -1,0 +1,183 @@
+# Release Promotion Authority v1
+
+## Purpose
+
+Woof treats repository qualification, staging qualification, and production promotion as different claims.
+
+A green pull request does not mean a release is deployed. A merge to `main` does not mean a release is production. Production is an explicit promotion of one exact commit that has already completed the staging deployment workflow successfully.
+
+## Authority model
+
+```text
+feature branch
+    |
+    v
+qualified pull request
+    |
+    v
+main
+    |
+    +--> Deploy to Staging
+    |      - exact SHA validation
+    |      - main ancestry validation
+    |      - API migration/deploy
+    |      - live + ready exact-SHA verification
+    |      - Web deploy
+    |      - Web release/API-origin provenance verification
+    |      - privacy-safe staging release receipt
+    |
+    v
+explicit workflow_dispatch(release_sha)
+    |
+    v
+Deploy to Production
+       - exact SHA validation
+       - main ancestry validation
+       - successful exact-SHA staging workflow required
+       - production environment authority
+       - API migration/deploy
+       - live + ready exact-SHA verification
+       - Web deploy
+       - Web release/API-origin provenance verification
+       - privacy-safe production release receipt
+```
+
+## Staging
+
+`Deploy to Staging` runs automatically for pushes to `main` and can also be dispatched manually for an exact historical `main` commit.
+
+The staging workflow rejects:
+
+- branch names, abbreviated SHAs, uppercase/non-hex release identifiers, and other ambiguous refs as release authority;
+- commits that are not reachable from `origin/main`;
+- a checkout whose resolved `HEAD` differs from the requested release SHA;
+- missing deployment credentials;
+- API liveness/readiness responses that do not report the exact candidate SHA;
+- Web deployments whose embedded release identity or API origin does not match the expected release.
+
+The old `develop`-branch trigger was removed because no canonical `develop` branch exists. A dormant staging workflow is not staging authority.
+
+## Production
+
+`Deploy to Production` is manual-only. It does not run on a push to `main`.
+
+The operator must provide the exact 40-character release SHA. Before any production deployment credentials are used, the workflow proves:
+
+1. the requested SHA resolves exactly;
+2. it is reachable from `origin/main`;
+3. GitHub Actions has a successful `Deploy to Staging` workflow run for that exact SHA.
+
+Only after those checks pass can the production environment jobs start.
+
+This allows repository environment protection and required reviewers to remain an additional external control without making a merge itself equivalent to a production release.
+
+## Release identity
+
+The selected candidate SHA is the release authority for both API and Web artifacts.
+
+The API image receives:
+
+```text
+WOOF_RELEASE_SHA=<exact selected SHA>
+```
+
+The Web build receives:
+
+```text
+NEXT_PUBLIC_WOOF_RELEASE_SHA=<exact selected SHA>
+```
+
+After deployment:
+
+- API `/ops/health/live` and `/ops/health/ready` must report the same exact SHA;
+- the Web deployment must expose the expected `woof-release` identity;
+- the Web deployment must expose the expected `woof-api-origin` identity.
+
+A successful workflow therefore means the released artifacts were checked against the selected candidate, not merely against whatever commit happened to trigger the workflow.
+
+## Privacy-safe release receipts
+
+Successful staging and production deployments retain small JSON receipts as GitHub Actions artifacts.
+
+Receipts contain only operational metadata:
+
+- environment;
+- exact release SHA;
+- repository/workflow/run identity;
+- API and Web HTTPS origins;
+- booleans recording the release/provenance checks that had to pass before the receipt job could run.
+
+They do not contain credentials, bearer tokens, request bodies, user/pet identifiers, database rows, free-form user content, or provider payloads.
+
+Staging receipts are retained for 30 days. Production receipts are retained for 90 days.
+
+A production receipt cannot be generated unless exact-SHA staging qualification was verified by the production workflow.
+
+## External configuration still required
+
+This repository code cannot manufacture provider authority. Before the first live release, operators must configure:
+
+### GitHub `staging` environment
+
+- `FLY_API_TOKEN`
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
+
+### GitHub `production` environment
+
+- `FLY_API_TOKEN`
+- `VERCEL_TOKEN`
+- `VERCEL_ORG_ID`
+- `VERCEL_PROJECT_ID`
+- optional `SLACK_WEBHOOK`
+
+The production environment should require explicit reviewer approval once repository/environment administration is configured.
+
+### Vercel
+
+An intended Woof Web project must exist and the IDs above must refer to that project. Do not reuse an unrelated Vercel project merely to satisfy the credential gate.
+
+### Fly.io
+
+The staging and production tokens must be authorized for the intended `woof-api-staging` and `woof-api-prod` applications respectively.
+
+## Repository governance boundary
+
+This release authority does not replace branch protection.
+
+`main` still requires a GitHub ruleset/branch-protection boundary that, at minimum:
+
+- requires pull requests for ordinary changes;
+- requires the intentionally selected release-critical checks;
+- prevents force pushes and branch deletion;
+- keeps bypass authority minimal and explicit.
+
+Until that external repository-admin control is enabled, Woof must not claim complete production source-governance authority.
+
+## Rollback
+
+Rollback is an explicit new production promotion of a previously qualified exact `main` SHA. Do not mutate release identity or redeploy an unknown local checkout.
+
+The chosen rollback SHA must still satisfy the same production preflight, including evidence of a successful staging workflow for that SHA.
+
+Database rollback is not implied by application rollback. Migrations must remain forward-safe, and destructive schema rollback requires its own reviewed recovery procedure.
+
+## Qualification
+
+Repository qualification is owned by:
+
+```bash
+python3 .github/scripts/assert-release-promotion-authority.py
+node .github/scripts/write-release-receipt.mjs --self-test
+node .github/scripts/verify-web-deployment-provenance.mjs --self-test
+python3 .github/scripts/assert-operational-privacy-release.py
+```
+
+These checks run in `Release Promotion Authority CI`.
+
+## Evidence boundary
+
+Passing this CI proves the repository's promotion contract and receipt machinery. It does **not** prove that Fly, Vercel, GitHub environments, alert routing, backups, physical-device distribution, or real-user pilots have been configured or exercised.
+
+Those remain separate launch gates and must only be claimed after live evidence exists.

--- a/docs/operations/RELEASE_PROMOTION_AUTHORITY_V1.md
+++ b/docs/operations/RELEASE_PROMOTION_AUTHORITY_V1.md
@@ -44,13 +44,13 @@ Deploy to Production
 
 ## Staging
 
-`Deploy to Staging` runs automatically for pushes to `main` and can also be dispatched manually for an exact historical `main` commit.
+`Deploy to Staging` runs automatically for pushes to `main`. A manual dispatch re-runs the workflow for the Git ref selected when dispatching; the workflow still rejects that candidate unless its exact SHA is reachable from `origin/main`.
 
 The staging workflow rejects:
 
-- branch names, abbreviated SHAs, uppercase/non-hex release identifiers, and other ambiguous refs as release authority;
+- branch names, abbreviated SHAs, uppercase/non-hex release identifiers, and other ambiguous values as release identity;
 - commits that are not reachable from `origin/main`;
-- a checkout whose resolved `HEAD` differs from the requested release SHA;
+- a checkout whose resolved `HEAD` differs from the workflow's exact candidate SHA;
 - missing deployment credentials;
 - API liveness/readiness responses that do not report the exact candidate SHA;
 - Web deployments whose embedded release identity or API origin does not match the expected release.
@@ -157,9 +157,9 @@ Until that external repository-admin control is enabled, Woof must not claim com
 
 ## Rollback
 
-Rollback is an explicit new production promotion of a previously qualified exact `main` SHA. Do not mutate release identity or redeploy an unknown local checkout.
+Rollback is an explicit new production promotion of a previously staging-qualified exact `main` SHA. Do not mutate release identity or redeploy an unknown local checkout.
 
-The chosen rollback SHA must still satisfy the same production preflight, including evidence of a successful staging workflow for that SHA.
+The chosen rollback SHA must satisfy the same production preflight, including a successful `Deploy to Staging` workflow run for that exact SHA. Commits from before this promotion authority existed are not grandfathered into production eligibility merely because they once existed on `main`.
 
 Database rollback is not implied by application rollback. Migrations must remain forward-safe, and destructive schema rollback requires its own reviewed recovery procedure.
 


### PR DESCRIPTION
## Why

Woof's repository qualification is stronger than its live promotion boundary today. Two concrete gaps are addressed here:

- staging was triggered by `develop`, but no canonical `develop` branch exists;
- production was triggered by every push to `main`, so adding real provider credentials would make ordinary merges production deployments.

This tranche separates integration, staging, and production claims before live credentials are configured.

## What changes

- stage every `main` release candidate automatically, with manual reruns still fail-closed to commits reachable from `main`;
- make production `workflow_dispatch` only;
- require an exact lowercase 40-character `release_sha` for production;
- prove the selected SHA is reachable from `origin/main` before either deployment;
- require a successful **Deploy to Staging** workflow for the exact SHA before production can start;
- checkout and build the selected SHA explicitly in API and Web deployment jobs;
- keep API `/live` + `/ready` exact-release checks and Web release/API-origin provenance checks;
- retain privacy-safe release receipts for successful staging and production runs;
- add dedicated `Release Promotion Authority CI` plus a self-testing receipt writer;
- update the existing operational privacy/release contract for selected-SHA authority;
- document operator configuration, rollback semantics, evidence boundaries, and the fact that branch protection remains external launch work.

## Important evidence boundary

This PR does **not** claim live deployment. The connected Vercel account currently has no Woof project, and production/staging provider credentials remain externally unconfigured. It also does not claim repository governance while `main` remains unprotected.

## Qualification expected

- Release Promotion Authority CI
- dogOS Operational Privacy CI
- root CI / action runtime / security lanes triggered by the workflow changes

No production or staging credential is required for the repository-only contract tests.

## Release discipline

This intentionally does not absorb Dependabot framework upgrades or new product/game features. The objective is to shrink release uncertainty before the first live staging deployment.