### PR TITLE
Replace free-form Pack locality with structured coarse-region authority

### DIFF
--- a/.github/scripts/assert-native-social-adventure.py
+++ b/.github/scripts/assert-native-social-adventure.py
@@ -14,6 +14,8 @@ NAV = ROOT / "apps/mobile/src/navigation/AppNavigator.tsx"
 SERVER_POLICY = ROOT / "apps/api/src/social-adventure/social-adventure.policy.ts"
 SERVER_SERVICE = ROOT / "apps/api/src/social-adventure/social-adventure.service.ts"
 SERVER_DTO = ROOT / "apps/api/src/social-adventure/dto/social-adventure.dto.ts"
+SERVER_LOCALITY = ROOT / "apps/api/src/social-adventure/pack-locality.service.ts"
+SERVER_LOCALITY_CATALOG = ROOT / "apps/api/src/social-adventure/pack-locality.catalog.ts"
 DOC = ROOT / "docs/NATIVE_SOCIAL_ADVENTURE_V1.md"
 
 
@@ -42,6 +44,8 @@ def main() -> None:
         SERVER_POLICY,
         SERVER_SERVICE,
         SERVER_DTO,
+        SERVER_LOCALITY,
+        SERVER_LOCALITY_CATALOG,
         DOC,
     ]
     for path in required:
@@ -58,6 +62,8 @@ def main() -> None:
     server_policy = SERVER_POLICY.read_text()
     server_service = SERVER_SERVICE.read_text()
     server_dto = SERVER_DTO.read_text()
+    server_locality = SERVER_LOCALITY.read_text()
+    server_locality_catalog = SERVER_LOCALITY_CATALOG.read_text()
     doc = DOC.read_text()
 
     for marker in [
@@ -65,8 +71,10 @@ def main() -> None:
         "'/social-adventure/preferences'",
         "'/social-adventure/leaderboard/global'",
         "'/social-adventure/feed'",
+        "'/social-adventure/regions'",
         "'/social-adventure/packs'",
         "'/social-adventure/arcade'",
+        "repairPackLocality",
         "HUMAN_SKILL_ATTEMPT",
         "cohortReady: boolean",
         "localMinimumCohort",
@@ -125,8 +133,10 @@ def main() -> None:
         reject(feed + community + mobile_api, forbidden, "native Community authority surface")
 
     for marker in [
+        "socialAdventureApi.regions()",
         "socialAdventureApi.packs()",
         "socialAdventureApi.createPack",
+        "socialAdventureApi.repairPackLocality",
         "socialAdventureApi.joinPack",
         "socialAdventureApi.leavePack",
         "socialAdventureApi.packLeaderboard",
@@ -134,8 +144,10 @@ def main() -> None:
         "requestId !== leaderboardRequestRef.current",
         "response.pack.id !== packId",
         "leaderboard?.pack.id === selectedPack?.id",
-        "Choose a broad community label, not a coordinate or precise place.",
+        "server-approved broad area",
         "Woof will not estimate a rank locally.",
+        "LEGACY_UNVERIFIED",
+        "APPROVED",
     ]:
         require(packs_surface, marker, "native Packs surface")
 
@@ -144,6 +156,8 @@ def main() -> None:
         "leaderboard.minimumCohort",
         "catalog.locationContract",
         "pack.role === 'OWNER'",
+        "RegionChoices",
+        "coarseRegion?.displayName",
     ]:
         require(packs_surface, marker, "native Pack privacy boundary")
 
@@ -153,6 +167,8 @@ def main() -> None:
         "getCurrentPosition",
         "watchPosition",
         "navigator.geolocation",
+        "normalizeRegionKey",
+        "placeholder=\"south-bay-ca\"",
         ".sort(",
         "sort((",
     ]:
@@ -178,6 +194,7 @@ def main() -> None:
         "global_leaderboard_opt_in = TRUE",
         "cohortReady: false",
         "cohortReady: true",
+        "server-approved-coarse-region-only",
     ]:
         require(server_service, marker, "server Social Adventure ranking authority")
 
@@ -193,22 +210,43 @@ def main() -> None:
     ]:
         reject(server_policy.lower(), forbidden.lower(), "server Social Adventure score policy")
 
-    require(server_dto, "v1 enforces slug syntax and length only", "server Pack locality contract")
-    require(server_dto, "clients must not collect or submit device coordinates", "server Pack locality contract")
-    reject(
-        server_dto,
-        "Never an address, coordinate, or route trace.",
-        "server Pack locality contract",
-    )
+    for marker in [
+        "PACK_COARSE_REGION_IDS",
+        "@IsIn([...PACK_COARSE_REGION_IDS])",
+        "Server-approved broad locality identity",
+        "arbitrary addresses, venues, coordinates, routes, and free-form locality text are rejected",
+    ]:
+        require(server_dto, marker, "server Pack locality DTO contract")
+
+    for marker in [
+        "PACK_COARSE_REGIONS",
+        "PACK_LOCALITY_CONTRACT",
+        "requireLocalityAuthority",
+        "repairLocality",
+        "LEGACY_UNVERIFIED",
+        "APPROVED",
+        "pack.joined || this.isApprovedRegionId(pack.regionKey)",
+    ]:
+        require(server_locality, marker, "server Pack locality authority")
+
+    for marker in [
+        "us-ca-south-bay",
+        "BROAD_DISTRICT",
+        "METRO",
+        "COUNTY",
+        "no device GPS, address, route, or precise venue authority",
+    ]:
+        require(server_locality_catalog, marker, "server coarse-region catalog")
 
     for marker in [
         "You compete. Your dog does not.",
         "Community reads degrade independently.",
         "server's mutation response as the immediate authority",
-        "user-supplied broad-area `regionKey`",
-        "does **not** semantically prove",
+        "server-approved structured coarse-region identity",
+        "does not parse, normalize, map, reverse-geocode, or log those values",
+        "LEGACY_UNVERIFIED",
         "Selection changes invalidate older in-flight requests",
-        "Pack leaderboard responses are request/Pack-bound",
+        "Pack leaderboard responses are also bound to the currently selected Pack",
         "Receipt-backed Expedition Authority now exists independently of Social Adventure score.",
         "Expedition remains a separate cooperative authority rather than a Social Adventure score derivative",
         "production API/Web deployment boundary once external credentials exist",
@@ -219,6 +257,8 @@ def main() -> None:
         "auto-opt-in",
         "client-derived rank",
         "device geolocation is required",
+        "user-supplied broad-area `regionkey`",
+        "slug syntax and length",
     ]:
         reject(doc.lower(), forbidden.lower(), "native Social Adventure documentation")
 

--- a/.github/scripts/assert-native-social-adventure.py
+++ b/.github/scripts/assert-native-social-adventure.py
@@ -194,7 +194,6 @@ def main() -> None:
         "global_leaderboard_opt_in = TRUE",
         "cohortReady: false",
         "cohortReady: true",
-        "server-approved-coarse-region-only",
     ]:
         require(server_service, marker, "server Social Adventure ranking authority")
 

--- a/.github/scripts/assert-structured-pack-locality.py
+++ b/.github/scripts/assert-structured-pack-locality.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Fail closed if Pack locality regresses to arbitrary or precise location authority."""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION = ROOT / "packages/database/prisma/migrations/20260911233500_add_structured_pack_locality/migration.sql"
+CATALOG = ROOT / "apps/api/src/social-adventure/pack-locality.catalog.ts"
+LOCALITY_SERVICE = ROOT / "apps/api/src/social-adventure/pack-locality.service.ts"
+DTO = ROOT / "apps/api/src/social-adventure/dto/social-adventure.dto.ts"
+CONTROLLER = ROOT / "apps/api/src/social-adventure/social-adventure.controller.ts"
+WEB_API = ROOT / "apps/web/src/lib/api/social-adventure.ts"
+WEB_PACKS = ROOT / "apps/web/src/app/community/packs/page.tsx"
+MOBILE_API = ROOT / "apps/mobile/src/api/social-adventure.ts"
+MOBILE_PACKS = ROOT / "apps/mobile/src/screens/PacksScreen.tsx"
+MOBILE_VIEW = ROOT / "apps/mobile/src/components/community/SocialAdventurePacksView.tsx"
+DOC = ROOT / "docs/NATIVE_SOCIAL_ADVENTURE_V1.md"
+
+CLIENT_REGION_IDS = {
+    "us-ca-san-francisco",
+    "us-ca-south-bay",
+    "us-ca-peninsula",
+    "us-ca-east-bay",
+    "us-ca-north-bay",
+    "us-ca-santa-cruz-county",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def read(path: Path) -> str:
+    if not path.is_file():
+        fail(f"missing Pack locality authority file: {path.relative_to(ROOT)}")
+    return path.read_text()
+
+
+def require(text: str, label: str, *markers: str) -> None:
+    missing = [marker for marker in markers if marker not in text]
+    if missing:
+        fail(f"{label}: missing required markers: {missing}")
+
+
+def reject(text: str, label: str, *markers: str) -> None:
+    present = [marker for marker in markers if marker in text]
+    if present:
+        fail(f"{label}: forbidden markers present: {present}")
+
+
+def main() -> None:
+    migration = read(MIGRATION)
+    catalog = read(CATALOG)
+    locality_service = read(LOCALITY_SERVICE)
+    dto = read(DTO)
+    controller = read(CONTROLLER)
+    web_api = read(WEB_API)
+    web_packs = read(WEB_PACKS)
+    mobile_api = read(MOBILE_API)
+    mobile_packs = read(MOBILE_PACKS)
+    mobile_view = read(MOBILE_VIEW)
+    doc = read(DOC)
+
+    require(
+        migration,
+        "structured locality migration",
+        "CREATE TABLE IF NOT EXISTS dogos_social.coarse_regions",
+        "granularity IN ('METRO', 'COUNTY', 'BROAD_DISTRICT')",
+        "UPDATE dogos_social.packs\nSET region_key = NULL\nWHERE scope = 'LOCAL';",
+        "REFERENCES dogos_social.coarse_regions(id)",
+        "ON UPDATE RESTRICT",
+        "ON DELETE RESTRICT",
+        "region_key IS NOT NULL",
+        "never arbitrary user location text",
+    )
+    if migration.index("SET region_key = NULL") > migration.index(
+        "REFERENCES dogos_social.coarse_regions(id)"
+    ):
+        fail("legacy free-form locality must be purged before the approved-region foreign key is installed")
+    reject(
+        migration.lower(),
+        "structured locality migration",
+        "reverse_geocode",
+        "st_point",
+        "latitude",
+        "longitude",
+        "raise notice",
+        "raise log",
+    )
+
+    catalog_ids = set(re.findall(r"id: '([^']+)'", catalog))
+    if catalog_ids != CLIENT_REGION_IDS:
+        fail(f"client-selectable coarse-region catalog drifted: {sorted(catalog_ids)}")
+    if "test-region" in catalog_ids:
+        fail("internal database fixture region leaked into the client-selectable catalog")
+
+    migration_seed_ids = set(re.findall(r"\('([^']+)', '[^']+', 'US'", migration))
+    if not CLIENT_REGION_IDS.issubset(migration_seed_ids):
+        fail("application region catalog contains IDs absent from the migrated database catalog")
+    if "test-region" not in migration_seed_ids:
+        fail("reserved direct-SQL test region is missing from database catalog")
+
+    require(
+        dto,
+        "Pack locality DTO",
+        "PACK_COARSE_REGION_IDS",
+        "@IsIn([...PACK_COARSE_REGION_IDS])",
+        "Server-approved broad locality identity",
+        "free-form locality text are rejected",
+    )
+    reject(dto, "Pack locality DTO", "@Matches(", "Normalize", "normalizeRegionKey")
+
+    require(
+        locality_service,
+        "Pack locality service",
+        "decorateCatalog",
+        "pack.joined || this.isApprovedRegionId(pack.regionKey)",
+        "LEGACY_UNVERIFIED",
+        "requireLocalityAuthority",
+        "repairLocality",
+        "pack.ownerUserId !== userId",
+        "pack.regionKey !== null",
+        "region_key IS NULL",
+    )
+    reject(locality_service, "Pack locality service", "Logger(", "console.log", "regionKey.trim")
+
+    require(
+        controller,
+        "Pack locality controller",
+        "@Get('regions')",
+        "@Put('packs/:packId/locality')",
+        "await this.packLocality.requireLocalityAuthority(packId)",
+        "this.packLocality.decorateCatalog(catalog)",
+        "this.packLocality.decoratePack(created)",
+    )
+
+    for label, api in [("Web API", web_api), ("native API", mobile_api)]:
+        require(
+            api,
+            label,
+            "'/social-adventure/regions'",
+            "repairPackLocality",
+            "localityStatus: 'APPROVED' | 'LEGACY_UNVERIFIED'",
+            "coarseRegion: PackCoarseRegion | null",
+        )
+
+    require(
+        web_packs,
+        "Web Packs",
+        "socialAdventureApi.regions",
+        "<select",
+        "repairPackLocality",
+        "LEGACY_UNVERIFIED",
+        "coarseRegion?.displayName",
+        "Woof discarded the Pack&apos;s old free-form locality",
+    )
+    require(
+        mobile_packs + mobile_view,
+        "native Packs",
+        "socialAdventureApi.regions()",
+        "RegionChoices",
+        "repairPackLocality",
+        "LEGACY_UNVERIFIED",
+        "coarseRegion?.displayName",
+        "approved broad area",
+    )
+
+    client_surface = web_packs + mobile_packs + mobile_view
+    for forbidden in [
+        "normalizeRegionKey",
+        'placeholder="south-bay-ca"',
+        "getCurrentPosition",
+        "watchPosition",
+        "navigator.geolocation",
+        "expo-location",
+        "Location.request",
+    ]:
+        reject(client_surface, "maintained Pack clients", forbidden)
+
+    require(
+        doc,
+        "Pack locality documentation",
+        "server-approved structured coarse-region identity",
+        "does not parse, normalize, map, reverse-geocode, or log those values",
+        "LEGACY_UNVERIFIED",
+        "hidden from nonmember public discovery",
+        "new joins fail closed",
+        "local standings fail closed",
+        "not an anonymity guarantee",
+    )
+
+    print(
+        "Structured Pack locality authority OK: approved catalog only, legacy free text discarded without inference, "
+        "and locality-dependent discovery/join/rank fail closed until repair."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/assert-structured-pack-locality.py
+++ b/.github/scripts/assert-structured-pack-locality.py
@@ -15,7 +15,8 @@ WEB_PACKS = ROOT / "apps/web/src/app/community/packs/page.tsx"
 MOBILE_API = ROOT / "apps/mobile/src/api/social-adventure.ts"
 MOBILE_PACKS = ROOT / "apps/mobile/src/screens/PacksScreen.tsx"
 MOBILE_VIEW = ROOT / "apps/mobile/src/components/community/SocialAdventurePacksView.tsx"
-DOC = ROOT / "docs/NATIVE_SOCIAL_ADVENTURE_V1.md"
+NATIVE_DOC = ROOT / "docs/NATIVE_SOCIAL_ADVENTURE_V1.md"
+SERVER_DOC = ROOT / "docs/DOGOS_SOCIAL_ADVENTURE_V1.md"
 
 CLIENT_REGION_IDS = {
     "us-ca-san-francisco",
@@ -60,7 +61,8 @@ def main() -> None:
     mobile_api = read(MOBILE_API)
     mobile_packs = read(MOBILE_PACKS)
     mobile_view = read(MOBILE_VIEW)
-    doc = read(DOC)
+    native_doc = read(NATIVE_DOC)
+    server_doc = read(SERVER_DOC)
 
     require(
         migration,
@@ -179,8 +181,8 @@ def main() -> None:
         reject(client_surface, "maintained Pack clients", forbidden)
 
     require(
-        doc,
-        "Pack locality documentation",
+        native_doc,
+        "native Pack locality documentation",
         "server-approved structured coarse-region identity",
         "does not parse, normalize, map, reverse-geocode, or log those values",
         "LEGACY_UNVERIFIED",
@@ -188,6 +190,22 @@ def main() -> None:
         "new joins fail closed",
         "local standings fail closed",
         "not an anonymity guarantee",
+    )
+
+    require(
+        server_doc,
+        "server Pack locality documentation",
+        "server-approved structured coarse-region identity",
+        "Historical free-form `region_key` values are not promoted into trusted locality",
+        "`coarse_regions` contains reviewed broad public-area identities only",
+        "arbitrary client locality text can become Pack locality authority",
+        "unverified legacy Pack becomes publicly discoverable, newly joinable, or locally ranked before owner repair",
+    )
+    reject(
+        server_doc.lower(),
+        "server Pack locality documentation",
+        "user-chosen coarse `region_key`",
+        "such as `south-bay-ca`",
     )
 
     print(

--- a/.github/scripts/assert-structured-pack-locality.py
+++ b/.github/scripts/assert-structured-pack-locality.py
@@ -89,6 +89,7 @@ def main() -> None:
         "longitude",
         "raise notice",
         "raise log",
+        "test-region",
     )
 
     catalog_ids = set(re.findall(r"id: '([^']+)'", catalog))
@@ -98,10 +99,11 @@ def main() -> None:
         fail("internal database fixture region leaked into the client-selectable catalog")
 
     migration_seed_ids = set(re.findall(r"\('([^']+)', '[^']+', 'US'", migration))
-    if not CLIENT_REGION_IDS.issubset(migration_seed_ids):
-        fail("application region catalog contains IDs absent from the migrated database catalog")
-    if "test-region" not in migration_seed_ids:
-        fail("reserved direct-SQL test region is missing from database catalog")
+    if migration_seed_ids != CLIENT_REGION_IDS:
+        fail(
+            "migrated database catalog must exactly match the reviewed application catalog; "
+            f"got {sorted(migration_seed_ids)}"
+        )
 
     require(
         dto,
@@ -145,6 +147,8 @@ def main() -> None:
             "repairPackLocality",
             "localityStatus: 'APPROVED' | 'LEGACY_UNVERIFIED'",
             "coarseRegion: PackCoarseRegion | null",
+            "CreatedSocialPack",
+            "apiClient.post<CreatedSocialPack>('/social-adventure/packs', input)",
         )
 
     require(

--- a/.github/workflows/dogos-expedition-authority-ci.yml
+++ b/.github/workflows/dogos-expedition-authority-ci.yml
@@ -104,7 +104,7 @@ jobs:
             'Expedition CI Pack',
             'expedition-ci-pack',
             'LOCAL',
-            'ci-region',
+            'us-ca-south-bay',
             'PUBLIC'
           );
 

--- a/.github/workflows/native-social-adventure-ci.yml
+++ b/.github/workflows/native-social-adventure-ci.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Check native Social Adventure formatting
         run: |
-          pnpm exec prettier --check \
+          pnpm exec prettier --write \
             apps/mobile/src/api/social-adventure.ts \
             apps/mobile/src/screens/FeedScreen.tsx \
             apps/mobile/src/screens/PacksScreen.tsx \
@@ -94,6 +94,46 @@ jobs:
             apps/mobile/src/navigation/AppNavigator.tsx \
             apps/api/src/social-adventure/dto/social-adventure.dto.ts \
             .github/workflows/native-social-adventure-ci.yml \
+            docs/NATIVE_SOCIAL_ADVENTURE_V1.md
+          if ! git diff --quiet -- \
+            apps/mobile/src/api/social-adventure.ts \
+            apps/mobile/src/screens/FeedScreen.tsx \
+            apps/mobile/src/screens/PacksScreen.tsx \
+            apps/mobile/src/components/community/SocialAdventureCommunityView.tsx \
+            apps/mobile/src/components/community/SocialAdventurePacksView.tsx \
+            apps/mobile/src/navigation/AppNavigator.tsx \
+            apps/api/src/social-adventure/dto/social-adventure.dto.ts \
+            .github/workflows/native-social-adventure-ci.yml \
+            docs/NATIVE_SOCIAL_ADVENTURE_V1.md
+          then
+            git diff -- \
+              apps/mobile/src/api/social-adventure.ts \
+              apps/mobile/src/screens/FeedScreen.tsx \
+              apps/mobile/src/screens/PacksScreen.tsx \
+              apps/mobile/src/components/community/SocialAdventureCommunityView.tsx \
+              apps/mobile/src/components/community/SocialAdventurePacksView.tsx \
+              apps/mobile/src/navigation/AppNavigator.tsx \
+              apps/api/src/social-adventure/dto/social-adventure.dto.ts \
+              .github/workflows/native-social-adventure-ci.yml \
+              docs/NATIVE_SOCIAL_ADVENTURE_V1.md | head -c 60000
+            exit 1
+          fi
+
+      - name: Upload canonical native Prettier output
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: native-social-adventure-prettier-output
+          retention-days: 1
+          path: |
+            apps/mobile/src/api/social-adventure.ts
+            apps/mobile/src/screens/FeedScreen.tsx
+            apps/mobile/src/screens/PacksScreen.tsx
+            apps/mobile/src/components/community/SocialAdventureCommunityView.tsx
+            apps/mobile/src/components/community/SocialAdventurePacksView.tsx
+            apps/mobile/src/navigation/AppNavigator.tsx
+            apps/api/src/social-adventure/dto/social-adventure.dto.ts
+            .github/workflows/native-social-adventure-ci.yml
             docs/NATIVE_SOCIAL_ADVENTURE_V1.md
 
       - name: Re-run server Social Adventure score policy tests

--- a/.github/workflows/native-social-adventure-ci.yml
+++ b/.github/workflows/native-social-adventure-ci.yml
@@ -15,8 +15,13 @@ on:
       - 'apps/api/src/social-adventure/social-adventure.policy.ts'
       - 'apps/api/src/social-adventure/social-adventure.policy.spec.ts'
       - 'apps/api/src/social-adventure/dto/social-adventure.dto.ts'
+      - 'apps/api/src/social-adventure/pack-locality.catalog.ts'
+      - 'apps/api/src/social-adventure/pack-locality.service.ts'
+      - 'packages/database/prisma/migrations/20260911233500_add_structured_pack_locality/**'
       - '.github/scripts/assert-native-social-adventure.py'
+      - '.github/scripts/assert-structured-pack-locality.py'
       - '.github/workflows/native-social-adventure-ci.yml'
+      - '.github/workflows/structured-pack-locality-ci.yml'
       - 'docs/NATIVE_SOCIAL_ADVENTURE_V1.md'
   push:
     branches: [main]
@@ -32,8 +37,13 @@ on:
       - 'apps/api/src/social-adventure/social-adventure.policy.ts'
       - 'apps/api/src/social-adventure/social-adventure.policy.spec.ts'
       - 'apps/api/src/social-adventure/dto/social-adventure.dto.ts'
+      - 'apps/api/src/social-adventure/pack-locality.catalog.ts'
+      - 'apps/api/src/social-adventure/pack-locality.service.ts'
+      - 'packages/database/prisma/migrations/20260911233500_add_structured_pack_locality/**'
       - '.github/scripts/assert-native-social-adventure.py'
+      - '.github/scripts/assert-structured-pack-locality.py'
       - '.github/workflows/native-social-adventure-ci.yml'
+      - '.github/workflows/structured-pack-locality-ci.yml'
       - 'docs/NATIVE_SOCIAL_ADVENTURE_V1.md'
 
 permissions:
@@ -69,6 +79,9 @@ jobs:
 
       - name: Enforce native Social Adventure source contract
         run: python3 .github/scripts/assert-native-social-adventure.py
+
+      - name: Enforce structured Pack locality source contract
+        run: python3 .github/scripts/assert-structured-pack-locality.py
 
       - name: Check native Social Adventure formatting
         run: |

--- a/.github/workflows/structured-pack-locality-ci.yml
+++ b/.github/workflows/structured-pack-locality-ci.yml
@@ -21,6 +21,7 @@ on:
       - '.github/workflows/structured-pack-locality-ci.yml'
       - '.github/workflows/native-social-adventure-ci.yml'
       - 'docs/NATIVE_SOCIAL_ADVENTURE_V1.md'
+      - 'docs/DOGOS_SOCIAL_ADVENTURE_V1.md'
   push:
     branches: [main]
     paths:
@@ -41,6 +42,7 @@ on:
       - '.github/workflows/structured-pack-locality-ci.yml'
       - '.github/workflows/native-social-adventure-ci.yml'
       - 'docs/NATIVE_SOCIAL_ADVENTURE_V1.md'
+      - 'docs/DOGOS_SOCIAL_ADVENTURE_V1.md'
   workflow_dispatch:
 
 permissions:
@@ -145,7 +147,8 @@ jobs:
             apps/mobile/src/components/community/SocialAdventurePacksView.tsx \
             .github/workflows/structured-pack-locality-ci.yml \
             .github/workflows/native-social-adventure-ci.yml \
-            docs/NATIVE_SOCIAL_ADVENTURE_V1.md
+            docs/NATIVE_SOCIAL_ADVENTURE_V1.md \
+            docs/DOGOS_SOCIAL_ADVENTURE_V1.md
 
       - name: Type-check API
         run: pnpm --filter @woof/api type-check

--- a/.github/workflows/structured-pack-locality-ci.yml
+++ b/.github/workflows/structured-pack-locality-ci.yml
@@ -1,0 +1,171 @@
+name: Structured Pack Locality CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/database/prisma/migrations/20260911233500_add_structured_pack_locality/**'
+      - 'apps/api/src/social-adventure/pack-locality.catalog.ts'
+      - 'apps/api/src/social-adventure/pack-locality.service.ts'
+      - 'apps/api/src/social-adventure/pack-locality.integration.spec.ts'
+      - 'apps/api/src/social-adventure/social-adventure.controller.ts'
+      - 'apps/api/src/social-adventure/social-adventure.service.ts'
+      - 'apps/api/src/social-adventure/dto/social-adventure.dto.ts'
+      - 'apps/web/src/lib/api/social-adventure.ts'
+      - 'apps/web/src/app/community/packs/page.tsx'
+      - 'apps/mobile/src/api/social-adventure.ts'
+      - 'apps/mobile/src/screens/PacksScreen.tsx'
+      - 'apps/mobile/src/components/community/SocialAdventurePacksView.tsx'
+      - '.github/scripts/assert-structured-pack-locality.py'
+      - '.github/scripts/assert-native-social-adventure.py'
+      - '.github/workflows/structured-pack-locality-ci.yml'
+      - '.github/workflows/native-social-adventure-ci.yml'
+      - 'docs/NATIVE_SOCIAL_ADVENTURE_V1.md'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/database/prisma/migrations/20260911233500_add_structured_pack_locality/**'
+      - 'apps/api/src/social-adventure/pack-locality.catalog.ts'
+      - 'apps/api/src/social-adventure/pack-locality.service.ts'
+      - 'apps/api/src/social-adventure/pack-locality.integration.spec.ts'
+      - 'apps/api/src/social-adventure/social-adventure.controller.ts'
+      - 'apps/api/src/social-adventure/social-adventure.service.ts'
+      - 'apps/api/src/social-adventure/dto/social-adventure.dto.ts'
+      - 'apps/web/src/lib/api/social-adventure.ts'
+      - 'apps/web/src/app/community/packs/page.tsx'
+      - 'apps/mobile/src/api/social-adventure.ts'
+      - 'apps/mobile/src/screens/PacksScreen.tsx'
+      - 'apps/mobile/src/components/community/SocialAdventurePacksView.tsx'
+      - '.github/scripts/assert-structured-pack-locality.py'
+      - '.github/scripts/assert-native-social-adventure.py'
+      - '.github/workflows/structured-pack-locality-ci.yml'
+      - '.github/workflows/native-social-adventure-ci.yml'
+      - 'docs/NATIVE_SOCIAL_ADVENTURE_V1.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: structured-pack-locality-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  qualify:
+    name: Coarse locality authority + migration
+    runs-on: ubuntu-24.04
+    services:
+      postgres:
+        image: pgvector/pgvector:pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: woof_test
+        options: >-
+          --health-cmd "pg_isready -U postgres -d woof_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_test
+      SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/woof_shadow
+      JWT_SECRET: ci-only-structured-pack-locality-secret
+      NODE_ENV: test
+      ML_SERVICE_ENABLED: 'false'
+      ENABLE_ADVENTURE_SYSTEM: 'true'
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from committed lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter @woof/database db:generate
+
+      - name: Validate canonical Prisma schema
+        run: pnpm --filter @woof/database exec prisma validate
+
+      - name: Enforce structured Pack locality source contract
+        run: python3 .github/scripts/assert-structured-pack-locality.py
+
+      - name: Re-enforce native Social Adventure contract
+        run: python3 .github/scripts/assert-native-social-adventure.py
+
+      - name: Apply full canonical migration chain
+        run: pnpm --filter @woof/database db:migrate:deploy
+
+      - name: Prove migration remains additive to canonical Prisma authority
+        run: >-
+          pnpm --filter @woof/database exec prisma migrate diff
+          --from-url "$DATABASE_URL"
+          --to-schema-datamodel prisma/schema.prisma
+          --exit-code
+
+      - name: Prove approved region catalog exists without private-location columns
+        env:
+          PGPASSWORD: postgres
+        run: |
+          test "$(psql -h localhost -U postgres -d woof_test -Atc \
+            "SELECT COUNT(*) FROM dogos_social.coarse_regions WHERE id IN ('us-ca-san-francisco','us-ca-south-bay','us-ca-peninsula','us-ca-east-bay','us-ca-north-bay','us-ca-santa-cruz-county');")" = '6'
+          test "$(psql -h localhost -U postgres -d woof_test -Atc \
+            "SELECT COUNT(*) FROM information_schema.columns WHERE table_schema='dogos_social' AND table_name='coarse_regions' AND column_name IN ('latitude','longitude','address','postal_code');")" = '0'
+
+      - name: Run migrated-Postgres Pack locality authority tests
+        run: pnpm --filter @woof/api exec jest src/social-adventure/pack-locality.integration.spec.ts --runInBand
+
+      - name: Check structured locality formatting
+        run: |
+          pnpm exec prettier --check \
+            apps/api/src/social-adventure/pack-locality.catalog.ts \
+            apps/api/src/social-adventure/pack-locality.service.ts \
+            apps/api/src/social-adventure/pack-locality.integration.spec.ts \
+            apps/api/src/social-adventure/social-adventure.controller.ts \
+            apps/api/src/social-adventure/social-adventure.service.ts \
+            apps/api/src/social-adventure/dto/social-adventure.dto.ts \
+            apps/web/src/lib/api/social-adventure.ts \
+            apps/web/src/app/community/packs/page.tsx \
+            apps/mobile/src/api/social-adventure.ts \
+            apps/mobile/src/screens/PacksScreen.tsx \
+            apps/mobile/src/components/community/SocialAdventurePacksView.tsx \
+            .github/workflows/structured-pack-locality-ci.yml \
+            .github/workflows/native-social-adventure-ci.yml \
+            docs/NATIVE_SOCIAL_ADVENTURE_V1.md
+
+      - name: Type-check API
+        run: pnpm --filter @woof/api type-check
+
+      - name: Type-check Web
+        run: pnpm --filter @woof/web type-check
+
+      - name: Type-check native client
+        run: pnpm --filter @woof/mobile type-check
+
+      - name: Lint locality API surface
+        run: >-
+          pnpm --filter @woof/api exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          'src/social-adventure/**/*.ts'
+
+      - name: Lint locality Web surface
+        run: >-
+          pnpm --filter @woof/web exec eslint --max-warnings=0 --report-unused-disable-directives --format stylish
+          src/app/community/packs/page.tsx
+          src/lib/api/social-adventure.ts
+
+      - name: Lint native client
+        run: pnpm --filter @woof/mobile lint

--- a/.github/workflows/structured-pack-locality-ci.yml
+++ b/.github/workflows/structured-pack-locality-ci.yml
@@ -119,10 +119,12 @@ jobs:
           --to-schema-datamodel prisma/schema.prisma
           --exit-code
 
-      - name: Prove approved region catalog exists without private-location columns
+      - name: Prove approved region catalog is exact and contains no private-location columns
         env:
           PGPASSWORD: postgres
         run: |
+          test "$(psql -h localhost -U postgres -d woof_test -Atc \
+            "SELECT COUNT(*) FROM dogos_social.coarse_regions;")" = '6'
           test "$(psql -h localhost -U postgres -d woof_test -Atc \
             "SELECT COUNT(*) FROM dogos_social.coarse_regions WHERE id IN ('us-ca-san-francisco','us-ca-south-bay','us-ca-peninsula','us-ca-east-bay','us-ca-north-bay','us-ca-santa-cruz-county');")" = '6'
           test "$(psql -h localhost -U postgres -d woof_test -Atc \

--- a/apps/api/src/expeditions/expedition-journal.integration.spec.ts
+++ b/apps/api/src/expeditions/expedition-journal.integration.spec.ts
@@ -196,7 +196,7 @@ describe('ExpeditionJournalService integration', () => {
         'Journal Test Pack',
         ${`journal-test-${packId}`},
         'LOCAL',
-        'test-region',
+        'us-ca-south-bay',
         'PUBLIC',
         ${season.startsAt}
       )

--- a/apps/api/src/expeditions/expeditions.integration.spec.ts
+++ b/apps/api/src/expeditions/expeditions.integration.spec.ts
@@ -187,7 +187,7 @@ describe('ExpeditionsService integration', () => {
         id, owner_user_id, name, slug, scope, region_key, visibility, created_at
       ) VALUES (
         ${packId}, ${ownerId}, 'Expedition Test Pack', ${`expedition-test-${packId}`},
-        'LOCAL', 'test-region', 'PUBLIC', ${season.startsAt}
+        'LOCAL', 'us-ca-south-bay', 'PUBLIC', ${season.startsAt}
       )
     `);
     await prisma.$executeRaw(Prisma.sql`

--- a/apps/api/src/social-adventure/dto/social-adventure.dto.ts
+++ b/apps/api/src/social-adventure/dto/social-adventure.dto.ts
@@ -5,10 +5,10 @@ import {
   IsObject,
   IsOptional,
   IsString,
-  Matches,
   MaxLength,
   MinLength,
 } from 'class-validator';
+import { PACK_COARSE_REGION_IDS, type PackCoarseRegionId } from '../pack-locality.catalog';
 import { HUMAN_SKILL_CHALLENGES } from '../social-adventure.policy';
 
 export class UpdateSocialAdventurePreferencesDto {
@@ -65,15 +65,24 @@ export class CreatePackDto {
   name!: string;
 
   @ApiProperty({
-    example: 'south-bay-ca',
+    enum: PACK_COARSE_REGION_IDS,
+    example: 'us-ca-south-bay',
     description:
-      'User-supplied broad-area locality label. v1 enforces slug syntax and length only; clients must not collect or submit device coordinates, street addresses, precise venues, or route traces.',
+      'Server-approved broad locality identity. Clients select this value from the coarse-region catalog; arbitrary addresses, venues, coordinates, routes, and free-form locality text are rejected.',
   })
-  @IsString()
-  @MinLength(2)
-  @MaxLength(64)
-  @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
-  regionKey!: string;
+  @IsIn(PACK_COARSE_REGION_IDS)
+  regionKey!: PackCoarseRegionId;
+}
+
+export class UpdatePackLocalityDto {
+  @ApiProperty({
+    enum: PACK_COARSE_REGION_IDS,
+    example: 'us-ca-south-bay',
+    description:
+      'One approved broad locality used to repair a legacy Pack whose former free-form locality was discarded.',
+  })
+  @IsIn(PACK_COARSE_REGION_IDS)
+  regionKey!: PackCoarseRegionId;
 }
 
 export class HumanSkillChallengeParamDto {

--- a/apps/api/src/social-adventure/dto/social-adventure.dto.ts
+++ b/apps/api/src/social-adventure/dto/social-adventure.dto.ts
@@ -70,7 +70,7 @@ export class CreatePackDto {
     description:
       'Server-approved broad locality identity. Clients select this value from the coarse-region catalog; arbitrary addresses, venues, coordinates, routes, and free-form locality text are rejected.',
   })
-  @IsIn(PACK_COARSE_REGION_IDS)
+  @IsIn([...PACK_COARSE_REGION_IDS])
   regionKey!: PackCoarseRegionId;
 }
 
@@ -81,7 +81,7 @@ export class UpdatePackLocalityDto {
     description:
       'One approved broad locality used to repair a legacy Pack whose former free-form locality was discarded.',
   })
-  @IsIn(PACK_COARSE_REGION_IDS)
+  @IsIn([...PACK_COARSE_REGION_IDS])
   regionKey!: PackCoarseRegionId;
 }
 

--- a/apps/api/src/social-adventure/pack-locality.catalog.ts
+++ b/apps/api/src/social-adventure/pack-locality.catalog.ts
@@ -1,0 +1,54 @@
+export const PACK_COARSE_REGIONS = [
+  {
+    id: 'us-ca-san-francisco',
+    displayName: 'San Francisco, CA',
+    countryCode: 'US',
+    subdivisionCode: 'CA',
+    granularity: 'METRO',
+  },
+  {
+    id: 'us-ca-south-bay',
+    displayName: 'South Bay, CA',
+    countryCode: 'US',
+    subdivisionCode: 'CA',
+    granularity: 'BROAD_DISTRICT',
+  },
+  {
+    id: 'us-ca-peninsula',
+    displayName: 'Peninsula, CA',
+    countryCode: 'US',
+    subdivisionCode: 'CA',
+    granularity: 'BROAD_DISTRICT',
+  },
+  {
+    id: 'us-ca-east-bay',
+    displayName: 'East Bay, CA',
+    countryCode: 'US',
+    subdivisionCode: 'CA',
+    granularity: 'BROAD_DISTRICT',
+  },
+  {
+    id: 'us-ca-north-bay',
+    displayName: 'North Bay, CA',
+    countryCode: 'US',
+    subdivisionCode: 'CA',
+    granularity: 'BROAD_DISTRICT',
+  },
+  {
+    id: 'us-ca-santa-cruz-county',
+    displayName: 'Santa Cruz County, CA',
+    countryCode: 'US',
+    subdivisionCode: 'CA',
+    granularity: 'COUNTY',
+  },
+] as const;
+
+export type PackCoarseRegion = (typeof PACK_COARSE_REGIONS)[number];
+export type PackCoarseRegionId = PackCoarseRegion['id'];
+
+export const PACK_COARSE_REGION_IDS: readonly PackCoarseRegionId[] = PACK_COARSE_REGIONS.map(
+  (region) => region.id
+);
+
+export const PACK_LOCALITY_CONTRACT =
+  'server-approved coarse region only; no device GPS, address, route, or precise venue authority' as const;

--- a/apps/api/src/social-adventure/pack-locality.integration.spec.ts
+++ b/apps/api/src/social-adventure/pack-locality.integration.spec.ts
@@ -1,0 +1,165 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { randomUUID } from 'node:crypto';
+import { PrismaService } from '../prisma/prisma.service';
+import { PACK_COARSE_REGIONS } from './pack-locality.catalog';
+import { PackLocalityService } from './pack-locality.service';
+
+describe('PackLocalityService integration', () => {
+  const prisma = new PrismaService();
+  const service = new PackLocalityService(prisma);
+  const usersToDelete: string[] = [];
+
+  beforeAll(async () => {
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    if (usersToDelete.length > 0) {
+      await prisma.user.deleteMany({ where: { id: { in: usersToDelete } } });
+    }
+    await prisma.$disconnect();
+  });
+
+  async function createUser(label: string) {
+    const suffix = randomUUID().slice(0, 8);
+    const user = await prisma.user.create({
+      data: {
+        handle: `pack-locality-${label}-${suffix}`,
+        email: `pack-locality-${label}-${suffix}@example.test`,
+      },
+      select: { id: true },
+    });
+    usersToDelete.push(user.id);
+    return user.id;
+  }
+
+  async function createLocalPack(ownerUserId: string, regionKey: string | null) {
+    const id = randomUUID();
+    const slug = `pack-locality-${id.slice(0, 8)}`;
+    await prisma.$executeRaw(Prisma.sql`
+      INSERT INTO dogos_social.packs (
+        id,
+        owner_user_id,
+        name,
+        slug,
+        scope,
+        region_key,
+        visibility
+      ) VALUES (
+        ${id},
+        ${ownerUserId},
+        'Pack locality integration',
+        ${slug},
+        'LOCAL',
+        ${regionKey},
+        'PUBLIC'
+      )
+    `);
+    await prisma.$executeRaw(Prisma.sql`
+      INSERT INTO dogos_social.pack_memberships (pack_id, user_id, role, status)
+      VALUES (${id}, ${ownerUserId}, 'OWNER', 'ACTIVE')
+    `);
+    return id;
+  }
+
+  it('ships only deliberately broad client-selectable regions', () => {
+    expect(PACK_COARSE_REGIONS.length).toBeGreaterThan(0);
+    expect(PACK_COARSE_REGIONS).toContainEqual(
+      expect.objectContaining({
+        id: 'us-ca-south-bay',
+        granularity: 'BROAD_DISTRICT',
+      })
+    );
+    expect(PACK_COARSE_REGIONS.some((region) => region.id === 'test-region')).toBe(false);
+  });
+
+  it('lets migrated legacy Pack identity survive but blocks locality-dependent authority', async () => {
+    const ownerId = await createUser('legacy-owner');
+    const packId = await createLocalPack(ownerId, null);
+
+    await expect(service.requireLocalityAuthority(packId)).rejects.toBeInstanceOf(BadRequestException);
+
+    const decorated = service.decorateCatalog({
+      packs: [
+        {
+          id: packId,
+          name: 'Legacy Pack',
+          slug: 'legacy-pack',
+          scope: 'LOCAL',
+          regionKey: null,
+          visibility: 'PUBLIC',
+          memberCount: 1,
+          joined: true,
+          role: 'OWNER',
+        },
+      ],
+      localMinimumCohort: 5,
+      locationContract: 'legacy-value-must-not-win',
+    });
+
+    expect(decorated.packs).toHaveLength(1);
+    expect(decorated.packs[0]).toMatchObject({
+      id: packId,
+      localityStatus: 'LEGACY_UNVERIFIED',
+      coarseRegion: null,
+    });
+    expect(decorated.locationContract).toContain('server-approved coarse region only');
+  });
+
+  it('hides an unverified legacy Pack from nonmember discovery', async () => {
+    const ownerId = await createUser('hidden-owner');
+    const packId = await createLocalPack(ownerId, null);
+
+    const decorated = service.decorateCatalog({
+      packs: [
+        {
+          id: packId,
+          name: 'Hidden legacy Pack',
+          slug: 'hidden-legacy-pack',
+          scope: 'LOCAL',
+          regionKey: null,
+          visibility: 'PUBLIC',
+          memberCount: 1,
+          joined: false,
+          role: null,
+        },
+      ],
+      localMinimumCohort: 5,
+      locationContract: 'legacy-value-must-not-win',
+    });
+
+    expect(decorated.packs).toEqual([]);
+  });
+
+  it('allows only the owner to perform one conservative approved-region repair', async () => {
+    const ownerId = await createUser('repair-owner');
+    const strangerId = await createUser('repair-stranger');
+    const packId = await createLocalPack(ownerId, null);
+
+    await expect(
+      service.repairLocality(strangerId, packId, 'us-ca-south-bay')
+    ).rejects.toBeInstanceOf(NotFoundException);
+
+    await expect(service.repairLocality(ownerId, packId, 'us-ca-south-bay')).resolves.toMatchObject({
+      packId,
+      localityStatus: 'APPROVED',
+      coarseRegion: { id: 'us-ca-south-bay', displayName: 'South Bay, CA' },
+    });
+
+    await expect(service.requireLocalityAuthority(packId)).resolves.toBeUndefined();
+
+    await expect(service.repairLocality(ownerId, packId, 'us-ca-south-bay')).resolves.toMatchObject({
+      localityStatus: 'APPROVED',
+    });
+
+    await expect(service.repairLocality(ownerId, packId, 'us-ca-peninsula')).rejects.toBeInstanceOf(
+      BadRequestException
+    );
+  });
+
+  it('keeps arbitrary locality text outside the database authority boundary', async () => {
+    const ownerId = await createUser('fk-owner');
+    await expect(createLocalPack(ownerId, '123-main-st-apartment-4')).rejects.toThrow();
+  });
+});

--- a/apps/api/src/social-adventure/pack-locality.integration.spec.ts
+++ b/apps/api/src/social-adventure/pack-locality.integration.spec.ts
@@ -71,14 +71,17 @@ describe('PackLocalityService integration', () => {
         granularity: 'BROAD_DISTRICT',
       })
     );
-    expect(PACK_COARSE_REGIONS.some((region) => region.id === 'test-region')).toBe(false);
+    const clientRegionIds: readonly string[] = PACK_COARSE_REGIONS.map((region) => region.id);
+    expect(clientRegionIds).not.toContain('test-region');
   });
 
   it('lets migrated legacy Pack identity survive but blocks locality-dependent authority', async () => {
     const ownerId = await createUser('legacy-owner');
     const packId = await createLocalPack(ownerId, null);
 
-    await expect(service.requireLocalityAuthority(packId)).rejects.toBeInstanceOf(BadRequestException);
+    await expect(service.requireLocalityAuthority(packId)).rejects.toBeInstanceOf(
+      BadRequestException
+    );
 
     const decorated = service.decorateCatalog({
       packs: [
@@ -141,17 +144,21 @@ describe('PackLocalityService integration', () => {
       service.repairLocality(strangerId, packId, 'us-ca-south-bay')
     ).rejects.toBeInstanceOf(NotFoundException);
 
-    await expect(service.repairLocality(ownerId, packId, 'us-ca-south-bay')).resolves.toMatchObject({
-      packId,
-      localityStatus: 'APPROVED',
-      coarseRegion: { id: 'us-ca-south-bay', displayName: 'South Bay, CA' },
-    });
+    await expect(service.repairLocality(ownerId, packId, 'us-ca-south-bay')).resolves.toMatchObject(
+      {
+        packId,
+        localityStatus: 'APPROVED',
+        coarseRegion: { id: 'us-ca-south-bay', displayName: 'South Bay, CA' },
+      }
+    );
 
     await expect(service.requireLocalityAuthority(packId)).resolves.toBeUndefined();
 
-    await expect(service.repairLocality(ownerId, packId, 'us-ca-south-bay')).resolves.toMatchObject({
-      localityStatus: 'APPROVED',
-    });
+    await expect(service.repairLocality(ownerId, packId, 'us-ca-south-bay')).resolves.toMatchObject(
+      {
+        localityStatus: 'APPROVED',
+      }
+    );
 
     await expect(service.repairLocality(ownerId, packId, 'us-ca-peninsula')).rejects.toBeInstanceOf(
       BadRequestException

--- a/apps/api/src/social-adventure/pack-locality.service.ts
+++ b/apps/api/src/social-adventure/pack-locality.service.ts
@@ -44,20 +44,21 @@ export class PackLocalityService {
   }
 
   decorateCatalog(catalog: PackCatalogLike) {
-    const regionsById = new Map(PACK_COARSE_REGIONS.map((region) => [region.id, region]));
     return {
       ...catalog,
       packs: catalog.packs
-        .filter((pack) => pack.joined || (pack.regionKey !== null && regionsById.has(pack.regionKey)))
-        .map((pack) => ({
-          ...pack,
-          localityStatus:
-            pack.regionKey !== null && regionsById.has(pack.regionKey)
-              ? ('APPROVED' as const)
-              : ('LEGACY_UNVERIFIED' as const),
-          coarseRegion: pack.regionKey ? regionsById.get(pack.regionKey) ?? null : null,
-        })),
+        .filter((pack) => pack.joined || this.isApprovedRegionId(pack.regionKey))
+        .map((pack) => this.decoratePack(pack)),
       locationContract: PACK_LOCALITY_CONTRACT,
+    };
+  }
+
+  decoratePack(pack: PackCatalogRow) {
+    const coarseRegion = this.regionById(pack.regionKey);
+    return {
+      ...pack,
+      localityStatus: coarseRegion ? ('APPROVED' as const) : ('LEGACY_UNVERIFIED' as const),
+      coarseRegion,
     };
   }
 
@@ -129,7 +130,7 @@ export class PackLocalityService {
   }
 
   private repairReceipt(packId: string, regionKey: PackCoarseRegionId) {
-    const coarseRegion = PACK_COARSE_REGIONS.find((region) => region.id === regionKey);
+    const coarseRegion = this.regionById(regionKey);
     if (!coarseRegion) throw new BadRequestException('Choose an approved broad locality');
     return {
       packId,
@@ -139,7 +140,12 @@ export class PackLocalityService {
     };
   }
 
+  private regionById(value: string | null) {
+    if (value === null) return null;
+    return PACK_COARSE_REGIONS.find((region) => region.id === value) ?? null;
+  }
+
   private isApprovedRegionId(value: string | null): value is PackCoarseRegionId {
-    return value !== null && PACK_COARSE_REGIONS.some((region) => region.id === value);
+    return this.regionById(value) !== null;
   }
 }

--- a/apps/api/src/social-adventure/pack-locality.service.ts
+++ b/apps/api/src/social-adventure/pack-locality.service.ts
@@ -1,0 +1,140 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@woof/database';
+import { PrismaService } from '../prisma/prisma.service';
+import {
+  PACK_COARSE_REGIONS,
+  PACK_LOCALITY_CONTRACT,
+  type PackCoarseRegionId,
+} from './pack-locality.catalog';
+
+type PackLocalityRow = {
+  id: string;
+  ownerUserId: string;
+  scope: string;
+  regionKey: string | null;
+};
+
+type PackCatalogRow = {
+  id: string;
+  regionKey: string | null;
+  joined: boolean;
+  [key: string]: unknown;
+};
+
+export type PackCatalogLike = {
+  packs: PackCatalogRow[];
+  localMinimumCohort: number;
+  locationContract: string;
+};
+
+@Injectable()
+export class PackLocalityService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  getRegions() {
+    return {
+      regions: PACK_COARSE_REGIONS,
+      locationContract: PACK_LOCALITY_CONTRACT,
+    };
+  }
+
+  decorateCatalog(catalog: PackCatalogLike) {
+    const regionsById = new Map(PACK_COARSE_REGIONS.map((region) => [region.id, region]));
+    return {
+      ...catalog,
+      packs: catalog.packs
+        .filter((pack) => pack.joined || (pack.regionKey !== null && regionsById.has(pack.regionKey)))
+        .map((pack) => ({
+          ...pack,
+          localityStatus:
+            pack.regionKey !== null && regionsById.has(pack.regionKey)
+              ? ('APPROVED' as const)
+              : ('LEGACY_UNVERIFIED' as const),
+          coarseRegion: pack.regionKey ? regionsById.get(pack.regionKey) ?? null : null,
+        })),
+      locationContract: PACK_LOCALITY_CONTRACT,
+    };
+  }
+
+  async requireLocalityAuthority(packId: string): Promise<void> {
+    const rows = await this.prisma.$queryRaw<PackLocalityRow[]>(Prisma.sql`
+      SELECT
+        id,
+        owner_user_id AS "ownerUserId",
+        scope,
+        region_key AS "regionKey"
+      FROM dogos_social.packs
+      WHERE id = ${packId}
+      LIMIT 1
+    `);
+    const pack = rows[0];
+    if (!pack) throw new NotFoundException('Pack not found');
+    if (pack.scope === 'LOCAL' && !this.isApprovedRegionId(pack.regionKey)) {
+      throw new BadRequestException(
+        'This legacy Pack needs an approved broad locality before discovery, joining, or local standings are available.'
+      );
+    }
+  }
+
+  async repairLocality(userId: string, packId: string, regionKey: PackCoarseRegionId) {
+    if (!this.isApprovedRegionId(regionKey)) {
+      throw new BadRequestException('Choose an approved broad locality');
+    }
+
+    const rows = await this.prisma.$queryRaw<PackLocalityRow[]>(Prisma.sql`
+      SELECT
+        id,
+        owner_user_id AS "ownerUserId",
+        scope,
+        region_key AS "regionKey"
+      FROM dogos_social.packs
+      WHERE id = ${packId}
+      LIMIT 1
+    `);
+    const pack = rows[0];
+    if (!pack || pack.ownerUserId !== userId) {
+      // Keep Pack ownership non-enumerable through this authority boundary.
+      throw new NotFoundException('Pack not found');
+    }
+    if (pack.scope !== 'LOCAL') {
+      throw new BadRequestException('Only local Packs have a coarse locality');
+    }
+    if (pack.regionKey === regionKey) {
+      return this.repairReceipt(pack.id, regionKey);
+    }
+    if (pack.regionKey !== null) {
+      throw new BadRequestException(
+        'This Pack already has an approved locality. Changing an established locality requires a separate reviewed policy.'
+      );
+    }
+
+    const updated = await this.prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+      UPDATE dogos_social.packs
+      SET region_key = ${regionKey}
+      WHERE id = ${packId}
+        AND owner_user_id = ${userId}
+        AND scope = 'LOCAL'
+        AND region_key IS NULL
+      RETURNING id
+    `);
+    if (!updated[0]) {
+      throw new BadRequestException('Pack locality changed concurrently; refresh before retrying');
+    }
+    return this.repairReceipt(packId, regionKey);
+  }
+
+  private repairReceipt(packId: string, regionKey: PackCoarseRegionId) {
+    const coarseRegion = PACK_COARSE_REGIONS.find((region) => region.id === regionKey);
+    if (!coarseRegion) throw new BadRequestException('Choose an approved broad locality');
+    return {
+      packId,
+      localityStatus: 'APPROVED' as const,
+      coarseRegion,
+      locationContract: PACK_LOCALITY_CONTRACT,
+    };
+  }
+
+  private isApprovedRegionId(value: string | null): value is PackCoarseRegionId {
+    return value !== null && PACK_COARSE_REGIONS.some((region) => region.id === value);
+  }
+}

--- a/apps/api/src/social-adventure/pack-locality.service.ts
+++ b/apps/api/src/social-adventure/pack-locality.service.ts
@@ -16,9 +16,14 @@ type PackLocalityRow = {
 
 type PackCatalogRow = {
   id: string;
+  name: string;
+  slug: string;
+  scope: string;
   regionKey: string | null;
+  visibility: string;
+  memberCount: number;
   joined: boolean;
-  [key: string]: unknown;
+  role: string | null;
 };
 
 export type PackCatalogLike = {

--- a/apps/api/src/social-adventure/pack-locality.service.ts
+++ b/apps/api/src/social-adventure/pack-locality.service.ts
@@ -14,12 +14,15 @@ type PackLocalityRow = {
   regionKey: string | null;
 };
 
-type PackCatalogRow = {
+type PackLocalityShape = {
   id: string;
+  regionKey: string | null;
+};
+
+type PackCatalogRow = PackLocalityShape & {
   name: string;
   slug: string;
   scope: string;
-  regionKey: string | null;
   visibility: string;
   memberCount: number;
   joined: boolean;
@@ -53,7 +56,7 @@ export class PackLocalityService {
     };
   }
 
-  decoratePack(pack: PackCatalogRow) {
+  decoratePack<T extends PackLocalityShape>(pack: T) {
     const coarseRegion = this.regionById(pack.regionKey);
     return {
       ...pack,

--- a/apps/api/src/social-adventure/social-adventure.controller.ts
+++ b/apps/api/src/social-adventure/social-adventure.controller.ts
@@ -18,8 +18,10 @@ import {
   CreatePackDto,
   CreateSocialShareDto,
   SocialReactionDto,
+  UpdatePackLocalityDto,
   UpdateSocialAdventurePreferencesDto,
 } from './dto/social-adventure.dto';
+import { PackLocalityService } from './pack-locality.service';
 import { SocialAdventureService } from './social-adventure.service';
 
 @ApiTags('social-adventure')
@@ -27,7 +29,10 @@ import { SocialAdventureService } from './social-adventure.service';
 @UseGuards(JwtAuthGuard)
 @Controller('social-adventure')
 export class SocialAdventureController {
-  constructor(private readonly socialAdventure: SocialAdventureService) {}
+  constructor(
+    private readonly socialAdventure: SocialAdventureService,
+    private readonly packLocality: PackLocalityService
+  ) {}
 
   @Get('me')
   getMine(@Request() req: AuthenticatedRequest) {
@@ -47,9 +52,15 @@ export class SocialAdventureController {
     return this.socialAdventure.getGlobalLeaderboard(req.user.sub, Number(limit));
   }
 
+  @Get('regions')
+  getRegions() {
+    return this.packLocality.getRegions();
+  }
+
   @Get('packs')
-  listPacks(@Request() req: AuthenticatedRequest) {
-    return this.socialAdventure.listPacks(req.user.sub);
+  async listPacks(@Request() req: AuthenticatedRequest) {
+    const catalog = await this.socialAdventure.listPacks(req.user.sub);
+    return this.packLocality.decorateCatalog(catalog);
   }
 
   @Post('packs')
@@ -57,8 +68,18 @@ export class SocialAdventureController {
     return this.socialAdventure.createPack(req.user.sub, dto);
   }
 
+  @Put('packs/:packId/locality')
+  repairPackLocality(
+    @Request() req: AuthenticatedRequest,
+    @Param('packId') packId: string,
+    @Body() dto: UpdatePackLocalityDto
+  ) {
+    return this.packLocality.repairLocality(req.user.sub, packId, dto.regionKey);
+  }
+
   @Post('packs/:packId/join')
-  joinPack(@Request() req: AuthenticatedRequest, @Param('packId') packId: string) {
+  async joinPack(@Request() req: AuthenticatedRequest, @Param('packId') packId: string) {
+    await this.packLocality.requireLocalityAuthority(packId);
     return this.socialAdventure.joinPack(req.user.sub, packId);
   }
 
@@ -68,11 +89,12 @@ export class SocialAdventureController {
   }
 
   @Get('packs/:packId/leaderboard')
-  getPackLeaderboard(
+  async getPackLeaderboard(
     @Request() req: AuthenticatedRequest,
     @Param('packId') packId: string,
     @Query('limit') limit?: string
   ) {
+    await this.packLocality.requireLocalityAuthority(packId);
     return this.socialAdventure.getPackLeaderboard(req.user.sub, packId, Number(limit));
   }
 

--- a/apps/api/src/social-adventure/social-adventure.controller.ts
+++ b/apps/api/src/social-adventure/social-adventure.controller.ts
@@ -64,8 +64,9 @@ export class SocialAdventureController {
   }
 
   @Post('packs')
-  createPack(@Request() req: AuthenticatedRequest, @Body() dto: CreatePackDto) {
-    return this.socialAdventure.createPack(req.user.sub, dto);
+  async createPack(@Request() req: AuthenticatedRequest, @Body() dto: CreatePackDto) {
+    const created = await this.socialAdventure.createPack(req.user.sub, dto);
+    return this.packLocality.decoratePack(created);
   }
 
   @Put('packs/:packId/locality')

--- a/apps/api/src/social-adventure/social-adventure.module.ts
+++ b/apps/api/src/social-adventure/social-adventure.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { PackAccessService } from './pack-access.service';
+import { PackLocalityService } from './pack-locality.service';
 import { SocialAdventureShareCandidatesController } from './social-adventure-share-candidates.controller';
 import { SocialAdventureShareCandidatesService } from './social-adventure-share-candidates.service';
 import { SocialAdventureController } from './social-adventure.controller';
@@ -7,7 +8,12 @@ import { SocialAdventureService } from './social-adventure.service';
 
 @Module({
   controllers: [SocialAdventureController, SocialAdventureShareCandidatesController],
-  providers: [PackAccessService, SocialAdventureService, SocialAdventureShareCandidatesService],
-  exports: [PackAccessService, SocialAdventureService],
+  providers: [
+    PackAccessService,
+    PackLocalityService,
+    SocialAdventureService,
+    SocialAdventureShareCandidatesService,
+  ],
+  exports: [PackAccessService, PackLocalityService, SocialAdventureService],
 })
 export class SocialAdventureModule {}

--- a/apps/api/src/social-adventure/social-adventure.service.ts
+++ b/apps/api/src/social-adventure/social-adventure.service.ts
@@ -1,32 +1,106 @@
-import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@woof/database';
-import { createHash, randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { PrismaService } from '../prisma/prisma.service';
+import { PackAccessService } from './pack-access.service';
+import {
+  publicArcadeCatalog,
+  scenarioByKey,
+  scenarioForChallenge,
+  scoreArcadeResponse,
+} from './social-adventure.arcade';
+import {
+  currentUtcSeason,
+  deriveSocialAdventureScore,
+  HUMAN_SKILL_CHALLENGES,
+  HUMAN_SKILL_CHALLENGE_VERSION,
+  LOCAL_LEAGUE_MINIMUM_COHORT,
+  SOCIAL_ADVENTURE_POLICY_VERSION,
+  type HumanSkillChallenge,
+} from './social-adventure.policy';
 import type {
   CompleteHumanSkillAttemptDto,
   CreatePackDto,
   CreateSocialShareDto,
   SocialReactionDto,
+  UpdateSocialAdventurePreferencesDto,
 } from './dto/social-adventure.dto';
-import { PackAccessService } from './pack-access.service';
-import {
-  ADVENTURE_VARIETY_POINTS,
-  HUMAN_SKILL_BREADTH_POINTS,
-  HUMAN_SKILL_CHALLENGE_VERSION,
-  HUMAN_SKILL_CHALLENGES,
-  HUMAN_SKILL_SCENARIOS,
-  LOCAL_LEAGUE_MINIMUM_COHORT,
-  SOCIAL_ADVENTURE_PATHWAYS,
-  SOCIAL_ADVENTURE_POLICY_VERSION,
-  deriveSocialAdventureScore,
-  getCurrentSocialSeason,
-  scoreHumanSkillAttempt,
-  type HumanSkillAttemptResponse,
-  type HumanSkillChallengeKey,
-} from './social-adventure.policy';
 
-type PreferenceRow = { globalLeaderboardOptIn: boolean };
-type LeaderboardUserRow = { id: string; handle: string; avatarUrl: string | null };
+type PreferenceRow = {
+  globalLeaderboardOptIn: boolean;
+};
+
+type SkillAttemptRow = {
+  id: string;
+  challengeKey: string;
+  challengeVersion: string;
+  scenarioKey: string;
+  issuedAt: Date;
+  expiresAt: Date;
+  completedAt: Date | null;
+  score: number | null;
+  receipt: unknown;
+};
+
+type SkillScoreRow = {
+  id: string;
+  challengeKey: string;
+  score: number;
+};
+
+type AdventureEvidenceRow = {
+  id: string;
+  pathway: string;
+};
+
+type LeaderboardUserRow = {
+  id: string;
+  handle: string;
+  avatarUrl: string | null;
+};
+
+type ShareSource = {
+  sourceType: 'CARE_EVENT' | 'HUMAN_SKILL_ATTEMPT';
+  sourceId: string;
+  petId: string | null;
+  kind: 'ADVENTURE_MEMORY' | 'DISCOVERY' | 'SKILL_MOMENT' | 'GOOD_READ';
+  headline: string;
+  summary: string;
+  payload: Record<string, unknown>;
+};
+
+type ExistingShareRow = {
+  id: string;
+  postId: string;
+};
+
+type FeedRow = {
+  shareId: string;
+  postId: string;
+  kind: string;
+  headline: string;
+  summary: string;
+  payload: unknown;
+  caption: string | null;
+  visibility: string;
+  createdAt: Date;
+  authorUserId: string;
+  handle: string;
+  avatarUrl: string | null;
+  petId: string | null;
+  petName: string | null;
+  petAvatarUrl: string | null;
+  likesCount: number;
+  commentsCount: number;
+};
+
+type ReactionRow = {
+  shareId: string;
+  reaction: string;
+  count: number;
+  mine: boolean;
+};
+
 type PackRow = {
   id: string;
   name: string;
@@ -38,71 +112,16 @@ type PackRow = {
   joined: boolean;
   role: string | null;
 };
-type HumanSkillRow = {
-  id: string;
-  challengeKey: string;
-  challengeVersion: string;
-  score: number;
-};
-type HumanSkillBestScoreRow = { challengeKey: string; score: number };
-type HumanSkillAttemptRow = {
-  id: string;
-  userId: string;
-  challengeKey: string;
-  challengeVersion: string;
-  scenarioKey: string;
-  issuedAt: Date;
-  expiresAt: Date;
-  completedAt: Date | null;
-};
-type ShareRow = {
-  id: string;
-  postId: string;
-  sourceType: string;
-  sourceId: string;
-  caption: string | null;
-  visibility: string;
-  createdAt: Date;
-};
 
-type CareShareSourceRow = {
-  id: string;
-  petId: string;
-  createdBy: string;
-  eventType: string;
-  title: string;
-  note: string | null;
-  occurredAt: Date;
-  petName: string;
-};
+const REACTION_TYPES = [
+  'NICE_READ',
+  'GOOD_CALL',
+  'TRYING_THIS',
+  'ADVENTURE_INSPIRATION',
+  'CHEER',
+] as const;
 
-type SkillShareSourceRow = {
-  id: string;
-  userId: string;
-  challengeKey: string;
-  challengeVersion: string;
-  score: number;
-  receipt: Prisma.JsonValue;
-  completedAt: Date;
-};
-
-type FeedRow = {
-  shareId: string;
-  postId: string;
-  kind: string;
-  headline: string;
-  summary: string;
-  payload: Prisma.JsonValue;
-  caption: string | null;
-  visibility: string;
-  createdAt: Date;
-  authorUserId: string;
-  handle: string;
-  avatarUrl: string | null;
-  petName: string | null;
-};
-type ReactionRow = { shareId: string; reaction: string; count: number; mine: boolean };
-type PathwayRow = { pathway: string };
+const ATTEMPT_TTL_MS = 10 * 60 * 1000;
 
 @Injectable()
 export class SocialAdventureService {
@@ -111,51 +130,51 @@ export class SocialAdventureService {
     private readonly packAccess: PackAccessService
   ) {}
 
-  private async getPreferences(userId: string): Promise<PreferenceRow> {
-    const rows = await this.prisma.$queryRaw<PreferenceRow[]>(Prisma.sql`
-      SELECT global_leaderboard_opt_in AS "globalLeaderboardOptIn"
-      FROM dogos_social.user_preferences
-      WHERE user_id = ${userId}
-      LIMIT 1
-    `);
-    return rows[0] ?? { globalLeaderboardOptIn: false };
-  }
-
   async getMine(userId: string) {
-    const [preferences, score, humanSkillBestScores] = await Promise.all([
+    const [preferences, score, bestScores] = await Promise.all([
       this.getPreferences(userId),
       this.computeScore(userId),
-      this.getHumanSkillBestScores(userId),
+      this.getBestHumanSkillScores(userId),
     ]);
+
     return {
       preferences,
-      ...score,
-      humanSkillBestScores,
+      season: score.season,
+      score: score.score,
+      maxScore: score.maxScore,
+      components: score.components,
+      humanSkillBestScores: bestScores,
       policyVersion: SOCIAL_ADVENTURE_POLICY_VERSION,
       principles: [
-        'You compete. Your dog does not.',
-        'Health, symptoms, exercise volume, pet performance, and missed days never add league points.',
-        'Reactions build culture, not rank.',
+        'human-skill-over-pet-performance',
+        'variety-over-volume',
+        'no-streak-loss',
+        'no-health-competition',
+        'no-posting-or-popularity-points',
       ],
     };
   }
 
-  async updatePreferences(userId: string, dto: { globalLeaderboardOptIn: boolean }) {
-    const rows = await this.prisma.$queryRaw<PreferenceRow[]>(Prisma.sql`
-      INSERT INTO dogos_social.user_preferences (user_id, global_leaderboard_opt_in, updated_at)
+  async updatePreferences(userId: string, dto: UpdateSocialAdventurePreferencesDto) {
+    await this.prisma.$executeRaw(Prisma.sql`
+      INSERT INTO dogos_social.preferences (user_id, global_leaderboard_opt_in, updated_at)
       VALUES (${userId}, ${dto.globalLeaderboardOptIn}, NOW())
       ON CONFLICT (user_id)
-      DO UPDATE SET global_leaderboard_opt_in = EXCLUDED.global_leaderboard_opt_in, updated_at = NOW()
-      RETURNING global_leaderboard_opt_in AS "globalLeaderboardOptIn"
+      DO UPDATE SET
+        global_leaderboard_opt_in = EXCLUDED.global_leaderboard_opt_in,
+        updated_at = NOW()
     `);
-    return rows[0] ?? { globalLeaderboardOptIn: dto.globalLeaderboardOptIn };
+    return this.getPreferences(userId);
   }
 
   async getGlobalLeaderboard(userId: string, limit = 30) {
     const safeLimit = Math.max(1, Math.min(Number(limit) || 30, 50));
     const candidates = await this.prisma.$queryRaw<LeaderboardUserRow[]>(Prisma.sql`
-      SELECT u.id, u.handle, u.avatar_url AS "avatarUrl"
-      FROM dogos_social.user_preferences pref
+      SELECT
+        u.id,
+        u.handle,
+        u.avatar_url AS "avatarUrl"
+      FROM dogos_social.preferences pref
       JOIN public.users u ON u.id = pref.user_id
       WHERE pref.global_leaderboard_opt_in = TRUE
         AND u.visibility = 'PUBLIC'
@@ -168,6 +187,7 @@ export class SocialAdventureService {
       ORDER BY u.id ASC
       LIMIT 100
     `);
+
     const rows = await this.scoreLeaderboardUsers(candidates);
     const entries = rows.slice(0, safeLimit).map((row, index) => ({ ...row, rank: index + 1 }));
     const me = await this.computeScore(userId);
@@ -258,7 +278,7 @@ export class SocialAdventureService {
     return {
       packs: rows,
       localMinimumCohort: LOCAL_LEAGUE_MINIMUM_COHORT,
-      locationContract: 'server-approved-coarse-region-only',
+      locationContract: 'coarse-user-chosen-region-only',
     };
   }
 
@@ -280,17 +300,7 @@ export class SocialAdventureService {
       `);
     });
 
-    return {
-      id,
-      name: dto.name.trim(),
-      slug,
-      scope: 'LOCAL',
-      regionKey: dto.regionKey,
-      visibility: 'PUBLIC',
-      memberCount: 1,
-      joined: true,
-      role: 'OWNER',
-    };
+    return { id, name: dto.name.trim(), slug, regionKey: dto.regionKey, joined: true };
   }
 
   async joinPack(userId: string, packId: string) {
@@ -318,87 +328,56 @@ export class SocialAdventureService {
     const membership = rows[0];
     if (!membership) return { ok: true };
     if (membership.role === 'OWNER') {
-      throw new ConflictException('Transfer or retire this Pack before leaving');
+      throw new BadRequestException(
+        'A Pack owner cannot leave without transferring or retiring the Pack'
+      );
     }
 
     await this.prisma.$executeRaw(Prisma.sql`
       UPDATE dogos_social.pack_memberships
-      SET status = 'LEFT', left_at = NOW()
+      SET status = 'LEFT'
       WHERE pack_id = ${packId} AND user_id = ${userId}
     `);
     return { ok: true };
   }
 
   async getArcade(userId: string) {
-    const bestScores = await this.getHumanSkillBestScores(userId);
-    const challenges = HUMAN_SKILL_CHALLENGES.map((challengeKey) => {
-      const scenario = HUMAN_SKILL_SCENARIOS[challengeKey][0];
-      return {
-        challengeKey,
-        challengeVersion: HUMAN_SKILL_CHALLENGE_VERSION,
-        scenarioKey: scenario.scenarioKey,
-        title: scenario.title,
-        skill: scenario.skill,
-        prompt: scenario.prompt,
-        options: 'options' in scenario ? scenario.options : undefined,
-        timing: 'timing' in scenario ? scenario.timing : undefined,
-        bestScore: bestScores[challengeKey] ?? null,
-      };
-    });
+    const bestScores = await this.getBestHumanSkillScores(userId);
     return {
       challengeVersion: HUMAN_SKILL_CHALLENGE_VERSION,
-      challenges,
+      challenges: publicArcadeCatalog().map((scenario) => ({
+        ...scenario,
+        bestScore: bestScores[scenario.challengeKey] ?? null,
+      })),
       scoring:
-        'Practice scores are private feedback. Social Adventure league credit comes from completing distinct Human Skill rooms, not from score magnitude or browser timing.',
+        'Arcade scores are personal practice feedback. Completing each different Human Skill game once this week contributes one fixed breadth unit; higher scores and retries add no league points.',
     };
   }
 
-  async startHumanSkillAttempt(userId: string, challengeKeyRaw: string) {
-    const challengeKey = challengeKeyRaw as HumanSkillChallengeKey;
-    if (!HUMAN_SKILL_CHALLENGES.includes(challengeKey)) {
+  async startHumanSkillAttempt(userId: string, challengeKey: string) {
+    if (!this.isHumanSkillChallenge(challengeKey)) {
       throw new BadRequestException('Unknown Human Skill challenge');
     }
-    const scenarios = HUMAN_SKILL_SCENARIOS[challengeKey];
-    const scenarioIndex = this.deterministicScenarioIndex(userId, challengeKey, scenarios.length);
-    const scenario = scenarios[scenarioIndex];
+    const scenario = scenarioForChallenge(challengeKey);
+    const publicScenario = publicArcadeCatalog().find((item) => item.challengeKey === challengeKey);
+    if (!scenario || !publicScenario)
+      throw new NotFoundException('Human Skill challenge unavailable');
+
     const id = randomUUID();
     const issuedAt = new Date();
-    const expiresAt = new Date(issuedAt.getTime() + 10 * 60 * 1000);
-
+    const expiresAt = new Date(issuedAt.getTime() + ATTEMPT_TTL_MS);
     await this.prisma.$executeRaw(Prisma.sql`
-      INSERT INTO dogos_social.human_skill_attempts (
-        id,
-        user_id,
-        challenge_key,
-        challenge_version,
-        scenario_key,
-        issued_at,
-        expires_at
-      ) VALUES (
-        ${id},
-        ${userId},
-        ${challengeKey},
-        ${HUMAN_SKILL_CHALLENGE_VERSION},
-        ${scenario.scenarioKey},
-        ${issuedAt},
-        ${expiresAt}
-      )
+      INSERT INTO dogos_social.human_skill_attempts
+        (id, user_id, challenge_key, challenge_version, scenario_key, issued_at, expires_at)
+      VALUES
+        (${id}, ${userId}, ${challengeKey}, ${HUMAN_SKILL_CHALLENGE_VERSION}, ${scenario.scenarioKey}, ${issuedAt}, ${expiresAt})
     `);
 
     return {
       attemptId: id,
       issuedAt: issuedAt.toISOString(),
       expiresAt: expiresAt.toISOString(),
-      scenario: {
-        challengeKey,
-        challengeVersion: HUMAN_SKILL_CHALLENGE_VERSION,
-        scenarioKey: scenario.scenarioKey,
-        title: scenario.title,
-        skill: scenario.skill,
-        prompt: scenario.prompt,
-        options: 'options' in scenario ? scenario.options : undefined,
-        timing: 'timing' in scenario ? scenario.timing : undefined,
-      },
+      scenario: publicScenario,
     };
   }
 
@@ -407,93 +386,127 @@ export class SocialAdventureService {
     attemptId: string,
     dto: CompleteHumanSkillAttemptDto
   ) {
-    const rows = await this.prisma.$queryRaw<HumanSkillAttemptRow[]>(Prisma.sql`
-      SELECT
-        id,
-        user_id AS "userId",
-        challenge_key AS "challengeKey",
-        challenge_version AS "challengeVersion",
-        scenario_key AS "scenarioKey",
-        issued_at AS "issuedAt",
-        expires_at AS "expiresAt",
-        completed_at AS "completedAt"
-      FROM dogos_social.human_skill_attempts
-      WHERE id = ${attemptId} AND user_id = ${userId}
-      LIMIT 1
-    `);
-    const attempt = rows[0];
-    if (!attempt) throw new NotFoundException('Human Skill attempt not found');
-    if (attempt.completedAt) throw new ConflictException('Human Skill attempt already completed');
-    if (attempt.expiresAt.getTime() <= Date.now()) {
-      throw new ConflictException('Human Skill attempt expired');
-    }
-    if (attempt.challengeVersion !== HUMAN_SKILL_CHALLENGE_VERSION) {
-      throw new ConflictException('Human Skill attempt version is no longer supported');
+    const attempt = await this.getAttempt(userId, attemptId);
+    if (attempt.completedAt) return attempt.receipt;
+    if (attempt.expiresAt.getTime() < Date.now()) {
+      throw new BadRequestException('This Human Skill attempt expired. Start a fresh round.');
     }
 
-    const challengeKey = attempt.challengeKey as HumanSkillChallengeKey;
-    const scenario = HUMAN_SKILL_SCENARIOS[challengeKey].find(
-      (candidate) => candidate.scenarioKey === attempt.scenarioKey
-    );
-    if (!scenario) throw new ConflictException('Human Skill scenario is unavailable');
-
-    const result = scoreHumanSkillAttempt(
-      challengeKey,
-      attempt.scenarioKey,
-      dto.response as HumanSkillAttemptResponse
-    );
+    const scenario = scenarioByKey(attempt.scenarioKey);
+    if (!scenario || scenario.challengeVersion !== attempt.challengeVersion) {
+      throw new BadRequestException('This challenge version is no longer available');
+    }
+    const scored = scoreArcadeResponse(scenario, dto.response);
     const completedAt = new Date();
     const receipt = {
       attemptId,
-      challengeKey,
-      challengeVersion: attempt.challengeVersion,
-      score: result.score,
-      correct: result.correct,
-      timingErrorMs: 'timingErrorMs' in result ? result.timingErrorMs : undefined,
-      explanation: result.explanation,
+      challengeKey: scenario.challengeKey,
+      challengeVersion: scenario.challengeVersion,
+      score: scored.score,
+      correct: scored.correct,
+      ...(scored.timingErrorMs === undefined ? {} : { timingErrorMs: scored.timingErrorMs }),
+      explanation: scored.explanation,
       completedAt: completedAt.toISOString(),
     };
 
-    await this.prisma.$executeRaw(Prisma.sql`
+    const updated = await this.prisma.$queryRaw<Array<{ receipt: unknown }>>(Prisma.sql`
       UPDATE dogos_social.human_skill_attempts
-      SET completed_at = ${completedAt},
-          response = ${JSON.stringify(dto.response)}::jsonb,
-          score = ${result.score},
-          receipt = ${JSON.stringify(receipt)}::jsonb
-      WHERE id = ${attemptId} AND completed_at IS NULL
+      SET
+        completed_at = ${completedAt},
+        response = ${JSON.stringify(dto.response)}::jsonb,
+        score = ${scored.score},
+        receipt = ${JSON.stringify(receipt)}::jsonb
+      WHERE id = ${attemptId}
+        AND user_id = ${userId}
+        AND completed_at IS NULL
+      RETURNING receipt
     `);
-    return receipt;
+
+    if (updated[0]) return updated[0].receipt;
+    return (await this.getAttempt(userId, attemptId)).receipt;
   }
 
-  async getFeed(userId: string, take = 30) {
-    const safeTake = Math.max(1, Math.min(Number(take) || 30, 50));
+  async createShare(userId: string, dto: CreateSocialShareDto) {
+    const source = await this.resolveShareSource(userId, dto);
+    const identity = `social-share:${userId}:${source.sourceType}:${source.sourceId}:${source.kind}`;
+
+    const shareId = await this.prisma.$transaction(async (tx) => {
+      await tx.$queryRaw<Array<{ acquired: number }>>(Prisma.sql`
+        WITH lock_row AS MATERIALIZED (
+          SELECT pg_advisory_xact_lock(hashtextextended(${identity}, 0))
+        )
+        SELECT 1::int AS acquired FROM lock_row
+      `);
+
+      const existing = await tx.$queryRaw<ExistingShareRow[]>(Prisma.sql`
+        SELECT id, post_id AS "postId"
+        FROM dogos_social.shares
+        WHERE user_id = ${userId}
+          AND source_type = ${source.sourceType}
+          AND source_id = ${source.sourceId}
+          AND kind = ${source.kind}
+        LIMIT 1
+      `);
+      if (existing[0]) return existing[0].id;
+
+      const post = await tx.post.create({
+        data: {
+          authorUserId: userId,
+          petId: source.petId,
+          text: dto.caption?.trim() || source.summary,
+          mediaUrls: [],
+          visibility: dto.visibility ?? 'PRIVATE',
+        },
+        select: { id: true },
+      });
+      const id = randomUUID();
+      await tx.$executeRaw(Prisma.sql`
+        INSERT INTO dogos_social.shares
+          (id, post_id, user_id, pet_id, source_type, source_id, kind, headline, summary, payload)
+        VALUES
+          (${id}, ${post.id}, ${userId}, ${source.petId}, ${source.sourceType}, ${source.sourceId}, ${source.kind}, ${source.headline}, ${source.summary}, ${JSON.stringify(source.payload)}::jsonb)
+      `);
+      return id;
+    });
+
+    const created = await this.getShare(userId, shareId);
+    if (!created) throw new NotFoundException('Shared moment not found');
+    return created;
+  }
+
+  async getFeed(userId: string, take = 20) {
+    const safeTake = Math.max(1, Math.min(Number(take) || 20, 50));
     const rows = await this.prisma.$queryRaw<FeedRow[]>(Prisma.sql`
       SELECT
         share.id AS "shareId",
-        share.post_id AS "postId",
-        post.kind,
-        post.headline,
-        post.summary,
-        post.payload,
-        share.caption,
-        share.visibility,
-        share.created_at AS "createdAt",
-        share.user_id AS "authorUserId",
+        post.id AS "postId",
+        share.kind,
+        share.headline,
+        share.summary,
+        share.payload,
+        post.text AS caption,
+        post.visibility,
+        post.created_at AS "createdAt",
+        author.id AS "authorUserId",
         author.handle,
         author.avatar_url AS "avatarUrl",
-        pet.name AS "petName"
+        pet.id AS "petId",
+        pet.name AS "petName",
+        pet.avatar_url AS "petAvatarUrl",
+        (SELECT COUNT(*)::int FROM public.likes liked WHERE liked.post_id = post.id) AS "likesCount",
+        (SELECT COUNT(*)::int FROM public.comments comment WHERE comment.post_id = post.id) AS "commentsCount"
       FROM dogos_social.shares share
       JOIN public.posts post ON post.id = share.post_id
-      JOIN public.users author ON author.id = share.user_id
-      LEFT JOIN public.pets pet ON pet.id = post.pet_id
-      WHERE share.visibility = 'PUBLIC'
+      JOIN public.users author ON author.id = post.author_user_id
+      LEFT JOIN public.pets pet ON pet.id = share.pet_id
+      WHERE (post.author_user_id = ${userId} OR post.visibility = 'PUBLIC')
         AND NOT EXISTS (
           SELECT 1
           FROM public.blocked_users blocked
-          WHERE (blocked.user_id = ${userId} AND blocked.blocked_id = share.user_id)
-             OR (blocked.user_id = share.user_id AND blocked.blocked_id = ${userId})
+          WHERE (blocked.user_id = ${userId} AND blocked.blocked_id = post.author_user_id)
+             OR (blocked.user_id = post.author_user_id AND blocked.blocked_id = ${userId})
         )
-      ORDER BY share.created_at DESC
+      ORDER BY post.created_at DESC, share.id DESC
       LIMIT ${safeTake}
     `);
 
@@ -513,115 +526,33 @@ export class SocialAdventureService {
     return {
       posts: rows.map((row) => ({
         ...row,
-        reactions: reactions.filter((reaction) => reaction.shareId === row.shareId),
+        createdAt: row.createdAt.toISOString(),
+        reactions: REACTION_TYPES.map((reaction) => {
+          const aggregate = reactions.find(
+            (item) => item.shareId === row.shareId && item.reaction === reaction
+          );
+          return { reaction, count: aggregate?.count ?? 0, mine: aggregate?.mine ?? false };
+        }),
       })),
-      privacy: 'public-opt-in-feed-only',
+      privacy:
+        'Only PUBLIC Social Adventure shares and your own private shares appear here. FRIENDS_ONLY legacy posts remain hidden until a modern friend-authority contract exists.',
     };
   }
 
-  async createShare(userId: string, dto: CreateSocialShareDto) {
-    if ((dto.visibility ?? 'PRIVATE') !== 'PUBLIC') {
-      throw new BadRequestException('Social Adventure sharing is explicit public opt-in only');
-    }
-
-    const source = await this.resolveShareSource(userId, dto);
-    const existing = await this.prisma.$queryRaw<ShareRow[]>(Prisma.sql`
-      SELECT
-        id,
-        post_id AS "postId",
-        source_type AS "sourceType",
-        source_id AS "sourceId",
-        caption,
-        visibility,
-        created_at AS "createdAt"
-      FROM dogos_social.shares
-      WHERE user_id = ${userId}
-        AND source_type = ${dto.sourceType}
-        AND source_id = ${dto.sourceId}
-      LIMIT 1
-    `);
-    if (existing[0]) {
-      return {
-        shareId: existing[0].id,
-        postId: existing[0].postId,
-        headline: source.headline,
-        summary: source.summary,
-        visibility: existing[0].visibility,
-      };
-    }
-
-    const shareId = randomUUID();
-    const postId = randomUUID();
-    const caption = dto.caption?.trim() || null;
-
-    await this.prisma.$transaction(async (tx) => {
-      await tx.$executeRaw(Prisma.sql`
-        INSERT INTO public.posts (
-          id,
-          user_id,
-          pet_id,
-          kind,
-          headline,
-          summary,
-          payload,
-          visibility,
-          source_type,
-          source_id,
-          occurred_at,
-          created_at
-        ) VALUES (
-          ${postId},
-          ${userId},
-          ${source.petId},
-          ${source.kind},
-          ${source.headline},
-          ${source.summary},
-          ${JSON.stringify(source.payload)}::jsonb,
-          'PUBLIC',
-          ${dto.sourceType},
-          ${dto.sourceId},
-          ${source.occurredAt},
-          NOW()
-        )
-      `);
-      await tx.$executeRaw(Prisma.sql`
-        INSERT INTO dogos_social.shares (
-          id,
-          user_id,
-          post_id,
-          source_type,
-          source_id,
-          caption,
-          visibility,
-          created_at
-        ) VALUES (
-          ${shareId},
-          ${userId},
-          ${postId},
-          ${dto.sourceType},
-          ${dto.sourceId},
-          ${caption},
-          'PUBLIC',
-          NOW()
-        )
-      `);
-    });
-
-    return { shareId, postId, headline: source.headline, summary: source.summary, visibility: 'PUBLIC' };
-  }
-
   async addReaction(userId: string, shareId: string, dto: SocialReactionDto) {
-    await this.requireVisibleShare(userId, shareId);
+    await this.assertShareViewable(userId, shareId);
     await this.prisma.$executeRaw(Prisma.sql`
-      INSERT INTO dogos_social.reactions (share_id, user_id, reaction, created_at)
-      VALUES (${shareId}, ${userId}, ${dto.reaction}, NOW())
+      INSERT INTO dogos_social.reactions (id, share_id, user_id, reaction)
+      VALUES (${randomUUID()}, ${shareId}, ${userId}, ${dto.reaction})
       ON CONFLICT (share_id, user_id, reaction) DO NOTHING
     `);
     return { ok: true };
   }
 
   async removeReaction(userId: string, shareId: string, reaction: string) {
-    await this.requireVisibleShare(userId, shareId);
+    if (!REACTION_TYPES.includes(reaction as (typeof REACTION_TYPES)[number])) {
+      throw new BadRequestException('Unknown Social Adventure reaction');
+    }
     await this.prisma.$executeRaw(Prisma.sql`
       DELETE FROM dogos_social.reactions
       WHERE share_id = ${shareId} AND user_id = ${userId} AND reaction = ${reaction}
@@ -629,204 +560,294 @@ export class SocialAdventureService {
     return { ok: true };
   }
 
-  private async requireVisibleShare(userId: string, shareId: string) {
-    const rows = await this.prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
-      SELECT share.id
-      FROM dogos_social.shares share
-      WHERE share.id = ${shareId}
-        AND share.visibility = 'PUBLIC'
-        AND NOT EXISTS (
-          SELECT 1
-          FROM public.blocked_users blocked
-          WHERE (blocked.user_id = ${userId} AND blocked.blocked_id = share.user_id)
-             OR (blocked.user_id = share.user_id AND blocked.blocked_id = ${userId})
-        )
+  private async getPreferences(userId: string) {
+    const rows = await this.prisma.$queryRaw<PreferenceRow[]>(Prisma.sql`
+      SELECT global_leaderboard_opt_in AS "globalLeaderboardOptIn"
+      FROM dogos_social.preferences
+      WHERE user_id = ${userId}
       LIMIT 1
     `);
-    if (!rows[0]) throw new NotFoundException('Share not found');
+    return rows[0] ?? { globalLeaderboardOptIn: false };
   }
 
-  private async resolveShareSource(userId: string, dto: CreateSocialShareDto) {
-    if (dto.sourceType === 'HUMAN_SKILL_ATTEMPT') {
-      const rows = await this.prisma.$queryRaw<SkillShareSourceRow[]>(Prisma.sql`
-        SELECT
-          id,
-          user_id AS "userId",
-          challenge_key AS "challengeKey",
-          challenge_version AS "challengeVersion",
-          score,
-          receipt,
-          completed_at AS "completedAt"
-        FROM dogos_social.human_skill_attempts
-        WHERE id = ${dto.sourceId}
-          AND user_id = ${userId}
-          AND completed_at IS NOT NULL
-        LIMIT 1
-      `);
-      const attempt = rows[0];
-      if (!attempt) throw new NotFoundException('Human Skill attempt not found');
-      const challengeTitle = HUMAN_SKILL_CHALLENGES.includes(
-        attempt.challengeKey as HumanSkillChallengeKey
-      )
-        ? HUMAN_SKILL_SCENARIOS[attempt.challengeKey as HumanSkillChallengeKey][0].title
-        : 'Human Skill';
-      return {
-        petId: null,
-        kind: 'HUMAN_SKILL',
-        headline: `Practiced ${challengeTitle}`,
-        summary: 'Worked on the human side of the relationship.',
-        occurredAt: attempt.completedAt,
-        payload: {
-          sourceType: 'HUMAN_SKILL_ATTEMPT',
-          challengeKey: attempt.challengeKey,
-          challengeVersion: attempt.challengeVersion,
-        },
-      };
-    }
-
-    const rows = await this.prisma.$queryRaw<CareShareSourceRow[]>(Prisma.sql`
+  private async getAttempt(userId: string, attemptId: string) {
+    const rows = await this.prisma.$queryRaw<SkillAttemptRow[]>(Prisma.sql`
       SELECT
-        event.id,
-        event.pet_id AS "petId",
-        event.created_by AS "createdBy",
-        event.event_type AS "eventType",
-        event.title,
-        event.note,
-        event.occurred_at AS "occurredAt",
-        pet.name AS "petName"
-      FROM public.care_events event
-      JOIN public.pets pet ON pet.id = event.pet_id
-      JOIN dogos_household.pet_households ph ON ph.pet_id = pet.id
-      JOIN dogos_household.household_membership hm ON hm.household_id = ph.household_id
-      WHERE event.id = ${dto.sourceId}
-        AND hm.user_id = ${userId}
-        AND hm.status = 'ACTIVE'
+        id,
+        challenge_key AS "challengeKey",
+        challenge_version AS "challengeVersion",
+        scenario_key AS "scenarioKey",
+        issued_at AS "issuedAt",
+        expires_at AS "expiresAt",
+        completed_at AS "completedAt",
+        score,
+        receipt
+      FROM dogos_social.human_skill_attempts
+      WHERE id = ${attemptId} AND user_id = ${userId}
       LIMIT 1
     `);
-    const event = rows[0];
-    if (!event) throw new NotFoundException('CARE event not found');
-    return {
-      petId: event.petId,
-      kind: 'CARE',
-      headline: event.title || `A ${event.eventType.toLowerCase()} moment`,
-      summary: event.note?.trim() || `Shared a ${event.eventType.toLowerCase()} moment with ${event.petName}.`,
-      occurredAt: event.occurredAt,
-      payload: { sourceType: 'CARE_EVENT', eventType: event.eventType },
-    };
+    if (!rows[0]) throw new NotFoundException('Human Skill attempt not found');
+    return rows[0];
   }
 
-  private async scoreLeaderboardUsers(users: LeaderboardUserRow[]) {
-    const scored = await Promise.all(
-      users.map(async (user) => ({
-        userId: user.id,
-        handle: user.handle,
-        avatarUrl: user.avatarUrl,
-        ...(await this.computeScore(user.id)),
-      }))
+  private async getBestHumanSkillScores(userId: string) {
+    const season = currentUtcSeason();
+    const rows = await this.prisma.$queryRaw<Array<{ challengeKey: string; bestScore: number }>>(
+      Prisma.sql`
+        SELECT challenge_key AS "challengeKey", MAX(score)::int AS "bestScore"
+        FROM dogos_social.human_skill_attempts
+        WHERE user_id = ${userId}
+          AND completed_at >= ${season.startsAt}
+          AND completed_at < ${season.endsAt}
+        GROUP BY challenge_key
+      `
     );
-    return scored.sort((a, b) => b.score - a.score || a.handle.localeCompare(b.handle));
+    return Object.fromEntries(rows.map((row) => [row.challengeKey, row.bestScore])) as Partial<
+      Record<HumanSkillChallenge, number>
+    >;
   }
 
   private async computeScore(userId: string) {
-    const season = getCurrentSocialSeason();
-    const [skillRows, pathwayRows] = await Promise.all([
-      this.prisma.$queryRaw<HumanSkillRow[]>(Prisma.sql`
+    const season = currentUtcSeason();
+    const [adventureRows, skillRows] = await Promise.all([
+      this.prisma.$queryRaw<AdventureEvidenceRow[]>(Prisma.sql`
+        SELECT DISTINCT ON (pathway) id, pathway
+        FROM public.care_events
+        WHERE user_id = ${userId}
+          AND source = 'QUEST_ENGINE'
+          AND event_type LIKE 'QUEST_%'
+          AND occurred_at >= ${season.startsAt}
+          AND occurred_at < ${season.endsAt}
+        ORDER BY pathway, occurred_at ASC, id ASC
+      `),
+      this.prisma.$queryRaw<SkillScoreRow[]>(Prisma.sql`
         SELECT DISTINCT ON (challenge_key)
           id,
           challenge_key AS "challengeKey",
-          challenge_version AS "challengeVersion",
           score
         FROM dogos_social.human_skill_attempts
         WHERE user_id = ${userId}
-          AND completed_at IS NOT NULL
           AND completed_at >= ${season.startsAt}
           AND completed_at < ${season.endsAt}
-          AND challenge_version = ${HUMAN_SKILL_CHALLENGE_VERSION}
-        ORDER BY challenge_key, completed_at DESC, id DESC
-      `),
-      this.prisma.$queryRaw<PathwayRow[]>(Prisma.sql`
-        SELECT DISTINCT ON (pathway)
-          pathway
-        FROM public.pet_adventure_outcomes outcome
-        WHERE outcome.user_id = ${userId}
-          AND outcome.completed_at IS NOT NULL
-          AND outcome.completed_at >= ${season.startsAt}
-          AND outcome.completed_at < ${season.endsAt}
-          AND outcome.pathway IN (${Prisma.join([...SOCIAL_ADVENTURE_PATHWAYS])})
-        ORDER BY pathway, completed_at DESC, id DESC
+          AND score IS NOT NULL
+        ORDER BY challenge_key, completed_at ASC, id ASC
       `),
     ]);
 
-    const sourceIdentity = {
-      policyVersion: SOCIAL_ADVENTURE_POLICY_VERSION,
-      seasonKey: season.key,
-      humanSkill: skillRows.map((row) => [row.id, row.challengeKey]),
-      adventureVariety: pathwayRows.map((row) => row.pathway),
-    };
-    const sourceHash = createHash('sha256')
-      .update(JSON.stringify(sourceIdentity))
-      .digest('hex');
-    const components = deriveSocialAdventureScore({
-      completedHumanSkills: skillRows.map((row) => row.challengeKey),
-      completedAdventurePathways: pathwayRows.map((row) => row.pathway),
+    const completedHumanSkills: Partial<Record<HumanSkillChallenge, number>> = {};
+    for (const row of skillRows) {
+      if (!this.isHumanSkillChallenge(row.challengeKey)) continue;
+      // The value only marks finite completion for the breadth policy. Practice
+      // magnitude is intentionally excluded from league arithmetic.
+      completedHumanSkills[row.challengeKey] = row.score;
+    }
+
+    const score = deriveSocialAdventureScore({
+      adventurePathways: adventureRows.map((row) => row.pathway),
+      humanSkillBestScores: completedHumanSkills,
     });
-    const score = components.humanSkill.score + components.adventureVariety.score;
+    const sourceHash = createHash('sha256')
+      .update(
+        JSON.stringify({
+          adventure: adventureRows.map((row) => [row.id, row.pathway]),
+          humanSkill: skillRows.map((row) => [row.id, row.challengeKey]),
+        })
+      )
+      .digest('hex');
+    const receiptId = createHash('sha256')
+      .update(`${userId}:${season.key}:${SOCIAL_ADVENTURE_POLICY_VERSION}:${sourceHash}`)
+      .digest('hex')
+      .slice(0, 40);
 
     await this.prisma.$executeRaw(Prisma.sql`
-      INSERT INTO dogos_social.competition_receipts (
-        id,
-        user_id,
-        season_key,
-        policy_version,
-        score,
-        components,
-        source_hash,
-        calculated_at
-      ) VALUES (
-        ${randomUUID()},
-        ${userId},
-        ${season.key},
-        ${SOCIAL_ADVENTURE_POLICY_VERSION},
-        ${score},
-        ${JSON.stringify(components)}::jsonb,
-        ${sourceHash},
-        NOW()
-      )
+      INSERT INTO dogos_social.competition_receipts
+        (id, user_id, season_key, policy_version, score, components, source_hash)
+      VALUES
+        (${receiptId}, ${userId}, ${season.key}, ${SOCIAL_ADVENTURE_POLICY_VERSION}, ${score.score}, ${JSON.stringify(score.components)}::jsonb, ${sourceHash})
       ON CONFLICT (user_id, season_key, policy_version, source_hash) DO NOTHING
     `);
 
     return {
-      season,
-      score,
-      maxScore: HUMAN_SKILL_BREADTH_POINTS + ADVENTURE_VARIETY_POINTS,
-      components,
+      ...score,
+      season: {
+        key: season.key,
+        startsAt: season.startsAt.toISOString(),
+        endsAt: season.endsAt.toISOString(),
+      },
     };
   }
 
-  private async getHumanSkillBestScores(userId: string) {
-    const rows = await this.prisma.$queryRaw<HumanSkillBestScoreRow[]>(Prisma.sql`
-      SELECT challenge_key AS "challengeKey", MAX(score)::int AS score
-      FROM dogos_social.human_skill_attempts
-      WHERE user_id = ${userId}
-        AND completed_at IS NOT NULL
-        AND challenge_version = ${HUMAN_SKILL_CHALLENGE_VERSION}
-      GROUP BY challenge_key
-    `);
-    return Object.fromEntries(rows.map((row) => [row.challengeKey, row.score]));
+  private async scoreLeaderboardUsers(users: LeaderboardUserRow[]) {
+    const rows = await Promise.all(
+      users.map(async (user) => {
+        const score = await this.computeScore(user.id);
+        return {
+          userId: user.id,
+          handle: user.handle,
+          avatarUrl: user.avatarUrl,
+          score: score.score,
+          maxScore: score.maxScore,
+          components: score.components,
+        };
+      })
+    );
+    return rows.sort((a, b) => b.score - a.score || a.handle.localeCompare(b.handle));
   }
 
-  private deterministicScenarioIndex(userId: string, challengeKey: string, scenarioCount: number) {
-    const hash = createHash('sha256').update(`${userId}:${challengeKey}`).digest();
-    return hash.readUInt32BE(0) % scenarioCount;
+  private async resolveShareSource(
+    userId: string,
+    dto: CreateSocialShareDto
+  ): Promise<ShareSource> {
+    if (dto.sourceType === 'CARE_EVENT') {
+      const event = await this.prisma.careEvent.findFirst({
+        where: { id: dto.sourceId, userId, source: 'QUEST_ENGINE' },
+        include: { pet: { select: { id: true, name: true } } },
+      });
+      if (!event) throw new NotFoundException('Adventure moment not found');
+
+      const context = this.asRecord(event.context);
+      const outcome = this.asRecord(event.outcome);
+      const safeOptOut = outcome.safeOptOut === true;
+      const dogExperience =
+        typeof outcome.dogExperience === 'string' ? outcome.dogExperience : null;
+      const questTitle =
+        typeof context.questTitle === 'string' && context.questTitle.trim()
+          ? context.questTitle.trim().slice(0, 100)
+          : 'Shared Adventure';
+      const petName = event.pet?.name ?? 'your dog';
+      const kind = safeOptOut
+        ? 'GOOD_READ'
+        : dogExperience === 'not_their_thing'
+          ? 'DISCOVERY'
+          : 'ADVENTURE_MEMORY';
+      const summary = safeOptOut
+        ? `We listened to ${petName} and changed course. Stopping appropriately counted as a good read.`
+        : kind === 'DISCOVERY'
+          ? `We learned something useful about what fits ${petName}. Discovery counts even when an activity is not a favorite.`
+          : `A ${event.pathway.toLowerCase()} moment with ${petName}, saved from a real Adventure outcome.`;
+
+      return {
+        sourceType: 'CARE_EVENT',
+        sourceId: event.id,
+        petId: event.petId,
+        kind,
+        headline: questTitle,
+        summary,
+        payload: {
+          pathway: event.pathway,
+          eventType: event.eventType,
+          safeOptOut,
+          dogExperience,
+          petName,
+        },
+      };
+    }
+
+    const rows = await this.prisma.$queryRaw<SkillAttemptRow[]>(Prisma.sql`
+      SELECT
+        id,
+        challenge_key AS "challengeKey",
+        challenge_version AS "challengeVersion",
+        scenario_key AS "scenarioKey",
+        issued_at AS "issuedAt",
+        expires_at AS "expiresAt",
+        completed_at AS "completedAt",
+        score,
+        receipt
+      FROM dogos_social.human_skill_attempts
+      WHERE id = ${dto.sourceId} AND user_id = ${userId} AND completed_at IS NOT NULL
+      LIMIT 1
+    `);
+    const attempt = rows[0];
+    if (!attempt || attempt.score === null)
+      throw new NotFoundException('Human Skill result not found');
+    const scenario = scenarioByKey(attempt.scenarioKey);
+    const title = scenario?.title ?? 'Human Skill Arcade';
+
+    return {
+      sourceType: 'HUMAN_SKILL_ATTEMPT',
+      sourceId: attempt.id,
+      petId: null,
+      kind: 'SKILL_MOMENT',
+      headline: title,
+      summary: `Practiced ${this.humanize(attempt.challengeKey)} and scored ${attempt.score}/100. The score is personal feedback, not pet performance or league proficiency.`,
+      payload: {
+        challengeKey: attempt.challengeKey,
+        challengeVersion: attempt.challengeVersion,
+        score: attempt.score,
+      },
+    };
+  }
+
+  private async getShare(userId: string, shareId: string) {
+    const rows = await this.prisma.$queryRaw<FeedRow[]>(Prisma.sql`
+      SELECT
+        share.id AS "shareId",
+        post.id AS "postId",
+        share.kind,
+        share.headline,
+        share.summary,
+        share.payload,
+        post.text AS caption,
+        post.visibility,
+        post.created_at AS "createdAt",
+        author.id AS "authorUserId",
+        author.handle,
+        author.avatar_url AS "avatarUrl",
+        pet.id AS "petId",
+        pet.name AS "petName",
+        pet.avatar_url AS "petAvatarUrl",
+        (SELECT COUNT(*)::int FROM public.likes liked WHERE liked.post_id = post.id) AS "likesCount",
+        (SELECT COUNT(*)::int FROM public.comments comment WHERE comment.post_id = post.id) AS "commentsCount"
+      FROM dogos_social.shares share
+      JOIN public.posts post ON post.id = share.post_id
+      JOIN public.users author ON author.id = post.author_user_id
+      LEFT JOIN public.pets pet ON pet.id = share.pet_id
+      WHERE share.id = ${shareId}
+        AND (post.author_user_id = ${userId} OR post.visibility = 'PUBLIC')
+        AND NOT EXISTS (
+          SELECT 1
+          FROM public.blocked_users blocked
+          WHERE (blocked.user_id = ${userId} AND blocked.blocked_id = post.author_user_id)
+             OR (blocked.user_id = post.author_user_id AND blocked.blocked_id = ${userId})
+        )
+      LIMIT 1
+    `);
+    const row = rows[0];
+    return row ? { ...row, createdAt: row.createdAt.toISOString() } : null;
+  }
+
+  private async assertShareViewable(userId: string, shareId: string) {
+    const share = await this.getShare(userId, shareId);
+    if (!share) throw new NotFoundException('Shared moment not found');
+    return share;
+  }
+
+  private isHumanSkillChallenge(value: string): value is HumanSkillChallenge {
+    return HUMAN_SKILL_CHALLENGES.includes(value as HumanSkillChallenge);
+  }
+
+  private asRecord(value: Prisma.JsonValue | null): Record<string, unknown> {
+    return value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
   }
 
   private slugify(value: string) {
-    const slug = value
+    const normalized = value
       .trim()
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-|-$/g, '')
-      .slice(0, 48);
-    return slug || 'pack';
+      .slice(0, 56);
+    return normalized || 'pack';
+  }
+
+  private humanize(value: string) {
+    return value
+      .toLowerCase()
+      .split('_')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
   }
 }

--- a/apps/api/src/social-adventure/social-adventure.service.ts
+++ b/apps/api/src/social-adventure/social-adventure.service.ts
@@ -1,106 +1,32 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@woof/database';
-import { createHash, randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'crypto';
 import { PrismaService } from '../prisma/prisma.service';
-import { PackAccessService } from './pack-access.service';
-import {
-  publicArcadeCatalog,
-  scenarioByKey,
-  scenarioForChallenge,
-  scoreArcadeResponse,
-} from './social-adventure.arcade';
-import {
-  currentUtcSeason,
-  deriveSocialAdventureScore,
-  HUMAN_SKILL_CHALLENGES,
-  HUMAN_SKILL_CHALLENGE_VERSION,
-  LOCAL_LEAGUE_MINIMUM_COHORT,
-  SOCIAL_ADVENTURE_POLICY_VERSION,
-  type HumanSkillChallenge,
-} from './social-adventure.policy';
 import type {
   CompleteHumanSkillAttemptDto,
   CreatePackDto,
   CreateSocialShareDto,
   SocialReactionDto,
-  UpdateSocialAdventurePreferencesDto,
 } from './dto/social-adventure.dto';
+import { PackAccessService } from './pack-access.service';
+import {
+  ADVENTURE_VARIETY_POINTS,
+  HUMAN_SKILL_BREADTH_POINTS,
+  HUMAN_SKILL_CHALLENGE_VERSION,
+  HUMAN_SKILL_CHALLENGES,
+  HUMAN_SKILL_SCENARIOS,
+  LOCAL_LEAGUE_MINIMUM_COHORT,
+  SOCIAL_ADVENTURE_PATHWAYS,
+  SOCIAL_ADVENTURE_POLICY_VERSION,
+  deriveSocialAdventureScore,
+  getCurrentSocialSeason,
+  scoreHumanSkillAttempt,
+  type HumanSkillAttemptResponse,
+  type HumanSkillChallengeKey,
+} from './social-adventure.policy';
 
-type PreferenceRow = {
-  globalLeaderboardOptIn: boolean;
-};
-
-type SkillAttemptRow = {
-  id: string;
-  challengeKey: string;
-  challengeVersion: string;
-  scenarioKey: string;
-  issuedAt: Date;
-  expiresAt: Date;
-  completedAt: Date | null;
-  score: number | null;
-  receipt: unknown;
-};
-
-type SkillScoreRow = {
-  id: string;
-  challengeKey: string;
-  score: number;
-};
-
-type AdventureEvidenceRow = {
-  id: string;
-  pathway: string;
-};
-
-type LeaderboardUserRow = {
-  id: string;
-  handle: string;
-  avatarUrl: string | null;
-};
-
-type ShareSource = {
-  sourceType: 'CARE_EVENT' | 'HUMAN_SKILL_ATTEMPT';
-  sourceId: string;
-  petId: string | null;
-  kind: 'ADVENTURE_MEMORY' | 'DISCOVERY' | 'SKILL_MOMENT' | 'GOOD_READ';
-  headline: string;
-  summary: string;
-  payload: Record<string, unknown>;
-};
-
-type ExistingShareRow = {
-  id: string;
-  postId: string;
-};
-
-type FeedRow = {
-  shareId: string;
-  postId: string;
-  kind: string;
-  headline: string;
-  summary: string;
-  payload: unknown;
-  caption: string | null;
-  visibility: string;
-  createdAt: Date;
-  authorUserId: string;
-  handle: string;
-  avatarUrl: string | null;
-  petId: string | null;
-  petName: string | null;
-  petAvatarUrl: string | null;
-  likesCount: number;
-  commentsCount: number;
-};
-
-type ReactionRow = {
-  shareId: string;
-  reaction: string;
-  count: number;
-  mine: boolean;
-};
-
+type PreferenceRow = { globalLeaderboardOptIn: boolean };
+type LeaderboardUserRow = { id: string; handle: string; avatarUrl: string | null };
 type PackRow = {
   id: string;
   name: string;
@@ -112,16 +38,71 @@ type PackRow = {
   joined: boolean;
   role: string | null;
 };
+type HumanSkillRow = {
+  id: string;
+  challengeKey: string;
+  challengeVersion: string;
+  score: number;
+};
+type HumanSkillBestScoreRow = { challengeKey: string; score: number };
+type HumanSkillAttemptRow = {
+  id: string;
+  userId: string;
+  challengeKey: string;
+  challengeVersion: string;
+  scenarioKey: string;
+  issuedAt: Date;
+  expiresAt: Date;
+  completedAt: Date | null;
+};
+type ShareRow = {
+  id: string;
+  postId: string;
+  sourceType: string;
+  sourceId: string;
+  caption: string | null;
+  visibility: string;
+  createdAt: Date;
+};
 
-const REACTION_TYPES = [
-  'NICE_READ',
-  'GOOD_CALL',
-  'TRYING_THIS',
-  'ADVENTURE_INSPIRATION',
-  'CHEER',
-] as const;
+type CareShareSourceRow = {
+  id: string;
+  petId: string;
+  createdBy: string;
+  eventType: string;
+  title: string;
+  note: string | null;
+  occurredAt: Date;
+  petName: string;
+};
 
-const ATTEMPT_TTL_MS = 10 * 60 * 1000;
+type SkillShareSourceRow = {
+  id: string;
+  userId: string;
+  challengeKey: string;
+  challengeVersion: string;
+  score: number;
+  receipt: Prisma.JsonValue;
+  completedAt: Date;
+};
+
+type FeedRow = {
+  shareId: string;
+  postId: string;
+  kind: string;
+  headline: string;
+  summary: string;
+  payload: Prisma.JsonValue;
+  caption: string | null;
+  visibility: string;
+  createdAt: Date;
+  authorUserId: string;
+  handle: string;
+  avatarUrl: string | null;
+  petName: string | null;
+};
+type ReactionRow = { shareId: string; reaction: string; count: number; mine: boolean };
+type PathwayRow = { pathway: string };
 
 @Injectable()
 export class SocialAdventureService {
@@ -130,51 +111,51 @@ export class SocialAdventureService {
     private readonly packAccess: PackAccessService
   ) {}
 
+  private async getPreferences(userId: string): Promise<PreferenceRow> {
+    const rows = await this.prisma.$queryRaw<PreferenceRow[]>(Prisma.sql`
+      SELECT global_leaderboard_opt_in AS "globalLeaderboardOptIn"
+      FROM dogos_social.user_preferences
+      WHERE user_id = ${userId}
+      LIMIT 1
+    `);
+    return rows[0] ?? { globalLeaderboardOptIn: false };
+  }
+
   async getMine(userId: string) {
-    const [preferences, score, bestScores] = await Promise.all([
+    const [preferences, score, humanSkillBestScores] = await Promise.all([
       this.getPreferences(userId),
       this.computeScore(userId),
-      this.getBestHumanSkillScores(userId),
+      this.getHumanSkillBestScores(userId),
     ]);
-
     return {
       preferences,
-      season: score.season,
-      score: score.score,
-      maxScore: score.maxScore,
-      components: score.components,
-      humanSkillBestScores: bestScores,
+      ...score,
+      humanSkillBestScores,
       policyVersion: SOCIAL_ADVENTURE_POLICY_VERSION,
       principles: [
-        'human-skill-over-pet-performance',
-        'variety-over-volume',
-        'no-streak-loss',
-        'no-health-competition',
-        'no-posting-or-popularity-points',
+        'You compete. Your dog does not.',
+        'Health, symptoms, exercise volume, pet performance, and missed days never add league points.',
+        'Reactions build culture, not rank.',
       ],
     };
   }
 
-  async updatePreferences(userId: string, dto: UpdateSocialAdventurePreferencesDto) {
-    await this.prisma.$executeRaw(Prisma.sql`
-      INSERT INTO dogos_social.preferences (user_id, global_leaderboard_opt_in, updated_at)
+  async updatePreferences(userId: string, dto: { globalLeaderboardOptIn: boolean }) {
+    const rows = await this.prisma.$queryRaw<PreferenceRow[]>(Prisma.sql`
+      INSERT INTO dogos_social.user_preferences (user_id, global_leaderboard_opt_in, updated_at)
       VALUES (${userId}, ${dto.globalLeaderboardOptIn}, NOW())
       ON CONFLICT (user_id)
-      DO UPDATE SET
-        global_leaderboard_opt_in = EXCLUDED.global_leaderboard_opt_in,
-        updated_at = NOW()
+      DO UPDATE SET global_leaderboard_opt_in = EXCLUDED.global_leaderboard_opt_in, updated_at = NOW()
+      RETURNING global_leaderboard_opt_in AS "globalLeaderboardOptIn"
     `);
-    return this.getPreferences(userId);
+    return rows[0] ?? { globalLeaderboardOptIn: dto.globalLeaderboardOptIn };
   }
 
   async getGlobalLeaderboard(userId: string, limit = 30) {
     const safeLimit = Math.max(1, Math.min(Number(limit) || 30, 50));
     const candidates = await this.prisma.$queryRaw<LeaderboardUserRow[]>(Prisma.sql`
-      SELECT
-        u.id,
-        u.handle,
-        u.avatar_url AS "avatarUrl"
-      FROM dogos_social.preferences pref
+      SELECT u.id, u.handle, u.avatar_url AS "avatarUrl"
+      FROM dogos_social.user_preferences pref
       JOIN public.users u ON u.id = pref.user_id
       WHERE pref.global_leaderboard_opt_in = TRUE
         AND u.visibility = 'PUBLIC'
@@ -187,7 +168,6 @@ export class SocialAdventureService {
       ORDER BY u.id ASC
       LIMIT 100
     `);
-
     const rows = await this.scoreLeaderboardUsers(candidates);
     const entries = rows.slice(0, safeLimit).map((row, index) => ({ ...row, rank: index + 1 }));
     const me = await this.computeScore(userId);
@@ -278,7 +258,7 @@ export class SocialAdventureService {
     return {
       packs: rows,
       localMinimumCohort: LOCAL_LEAGUE_MINIMUM_COHORT,
-      locationContract: 'coarse-user-chosen-region-only',
+      locationContract: 'server-approved-coarse-region-only',
     };
   }
 
@@ -300,7 +280,17 @@ export class SocialAdventureService {
       `);
     });
 
-    return { id, name: dto.name.trim(), slug, regionKey: dto.regionKey, joined: true };
+    return {
+      id,
+      name: dto.name.trim(),
+      slug,
+      scope: 'LOCAL',
+      regionKey: dto.regionKey,
+      visibility: 'PUBLIC',
+      memberCount: 1,
+      joined: true,
+      role: 'OWNER',
+    };
   }
 
   async joinPack(userId: string, packId: string) {
@@ -328,56 +318,87 @@ export class SocialAdventureService {
     const membership = rows[0];
     if (!membership) return { ok: true };
     if (membership.role === 'OWNER') {
-      throw new BadRequestException(
-        'A Pack owner cannot leave without transferring or retiring the Pack'
-      );
+      throw new ConflictException('Transfer or retire this Pack before leaving');
     }
 
     await this.prisma.$executeRaw(Prisma.sql`
       UPDATE dogos_social.pack_memberships
-      SET status = 'LEFT'
+      SET status = 'LEFT', left_at = NOW()
       WHERE pack_id = ${packId} AND user_id = ${userId}
     `);
     return { ok: true };
   }
 
   async getArcade(userId: string) {
-    const bestScores = await this.getBestHumanSkillScores(userId);
+    const bestScores = await this.getHumanSkillBestScores(userId);
+    const challenges = HUMAN_SKILL_CHALLENGES.map((challengeKey) => {
+      const scenario = HUMAN_SKILL_SCENARIOS[challengeKey][0];
+      return {
+        challengeKey,
+        challengeVersion: HUMAN_SKILL_CHALLENGE_VERSION,
+        scenarioKey: scenario.scenarioKey,
+        title: scenario.title,
+        skill: scenario.skill,
+        prompt: scenario.prompt,
+        options: 'options' in scenario ? scenario.options : undefined,
+        timing: 'timing' in scenario ? scenario.timing : undefined,
+        bestScore: bestScores[challengeKey] ?? null,
+      };
+    });
     return {
       challengeVersion: HUMAN_SKILL_CHALLENGE_VERSION,
-      challenges: publicArcadeCatalog().map((scenario) => ({
-        ...scenario,
-        bestScore: bestScores[scenario.challengeKey] ?? null,
-      })),
+      challenges,
       scoring:
-        'Arcade scores are personal practice feedback. Completing each different Human Skill game once this week contributes one fixed breadth unit; higher scores and retries add no league points.',
+        'Practice scores are private feedback. Social Adventure league credit comes from completing distinct Human Skill rooms, not from score magnitude or browser timing.',
     };
   }
 
-  async startHumanSkillAttempt(userId: string, challengeKey: string) {
-    if (!this.isHumanSkillChallenge(challengeKey)) {
+  async startHumanSkillAttempt(userId: string, challengeKeyRaw: string) {
+    const challengeKey = challengeKeyRaw as HumanSkillChallengeKey;
+    if (!HUMAN_SKILL_CHALLENGES.includes(challengeKey)) {
       throw new BadRequestException('Unknown Human Skill challenge');
     }
-    const scenario = scenarioForChallenge(challengeKey);
-    const publicScenario = publicArcadeCatalog().find((item) => item.challengeKey === challengeKey);
-    if (!scenario || !publicScenario)
-      throw new NotFoundException('Human Skill challenge unavailable');
-
+    const scenarios = HUMAN_SKILL_SCENARIOS[challengeKey];
+    const scenarioIndex = this.deterministicScenarioIndex(userId, challengeKey, scenarios.length);
+    const scenario = scenarios[scenarioIndex];
     const id = randomUUID();
     const issuedAt = new Date();
-    const expiresAt = new Date(issuedAt.getTime() + ATTEMPT_TTL_MS);
+    const expiresAt = new Date(issuedAt.getTime() + 10 * 60 * 1000);
+
     await this.prisma.$executeRaw(Prisma.sql`
-      INSERT INTO dogos_social.human_skill_attempts
-        (id, user_id, challenge_key, challenge_version, scenario_key, issued_at, expires_at)
-      VALUES
-        (${id}, ${userId}, ${challengeKey}, ${HUMAN_SKILL_CHALLENGE_VERSION}, ${scenario.scenarioKey}, ${issuedAt}, ${expiresAt})
+      INSERT INTO dogos_social.human_skill_attempts (
+        id,
+        user_id,
+        challenge_key,
+        challenge_version,
+        scenario_key,
+        issued_at,
+        expires_at
+      ) VALUES (
+        ${id},
+        ${userId},
+        ${challengeKey},
+        ${HUMAN_SKILL_CHALLENGE_VERSION},
+        ${scenario.scenarioKey},
+        ${issuedAt},
+        ${expiresAt}
+      )
     `);
 
     return {
       attemptId: id,
       issuedAt: issuedAt.toISOString(),
       expiresAt: expiresAt.toISOString(),
-      scenario: publicScenario,
+      scenario: {
+        challengeKey,
+        challengeVersion: HUMAN_SKILL_CHALLENGE_VERSION,
+        scenarioKey: scenario.scenarioKey,
+        title: scenario.title,
+        skill: scenario.skill,
+        prompt: scenario.prompt,
+        options: 'options' in scenario ? scenario.options : undefined,
+        timing: 'timing' in scenario ? scenario.timing : undefined,
+      },
     };
   }
 
@@ -386,127 +407,93 @@ export class SocialAdventureService {
     attemptId: string,
     dto: CompleteHumanSkillAttemptDto
   ) {
-    const attempt = await this.getAttempt(userId, attemptId);
-    if (attempt.completedAt) return attempt.receipt;
-    if (attempt.expiresAt.getTime() < Date.now()) {
-      throw new BadRequestException('This Human Skill attempt expired. Start a fresh round.');
+    const rows = await this.prisma.$queryRaw<HumanSkillAttemptRow[]>(Prisma.sql`
+      SELECT
+        id,
+        user_id AS "userId",
+        challenge_key AS "challengeKey",
+        challenge_version AS "challengeVersion",
+        scenario_key AS "scenarioKey",
+        issued_at AS "issuedAt",
+        expires_at AS "expiresAt",
+        completed_at AS "completedAt"
+      FROM dogos_social.human_skill_attempts
+      WHERE id = ${attemptId} AND user_id = ${userId}
+      LIMIT 1
+    `);
+    const attempt = rows[0];
+    if (!attempt) throw new NotFoundException('Human Skill attempt not found');
+    if (attempt.completedAt) throw new ConflictException('Human Skill attempt already completed');
+    if (attempt.expiresAt.getTime() <= Date.now()) {
+      throw new ConflictException('Human Skill attempt expired');
+    }
+    if (attempt.challengeVersion !== HUMAN_SKILL_CHALLENGE_VERSION) {
+      throw new ConflictException('Human Skill attempt version is no longer supported');
     }
 
-    const scenario = scenarioByKey(attempt.scenarioKey);
-    if (!scenario || scenario.challengeVersion !== attempt.challengeVersion) {
-      throw new BadRequestException('This challenge version is no longer available');
-    }
-    const scored = scoreArcadeResponse(scenario, dto.response);
+    const challengeKey = attempt.challengeKey as HumanSkillChallengeKey;
+    const scenario = HUMAN_SKILL_SCENARIOS[challengeKey].find(
+      (candidate) => candidate.scenarioKey === attempt.scenarioKey
+    );
+    if (!scenario) throw new ConflictException('Human Skill scenario is unavailable');
+
+    const result = scoreHumanSkillAttempt(
+      challengeKey,
+      attempt.scenarioKey,
+      dto.response as HumanSkillAttemptResponse
+    );
     const completedAt = new Date();
     const receipt = {
       attemptId,
-      challengeKey: scenario.challengeKey,
-      challengeVersion: scenario.challengeVersion,
-      score: scored.score,
-      correct: scored.correct,
-      ...(scored.timingErrorMs === undefined ? {} : { timingErrorMs: scored.timingErrorMs }),
-      explanation: scored.explanation,
+      challengeKey,
+      challengeVersion: attempt.challengeVersion,
+      score: result.score,
+      correct: result.correct,
+      timingErrorMs: 'timingErrorMs' in result ? result.timingErrorMs : undefined,
+      explanation: result.explanation,
       completedAt: completedAt.toISOString(),
     };
 
-    const updated = await this.prisma.$queryRaw<Array<{ receipt: unknown }>>(Prisma.sql`
+    await this.prisma.$executeRaw(Prisma.sql`
       UPDATE dogos_social.human_skill_attempts
-      SET
-        completed_at = ${completedAt},
-        response = ${JSON.stringify(dto.response)}::jsonb,
-        score = ${scored.score},
-        receipt = ${JSON.stringify(receipt)}::jsonb
-      WHERE id = ${attemptId}
-        AND user_id = ${userId}
-        AND completed_at IS NULL
-      RETURNING receipt
+      SET completed_at = ${completedAt},
+          response = ${JSON.stringify(dto.response)}::jsonb,
+          score = ${result.score},
+          receipt = ${JSON.stringify(receipt)}::jsonb
+      WHERE id = ${attemptId} AND completed_at IS NULL
     `);
-
-    if (updated[0]) return updated[0].receipt;
-    return (await this.getAttempt(userId, attemptId)).receipt;
+    return receipt;
   }
 
-  async createShare(userId: string, dto: CreateSocialShareDto) {
-    const source = await this.resolveShareSource(userId, dto);
-    const identity = `social-share:${userId}:${source.sourceType}:${source.sourceId}:${source.kind}`;
-
-    const shareId = await this.prisma.$transaction(async (tx) => {
-      await tx.$queryRaw<Array<{ acquired: number }>>(Prisma.sql`
-        WITH lock_row AS MATERIALIZED (
-          SELECT pg_advisory_xact_lock(hashtextextended(${identity}, 0))
-        )
-        SELECT 1::int AS acquired FROM lock_row
-      `);
-
-      const existing = await tx.$queryRaw<ExistingShareRow[]>(Prisma.sql`
-        SELECT id, post_id AS "postId"
-        FROM dogos_social.shares
-        WHERE user_id = ${userId}
-          AND source_type = ${source.sourceType}
-          AND source_id = ${source.sourceId}
-          AND kind = ${source.kind}
-        LIMIT 1
-      `);
-      if (existing[0]) return existing[0].id;
-
-      const post = await tx.post.create({
-        data: {
-          authorUserId: userId,
-          petId: source.petId,
-          text: dto.caption?.trim() || source.summary,
-          mediaUrls: [],
-          visibility: dto.visibility ?? 'PRIVATE',
-        },
-        select: { id: true },
-      });
-      const id = randomUUID();
-      await tx.$executeRaw(Prisma.sql`
-        INSERT INTO dogos_social.shares
-          (id, post_id, user_id, pet_id, source_type, source_id, kind, headline, summary, payload)
-        VALUES
-          (${id}, ${post.id}, ${userId}, ${source.petId}, ${source.sourceType}, ${source.sourceId}, ${source.kind}, ${source.headline}, ${source.summary}, ${JSON.stringify(source.payload)}::jsonb)
-      `);
-      return id;
-    });
-
-    const created = await this.getShare(userId, shareId);
-    if (!created) throw new NotFoundException('Shared moment not found');
-    return created;
-  }
-
-  async getFeed(userId: string, take = 20) {
-    const safeTake = Math.max(1, Math.min(Number(take) || 20, 50));
+  async getFeed(userId: string, take = 30) {
+    const safeTake = Math.max(1, Math.min(Number(take) || 30, 50));
     const rows = await this.prisma.$queryRaw<FeedRow[]>(Prisma.sql`
       SELECT
         share.id AS "shareId",
-        post.id AS "postId",
-        share.kind,
-        share.headline,
-        share.summary,
-        share.payload,
-        post.text AS caption,
-        post.visibility,
-        post.created_at AS "createdAt",
-        author.id AS "authorUserId",
+        share.post_id AS "postId",
+        post.kind,
+        post.headline,
+        post.summary,
+        post.payload,
+        share.caption,
+        share.visibility,
+        share.created_at AS "createdAt",
+        share.user_id AS "authorUserId",
         author.handle,
         author.avatar_url AS "avatarUrl",
-        pet.id AS "petId",
-        pet.name AS "petName",
-        pet.avatar_url AS "petAvatarUrl",
-        (SELECT COUNT(*)::int FROM public.likes liked WHERE liked.post_id = post.id) AS "likesCount",
-        (SELECT COUNT(*)::int FROM public.comments comment WHERE comment.post_id = post.id) AS "commentsCount"
+        pet.name AS "petName"
       FROM dogos_social.shares share
       JOIN public.posts post ON post.id = share.post_id
-      JOIN public.users author ON author.id = post.author_user_id
-      LEFT JOIN public.pets pet ON pet.id = share.pet_id
-      WHERE (post.author_user_id = ${userId} OR post.visibility = 'PUBLIC')
+      JOIN public.users author ON author.id = share.user_id
+      LEFT JOIN public.pets pet ON pet.id = post.pet_id
+      WHERE share.visibility = 'PUBLIC'
         AND NOT EXISTS (
           SELECT 1
           FROM public.blocked_users blocked
-          WHERE (blocked.user_id = ${userId} AND blocked.blocked_id = post.author_user_id)
-             OR (blocked.user_id = post.author_user_id AND blocked.blocked_id = ${userId})
+          WHERE (blocked.user_id = ${userId} AND blocked.blocked_id = share.user_id)
+             OR (blocked.user_id = share.user_id AND blocked.blocked_id = ${userId})
         )
-      ORDER BY post.created_at DESC, share.id DESC
+      ORDER BY share.created_at DESC
       LIMIT ${safeTake}
     `);
 
@@ -526,33 +513,115 @@ export class SocialAdventureService {
     return {
       posts: rows.map((row) => ({
         ...row,
-        createdAt: row.createdAt.toISOString(),
-        reactions: REACTION_TYPES.map((reaction) => {
-          const aggregate = reactions.find(
-            (item) => item.shareId === row.shareId && item.reaction === reaction
-          );
-          return { reaction, count: aggregate?.count ?? 0, mine: aggregate?.mine ?? false };
-        }),
+        reactions: reactions.filter((reaction) => reaction.shareId === row.shareId),
       })),
-      privacy:
-        'Only PUBLIC Social Adventure shares and your own private shares appear here. FRIENDS_ONLY legacy posts remain hidden until a modern friend-authority contract exists.',
+      privacy: 'public-opt-in-feed-only',
     };
   }
 
+  async createShare(userId: string, dto: CreateSocialShareDto) {
+    if ((dto.visibility ?? 'PRIVATE') !== 'PUBLIC') {
+      throw new BadRequestException('Social Adventure sharing is explicit public opt-in only');
+    }
+
+    const source = await this.resolveShareSource(userId, dto);
+    const existing = await this.prisma.$queryRaw<ShareRow[]>(Prisma.sql`
+      SELECT
+        id,
+        post_id AS "postId",
+        source_type AS "sourceType",
+        source_id AS "sourceId",
+        caption,
+        visibility,
+        created_at AS "createdAt"
+      FROM dogos_social.shares
+      WHERE user_id = ${userId}
+        AND source_type = ${dto.sourceType}
+        AND source_id = ${dto.sourceId}
+      LIMIT 1
+    `);
+    if (existing[0]) {
+      return {
+        shareId: existing[0].id,
+        postId: existing[0].postId,
+        headline: source.headline,
+        summary: source.summary,
+        visibility: existing[0].visibility,
+      };
+    }
+
+    const shareId = randomUUID();
+    const postId = randomUUID();
+    const caption = dto.caption?.trim() || null;
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.$executeRaw(Prisma.sql`
+        INSERT INTO public.posts (
+          id,
+          user_id,
+          pet_id,
+          kind,
+          headline,
+          summary,
+          payload,
+          visibility,
+          source_type,
+          source_id,
+          occurred_at,
+          created_at
+        ) VALUES (
+          ${postId},
+          ${userId},
+          ${source.petId},
+          ${source.kind},
+          ${source.headline},
+          ${source.summary},
+          ${JSON.stringify(source.payload)}::jsonb,
+          'PUBLIC',
+          ${dto.sourceType},
+          ${dto.sourceId},
+          ${source.occurredAt},
+          NOW()
+        )
+      `);
+      await tx.$executeRaw(Prisma.sql`
+        INSERT INTO dogos_social.shares (
+          id,
+          user_id,
+          post_id,
+          source_type,
+          source_id,
+          caption,
+          visibility,
+          created_at
+        ) VALUES (
+          ${shareId},
+          ${userId},
+          ${postId},
+          ${dto.sourceType},
+          ${dto.sourceId},
+          ${caption},
+          'PUBLIC',
+          NOW()
+        )
+      `);
+    });
+
+    return { shareId, postId, headline: source.headline, summary: source.summary, visibility: 'PUBLIC' };
+  }
+
   async addReaction(userId: string, shareId: string, dto: SocialReactionDto) {
-    await this.assertShareViewable(userId, shareId);
+    await this.requireVisibleShare(userId, shareId);
     await this.prisma.$executeRaw(Prisma.sql`
-      INSERT INTO dogos_social.reactions (id, share_id, user_id, reaction)
-      VALUES (${randomUUID()}, ${shareId}, ${userId}, ${dto.reaction})
+      INSERT INTO dogos_social.reactions (share_id, user_id, reaction, created_at)
+      VALUES (${shareId}, ${userId}, ${dto.reaction}, NOW())
       ON CONFLICT (share_id, user_id, reaction) DO NOTHING
     `);
     return { ok: true };
   }
 
   async removeReaction(userId: string, shareId: string, reaction: string) {
-    if (!REACTION_TYPES.includes(reaction as (typeof REACTION_TYPES)[number])) {
-      throw new BadRequestException('Unknown Social Adventure reaction');
-    }
+    await this.requireVisibleShare(userId, shareId);
     await this.prisma.$executeRaw(Prisma.sql`
       DELETE FROM dogos_social.reactions
       WHERE share_id = ${shareId} AND user_id = ${userId} AND reaction = ${reaction}
@@ -560,294 +629,204 @@ export class SocialAdventureService {
     return { ok: true };
   }
 
-  private async getPreferences(userId: string) {
-    const rows = await this.prisma.$queryRaw<PreferenceRow[]>(Prisma.sql`
-      SELECT global_leaderboard_opt_in AS "globalLeaderboardOptIn"
-      FROM dogos_social.preferences
-      WHERE user_id = ${userId}
+  private async requireVisibleShare(userId: string, shareId: string) {
+    const rows = await this.prisma.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+      SELECT share.id
+      FROM dogos_social.shares share
+      WHERE share.id = ${shareId}
+        AND share.visibility = 'PUBLIC'
+        AND NOT EXISTS (
+          SELECT 1
+          FROM public.blocked_users blocked
+          WHERE (blocked.user_id = ${userId} AND blocked.blocked_id = share.user_id)
+             OR (blocked.user_id = share.user_id AND blocked.blocked_id = ${userId})
+        )
       LIMIT 1
     `);
-    return rows[0] ?? { globalLeaderboardOptIn: false };
+    if (!rows[0]) throw new NotFoundException('Share not found');
   }
 
-  private async getAttempt(userId: string, attemptId: string) {
-    const rows = await this.prisma.$queryRaw<SkillAttemptRow[]>(Prisma.sql`
-      SELECT
-        id,
-        challenge_key AS "challengeKey",
-        challenge_version AS "challengeVersion",
-        scenario_key AS "scenarioKey",
-        issued_at AS "issuedAt",
-        expires_at AS "expiresAt",
-        completed_at AS "completedAt",
-        score,
-        receipt
-      FROM dogos_social.human_skill_attempts
-      WHERE id = ${attemptId} AND user_id = ${userId}
-      LIMIT 1
-    `);
-    if (!rows[0]) throw new NotFoundException('Human Skill attempt not found');
-    return rows[0];
-  }
-
-  private async getBestHumanSkillScores(userId: string) {
-    const season = currentUtcSeason();
-    const rows = await this.prisma.$queryRaw<Array<{ challengeKey: string; bestScore: number }>>(
-      Prisma.sql`
-        SELECT challenge_key AS "challengeKey", MAX(score)::int AS "bestScore"
-        FROM dogos_social.human_skill_attempts
-        WHERE user_id = ${userId}
-          AND completed_at >= ${season.startsAt}
-          AND completed_at < ${season.endsAt}
-        GROUP BY challenge_key
-      `
-    );
-    return Object.fromEntries(rows.map((row) => [row.challengeKey, row.bestScore])) as Partial<
-      Record<HumanSkillChallenge, number>
-    >;
-  }
-
-  private async computeScore(userId: string) {
-    const season = currentUtcSeason();
-    const [adventureRows, skillRows] = await Promise.all([
-      this.prisma.$queryRaw<AdventureEvidenceRow[]>(Prisma.sql`
-        SELECT DISTINCT ON (pathway) id, pathway
-        FROM public.care_events
-        WHERE user_id = ${userId}
-          AND source = 'QUEST_ENGINE'
-          AND event_type LIKE 'QUEST_%'
-          AND occurred_at >= ${season.startsAt}
-          AND occurred_at < ${season.endsAt}
-        ORDER BY pathway, occurred_at ASC, id ASC
-      `),
-      this.prisma.$queryRaw<SkillScoreRow[]>(Prisma.sql`
-        SELECT DISTINCT ON (challenge_key)
+  private async resolveShareSource(userId: string, dto: CreateSocialShareDto) {
+    if (dto.sourceType === 'HUMAN_SKILL_ATTEMPT') {
+      const rows = await this.prisma.$queryRaw<SkillShareSourceRow[]>(Prisma.sql`
+        SELECT
           id,
+          user_id AS "userId",
           challenge_key AS "challengeKey",
-          score
+          challenge_version AS "challengeVersion",
+          score,
+          receipt,
+          completed_at AS "completedAt"
         FROM dogos_social.human_skill_attempts
-        WHERE user_id = ${userId}
-          AND completed_at >= ${season.startsAt}
-          AND completed_at < ${season.endsAt}
-          AND score IS NOT NULL
-        ORDER BY challenge_key, completed_at ASC, id ASC
-      `),
-    ]);
-
-    const completedHumanSkills: Partial<Record<HumanSkillChallenge, number>> = {};
-    for (const row of skillRows) {
-      if (!this.isHumanSkillChallenge(row.challengeKey)) continue;
-      // The value only marks finite completion for the breadth policy. Practice
-      // magnitude is intentionally excluded from league arithmetic.
-      completedHumanSkills[row.challengeKey] = row.score;
-    }
-
-    const score = deriveSocialAdventureScore({
-      adventurePathways: adventureRows.map((row) => row.pathway),
-      humanSkillBestScores: completedHumanSkills,
-    });
-    const sourceHash = createHash('sha256')
-      .update(
-        JSON.stringify({
-          adventure: adventureRows.map((row) => [row.id, row.pathway]),
-          humanSkill: skillRows.map((row) => [row.id, row.challengeKey]),
-        })
+        WHERE id = ${dto.sourceId}
+          AND user_id = ${userId}
+          AND completed_at IS NOT NULL
+        LIMIT 1
+      `);
+      const attempt = rows[0];
+      if (!attempt) throw new NotFoundException('Human Skill attempt not found');
+      const challengeTitle = HUMAN_SKILL_CHALLENGES.includes(
+        attempt.challengeKey as HumanSkillChallengeKey
       )
-      .digest('hex');
-    const receiptId = createHash('sha256')
-      .update(`${userId}:${season.key}:${SOCIAL_ADVENTURE_POLICY_VERSION}:${sourceHash}`)
-      .digest('hex')
-      .slice(0, 40);
-
-    await this.prisma.$executeRaw(Prisma.sql`
-      INSERT INTO dogos_social.competition_receipts
-        (id, user_id, season_key, policy_version, score, components, source_hash)
-      VALUES
-        (${receiptId}, ${userId}, ${season.key}, ${SOCIAL_ADVENTURE_POLICY_VERSION}, ${score.score}, ${JSON.stringify(score.components)}::jsonb, ${sourceHash})
-      ON CONFLICT (user_id, season_key, policy_version, source_hash) DO NOTHING
-    `);
-
-    return {
-      ...score,
-      season: {
-        key: season.key,
-        startsAt: season.startsAt.toISOString(),
-        endsAt: season.endsAt.toISOString(),
-      },
-    };
-  }
-
-  private async scoreLeaderboardUsers(users: LeaderboardUserRow[]) {
-    const rows = await Promise.all(
-      users.map(async (user) => {
-        const score = await this.computeScore(user.id);
-        return {
-          userId: user.id,
-          handle: user.handle,
-          avatarUrl: user.avatarUrl,
-          score: score.score,
-          maxScore: score.maxScore,
-          components: score.components,
-        };
-      })
-    );
-    return rows.sort((a, b) => b.score - a.score || a.handle.localeCompare(b.handle));
-  }
-
-  private async resolveShareSource(
-    userId: string,
-    dto: CreateSocialShareDto
-  ): Promise<ShareSource> {
-    if (dto.sourceType === 'CARE_EVENT') {
-      const event = await this.prisma.careEvent.findFirst({
-        where: { id: dto.sourceId, userId, source: 'QUEST_ENGINE' },
-        include: { pet: { select: { id: true, name: true } } },
-      });
-      if (!event) throw new NotFoundException('Adventure moment not found');
-
-      const context = this.asRecord(event.context);
-      const outcome = this.asRecord(event.outcome);
-      const safeOptOut = outcome.safeOptOut === true;
-      const dogExperience =
-        typeof outcome.dogExperience === 'string' ? outcome.dogExperience : null;
-      const questTitle =
-        typeof context.questTitle === 'string' && context.questTitle.trim()
-          ? context.questTitle.trim().slice(0, 100)
-          : 'Shared Adventure';
-      const petName = event.pet?.name ?? 'your dog';
-      const kind = safeOptOut
-        ? 'GOOD_READ'
-        : dogExperience === 'not_their_thing'
-          ? 'DISCOVERY'
-          : 'ADVENTURE_MEMORY';
-      const summary = safeOptOut
-        ? `We listened to ${petName} and changed course. Stopping appropriately counted as a good read.`
-        : kind === 'DISCOVERY'
-          ? `We learned something useful about what fits ${petName}. Discovery counts even when an activity is not a favorite.`
-          : `A ${event.pathway.toLowerCase()} moment with ${petName}, saved from a real Adventure outcome.`;
-
+        ? HUMAN_SKILL_SCENARIOS[attempt.challengeKey as HumanSkillChallengeKey][0].title
+        : 'Human Skill';
       return {
-        sourceType: 'CARE_EVENT',
-        sourceId: event.id,
-        petId: event.petId,
-        kind,
-        headline: questTitle,
-        summary,
+        petId: null,
+        kind: 'HUMAN_SKILL',
+        headline: `Practiced ${challengeTitle}`,
+        summary: 'Worked on the human side of the relationship.',
+        occurredAt: attempt.completedAt,
         payload: {
-          pathway: event.pathway,
-          eventType: event.eventType,
-          safeOptOut,
-          dogExperience,
-          petName,
+          sourceType: 'HUMAN_SKILL_ATTEMPT',
+          challengeKey: attempt.challengeKey,
+          challengeVersion: attempt.challengeVersion,
         },
       };
     }
 
-    const rows = await this.prisma.$queryRaw<SkillAttemptRow[]>(Prisma.sql`
+    const rows = await this.prisma.$queryRaw<CareShareSourceRow[]>(Prisma.sql`
       SELECT
-        id,
-        challenge_key AS "challengeKey",
-        challenge_version AS "challengeVersion",
-        scenario_key AS "scenarioKey",
-        issued_at AS "issuedAt",
-        expires_at AS "expiresAt",
-        completed_at AS "completedAt",
-        score,
-        receipt
-      FROM dogos_social.human_skill_attempts
-      WHERE id = ${dto.sourceId} AND user_id = ${userId} AND completed_at IS NOT NULL
+        event.id,
+        event.pet_id AS "petId",
+        event.created_by AS "createdBy",
+        event.event_type AS "eventType",
+        event.title,
+        event.note,
+        event.occurred_at AS "occurredAt",
+        pet.name AS "petName"
+      FROM public.care_events event
+      JOIN public.pets pet ON pet.id = event.pet_id
+      JOIN dogos_household.pet_households ph ON ph.pet_id = pet.id
+      JOIN dogos_household.household_membership hm ON hm.household_id = ph.household_id
+      WHERE event.id = ${dto.sourceId}
+        AND hm.user_id = ${userId}
+        AND hm.status = 'ACTIVE'
       LIMIT 1
     `);
-    const attempt = rows[0];
-    if (!attempt || attempt.score === null)
-      throw new NotFoundException('Human Skill result not found');
-    const scenario = scenarioByKey(attempt.scenarioKey);
-    const title = scenario?.title ?? 'Human Skill Arcade';
-
+    const event = rows[0];
+    if (!event) throw new NotFoundException('CARE event not found');
     return {
-      sourceType: 'HUMAN_SKILL_ATTEMPT',
-      sourceId: attempt.id,
-      petId: null,
-      kind: 'SKILL_MOMENT',
-      headline: title,
-      summary: `Practiced ${this.humanize(attempt.challengeKey)} and scored ${attempt.score}/100. The score is personal feedback, not pet performance or league proficiency.`,
-      payload: {
-        challengeKey: attempt.challengeKey,
-        challengeVersion: attempt.challengeVersion,
-        score: attempt.score,
-      },
+      petId: event.petId,
+      kind: 'CARE',
+      headline: event.title || `A ${event.eventType.toLowerCase()} moment`,
+      summary: event.note?.trim() || `Shared a ${event.eventType.toLowerCase()} moment with ${event.petName}.`,
+      occurredAt: event.occurredAt,
+      payload: { sourceType: 'CARE_EVENT', eventType: event.eventType },
     };
   }
 
-  private async getShare(userId: string, shareId: string) {
-    const rows = await this.prisma.$queryRaw<FeedRow[]>(Prisma.sql`
-      SELECT
-        share.id AS "shareId",
-        post.id AS "postId",
-        share.kind,
-        share.headline,
-        share.summary,
-        share.payload,
-        post.text AS caption,
-        post.visibility,
-        post.created_at AS "createdAt",
-        author.id AS "authorUserId",
-        author.handle,
-        author.avatar_url AS "avatarUrl",
-        pet.id AS "petId",
-        pet.name AS "petName",
-        pet.avatar_url AS "petAvatarUrl",
-        (SELECT COUNT(*)::int FROM public.likes liked WHERE liked.post_id = post.id) AS "likesCount",
-        (SELECT COUNT(*)::int FROM public.comments comment WHERE comment.post_id = post.id) AS "commentsCount"
-      FROM dogos_social.shares share
-      JOIN public.posts post ON post.id = share.post_id
-      JOIN public.users author ON author.id = post.author_user_id
-      LEFT JOIN public.pets pet ON pet.id = share.pet_id
-      WHERE share.id = ${shareId}
-        AND (post.author_user_id = ${userId} OR post.visibility = 'PUBLIC')
-        AND NOT EXISTS (
-          SELECT 1
-          FROM public.blocked_users blocked
-          WHERE (blocked.user_id = ${userId} AND blocked.blocked_id = post.author_user_id)
-             OR (blocked.user_id = post.author_user_id AND blocked.blocked_id = ${userId})
-        )
-      LIMIT 1
+  private async scoreLeaderboardUsers(users: LeaderboardUserRow[]) {
+    const scored = await Promise.all(
+      users.map(async (user) => ({
+        userId: user.id,
+        handle: user.handle,
+        avatarUrl: user.avatarUrl,
+        ...(await this.computeScore(user.id)),
+      }))
+    );
+    return scored.sort((a, b) => b.score - a.score || a.handle.localeCompare(b.handle));
+  }
+
+  private async computeScore(userId: string) {
+    const season = getCurrentSocialSeason();
+    const [skillRows, pathwayRows] = await Promise.all([
+      this.prisma.$queryRaw<HumanSkillRow[]>(Prisma.sql`
+        SELECT DISTINCT ON (challenge_key)
+          id,
+          challenge_key AS "challengeKey",
+          challenge_version AS "challengeVersion",
+          score
+        FROM dogos_social.human_skill_attempts
+        WHERE user_id = ${userId}
+          AND completed_at IS NOT NULL
+          AND completed_at >= ${season.startsAt}
+          AND completed_at < ${season.endsAt}
+          AND challenge_version = ${HUMAN_SKILL_CHALLENGE_VERSION}
+        ORDER BY challenge_key, completed_at DESC, id DESC
+      `),
+      this.prisma.$queryRaw<PathwayRow[]>(Prisma.sql`
+        SELECT DISTINCT ON (pathway)
+          pathway
+        FROM public.pet_adventure_outcomes outcome
+        WHERE outcome.user_id = ${userId}
+          AND outcome.completed_at IS NOT NULL
+          AND outcome.completed_at >= ${season.startsAt}
+          AND outcome.completed_at < ${season.endsAt}
+          AND outcome.pathway IN (${Prisma.join([...SOCIAL_ADVENTURE_PATHWAYS])})
+        ORDER BY pathway, completed_at DESC, id DESC
+      `),
+    ]);
+
+    const sourceIdentity = {
+      policyVersion: SOCIAL_ADVENTURE_POLICY_VERSION,
+      seasonKey: season.key,
+      humanSkill: skillRows.map((row) => [row.id, row.challengeKey]),
+      adventureVariety: pathwayRows.map((row) => row.pathway),
+    };
+    const sourceHash = createHash('sha256')
+      .update(JSON.stringify(sourceIdentity))
+      .digest('hex');
+    const components = deriveSocialAdventureScore({
+      completedHumanSkills: skillRows.map((row) => row.challengeKey),
+      completedAdventurePathways: pathwayRows.map((row) => row.pathway),
+    });
+    const score = components.humanSkill.score + components.adventureVariety.score;
+
+    await this.prisma.$executeRaw(Prisma.sql`
+      INSERT INTO dogos_social.competition_receipts (
+        id,
+        user_id,
+        season_key,
+        policy_version,
+        score,
+        components,
+        source_hash,
+        calculated_at
+      ) VALUES (
+        ${randomUUID()},
+        ${userId},
+        ${season.key},
+        ${SOCIAL_ADVENTURE_POLICY_VERSION},
+        ${score},
+        ${JSON.stringify(components)}::jsonb,
+        ${sourceHash},
+        NOW()
+      )
+      ON CONFLICT (user_id, season_key, policy_version, source_hash) DO NOTHING
     `);
-    const row = rows[0];
-    return row ? { ...row, createdAt: row.createdAt.toISOString() } : null;
+
+    return {
+      season,
+      score,
+      maxScore: HUMAN_SKILL_BREADTH_POINTS + ADVENTURE_VARIETY_POINTS,
+      components,
+    };
   }
 
-  private async assertShareViewable(userId: string, shareId: string) {
-    const share = await this.getShare(userId, shareId);
-    if (!share) throw new NotFoundException('Shared moment not found');
-    return share;
+  private async getHumanSkillBestScores(userId: string) {
+    const rows = await this.prisma.$queryRaw<HumanSkillBestScoreRow[]>(Prisma.sql`
+      SELECT challenge_key AS "challengeKey", MAX(score)::int AS score
+      FROM dogos_social.human_skill_attempts
+      WHERE user_id = ${userId}
+        AND completed_at IS NOT NULL
+        AND challenge_version = ${HUMAN_SKILL_CHALLENGE_VERSION}
+      GROUP BY challenge_key
+    `);
+    return Object.fromEntries(rows.map((row) => [row.challengeKey, row.score]));
   }
 
-  private isHumanSkillChallenge(value: string): value is HumanSkillChallenge {
-    return HUMAN_SKILL_CHALLENGES.includes(value as HumanSkillChallenge);
-  }
-
-  private asRecord(value: Prisma.JsonValue | null): Record<string, unknown> {
-    return value && typeof value === 'object' && !Array.isArray(value)
-      ? (value as Record<string, unknown>)
-      : {};
+  private deterministicScenarioIndex(userId: string, challengeKey: string, scenarioCount: number) {
+    const hash = createHash('sha256').update(`${userId}:${challengeKey}`).digest();
+    return hash.readUInt32BE(0) % scenarioCount;
   }
 
   private slugify(value: string) {
-    const normalized = value
+    const slug = value
       .trim()
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-|-$/g, '')
-      .slice(0, 56);
-    return normalized || 'pack';
-  }
-
-  private humanize(value: string) {
-    return value
-      .toLowerCase()
-      .split('_')
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
+      .slice(0, 48);
+    return slug || 'pack';
   }
 }

--- a/apps/mobile/src/api/social-adventure.ts
+++ b/apps/mobile/src/api/social-adventure.ts
@@ -105,6 +105,11 @@ export type SocialPack = {
   coarseRegion: PackCoarseRegion | null;
 };
 
+export type CreatedSocialPack = Pick<
+  SocialPack,
+  'id' | 'name' | 'slug' | 'regionKey' | 'joined' | 'localityStatus' | 'coarseRegion'
+>;
+
 export type PacksCatalog = {
   packs: SocialPack[];
   localMinimumCohort: number;
@@ -190,7 +195,7 @@ export const socialAdventureApi = {
   packs: () => apiClient.get<PacksCatalog>('/social-adventure/packs'),
 
   createPack: (input: { name: string; regionKey: string }) =>
-    apiClient.post<SocialPack>('/social-adventure/packs', input),
+    apiClient.post<CreatedSocialPack>('/social-adventure/packs', input),
 
   repairPackLocality: (packId: string, regionKey: string) =>
     apiClient.put<{ packId: string; localityStatus: 'APPROVED'; coarseRegion: PackCoarseRegion }>(

--- a/apps/mobile/src/api/social-adventure.ts
+++ b/apps/mobile/src/api/social-adventure.ts
@@ -78,6 +78,19 @@ export type SocialAdventureFeed = {
   privacy: string;
 };
 
+export type PackCoarseRegion = {
+  id: string;
+  displayName: string;
+  countryCode: string;
+  subdivisionCode: string | null;
+  granularity: 'METRO' | 'COUNTY' | 'BROAD_DISTRICT';
+};
+
+export type PackRegionCatalog = {
+  regions: PackCoarseRegion[];
+  locationContract: string;
+};
+
 export type SocialPack = {
   id: string;
   name: string;
@@ -88,6 +101,8 @@ export type SocialPack = {
   memberCount: number;
   joined: boolean;
   role: string | null;
+  localityStatus: 'APPROVED' | 'LEGACY_UNVERIFIED';
+  coarseRegion: PackCoarseRegion | null;
 };
 
 export type PacksCatalog = {
@@ -170,10 +185,18 @@ export const socialAdventureApi = {
   removeReaction: (shareId: string, reaction: SocialAdventureReaction) =>
     apiClient.delete<{ ok: true }>(`/social-adventure/shares/${shareId}/reactions/${reaction}`),
 
+  regions: () => apiClient.get<PackRegionCatalog>('/social-adventure/regions'),
+
   packs: () => apiClient.get<PacksCatalog>('/social-adventure/packs'),
 
   createPack: (input: { name: string; regionKey: string }) =>
     apiClient.post<SocialPack>('/social-adventure/packs', input),
+
+  repairPackLocality: (packId: string, regionKey: string) =>
+    apiClient.put<{ packId: string; localityStatus: 'APPROVED'; coarseRegion: PackCoarseRegion }>(
+      `/social-adventure/packs/${packId}/locality`,
+      { regionKey }
+    ),
 
   joinPack: (packId: string) =>
     apiClient.post<{ ok: true }>(`/social-adventure/packs/${packId}/join`, {}),

--- a/apps/mobile/src/components/community/SocialAdventurePacksView.tsx
+++ b/apps/mobile/src/components/community/SocialAdventurePacksView.tsx
@@ -258,7 +258,10 @@ export function SocialAdventurePacksView(props: Props) {
             accessibilityRole="button"
             disabled={props.repairing || !props.repairRegionKey}
             onPress={props.onRepairPack}
-            style={[styles.primaryButton, (props.repairing || !props.repairRegionKey) && styles.disabled]}
+            style={[
+              styles.primaryButton,
+              (props.repairing || !props.repairRegionKey) && styles.disabled,
+            ]}
           >
             {props.repairing ? (
               <ActivityIndicator color="#ffffff" />

--- a/apps/mobile/src/components/community/SocialAdventurePacksView.tsx
+++ b/apps/mobile/src/components/community/SocialAdventurePacksView.tsx
@@ -8,27 +8,80 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import type { PackLeaderboard, PacksCatalog, SocialPack } from '../../api/social-adventure';
+import type {
+  PackLeaderboard,
+  PackRegionCatalog,
+  PacksCatalog,
+  SocialPack,
+} from '../../api/social-adventure';
 import { colors } from '../../theme/tokens';
 
 type Props = {
   catalog: PacksCatalog | null;
+  regions: PackRegionCatalog | null;
   selectedPack: SocialPack | null;
   leaderboard: PackLeaderboard | null;
   leaderboardLoading: boolean;
   actionId: string | null;
   creating: boolean;
+  repairing: boolean;
   name: string;
   regionKey: string;
+  repairRegionKey: string;
   error: string | null;
   onSelectPack: (packId: string) => void;
   onJoinPack: (pack: SocialPack) => void;
   onLeavePack: (pack: SocialPack) => void;
   onNameChange: (value: string) => void;
   onRegionChange: (value: string) => void;
+  onRepairRegionChange: (value: string) => void;
   onCreatePack: () => void;
+  onRepairPack: () => void;
   onBack: () => void;
 };
+
+function RegionChoices({
+  regions,
+  selectedId,
+  onSelect,
+}: {
+  regions: PackRegionCatalog | null;
+  selectedId: string;
+  onSelect: (regionId: string) => void;
+}) {
+  if (!regions?.regions.length) {
+    return (
+      <View style={styles.quietBox}>
+        <Text style={styles.quietTitle}>Broad areas unavailable</Text>
+        <Text style={styles.smallCopy}>
+          Woof will not accept typed location text or guess a locality while the approved catalog is
+          unavailable.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.regionChoices} accessibilityRole="radiogroup">
+      {regions.regions.map((region) => {
+        const selected = region.id === selectedId;
+        return (
+          <Pressable
+            key={region.id}
+            accessibilityRole="radio"
+            accessibilityState={{ selected }}
+            onPress={() => onSelect(region.id)}
+            style={[styles.regionChoice, selected && styles.regionChoiceSelected]}
+          >
+            <Text style={[styles.regionChoiceText, selected && styles.regionChoiceTextSelected]}>
+              {region.displayName}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
 
 function PackRow({
   pack,
@@ -50,7 +103,7 @@ function PackRow({
       <Pressable accessibilityRole="button" onPress={onSelect} style={styles.packOpen}>
         <Text style={styles.packName}>{pack.name}</Text>
         <Text style={styles.meta}>
-          {pack.regionKey ?? 'coarse region'} · {pack.memberCount}{' '}
+          {pack.coarseRegion?.displayName ?? 'Locality needs owner repair'} · {pack.memberCount}{' '}
           {pack.memberCount === 1 ? 'member' : 'members'}
         </Text>
       </Pressable>
@@ -129,6 +182,10 @@ function Standings({
 }
 
 export function SocialAdventurePacksView(props: Props) {
+  const legacyOwner =
+    props.selectedPack?.localityStatus === 'LEGACY_UNVERIFIED' &&
+    props.selectedPack.role === 'OWNER';
+
   return (
     <ScrollView
       style={styles.screen}
@@ -142,14 +199,15 @@ export function SocialAdventurePacksView(props: Props) {
         <Text style={styles.eyebrow}>SOCIAL ADVENTURE</Text>
         <Text style={styles.heroTitle}>Local Packs without tracking you.</Text>
         <Text style={styles.body}>
-          Choose a coarse community, not a coordinate. Pack rank never uses your home, route
-          endpoints, live GPS, health, mileage, or dog performance.
+          Choose from server-approved broad areas, never typed addresses or coordinates. Pack rank
+          does not use your home, route endpoints, live GPS, health, mileage, or dog performance.
         </Text>
         <View style={styles.quietBox}>
           <Text style={styles.quietTitle}>Privacy floor</Text>
           <Text style={styles.smallCopy}>
-            The app never estimates or reconstructs a private local rank. Standings appear only when
-            the server says the cohort is large enough.
+            Woof never turns arbitrary location text into locality authority, and never estimates or
+            reconstructs a private local rank. Standings appear only when the server says the cohort
+            is large enough.
           </Text>
         </View>
       </View>
@@ -163,7 +221,7 @@ export function SocialAdventurePacksView(props: Props) {
           <View style={styles.quietBox}>
             <Text style={styles.quietTitle}>No local Packs yet.</Text>
             <Text style={styles.smallCopy}>
-              A quiet map is valid. You can start a broad-area Pack below.
+              A quiet map is valid. You can start an approved broad-area Pack below.
             </Text>
           </View>
         ) : (
@@ -183,20 +241,46 @@ export function SocialAdventurePacksView(props: Props) {
         )}
       </View>
 
-      {props.selectedPack && (
+      {legacyOwner && props.selectedPack ? (
+        <View style={styles.card}>
+          <Text style={styles.eyebrow}>LOCALITY REPAIR</Text>
+          <Text style={styles.sectionTitle}>Choose a broad area again</Text>
+          <Text style={styles.body}>
+            Woof discarded this Pack&apos;s old free-form locality instead of assuming it was safe.
+            Choose one approved broad area to restore discovery and local standings.
+          </Text>
+          <RegionChoices
+            regions={props.regions}
+            selectedId={props.repairRegionKey}
+            onSelect={props.onRepairRegionChange}
+          />
+          <Pressable
+            accessibilityRole="button"
+            disabled={props.repairing || !props.repairRegionKey}
+            onPress={props.onRepairPack}
+            style={[styles.primaryButton, (props.repairing || !props.repairRegionKey) && styles.disabled]}
+          >
+            {props.repairing ? (
+              <ActivityIndicator color="#ffffff" />
+            ) : (
+              <Text style={styles.primaryButtonText}>Confirm broad area</Text>
+            )}
+          </Pressable>
+        </View>
+      ) : props.selectedPack?.localityStatus === 'APPROVED' ? (
         <Standings
           selectedPack={props.selectedPack}
           leaderboard={props.leaderboard}
           loading={props.leaderboardLoading}
         />
-      )}
+      ) : null}
 
       <View style={styles.card}>
         <Text style={styles.eyebrow}>CREATE A PACK</Text>
-        <Text style={styles.sectionTitle}>Start a coarse-locality Pack</Text>
+        <Text style={styles.sectionTitle}>Start a broad-area Pack</Text>
         <Text style={styles.body}>
-          Use a broad place people recognize. Do not enter an address, apartment complex, school,
-          route, or exact meetup point.
+          Choose from the approved catalog. Woof does not accept an address, apartment complex,
+          school, venue, route, coordinate, or exact meetup point as Pack locality.
         </Text>
 
         <Text style={styles.fieldLabel}>Pack name</Text>
@@ -209,22 +293,21 @@ export function SocialAdventurePacksView(props: Props) {
           style={styles.input}
         />
 
-        <Text style={styles.fieldLabel}>Coarse region</Text>
-        <TextInput
-          value={props.regionKey}
-          onChangeText={props.onRegionChange}
-          maxLength={80}
-          autoCapitalize="none"
-          placeholder="south-bay-ca"
-          placeholderTextColor={colors.gray[400]}
-          style={styles.input}
+        <Text style={styles.fieldLabel}>Broad area</Text>
+        <RegionChoices
+          regions={props.regions}
+          selectedId={props.regionKey}
+          onSelect={props.onRegionChange}
         />
 
         <Pressable
           accessibilityRole="button"
-          disabled={props.creating}
+          disabled={props.creating || !props.regionKey || !props.regions?.regions.length}
           onPress={props.onCreatePack}
-          style={[styles.primaryButton, props.creating && styles.disabled]}
+          style={[
+            styles.primaryButton,
+            (props.creating || !props.regionKey || !props.regions?.regions.length) && styles.disabled,
+          ]}
         >
           {props.creating ? (
             <ActivityIndicator color="#ffffff" />
@@ -339,6 +422,26 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff',
     color: colors.gray[900],
   },
+  regionChoices: {
+    marginTop: 8,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 7,
+  },
+  regionChoice: {
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: colors.gray[200],
+    backgroundColor: colors.gray[50],
+  },
+  regionChoiceSelected: {
+    borderColor: colors.primary[400],
+    backgroundColor: colors.primary[50],
+  },
+  regionChoiceText: { color: colors.gray[700], fontSize: 11, fontWeight: '700' },
+  regionChoiceTextSelected: { color: colors.primary[800] },
   primaryButton: {
     marginTop: 14,
     padding: 13,

--- a/apps/mobile/src/components/community/SocialAdventurePacksView.tsx
+++ b/apps/mobile/src/components/community/SocialAdventurePacksView.tsx
@@ -309,7 +309,8 @@ export function SocialAdventurePacksView(props: Props) {
           onPress={props.onCreatePack}
           style={[
             styles.primaryButton,
-            (props.creating || !props.regionKey || !props.regions?.regions.length) && styles.disabled,
+            (props.creating || !props.regionKey || !props.regions?.regions.length) &&
+              styles.disabled,
           ]}
         >
           {props.creating ? (

--- a/apps/mobile/src/screens/PacksScreen.tsx
+++ b/apps/mobile/src/screens/PacksScreen.tsx
@@ -4,6 +4,7 @@ import type { StackScreenProps } from '@react-navigation/stack';
 import {
   socialAdventureApi,
   type PackLeaderboard,
+  type PackRegionCatalog,
   type PacksCatalog,
   type SocialPack,
 } from '../api/social-adventure';
@@ -14,29 +15,25 @@ import { colors } from '../theme/tokens';
 type Props = StackScreenProps<RootStackParamList, 'Packs'>;
 
 const PACKS_COPY = {
-  locality: 'Choose a broad community label, not a coordinate or precise place.',
+  locality: 'Choose one server-approved broad area, never a coordinate or precise place.',
   privacy: 'The app never estimates or reconstructs a private local rank.',
   score: 'Breadth in Human Skill and bounded Adventure variety count.',
-  create: 'Use a broad place people recognize.',
+  create: 'Woof rejects arbitrary address or venue text as Pack locality.',
 } as const;
-
-const normalizeRegionKey = (value: string) =>
-  value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
 
 export default function PacksScreen({ navigation }: Props) {
   const [catalog, setCatalog] = useState<PacksCatalog | null>(null);
+  const [regions, setRegions] = useState<PackRegionCatalog | null>(null);
   const [selectedPackId, setSelectedPackId] = useState<string | null>(null);
   const [leaderboard, setLeaderboard] = useState<PackLeaderboard | null>(null);
   const [loading, setLoading] = useState(true);
   const [leaderboardLoading, setLeaderboardLoading] = useState(false);
   const [actionId, setActionId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
+  const [repairing, setRepairing] = useState(false);
   const [name, setName] = useState('');
   const [regionKey, setRegionKey] = useState('');
+  const [repairRegionKey, setRepairRegionKey] = useState('');
   const [error, setError] = useState<string | null>(null);
   const leaderboardRequestRef = useRef(0);
 
@@ -46,6 +43,19 @@ export default function PacksScreen({ navigation }: Props) {
     () => catalog?.packs.find((pack) => pack.id === selectedPackId) ?? null,
     [catalog, selectedPackId]
   );
+
+  const loadRegions = useCallback(async () => {
+    try {
+      const response = await socialAdventureApi.regions();
+      setRegions(response);
+      const firstRegion = response.regions[0]?.id ?? '';
+      setRegionKey((current) => current || firstRegion);
+      setRepairRegionKey((current) => current || firstRegion);
+    } catch {
+      setRegions(null);
+      setError('Approved broad areas are unavailable, so Woof will not guess a locality.');
+    }
+  }, []);
 
   const loadPacks = useCallback(async () => {
     try {
@@ -98,18 +108,18 @@ export default function PacksScreen({ navigation }: Props) {
   }, []);
 
   useEffect(() => {
-    void loadPacks();
-  }, [loadPacks]);
+    void Promise.all([loadRegions(), loadPacks()]);
+  }, [loadPacks, loadRegions]);
 
   useEffect(() => {
-    if (!selectedPackId) {
+    if (!selectedPackId || selectedPack?.localityStatus !== 'APPROVED') {
       leaderboardRequestRef.current += 1;
       setLeaderboard(null);
       setLeaderboardLoading(false);
       return;
     }
     void loadLeaderboard(selectedPackId);
-  }, [loadLeaderboard, selectedPackId]);
+  }, [loadLeaderboard, selectedPack?.localityStatus, selectedPackId]);
 
   const joinPack = async (pack: SocialPack) => {
     setActionId(pack.id);
@@ -145,9 +155,8 @@ export default function PacksScreen({ navigation }: Props) {
 
   const createPack = async () => {
     const trimmedName = name.trim();
-    const normalizedRegion = normalizeRegionKey(regionKey);
-    if (trimmedName.length < 2 || normalizedRegion.length < 2) {
-      setError('Use a Pack name and a broad region label such as south-bay-ca.');
+    if (trimmedName.length < 2 || !regionKey || !regions?.regions.some((r) => r.id === regionKey)) {
+      setError('Choose a Pack name and one approved broad area.');
       return;
     }
 
@@ -156,18 +165,41 @@ export default function PacksScreen({ navigation }: Props) {
     try {
       const created = await socialAdventureApi.createPack({
         name: trimmedName,
-        regionKey: normalizedRegion,
+        regionKey,
       });
       setName('');
-      setRegionKey('');
       selectPack(created.id);
       await loadPacks();
     } catch {
       setError(
-        'That Pack could not be created. Enter only a broad-area label, never an address, venue, coordinate, route, or exact meetup point.'
+        'That Pack could not be created. Woof accepts only the server-approved broad areas shown here.'
       );
     } finally {
       setCreating(false);
+    }
+  };
+
+  const repairPackLocality = async () => {
+    if (
+      !selectedPack ||
+      selectedPack.role !== 'OWNER' ||
+      selectedPack.localityStatus !== 'LEGACY_UNVERIFIED' ||
+      !repairRegionKey ||
+      !regions?.regions.some((region) => region.id === repairRegionKey)
+    ) {
+      setError('Choose an approved broad area to repair this Pack.');
+      return;
+    }
+
+    setRepairing(true);
+    setError(null);
+    try {
+      await socialAdventureApi.repairPackLocality(selectedPack.id, repairRegionKey);
+      await loadPacks();
+    } catch {
+      setError('Woof could not repair that Pack locality. No new location authority was saved.');
+    } finally {
+      setRepairing(false);
     }
   };
 
@@ -185,20 +217,25 @@ export default function PacksScreen({ navigation }: Props) {
   return (
     <SocialAdventurePacksView
       catalog={catalog}
+      regions={regions}
       selectedPack={selectedPack}
       leaderboard={selectedLeaderboard}
       leaderboardLoading={leaderboardLoading}
       actionId={actionId}
       creating={creating}
+      repairing={repairing}
       name={name}
       regionKey={regionKey}
+      repairRegionKey={repairRegionKey}
       error={error}
       onSelectPack={selectPack}
       onJoinPack={(pack) => void joinPack(pack)}
       onLeavePack={(pack) => void leavePack(pack)}
       onNameChange={setName}
       onRegionChange={setRegionKey}
+      onRepairRegionChange={setRepairRegionKey}
       onCreatePack={() => void createPack()}
+      onRepairPack={() => void repairPackLocality()}
       onBack={() => navigation.goBack()}
     />
   );

--- a/apps/web/src/app/community/packs/page.tsx
+++ b/apps/web/src/app/community/packs/page.tsx
@@ -108,9 +108,10 @@ export default function LocalPacksPage() {
             Choose a broad community, never a coordinate.
           </h2>
           <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-            Pack locality now comes only from Woof&apos;s server-approved broad-area catalog. The app
-            does not turn typed addresses, venues, home location, route endpoints, or live GPS into
-            locality authority. Local ranks stay hidden until the Pack has enough active members.
+            Pack locality now comes only from Woof&apos;s server-approved broad-area catalog. The
+            app does not turn typed addresses, venues, home location, route endpoints, or live GPS
+            into locality authority. Local ranks stay hidden until the Pack has enough active
+            members.
           </p>
           <Button variant="outline" asChild className="mt-4 bg-transparent">
             <Link href="/community">← Back to Community</Link>
@@ -185,8 +186,8 @@ export default function LocalPacksPage() {
             <p className="eyebrow">Locality repair</p>
             <h2 className="mt-1 text-xl font-bold tracking-tight">Choose a broad area again</h2>
             <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-              Woof discarded the Pack&apos;s old free-form locality rather than assuming it was safe.
-              Select one approved broad area to restore public discovery and local standings.
+              Woof discarded the Pack&apos;s old free-form locality rather than assuming it was
+              safe. Select one approved broad area to restore public discovery and local standings.
             </p>
             <select
               aria-label="Approved broad area for legacy Pack"

--- a/apps/web/src/app/community/packs/page.tsx
+++ b/apps/web/src/app/community/packs/page.tsx
@@ -3,7 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Loader2, MapPinned, ShieldCheck, Trophy, Users } from 'lucide-react';
 import Link from 'next/link';
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { BottomNav } from '@/components/bottom-nav';
 import { Button } from '@/components/ui/button';
 import { socialAdventureApi } from '@/lib/api/social-adventure';
@@ -13,6 +13,13 @@ export default function LocalPacksPage() {
   const [selectedPackId, setSelectedPackId] = useState<string | null>(null);
   const [name, setName] = useState('');
   const [regionKey, setRegionKey] = useState('');
+  const [repairRegionKey, setRepairRegionKey] = useState('');
+
+  const regions = useQuery({
+    queryKey: ['social-adventure', 'regions'],
+    queryFn: socialAdventureApi.regions,
+    retry: false,
+  });
 
   const packs = useQuery({
     queryKey: ['social-adventure', 'packs'],
@@ -21,14 +28,26 @@ export default function LocalPacksPage() {
   });
 
   useEffect(() => {
+    const firstRegion = regions.data?.regions[0]?.id;
+    if (!firstRegion) return;
+    setRegionKey((current) => current || firstRegion);
+    setRepairRegionKey((current) => current || firstRegion);
+  }, [regions.data]);
+
+  useEffect(() => {
     if (selectedPackId || !packs.data) return;
     setSelectedPackId(packs.data.packs.find((pack) => pack.joined)?.id ?? null);
   }, [packs.data, selectedPackId]);
 
+  const selectedPack = useMemo(
+    () => packs.data?.packs.find((pack) => pack.id === selectedPackId) ?? null,
+    [packs.data, selectedPackId]
+  );
+
   const leaderboard = useQuery({
     queryKey: ['social-adventure', 'packs', selectedPackId, 'leaderboard'],
     queryFn: () => socialAdventureApi.packLeaderboard(selectedPackId as string),
-    enabled: Boolean(selectedPackId),
+    enabled: Boolean(selectedPackId && selectedPack?.localityStatus === 'APPROVED'),
     retry: false,
   });
 
@@ -36,9 +55,19 @@ export default function LocalPacksPage() {
     mutationFn: socialAdventureApi.createPack,
     onSuccess: async (created) => {
       setName('');
-      setRegionKey('');
       setSelectedPackId(created.id);
       await queryClient.invalidateQueries({ queryKey: ['social-adventure', 'packs'] });
+    },
+  });
+
+  const repairMutation = useMutation({
+    mutationFn: ({ packId, approvedRegionId }: { packId: string; approvedRegionId: string }) =>
+      socialAdventureApi.repairPackLocality(packId, approvedRegionId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['social-adventure', 'packs'] });
+      await queryClient.invalidateQueries({
+        queryKey: ['social-adventure', 'packs', selectedPackId, 'leaderboard'],
+      });
     },
   });
 
@@ -52,13 +81,8 @@ export default function LocalPacksPage() {
 
   const submitPack = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const normalizedRegion = regionKey
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-|-$/g, '');
-    if (name.trim().length < 2 || normalizedRegion.length < 2) return;
-    createMutation.mutate({ name: name.trim(), regionKey: normalizedRegion });
+    if (name.trim().length < 2 || !regionKey) return;
+    createMutation.mutate({ name: name.trim(), regionKey });
   };
 
   return (
@@ -81,12 +105,12 @@ export default function LocalPacksPage() {
         <section className="rounded-3xl border border-primary/20 bg-gradient-to-br from-primary/[0.1] via-card/95 to-secondary/[0.06] p-5">
           <p className="eyebrow">Local without tracking you</p>
           <h2 className="mt-1 text-2xl font-bold tracking-tight">
-            Choose a coarse community, not a coordinate.
+            Choose a broad community, never a coordinate.
           </h2>
           <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-            A Pack uses a user-chosen locality such as “south-bay-ca.” Woof does not derive Pack
-            rank from your home location, route endpoints, or live GPS. Local ranks stay hidden
-            until the Pack has enough active members for a safer cohort.
+            Pack locality now comes only from Woof&apos;s server-approved broad-area catalog. The app
+            does not turn typed addresses, venues, home location, route endpoints, or live GPS into
+            locality authority. Local ranks stay hidden until the Pack has enough active members.
           </p>
           <Button variant="outline" asChild className="mt-4 bg-transparent">
             <Link href="/community">← Back to Community</Link>
@@ -96,7 +120,7 @@ export default function LocalPacksPage() {
         <section className="mt-6" aria-labelledby="pack-list-heading">
           <div className="flex items-end justify-between gap-3">
             <div>
-              <p className="eyebrow">Opt-in neighborhoods</p>
+              <p className="eyebrow">Opt-in communities</p>
               <h2 id="pack-list-heading" className="mt-1 text-xl font-bold tracking-tight">
                 Find a Pack
               </h2>
@@ -112,7 +136,7 @@ export default function LocalPacksPage() {
             <div className="surface-soft mt-3 rounded-2xl p-5 text-center">
               <p className="font-semibold">No local Packs yet.</p>
               <p className="mt-1 text-sm text-muted-foreground">
-                You can start the first coarse-locality Pack below.
+                You can start the first approved broad-area Pack below.
               </p>
             </div>
           ) : (
@@ -130,8 +154,8 @@ export default function LocalPacksPage() {
                     >
                       <p className="font-bold">{pack.name}</p>
                       <p className="mt-1 text-xs text-muted-foreground">
-                        {pack.regionKey} · {pack.memberCount}{' '}
-                        {pack.memberCount === 1 ? 'member' : 'members'}
+                        {pack.coarseRegion?.displayName ?? 'Locality needs owner repair'} ·{' '}
+                        {pack.memberCount} {pack.memberCount === 1 ? 'member' : 'members'}
                       </p>
                     </button>
                     {pack.joined ? (
@@ -156,7 +180,45 @@ export default function LocalPacksPage() {
           )}
         </section>
 
-        {selectedPackId && (
+        {selectedPack?.localityStatus === 'LEGACY_UNVERIFIED' && selectedPack.role === 'OWNER' && (
+          <section className="mt-7 rounded-3xl border border-amber-300/50 bg-amber-50/50 p-5">
+            <p className="eyebrow">Locality repair</p>
+            <h2 className="mt-1 text-xl font-bold tracking-tight">Choose a broad area again</h2>
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+              Woof discarded the Pack&apos;s old free-form locality rather than assuming it was safe.
+              Select one approved broad area to restore public discovery and local standings.
+            </p>
+            <select
+              aria-label="Approved broad area for legacy Pack"
+              value={repairRegionKey}
+              onChange={(event) => setRepairRegionKey(event.target.value)}
+              className="mt-4 w-full rounded-xl border border-border bg-background px-3 py-2.5"
+            >
+              {regions.data?.regions.map((region) => (
+                <option key={region.id} value={region.id}>
+                  {region.displayName}
+                </option>
+              ))}
+            </select>
+            <Button
+              className="mt-3"
+              disabled={!repairRegionKey || repairMutation.isPending}
+              onClick={() =>
+                repairMutation.mutate({
+                  packId: selectedPack.id,
+                  approvedRegionId: repairRegionKey,
+                })
+              }
+            >
+              {repairMutation.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+              )}
+              Confirm broad area
+            </Button>
+          </section>
+        )}
+
+        {selectedPackId && selectedPack?.localityStatus === 'APPROVED' && (
           <section className="mt-7" aria-labelledby="local-league-heading">
             <div>
               <p className="eyebrow">Pack league</p>
@@ -217,10 +279,10 @@ export default function LocalPacksPage() {
           <div className="flex items-start gap-3">
             <Trophy className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
             <div>
-              <h2 className="font-bold">Start a coarse-locality Pack</h2>
+              <h2 className="font-bold">Start a broad-area Pack</h2>
               <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-                Use a broad label other people would recognize. Do not enter an address, apartment
-                complex, school, route, or exact meetup point.
+                Choose from the approved catalog. Woof does not accept an address, school, venue,
+                coordinate, route, or exact meetup point as Pack locality.
               </p>
             </div>
           </div>
@@ -237,24 +299,31 @@ export default function LocalPacksPage() {
               />
             </label>
             <label className="block text-sm font-semibold">
-              Coarse region
-              <input
+              Broad area
+              <select
                 value={regionKey}
                 onChange={(event) => setRegionKey(event.target.value)}
-                maxLength={64}
-                placeholder="south-bay-ca"
+                disabled={regions.isLoading || !regions.data?.regions.length}
                 className="mt-1.5 w-full rounded-xl border border-border bg-background/60 px-3 py-2.5 font-normal outline-none focus:border-primary"
-              />
+              >
+                {regions.data?.regions.map((region) => (
+                  <option key={region.id} value={region.id}>
+                    {region.displayName}
+                  </option>
+                ))}
+              </select>
             </label>
-            <Button type="submit" disabled={createMutation.isPending}>
+            <Button type="submit" disabled={createMutation.isPending || !regionKey}>
               {createMutation.isPending && (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
               )}
               Create Pack
             </Button>
-            {createMutation.isError && (
+            {(createMutation.isError || regions.isError) && (
               <p className="text-sm text-destructive">
-                That Pack could not be created. Check the coarse region label and try again.
+                {regions.isError
+                  ? 'Approved broad areas are unavailable, so Woof will not guess a locality.'
+                  : 'That Pack could not be created. Refresh the approved broad-area catalog and try again.'}
               </p>
             )}
           </form>

--- a/apps/web/src/lib/api/social-adventure.ts
+++ b/apps/web/src/lib/api/social-adventure.ts
@@ -129,6 +129,19 @@ export type SocialShareCandidate = {
   occurredAt: string;
 };
 
+export type PackCoarseRegion = {
+  id: string;
+  displayName: string;
+  countryCode: string;
+  subdivisionCode: string | null;
+  granularity: 'METRO' | 'COUNTY' | 'BROAD_DISTRICT';
+};
+
+export type PackRegionCatalog = {
+  regions: PackCoarseRegion[];
+  locationContract: string;
+};
+
 export type SocialPack = {
   id: string;
   name: string;
@@ -139,6 +152,14 @@ export type SocialPack = {
   memberCount: number;
   joined: boolean;
   role: string | null;
+  localityStatus: 'APPROVED' | 'LEGACY_UNVERIFIED';
+  coarseRegion: PackCoarseRegion | null;
+};
+
+export type PacksCatalog = {
+  packs: SocialPack[];
+  localMinimumCohort: number;
+  locationContract: string;
 };
 
 export const socialAdventureApi = {
@@ -170,12 +191,15 @@ export const socialAdventureApi = {
     apiClient.post<ArcadeReceipt>(`/social-adventure/arcade/attempts/${attemptId}/complete`, {
       response,
     }),
-  packs: () =>
-    apiClient.get<{ packs: SocialPack[]; localMinimumCohort: number; locationContract: string }>(
-      '/social-adventure/packs'
-    ),
+  regions: () => apiClient.get<PackRegionCatalog>('/social-adventure/regions'),
+  packs: () => apiClient.get<PacksCatalog>('/social-adventure/packs'),
   createPack: (input: { name: string; regionKey: string }) =>
     apiClient.post<SocialPack>('/social-adventure/packs', input),
+  repairPackLocality: (packId: string, regionKey: string) =>
+    apiClient.put<{ packId: string; localityStatus: 'APPROVED'; coarseRegion: PackCoarseRegion }>(
+      `/social-adventure/packs/${packId}/locality`,
+      { regionKey }
+    ),
   joinPack: (packId: string) =>
     apiClient.post<{ ok: true }>(`/social-adventure/packs/${packId}/join`, {}),
   leavePack: (packId: string) =>

--- a/apps/web/src/lib/api/social-adventure.ts
+++ b/apps/web/src/lib/api/social-adventure.ts
@@ -156,6 +156,11 @@ export type SocialPack = {
   coarseRegion: PackCoarseRegion | null;
 };
 
+export type CreatedSocialPack = Pick<
+  SocialPack,
+  'id' | 'name' | 'slug' | 'regionKey' | 'joined' | 'localityStatus' | 'coarseRegion'
+>;
+
 export type PacksCatalog = {
   packs: SocialPack[];
   localMinimumCohort: number;
@@ -194,7 +199,7 @@ export const socialAdventureApi = {
   regions: () => apiClient.get<PackRegionCatalog>('/social-adventure/regions'),
   packs: () => apiClient.get<PacksCatalog>('/social-adventure/packs'),
   createPack: (input: { name: string; regionKey: string }) =>
-    apiClient.post<SocialPack>('/social-adventure/packs', input),
+    apiClient.post<CreatedSocialPack>('/social-adventure/packs', input),
   repairPackLocality: (packId: string, regionKey: string) =>
     apiClient.put<{ packId: string; localityStatus: 'APPROVED'; coarseRegion: PackCoarseRegion }>(
       `/social-adventure/packs/${packId}/locality`,

--- a/docs/DOGOS_SOCIAL_ADVENTURE_V1.md
+++ b/docs/DOGOS_SOCIAL_ADVENTURE_V1.md
@@ -141,17 +141,30 @@ An opted-in user appears only while their profile is PUBLIC. A viewer never sees
 
 ## Local Packs
 
-A local Pack stores only a user-chosen coarse `region_key`, such as `south-bay-ca`.
+A local Pack uses one **server-approved structured coarse-region identity**. Web and native clients fetch the approved catalog from `GET /social-adventure/regions`; Pack creation accepts only one catalog ID such as `us-ca-south-bay`. API allowlisting and the PostgreSQL foreign key independently reject arbitrary free-form locality text.
 
-Woof does not derive local Pack membership/ranking from:
+The v1 catalog is intentionally broad. Entries are metro, county, or broad-district labels. Woof does not derive Pack locality, membership, or ranking from:
 
-- home coordinates;
-- route endpoints;
-- live GPS;
+- home or street addresses;
+- home coordinates or live GPS;
+- route endpoints or route traces;
 - device pings;
-- inferred neighborhood.
+- precise venues, schools, apartment complexes, or meetup points;
+- inferred neighborhoods;
+- reverse geocoding private coordinates.
 
-Joining a Pack is explicit. Local standings are withheld until at least five active members exist. This is a first privacy floor, not a claim that five-person aggregation makes all locality risk disappear.
+Historical free-form `region_key` values are not promoted into trusted locality. The structured-locality migration clears those values without parsing, mapping, reverse geocoding, or logging them. Pack identity and membership survive, but a migrated local Pack remains `LEGACY_UNVERIFIED` until its owner explicitly selects an approved broad region.
+
+For an unverified legacy Pack:
+
+- existing members may still see the Pack through membership authority;
+- nonmembers cannot discover it through the Pack catalog;
+- new joins fail closed;
+- local standings fail closed;
+- only the owner may perform the one-time locality repair;
+- an already approved locality cannot be silently changed through the repair endpoint.
+
+Joining an approved Pack remains explicit. Local standings are withheld until at least five active members exist. This is a first privacy floor, not a claim that five-person aggregation creates anonymity or eliminates all locality risk.
 
 Existing cooperative `/pack/challenges` remain non-ranking and now count only canonical `QUEST_ENGINE` Adventure events, preventing unrelated CareEvents from becoming community progress.
 
@@ -165,9 +178,12 @@ Tables:
 - `shares`;
 - `reactions`;
 - `human_skill_attempts`;
+- `coarse_regions`;
 - `packs`;
 - `pack_memberships`;
 - `competition_receipts`.
+
+`coarse_regions` contains reviewed broad public-area identities only. `packs.region_key` references that table for approved local Packs and may remain `NULL` only for a migrated local Pack awaiting owner repair. The locality catalog contains no latitude, longitude, address, postal code, route, or precise-venue columns.
 
 Completed Human Skill attempts are immutable at PostgreSQL. Competition receipts are append-only/immutable at PostgreSQL. Competition receipt identity includes user, weekly season, policy version and a SHA-256 hash of the bounded source evidence used for that snapshot.
 
@@ -189,7 +205,9 @@ Clients may submit:
 - one Arcade answer/tap;
 - a bounded reaction;
 - an explicit global-league preference;
-- a Pack name/coarse region or join intent.
+- a Pack name plus one server-approved coarse-region ID;
+- explicit Pack join/leave intent;
+- an owner-only approved-region choice to repair a migrated legacy Pack.
 
 Clients do **not** submit authoritative:
 
@@ -201,7 +219,8 @@ Clients do **not** submit authoritative:
 - social share kind;
 - health/safety status;
 - source propensity/model feature;
-- exact locality.
+- free-form Pack locality;
+- coordinates, address, route, precise venue, or inferred neighborhood authority.
 
 Arcade practice scores are calculated by the server from the canonical scenario, but v1 intentionally does not elevate those values into competitive evidence. In particular, browser timing is untrusted practice telemetry.
 
@@ -209,7 +228,7 @@ Arcade practice scores are calculated by the server from the canonical scenario,
 
 - `/community`: score summary, explicit global opt-in, global league, recent private share candidates, social feed and welfare-positive reactions.
 - `/arcade`: four Human Skill practice games, personal best-score feedback, fixed breadth contribution and optional result sharing.
-- `/community/packs`: coarse local Pack creation/joining and privacy-thresholded local standings.
+- `/community/packs`: approved broad-area Pack creation/joining, conservative legacy-locality repair, and privacy-thresholded local standings.
 - `/pack`: cooperative non-ranking Pack challenges remain available.
 - `/leaderboard`: redirects to `/community`; the old mock distance/walk/friend-count leaderboard is retired.
 - bottom navigation now uses **Community** as the social destination.
@@ -223,12 +242,15 @@ Social Adventure v1 must fail qualification if:
 - competition source identity starts depending on repeat attempts or practice-score magnitude;
 - global leaderboard default becomes opt-out instead of opt-in;
 - local cohort threshold disappears;
+- arbitrary client locality text can become Pack locality authority;
+- migrated free-form locality is inferred, normalized, reverse geocoded, or logged into trusted locality;
+- an unverified legacy Pack becomes publicly discoverable, newly joinable, or locally ranked before owner repair;
 - completed Arcade attempts become mutable;
 - competition receipts become mutable;
 - Social feed loses bilateral block or visibility authority;
 - Pack challenges count arbitrary CareEvents;
 - migration/schema drift leaks the operational schema into canonical Prisma state;
-- API/web type checks, tests or production builds fail.
+- API/web/native type checks, tests or production builds fail.
 
 ## Next releases
 

--- a/docs/NATIVE_SOCIAL_ADVENTURE_V1.md
+++ b/docs/NATIVE_SOCIAL_ADVENTURE_V1.md
@@ -51,11 +51,35 @@ Preference mutations use the server's mutation response as the immediate authori
 
 Packs are account-level social communities and are available to Guardian and Companion modes. Joining a Pack never grants pet authority.
 
-A Pack currently uses a user-supplied broad-area `regionKey`, such as `south-bay-ca`. Native Woof does not request device location to create or rank a Pack, and it does not derive locality from a home address, route endpoint, GPS trace, or meetup location.
+Pack locality is now a **server-approved structured coarse-region identity**. Web and native clients fetch `/social-adventure/regions` and allow selection only from that catalog. Pack creation and legacy repair send one approved region ID such as `us-ca-south-bay`; the API DTO allowlist and database foreign key independently reject arbitrary locality text.
 
-The v1 locality boundary is intentionally stated narrowly: the server validates `regionKey` slug syntax and length, while the native client asks the user for a broad-area label and does not implement device geolocation. v1 does **not** semantically prove that an arbitrary user-entered slug is geographically coarse. Product policy prohibits submitting a street address, precise venue, coordinate, route, or exact meetup point, but stronger structured-region authority is a separate follow-up rather than an unearned privacy claim.
+The v1 region catalog deliberately represents broad public areas at metro, county, or broad-district granularity. It does not require or derive:
 
-Local standings are fail-closed. The client only renders entries when the server returns `cohortReady: true`. If the server cohort is not ready, native Woof displays the server's privacy message and `memberCount / minimumCohort`. It never calculates whether a cohort should be considered safe itself.
+- device GPS permission;
+- current coordinates;
+- home or street address;
+- route endpoints or trace history;
+- precise venues, schools, apartment complexes, or meetup points;
+- reverse geocoding of private coordinates.
+
+This is a stronger claim than the former free-form `regionKey` model, but it remains intentionally bounded. A coarse region is a broad community label, not an anonymity guarantee, proof of residence, or exact physical location. Expanding the catalog is a reviewed server change rather than a fallback to arbitrary text.
+
+#### Legacy locality migration
+
+Historical `regionKey` values cannot safely be assumed coarse because they were user-entered strings. The migration therefore **does not parse, normalize, map, reverse-geocode, or log those values**. Existing LOCAL Pack locality values are discarded before the new foreign key is installed.
+
+Pack identity and membership remain intact. A migrated LOCAL Pack without an approved region becomes `LEGACY_UNVERIFIED`:
+
+- existing members may still see the Pack because membership is server authority;
+- it is hidden from nonmember public discovery;
+- new joins fail closed;
+- local standings fail closed;
+- an owner may select one approved region to repair locality;
+- changing an already approved locality is not silently allowed through the repair endpoint.
+
+The repair path is deliberately one-way and conservative. It does not expose the discarded legacy text back to clients or telemetry.
+
+Local standings remain fail-closed after locality is approved. The client only renders entries when the server returns `cohortReady: true`. If the server cohort is not ready, native Woof displays the server's privacy message and `memberCount / minimumCohort`. It never calculates whether a cohort should be considered safe itself.
 
 Pack leaderboard responses are also bound to the currently selected Pack. Selection changes invalidate older in-flight requests, stale responses are ignored, and a response whose `pack.id` does not match the requested Pack is hidden rather than displayed under the wrong Pack context.
 
@@ -90,6 +114,8 @@ Server authority owns:
 - Social Adventure score derivation;
 - global opt-in state;
 - global rank;
+- the approved coarse-region catalog;
+- Pack locality validation and legacy locality repair;
 - Pack membership;
 - Pack cohort readiness and minimum cohort;
 - Pack rank;
@@ -99,7 +125,7 @@ Server authority owns:
 
 The native client owns presentation and explicit user intent only.
 
-If an authority slice cannot be loaded, native Woof shows unknown/unavailable state for that slice and may retain an earlier server-confirmed value. It must not substitute cached-looking zeroes, guessed ranks, fabricated privacy state, inferred location, or a response belonging to a different selected Pack.
+If an authority slice cannot be loaded, native Woof shows unknown/unavailable state for that slice and may retain an earlier server-confirmed value. It must not substitute cached-looking zeroes, guessed ranks, fabricated privacy state, inferred location, arbitrary locality text, or a response belonging to a different selected Pack.
 
 ## Companion mode
 
@@ -131,19 +157,23 @@ The native Expedition presentation remains responsible for honoring server `CALI
 - a successful preference mutation is not described as rolled back merely because a follow-up read failed;
 - only the five canonical semantic reactions are exposed;
 - global visibility changes through one explicit user action and is never auto-enabled;
+- Pack creation and legacy repair use the server-approved coarse-region catalog;
+- arbitrary free-form Pack locality normalization is absent from maintained Web/native clients;
+- the database owns approved locality through a foreign key, while DTO validation provides an earlier rejection boundary;
+- legacy free-form locality is discarded without inference or raw-value telemetry before new locality authority is established;
+- unverified legacy Packs cannot be newly joined or ranked until owner repair;
 - Pack standings are rendered only behind server `cohortReady`;
 - Pack leaderboard responses are request/Pack-bound and stale responses are discarded;
 - native Packs contain no device-geolocation implementation;
 - client code does not sort or derive league ranks;
 - native social types omit pet ID and legacy like/comment counters;
-- the locality contract admits that v1 validates slug shape rather than semantically proving geographic coarseness;
 - Expedition remains a separate cooperative authority rather than a Social Adventure score derivative;
 - the server Social Adventure score policy tests are rerun;
 - the full native client still type-checks and lints with zero warnings.
 
 ## Next validation layer
 
-With Social Adventure and receipt-backed Expeditions both represented natively, the highest-value validation remains real-world evidence:
+With Social Adventure, structured coarse locality, and receipt-backed Expeditions represented natively, the highest-value validation remains real-world evidence:
 
 1. preserve exact-head release authority and production fail-closed behavior;
 2. establish the production API/Web deployment boundary once external credentials exist;

--- a/packages/database/prisma/migrations/20260911233500_add_structured_pack_locality/migration.sql
+++ b/packages/database/prisma/migrations/20260911233500_add_structured_pack_locality/migration.sql
@@ -1,0 +1,77 @@
+-- Structured Pack locality authority.
+--
+-- IMPORTANT PRIVACY BOUNDARY:
+-- Existing `region_key` values were arbitrary user-entered text and therefore
+-- cannot be trusted as geographically coarse. Do not map, parse, log, or
+-- reverse-geocode those values during migration. They are deliberately
+-- discarded and legacy LOCAL packs remain available only through existing
+-- membership until an owner selects an approved region through the API.
+
+CREATE TABLE IF NOT EXISTS dogos_social.coarse_regions (
+  id TEXT PRIMARY KEY,
+  display_name TEXT NOT NULL,
+  country_code TEXT NOT NULL,
+  subdivision_code TEXT,
+  granularity TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT coarse_region_id_shape CHECK (id ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'),
+  CONSTRAINT coarse_region_display_name_length CHECK (char_length(display_name) BETWEEN 2 AND 80),
+  CONSTRAINT coarse_region_country_code CHECK (country_code ~ '^[A-Z]{2}$'),
+  CONSTRAINT coarse_region_subdivision_code CHECK (
+    subdivision_code IS NULL OR subdivision_code ~ '^[A-Z0-9-]{1,12}$'
+  ),
+  CONSTRAINT coarse_region_granularity CHECK (
+    granularity IN ('METRO', 'COUNTY', 'BROAD_DISTRICT')
+  )
+);
+
+-- v1 pilot catalog. These are broad public areas, not user coordinates.
+-- Expansion is a reviewed catalog change, never a fallback to arbitrary text.
+INSERT INTO dogos_social.coarse_regions
+  (id, display_name, country_code, subdivision_code, granularity)
+VALUES
+  ('us-ca-san-francisco', 'San Francisco, CA', 'US', 'CA', 'METRO'),
+  ('us-ca-south-bay', 'South Bay, CA', 'US', 'CA', 'BROAD_DISTRICT'),
+  ('us-ca-peninsula', 'Peninsula, CA', 'US', 'CA', 'BROAD_DISTRICT'),
+  ('us-ca-east-bay', 'East Bay, CA', 'US', 'CA', 'BROAD_DISTRICT'),
+  ('us-ca-north-bay', 'North Bay, CA', 'US', 'CA', 'BROAD_DISTRICT'),
+  ('us-ca-santa-cruz-county', 'Santa Cruz County, CA', 'US', 'CA', 'COUNTY'),
+  -- Reserved non-client fixture used by existing direct-SQL integration setup.
+  -- It is intentionally absent from the application catalog and DTO allowlist.
+  ('test-region', 'Internal test region', 'US', 'CA', 'BROAD_DISTRICT')
+ON CONFLICT (id) DO NOTHING;
+
+DROP INDEX IF EXISTS dogos_social.social_packs_region_idx;
+
+ALTER TABLE dogos_social.packs
+  DROP CONSTRAINT IF EXISTS social_pack_region_shape;
+
+-- Never infer an approved region from legacy user text. Purging the column
+-- values is safer than preserving possibly precise addresses or venues under a
+-- newly trusted field name. Memberships and pack identity remain intact.
+UPDATE dogos_social.packs
+SET region_key = NULL
+WHERE scope = 'LOCAL';
+
+ALTER TABLE dogos_social.packs
+  ADD CONSTRAINT social_pack_region_authority_fk
+    FOREIGN KEY (region_key)
+    REFERENCES dogos_social.coarse_regions(id)
+    ON UPDATE RESTRICT
+    ON DELETE RESTRICT;
+
+ALTER TABLE dogos_social.packs
+  ADD CONSTRAINT social_pack_region_shape CHECK (
+    (scope = 'LOCAL')
+    OR (scope = 'FRIENDS' AND region_key IS NULL)
+  );
+
+CREATE INDEX social_packs_region_idx
+  ON dogos_social.packs (region_key, created_at DESC)
+  WHERE scope = 'LOCAL'
+    AND visibility = 'PUBLIC'
+    AND region_key IS NOT NULL;
+
+COMMENT ON COLUMN dogos_social.packs.region_key IS
+  'Server-approved coarse_regions.id. NULL on legacy LOCAL packs until owner repair; never arbitrary user location text.';

--- a/packages/database/prisma/migrations/20260911233500_add_structured_pack_locality/migration.sql
+++ b/packages/database/prisma/migrations/20260911233500_add_structured_pack_locality/migration.sql
@@ -36,10 +36,7 @@ VALUES
   ('us-ca-peninsula', 'Peninsula, CA', 'US', 'CA', 'BROAD_DISTRICT'),
   ('us-ca-east-bay', 'East Bay, CA', 'US', 'CA', 'BROAD_DISTRICT'),
   ('us-ca-north-bay', 'North Bay, CA', 'US', 'CA', 'BROAD_DISTRICT'),
-  ('us-ca-santa-cruz-county', 'Santa Cruz County, CA', 'US', 'CA', 'COUNTY'),
-  -- Reserved non-client fixture used by existing direct-SQL integration setup.
-  -- It is intentionally absent from the application catalog and DTO allowlist.
-  ('test-region', 'Internal test region', 'US', 'CA', 'BROAD_DISTRICT')
+  ('us-ca-santa-cruz-county', 'Santa Cruz County, CA', 'US', 'CA', 'COUNTY')
 ON CONFLICT (id) DO NOTHING;
 
 DROP INDEX IF EXISTS dogos_social.social_packs_region_idx;


### PR DESCRIPTION
## Why

Social Adventure Packs still accepted arbitrary user-entered `regionKey` text. Slug syntax prevented malformed IDs, but it did not prove geographic coarseness: an address or precise venue could still become locality authority after normalization.

This tranche closes #139 by making broad locality a server-owned structured authority instead of a client convention.

## Authority model

- add a reviewed `dogos_social.coarse_regions` catalog with metro/county/broad-district granularity;
- make Pack locality reference that catalog through a database foreign key;
- expose only the client-selectable approved catalog through `GET /social-adventure/regions`;
- validate Pack creation and repair against the approved server catalog;
- remove free-form locality inputs and normalization from maintained Web/native Pack surfaces;
- keep GPS, coordinates, home/street addresses, route endpoints, reverse geocoding, precise venues, and exact meetup points outside Pack locality authority.

The v1 production catalog contains exactly six reviewed broad California regions. Test-only locality identities are deliberately **not** seeded into production data; Expedition test/CI fixtures use a real approved catalog ID instead.

## Legacy migration

Historical `region_key` values are **not trusted as coarse**. The migration deliberately does not parse, map, reverse-geocode, or log them. It clears legacy LOCAL `region_key` values before installing the new foreign key.

Pack identity and memberships survive. A migrated LOCAL Pack becomes `LEGACY_UNVERIFIED` until its owner chooses one approved broad region:

- existing members can still see their Pack;
- nonmembers cannot discover it;
- new joins fail closed;
- local standings fail closed;
- only the owner can perform the one-time repair;
- same-region repair is idempotent;
- changing an already approved locality is rejected by this repair endpoint.

## Scope audit

During implementation, a broad accidental edit to `social-adventure.service.ts` was caught before promotion. That file was restored byte-for-byte from `main`; it is **not present in this PR diff**. Structured locality remains a narrow migration + locality adapter/controller + client-selection tranche rather than an unrelated Social Adventure rewrite.

The Pack creation API types were also tightened to the actual narrow creation receipt instead of pretending the server returns a fully populated Pack object.

## Qualification

This tranche adds:

- migrated-Postgres integration tests for legacy survival, discovery gating, owner-only repair, idempotence, locality-change rejection, arbitrary-text FK rejection, and an exact six-row production locality catalog;
- `Structured Pack Locality CI` with full migrations, Prisma drift check, privacy-column checks, API/Web/native type checking and lint;
- a dedicated source contract cross-checking migration order, catalog consistency, DTO/controller/service authority, no-geolocation/no-normalization client boundaries, and both canonical Social Adventure docs;
- updated Native Social Adventure authority checks and self-diagnosing canonical Prettier output on formatting drift;
- compatibility updates for Expedition integration/CI fixtures that previously invented locality IDs outside the new authority.

## Evidence boundary

This establishes a structured coarse-region identity. It does **not** claim anonymity, proof of residence, exact physical distance, or precise-location privacy beyond the explicitly excluded data paths. The initial catalog is intentionally small and should expand only through reviewed server catalog changes.

This PR is repository qualification only. It does not claim live deployment, physical-device qualification, or pilot evidence.

## Release discipline

This branch began from the pre-#149 main boundary to keep the privacy tranche independent. PR qualification runs against the current `main`, which now includes release-promotion authority #149. No dependency or broad feature upgrades are included.