### PR TITLE
Production deployment closure: exact-SHA gates, stable staging, live release smoke

### DIFF
--- a/.github/scripts/assert-operational-privacy-release.py
+++ b/.github/scripts/assert-operational-privacy-release.py
@@ -91,14 +91,34 @@ require(
     "--self-test",
 )
 require(
+    ".github/scripts/verify-live-release.mjs",
+    "assertReleaseBody",
+    "x-content-type-options",
+    "access-control-allow-origin",
+    "auth/me",
+    "EXPECTED_RELEASE",
+    "--self-test",
+)
+require(
     ".github/scripts/write-release-receipt.mjs",
+    "schemaVersion: 2",
     "SHA_PATTERN",
     "buildReleaseReceipt",
     "production receipt requires successful exact-SHA staging qualification",
+    "canonicalReleaseChecksVerified",
     "apiReleaseIdentityVerified: true",
     "webReleaseIdentityVerified: true",
     "webApiOriginVerified: true",
+    "liveBlackBoxVerified",
+    "webDeploymentUrl",
     "--self-test",
+)
+reject(
+    ".github/scripts/write-release-receipt.mjs",
+    "FLY_API_TOKEN",
+    "VERCEL_TOKEN",
+    "Authorization",
+    "password",
 )
 
 require(
@@ -115,11 +135,21 @@ for path in [
         '--build-arg WOOF_RELEASE_SHA="${RELEASE_SHA}"',
         "NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ env.RELEASE_SHA }}",
         "NEXT_PUBLIC_SENTRY_REPLAY_ENABLED: 'false'",
+        "STABLE_WEB_ORIGIN: ${{ vars.WEB_ORIGIN }}",
         "Enforce deployed API release identity",
-        "Verify deployed Web release and API integration",
+        "Verify immutable Web deployment release and API integration",
+        "Verify stable",
+        "Web origin release and API integration",
+        "Run non-destructive live release smoke",
         "verify-web-deployment-provenance.mjs",
+        "verify-live-release.mjs",
+        "CANONICAL_RELEASE_CHECKS_VERIFIED: 'true'",
+        "LIVE_BLACK_BOX_VERIFIED: 'true'",
         "write-release-receipt.mjs",
         "actions/upload-artifact@v7",
     )
 
-print("Operational privacy contract preserves exact release identity, Web/API provenance, and privacy-safe release receipts.")
+print(
+    "Operational privacy contract preserves exact API/Web release identity, stable-origin provenance, "
+    "non-destructive live verification, and privacy-safe release receipts."
+)

--- a/.github/scripts/assert-operational-privacy-release.py
+++ b/.github/scripts/assert-operational-privacy-release.py
@@ -111,14 +111,17 @@ require(
     "webApiOriginVerified: true",
     "liveBlackBoxVerified",
     "webDeploymentUrl",
+    "parsed.username = '';",
+    "parsed.password = '';",
     "--self-test",
 )
 reject(
     ".github/scripts/write-release-receipt.mjs",
     "FLY_API_TOKEN",
     "VERCEL_TOKEN",
+    "DATABASE_URL",
+    "JWT_SECRET",
     "Authorization",
-    "password",
 )
 
 require(

--- a/.github/scripts/assert-release-promotion-authority.py
+++ b/.github/scripts/assert-release-promotion-authority.py
@@ -6,7 +6,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 STAGING = ROOT / ".github/workflows/deploy-staging.yml"
 PRODUCTION = ROOT / ".github/workflows/deploy-production.yml"
+RELEASE_CI = ROOT / ".github/workflows/release-promotion-authority-ci.yml"
+CHECK_VERIFIER = ROOT / ".github/scripts/verify-main-release-checks.py"
+LIVE_VERIFIER = ROOT / ".github/scripts/verify-live-release.mjs"
 RECEIPT = ROOT / ".github/scripts/write-release-receipt.mjs"
+DEPLOYMENT_GUIDE = ROOT / "DEPLOYMENT_GUIDE.md"
 
 
 def read(path: Path) -> str:
@@ -29,24 +33,40 @@ def reject(text: str, label: str, *markers: str) -> None:
 
 staging = read(STAGING)
 production = read(PRODUCTION)
+release_ci = read(RELEASE_CI)
+check_verifier = read(CHECK_VERIFIER)
+live_verifier = read(LIVE_VERIFIER)
 receipt = read(RECEIPT)
+deployment_guide = read(DEPLOYMENT_GUIDE)
 
 require(
     staging,
     "deploy-staging.yml",
     "branches: [main]",
     "workflow_dispatch:",
+    "actions: read",
     "REQUESTED_SHA: ${{ github.sha }}",
     "Validate Staging Release Candidate",
     "git merge-base --is-ancestor \"${RELEASE_SHA}\" origin/main",
+    "Require exact-SHA canonical main release checks",
+    "python3 .github/scripts/verify-main-release-checks.py",
     "ref: ${{ env.RELEASE_SHA }}",
     '--build-arg WOOF_RELEASE_SHA="${RELEASE_SHA}"',
     "NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ env.RELEASE_SHA }}",
+    "STABLE_WEB_ORIGIN: ${{ vars.WEB_ORIGIN }}",
+    "vercel pull --yes --environment=production",
+    "vercel build --prod",
+    "vercel deploy --prebuilt --prod",
+    "Verify stable staging Web origin release and API integration",
+    "Run non-destructive live release smoke",
+    "node .github/scripts/verify-live-release.mjs",
+    "CANONICAL_RELEASE_CHECKS_VERIFIED: 'true'",
+    "LIVE_BLACK_BOX_VERIFIED: 'true'",
     "Retain Staging Release Receipt",
     "staging-release-${{ env.RELEASE_SHA }}",
     "retention-days: 30",
 )
-reject(staging, "deploy-staging.yml", "branches: [develop]")
+reject(staging, "deploy-staging.yml", "branches: [develop]", "--environment=preview")
 
 require(
     production,
@@ -57,13 +77,21 @@ require(
     "actions: read",
     "Validate Production Release Candidate",
     "git merge-base --is-ancestor \"${RELEASE_SHA}\" origin/main",
+    "Require exact-SHA canonical main release checks",
+    "python3 .github/scripts/verify-main-release-checks.py",
     "Verify exact staging qualification",
     "actions/workflows/deploy-staging.yml/runs",
     '.conclusion == "success"',
     "ref: ${{ env.RELEASE_SHA }}",
     '--build-arg WOOF_RELEASE_SHA="${RELEASE_SHA}"',
     "NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ env.RELEASE_SHA }}",
+    "STABLE_WEB_ORIGIN: ${{ vars.WEB_ORIGIN }}",
+    "Verify stable production Web origin release and API integration",
+    "Run non-destructive live release smoke",
+    "node .github/scripts/verify-live-release.mjs",
     "environment: production",
+    "CANONICAL_RELEASE_CHECKS_VERIFIED: 'true'",
+    "LIVE_BLACK_BOX_VERIFIED: 'true'",
     "Retain Production Release Receipt",
     "production-release-${{ env.RELEASE_SHA }}",
     "retention-days: 90",
@@ -78,20 +106,87 @@ reject(
 )
 
 require(
+    release_ci,
+    "release-promotion-authority-ci.yml",
+    "pull_request:",
+    "branches: [main]",
+    "push:",
+    "Release Promotion Authority",
+    "verify-main-release-checks.py --self-test",
+    "verify-live-release.mjs --self-test",
+)
+reject(release_ci, "release-promotion-authority-ci.yml", "paths:")
+
+for workflow in [
+    '"ci.yml"',
+    '"security-baseline-ci.yml"',
+    '"codeql.yml"',
+    '"release-promotion-authority-ci.yml"',
+]:
+    require(check_verifier, "verify-main-release-checks.py", workflow)
+require(
+    check_verifier,
+    "verify-main-release-checks.py",
+    'run.get("head_sha") != release_sha',
+    'run.get("event") != "push"',
+    'success="success" in states',
+    "--self-test",
+)
+
+require(
+    live_verifier,
+    "verify-live-release.mjs",
+    "ops/health/live",
+    "ops/health/ready",
+    "auth/me",
+    "x-content-type-options",
+    "access-control-allow-origin",
+    "access-control-allow-credentials",
+    "production-shaped API documentation is unexpectedly reachable",
+    "--self-test",
+)
+reject(live_verifier, "verify-live-release.mjs", "Authorization: Bearer", "email", "petId")
+
+require(
     receipt,
     "write-release-receipt.mjs",
+    "schemaVersion: 2",
     "SHA_PATTERN",
     "ALLOWED_ENVIRONMENTS",
     "mainAncestryVerified: true",
+    "canonicalReleaseChecksVerified",
     "apiReleaseIdentityVerified: true",
     "webReleaseIdentityVerified: true",
     "webApiOriginVerified: true",
+    "liveBlackBoxVerified",
+    "webDeploymentUrl",
     "production receipt requires successful exact-SHA staging qualification",
     "--self-test",
 )
 reject(receipt, "write-release-receipt.mjs", "process.env.FLY_API_TOKEN", "process.env.VERCEL_TOKEN")
 
+require(
+    deployment_guide,
+    "DEPLOYMENT_GUIDE.md",
+    "Pre-public-beta deployment authority",
+    "woof-api-staging",
+    "woof-api-prod",
+    "separate Vercel projects",
+    "WEB_ORIGIN",
+    "backup and restore rehearsal",
+    "TestFlight",
+    "repository-qualified ≠ deployed ≠ device-qualified ≠ pilot-validated",
+)
+reject(
+    deployment_guide,
+    "DEPLOYMENT_GUIDE.md",
+    "Ready for deployment ✅",
+    "pnpm --filter @woof/database db:seed",
+    "API_DOCS_ENABLED=true",
+    "PWA Configuration",
+)
+
 print(
-    "Release promotion authority is explicit: main stages automatically, production is manual exact-SHA promotion, "
-    "successful staging is required, and privacy-safe receipts are retained."
+    "Release promotion authority is fail-closed: exact main SHA, canonical release checks, isolated stable Web origin, "
+    "successful staging, live black-box proof, and privacy-safe receipts are required before production is claimed."
 )

--- a/.github/scripts/assert-release-promotion-authority.py
+++ b/.github/scripts/assert-release-promotion-authority.py
@@ -136,8 +136,7 @@ require(
 require(
     live_verifier,
     "verify-live-release.mjs",
-    "ops/health/live",
-    "ops/health/ready",
+    "ops/health/${endpoint}",
     "auth/me",
     "x-content-type-options",
     "access-control-allow-origin",

--- a/.github/scripts/verify-live-release.mjs
+++ b/.github/scripts/verify-live-release.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+import process from 'node:process';
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const INVALID_ORIGIN = 'https://woof-invalid-origin.example';
+
+function requireValue(name, value) {
+  if (!value || !value.trim()) throw new Error(`${name} is required`);
+  return value.trim();
+}
+
+function requireHttpsOrigin(name, value) {
+  const raw = requireValue(name, value);
+  const parsed = new URL(raw);
+  if (parsed.protocol !== 'https:' || parsed.origin !== raw.replace(/\/$/, '')) {
+    throw new Error(`${name} must be an exact HTTPS origin without a path, query, or fragment`);
+  }
+  return parsed.origin;
+}
+
+function requireApiUrl(value) {
+  const raw = requireValue('API_URL', value).replace(/\/$/, '');
+  const parsed = new URL(raw);
+  if (parsed.protocol !== 'https:' || parsed.username || parsed.password) {
+    throw new Error('API_URL must be an HTTPS URL without credentials');
+  }
+  return raw;
+}
+
+function assertReleaseBody(label, body, expectedRelease) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw new Error(`${label} did not return a JSON object`);
+  }
+  if (body.release !== expectedRelease) {
+    throw new Error(`${label} release mismatch: expected ${expectedRelease}, received ${body.release}`);
+  }
+}
+
+function assertSecurityHeaders(label, response) {
+  if (response.headers.get('x-content-type-options') !== 'nosniff') {
+    throw new Error(`${label} is missing X-Content-Type-Options: nosniff`);
+  }
+}
+
+async function fetchWithTimeout(url, options = {}) {
+  return fetch(url, {
+    ...options,
+    redirect: 'follow',
+    signal: AbortSignal.timeout(15_000),
+  });
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetchWithTimeout(url, options);
+  let body = null;
+  const text = await response.text();
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      throw new Error(`${url} returned non-JSON content`);
+    }
+  }
+  return { response, body };
+}
+
+async function verifyLiveRelease({ apiUrl, webOrigin, expectedRelease }) {
+  for (const endpoint of ['live', 'ready']) {
+    const url = `${apiUrl}/ops/health/${endpoint}`;
+    const { response, body } = await fetchJson(url, {
+      headers: { Origin: webOrigin },
+    });
+    if (response.status !== 200) {
+      throw new Error(`${endpoint} returned HTTP ${response.status}`);
+    }
+    assertReleaseBody(endpoint, body, expectedRelease);
+    assertSecurityHeaders(endpoint, response);
+    if (response.headers.get('access-control-allow-origin') !== webOrigin) {
+      throw new Error(`${endpoint} did not authorize the configured Web origin`);
+    }
+    if (response.headers.get('access-control-allow-credentials') !== 'true') {
+      throw new Error(`${endpoint} did not expose credentialed CORS authority`);
+    }
+  }
+
+  const authResponse = await fetchWithTimeout(`${apiUrl}/auth/me`, {
+    headers: { Origin: webOrigin },
+  });
+  if (authResponse.status !== 401) {
+    throw new Error(`unauthenticated /auth/me must fail closed with 401, received ${authResponse.status}`);
+  }
+  assertSecurityHeaders('auth/me', authResponse);
+
+  for (const docsUrl of [new URL('/docs', apiUrl).toString(), `${apiUrl}/docs`]) {
+    const response = await fetchWithTimeout(docsUrl);
+    if (response.ok) {
+      throw new Error(`production-shaped API documentation is unexpectedly reachable at ${docsUrl}`);
+    }
+  }
+
+  // Repository qualification already proves hostile origins are rejected. Avoid
+  // deliberately generating a production 5xx solely to prove that negative path.
+  if (webOrigin === INVALID_ORIGIN) {
+    throw new Error('configured Web origin must not equal the reserved invalid-origin probe value');
+  }
+
+  console.log(`live release smoke verified for ${expectedRelease} via ${webOrigin}`);
+}
+
+function selfTest() {
+  const sha = 'a'.repeat(40);
+  assertReleaseBody('self-test', { release: sha }, sha);
+
+  let rejected = false;
+  try {
+    assertReleaseBody('self-test', { release: 'b'.repeat(40) }, sha);
+  } catch {
+    rejected = true;
+  }
+  if (!rejected) throw new Error('release mismatch self-test failed');
+
+  if (requireHttpsOrigin('WEB_ORIGIN', 'https://woof.example') !== 'https://woof.example') {
+    throw new Error('HTTPS origin self-test failed');
+  }
+
+  rejected = false;
+  try {
+    requireHttpsOrigin('WEB_ORIGIN', 'https://woof.example/path');
+  } catch {
+    rejected = true;
+  }
+  if (!rejected) throw new Error('path-bearing Web origin self-test failed');
+
+  console.log('live release smoke verifier self-test passed');
+}
+
+if (process.argv.includes('--self-test')) {
+  selfTest();
+} else {
+  const apiUrl = requireApiUrl(process.env.API_URL);
+  const webOrigin = requireHttpsOrigin('WEB_ORIGIN', process.env.WEB_ORIGIN);
+  const expectedRelease = requireValue('EXPECTED_RELEASE', process.env.EXPECTED_RELEASE);
+  if (!SHA_PATTERN.test(expectedRelease)) {
+    throw new Error('EXPECTED_RELEASE must be an exact lowercase 40-character Git SHA');
+  }
+  await verifyLiveRelease({ apiUrl, webOrigin, expectedRelease });
+}

--- a/.github/scripts/verify-main-release-checks.py
+++ b/.github/scripts/verify-main-release-checks.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Wait for the canonical exact-SHA main release checks before provider side effects."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
+from urllib import error, parse, request
+
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+REQUIRED_WORKFLOWS = (
+    "ci.yml",
+    "security-baseline-ci.yml",
+    "codeql.yml",
+    "release-promotion-authority-ci.yml",
+)
+DEFAULT_TIMEOUT_SECONDS = 30 * 60
+DEFAULT_POLL_SECONDS = 15
+
+
+@dataclass(frozen=True)
+class WorkflowState:
+    workflow: str
+    success: bool
+    states: tuple[str, ...]
+
+
+def require_value(name: str, value: str | None) -> str:
+    if value is None or not value.strip():
+        raise SystemExit(f"{name} is required")
+    return value.strip()
+
+
+def matching_states(payload: dict[str, Any], release_sha: str) -> tuple[str, ...]:
+    runs = payload.get("workflow_runs")
+    if not isinstance(runs, list):
+        return ()
+
+    states: list[str] = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        if run.get("head_sha") != release_sha or run.get("event") != "push":
+            continue
+        status = str(run.get("status") or "unknown")
+        conclusion = run.get("conclusion")
+        states.append(str(conclusion) if conclusion else status)
+    return tuple(states)
+
+
+def evaluate_workflow(workflow: str, payload: dict[str, Any], release_sha: str) -> WorkflowState:
+    states = matching_states(payload, release_sha)
+    return WorkflowState(workflow=workflow, success="success" in states, states=states)
+
+
+def fetch_runs(repository: str, workflow: str, release_sha: str, token: str) -> dict[str, Any]:
+    encoded_workflow = parse.quote(workflow, safe="")
+    query = parse.urlencode({"head_sha": release_sha, "event": "push", "per_page": 20})
+    url = (
+        f"https://api.github.com/repos/{repository}/actions/workflows/"
+        f"{encoded_workflow}/runs?{query}"
+    )
+    req = request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "woof-release-authority",
+        },
+    )
+    try:
+        with request.urlopen(req, timeout=20) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")[:500]
+        raise RuntimeError(f"GitHub Actions query failed for {workflow}: HTTP {exc.code}: {body}") from exc
+    except error.URLError as exc:
+        raise RuntimeError(f"GitHub Actions query failed for {workflow}: {exc.reason}") from exc
+
+
+def wait_for_release_checks(
+    repository: str,
+    release_sha: str,
+    token: str,
+    timeout_seconds: int,
+    poll_seconds: int,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+
+    while True:
+        states = [
+            evaluate_workflow(
+                workflow,
+                fetch_runs(repository, workflow, release_sha, token),
+                release_sha,
+            )
+            for workflow in REQUIRED_WORKFLOWS
+        ]
+        missing = [state for state in states if not state.success]
+        if not missing:
+            print(
+                "Exact-SHA main release checks verified for "
+                f"{release_sha}: {', '.join(REQUIRED_WORKFLOWS)}"
+            )
+            return
+
+        summary = "; ".join(
+            f"{state.workflow}={','.join(state.states) if state.states else 'not-found'}"
+            for state in missing
+        )
+        if time.monotonic() >= deadline:
+            raise SystemExit(
+                "Timed out waiting for exact-SHA canonical main release checks: " + summary
+            )
+        print(f"Waiting for exact-SHA main release checks: {summary}")
+        time.sleep(poll_seconds)
+
+
+def self_test() -> None:
+    release_sha = "a" * 40
+    payload = {
+        "workflow_runs": [
+            {
+                "head_sha": release_sha,
+                "event": "push",
+                "status": "completed",
+                "conclusion": "success",
+            },
+            {
+                "head_sha": "b" * 40,
+                "event": "push",
+                "status": "completed",
+                "conclusion": "failure",
+            },
+            {
+                "head_sha": release_sha,
+                "event": "pull_request",
+                "status": "completed",
+                "conclusion": "success",
+            },
+        ]
+    }
+    state = evaluate_workflow("ci.yml", payload, release_sha)
+    if not state.success or state.states != ("success",):
+        raise SystemExit("release-check evaluator accepted the wrong workflow evidence")
+
+    pending = evaluate_workflow(
+        "ci.yml",
+        {
+            "workflow_runs": [
+                {
+                    "head_sha": release_sha,
+                    "event": "push",
+                    "status": "in_progress",
+                    "conclusion": None,
+                }
+            ]
+        },
+        release_sha,
+    )
+    if pending.success or pending.states != ("in_progress",):
+        raise SystemExit("pending release-check self-test failed")
+
+    if any(workflow not in REQUIRED_WORKFLOWS for workflow in REQUIRED_WORKFLOWS):
+        raise SystemExit("required workflow self-test failed")
+
+    print("exact-SHA main release-check verifier self-test passed")
+
+
+def main() -> None:
+    if "--self-test" in sys.argv:
+        self_test()
+        return
+
+    repository = require_value("GITHUB_REPOSITORY", os.environ.get("GITHUB_REPOSITORY"))
+    release_sha = require_value("RELEASE_SHA", os.environ.get("RELEASE_SHA"))
+    token = require_value("GH_TOKEN", os.environ.get("GH_TOKEN"))
+    if not SHA_PATTERN.fullmatch(release_sha):
+        raise SystemExit("RELEASE_SHA must be an exact lowercase 40-character Git SHA")
+
+    timeout_seconds = int(os.environ.get("RELEASE_CHECK_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS))
+    poll_seconds = int(os.environ.get("RELEASE_CHECK_POLL_SECONDS", DEFAULT_POLL_SECONDS))
+    if timeout_seconds <= 0 or poll_seconds <= 0:
+        raise SystemExit("release-check timeout and poll interval must be positive")
+
+    wait_for_release_checks(repository, release_sha, token, timeout_seconds, poll_seconds)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/write-release-receipt.mjs
+++ b/.github/scripts/write-release-receipt.mjs
@@ -27,6 +27,13 @@ function requireHttpsUrl(name, value) {
   return parsed.toString().replace(/\/$/, '');
 }
 
+function requireProof(name, value) {
+  if (value !== 'true') {
+    throw new Error(`${name} must be true before a release receipt can be retained`);
+  }
+  return true;
+}
+
 export function buildReleaseReceipt(env) {
   const releaseEnvironment = requireValue('RELEASE_ENVIRONMENT', env.RELEASE_ENVIRONMENT);
   if (!ALLOWED_ENVIRONMENTS.has(releaseEnvironment)) {
@@ -44,6 +51,12 @@ export function buildReleaseReceipt(env) {
   const runAttempt = requireValue('GITHUB_RUN_ATTEMPT', env.GITHUB_RUN_ATTEMPT);
   const apiUrl = requireHttpsUrl('API_URL', env.API_URL);
   const webUrl = requireHttpsUrl('WEB_URL', env.WEB_URL);
+  const webDeploymentUrl = requireHttpsUrl('WEB_DEPLOYMENT_URL', env.WEB_DEPLOYMENT_URL);
+  const canonicalReleaseChecksVerified = requireProof(
+    'CANONICAL_RELEASE_CHECKS_VERIFIED',
+    env.CANONICAL_RELEASE_CHECKS_VERIFIED
+  );
+  const liveBlackBoxVerified = requireProof('LIVE_BLACK_BOX_VERIFIED', env.LIVE_BLACK_BOX_VERIFIED);
   const stagingWorkflowVerified = env.STAGING_WORKFLOW_VERIFIED === 'true';
 
   if (releaseEnvironment === 'production' && !stagingWorkflowVerified) {
@@ -51,7 +64,7 @@ export function buildReleaseReceipt(env) {
   }
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     environment: releaseEnvironment,
     releaseSha,
     repository,
@@ -60,11 +73,14 @@ export function buildReleaseReceipt(env) {
     runAttempt,
     apiUrl,
     webUrl,
+    webDeploymentUrl,
     evidence: {
       mainAncestryVerified: true,
+      canonicalReleaseChecksVerified,
       apiReleaseIdentityVerified: true,
       webReleaseIdentityVerified: true,
       webApiOriginVerified: true,
+      liveBlackBoxVerified,
       stagingWorkflowVerified,
     },
   };
@@ -80,11 +96,20 @@ function selfTest() {
     GITHUB_RUN_ATTEMPT: '1',
     API_URL: 'https://api.example.test/api/v1',
     WEB_URL: 'https://web.example.test',
+    WEB_DEPLOYMENT_URL: 'https://deployment.example.test',
+    CANONICAL_RELEASE_CHECKS_VERIFIED: 'true',
+    LIVE_BLACK_BOX_VERIFIED: 'true',
     STAGING_WORKFLOW_VERIFIED: 'false',
   };
 
   const staging = buildReleaseReceipt(base);
-  if (staging.releaseSha !== base.RELEASE_SHA || staging.evidence.stagingWorkflowVerified) {
+  if (
+    staging.schemaVersion !== 2 ||
+    staging.releaseSha !== base.RELEASE_SHA ||
+    staging.evidence.stagingWorkflowVerified ||
+    !staging.evidence.canonicalReleaseChecksVerified ||
+    !staging.evidence.liveBlackBoxVerified
+  ) {
     throw new Error('staging receipt self-test failed');
   }
 
@@ -98,17 +123,23 @@ function selfTest() {
     throw new Error('production receipt self-test failed');
   }
 
-  let rejected = false;
-  try {
-    buildReleaseReceipt({ ...base, RELEASE_SHA: 'main' });
-  } catch {
-    rejected = true;
-  }
-  if (!rejected) {
-    throw new Error('non-SHA release identity was accepted');
+  for (const patch of [
+    { RELEASE_SHA: 'main' },
+    { CANONICAL_RELEASE_CHECKS_VERIFIED: 'false' },
+    { LIVE_BLACK_BOX_VERIFIED: 'false' },
+  ]) {
+    let rejected = false;
+    try {
+      buildReleaseReceipt({ ...base, ...patch });
+    } catch {
+      rejected = true;
+    }
+    if (!rejected) {
+      throw new Error(`invalid release receipt evidence was accepted: ${JSON.stringify(patch)}`);
+    }
   }
 
-  rejected = false;
+  let rejected = false;
   try {
     buildReleaseReceipt({
       ...base,

--- a/.github/workflows/ci-action-runtime-ci.yml
+++ b/.github/workflows/ci-action-runtime-ci.yml
@@ -101,7 +101,7 @@ jobs:
               raise SystemExit(f'missing required maintained action families: {missing}')
           PY
 
-      - name: Enforce explicit deployment credential and notification contracts
+      - name: Enforce explicit deployment credential and authority contracts
         run: |
           python - <<'PY'
           from pathlib import Path
@@ -119,7 +119,7 @@ jobs:
               secret_mapping('VERCEL_ORG_ID'),
               secret_mapping('VERCEL_PROJECT_ID'),
               'Validate production API deployment credentials',
-              'Validate production Web deployment credentials',
+              'Validate production Web deployment authority',
           ]
           required_staging = [
               secret_mapping('FLY_API_TOKEN'),
@@ -127,7 +127,7 @@ jobs:
               secret_mapping('VERCEL_ORG_ID'),
               secret_mapping('VERCEL_PROJECT_ID'),
               'Validate staging API deployment credentials',
-              'Validate staging Web deployment credentials',
+              'Validate staging Web deployment authority',
           ]
 
           missing = [
@@ -140,7 +140,9 @@ jobs:
               if marker not in staging
           ]
           if missing:
-              raise SystemExit('deployment credential contract drift:\n' + '\n'.join(missing))
+              raise SystemExit(
+                  'deployment credential/authority contract drift:\n' + '\n'.join(missing)
+              )
 
           forbidden = '8398a7/action-slack'
           if forbidden in production or forbidden in staging:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -55,6 +55,12 @@ jobs:
             exit 1
           fi
 
+      - name: Require exact-SHA canonical main release checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ steps.candidate.outputs.sha }}
+        run: python3 .github/scripts/verify-main-release-checks.py
+
       - name: Verify exact staging qualification
         env:
           GH_TOKEN: ${{ github.token }}
@@ -146,7 +152,6 @@ jobs:
             echo "SLACK_WEBHOOK is not configured; skipping optional deployment notification."
             exit 0
           fi
-
           payload=$(printf '{"text":"Woof production API deployment: %s (%.12s)"}' \
             "${DEPLOYMENT_STATUS}" "${RELEASE_SHA}")
           curl --fail --silent --show-error \
@@ -161,11 +166,13 @@ jobs:
     needs: [validate-release-candidate, deploy-api-production]
     outputs:
       deployment_url: ${{ steps.deploy_web.outputs.url }}
+      web_origin: ${{ steps.web_origin.outputs.origin }}
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+      STABLE_WEB_ORIGIN: ${{ vars.WEB_ORIGIN }}
       EXPECTED_API_URL: https://woof-api-prod.fly.dev/api/v1
       RELEASE_SHA: ${{ needs.validate-release-candidate.outputs.release_sha }}
     steps:
@@ -173,23 +180,26 @@ jobs:
         with:
           ref: ${{ env.RELEASE_SHA }}
 
-      - name: Validate production Web deployment credentials
+      - name: Validate production Web deployment authority
+        id: web_origin
         run: |
           missing=0
-          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID STABLE_WEB_ORIGIN; do
             if [[ -z "${!name}" ]]; then
-              echo "::error title=Missing production secret::${name} is not configured for the production environment."
+              echo "::error title=Missing production authority::${name} is not configured for the production environment."
               missing=1
             fi
           done
           if [[ "${missing}" -ne 0 ]]; then
             exit 1
           fi
+          origin=$(node -e "const u=new URL(process.env.STABLE_WEB_ORIGIN); if(u.protocol!=='https:'||u.origin!==process.env.STABLE_WEB_ORIGIN.replace(/\/$/,'')) process.exit(1); process.stdout.write(u.origin)")
+          echo "origin=${origin}" >> "$GITHUB_OUTPUT"
 
       - name: Install pinned Vercel CLI
         run: npm install --global vercel@58.4.4
 
-      - name: Pull Vercel Environment Information
+      - name: Pull production Vercel project information
         run: vercel pull --yes --environment=production --token="${VERCEL_TOKEN}"
         working-directory: apps/web
 
@@ -212,7 +222,7 @@ jobs:
           fi
           echo "url=${deployment_url}" >> "$GITHUB_OUTPUT"
 
-      - name: Verify deployed Web release and API integration
+      - name: Verify immutable Web deployment release and API integration
         env:
           WEB_URL: ${{ steps.deploy_web.outputs.url }}
           EXPECTED_RELEASE: ${{ env.RELEASE_SHA }}
@@ -220,6 +230,22 @@ jobs:
           html=$(curl --fail --silent --show-error --location --retry 8 --retry-all-errors --retry-delay 3 \
             "${WEB_URL}/demo")
           WEB_HTML="$html" node .github/scripts/verify-web-deployment-provenance.mjs
+
+      - name: Verify stable production Web origin release and API integration
+        env:
+          WEB_URL: ${{ steps.web_origin.outputs.origin }}
+          EXPECTED_RELEASE: ${{ env.RELEASE_SHA }}
+        run: |
+          html=$(curl --fail --silent --show-error --location --retry 8 --retry-all-errors --retry-delay 3 \
+            "${WEB_URL}/demo")
+          WEB_HTML="$html" node .github/scripts/verify-web-deployment-provenance.mjs
+
+      - name: Run non-destructive live release smoke
+        env:
+          API_URL: ${{ env.EXPECTED_API_URL }}
+          WEB_ORIGIN: ${{ steps.web_origin.outputs.origin }}
+          EXPECTED_RELEASE: ${{ env.RELEASE_SHA }}
+        run: node .github/scripts/verify-live-release.mjs
 
       - name: Notify production Web deployment when configured
         if: ${{ always() }}
@@ -231,7 +257,6 @@ jobs:
             echo "SLACK_WEBHOOK is not configured; skipping optional deployment notification."
             exit 0
           fi
-
           payload=$(printf '{"text":"Woof production Web deployment: %s (%.12s)"}' \
             "${DEPLOYMENT_STATUS}" "${RELEASE_SHA}")
           curl --fail --silent --show-error \
@@ -245,7 +270,8 @@ jobs:
     needs: [validate-release-candidate, deploy-api-production, deploy-web-production]
     env:
       RELEASE_SHA: ${{ needs.validate-release-candidate.outputs.release_sha }}
-      WEB_URL: ${{ needs.deploy-web-production.outputs.deployment_url }}
+      WEB_URL: ${{ needs.deploy-web-production.outputs.web_origin }}
+      WEB_DEPLOYMENT_URL: ${{ needs.deploy-web-production.outputs.deployment_url }}
       API_URL: https://woof-api-prod.fly.dev/api/v1
     steps:
       - uses: actions/checkout@v7
@@ -256,6 +282,8 @@ jobs:
         env:
           RELEASE_ENVIRONMENT: production
           RELEASE_RECEIPT_PATH: .release-evidence/production-release-receipt.json
+          CANONICAL_RELEASE_CHECKS_VERIFIED: 'true'
+          LIVE_BLACK_BOX_VERIFIED: 'true'
           STAGING_WORKFLOW_VERIFIED: 'true'
         run: node .github/scripts/write-release-receipt.mjs
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -50,6 +51,12 @@ jobs:
             echo "::error title=Untrusted staging candidate::${RELEASE_SHA} is not reachable from origin/main."
             exit 1
           fi
+
+      - name: Require exact-SHA canonical main release checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ steps.candidate.outputs.sha }}
+        run: python3 .github/scripts/verify-main-release-checks.py
 
   deploy-api-staging:
     name: Deploy API to Staging
@@ -122,10 +129,12 @@ jobs:
     needs: [validate-release-candidate, deploy-api-staging]
     outputs:
       deployment_url: ${{ steps.deploy_web.outputs.url }}
+      web_origin: ${{ steps.web_origin.outputs.origin }}
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      STABLE_WEB_ORIGIN: ${{ vars.WEB_ORIGIN }}
       EXPECTED_API_URL: https://woof-api-staging.fly.dev/api/v1
       RELEASE_SHA: ${{ needs.validate-release-candidate.outputs.release_sha }}
     steps:
@@ -133,46 +142,49 @@ jobs:
         with:
           ref: ${{ env.RELEASE_SHA }}
 
-      - name: Validate staging Web deployment credentials
+      - name: Validate staging Web deployment authority
+        id: web_origin
         run: |
           missing=0
-          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+          for name in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID STABLE_WEB_ORIGIN; do
             if [[ -z "${!name}" ]]; then
-              echo "::error title=Missing staging secret::${name} is not configured for the staging environment."
+              echo "::error title=Missing staging authority::${name} is not configured for the staging environment."
               missing=1
             fi
           done
           if [[ "${missing}" -ne 0 ]]; then
             exit 1
           fi
+          origin=$(node -e "const u=new URL(process.env.STABLE_WEB_ORIGIN); if(u.protocol!=='https:'||u.origin!==process.env.STABLE_WEB_ORIGIN.replace(/\/$/,'')) process.exit(1); process.stdout.write(u.origin)")
+          echo "origin=${origin}" >> "$GITHUB_OUTPUT"
 
       - name: Install pinned Vercel CLI
         run: npm install --global vercel@58.4.4
 
-      - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=preview --token="${VERCEL_TOKEN}"
+      - name: Pull isolated staging project information
+        run: vercel pull --yes --environment=production --token="${VERCEL_TOKEN}"
         working-directory: apps/web
 
-      - name: Build Project Artifacts
-        run: vercel build --token="${VERCEL_TOKEN}"
+      - name: Build production-shaped staging artifacts
+        run: vercel build --prod --token="${VERCEL_TOKEN}"
         working-directory: apps/web
         env:
           NEXT_PUBLIC_API_URL: ${{ env.EXPECTED_API_URL }}
           NEXT_PUBLIC_WOOF_RELEASE_SHA: ${{ env.RELEASE_SHA }}
           NEXT_PUBLIC_SENTRY_REPLAY_ENABLED: 'false'
 
-      - name: Deploy to Vercel
+      - name: Deploy to isolated staging project production alias
         id: deploy_web
         working-directory: apps/web
         run: |
-          deployment_url=$(vercel deploy --prebuilt --token="${VERCEL_TOKEN}" | tail -n 1 | tr -d '\r')
+          deployment_url=$(vercel deploy --prebuilt --prod --token="${VERCEL_TOKEN}" | tail -n 1 | tr -d '\r')
           if [[ ! "${deployment_url}" =~ ^https:// ]]; then
             echo "::error title=Invalid Vercel deployment URL::Expected an HTTPS deployment URL, received '${deployment_url}'."
             exit 1
           fi
           echo "url=${deployment_url}" >> "$GITHUB_OUTPUT"
 
-      - name: Verify deployed Web release and API integration
+      - name: Verify immutable Web deployment release and API integration
         env:
           WEB_URL: ${{ steps.deploy_web.outputs.url }}
           EXPECTED_RELEASE: ${{ env.RELEASE_SHA }}
@@ -181,13 +193,30 @@ jobs:
             "${WEB_URL}/demo")
           WEB_HTML="$html" node .github/scripts/verify-web-deployment-provenance.mjs
 
+      - name: Verify stable staging Web origin release and API integration
+        env:
+          WEB_URL: ${{ steps.web_origin.outputs.origin }}
+          EXPECTED_RELEASE: ${{ env.RELEASE_SHA }}
+        run: |
+          html=$(curl --fail --silent --show-error --location --retry 8 --retry-all-errors --retry-delay 3 \
+            "${WEB_URL}/demo")
+          WEB_HTML="$html" node .github/scripts/verify-web-deployment-provenance.mjs
+
+      - name: Run non-destructive live release smoke
+        env:
+          API_URL: ${{ env.EXPECTED_API_URL }}
+          WEB_ORIGIN: ${{ steps.web_origin.outputs.origin }}
+          EXPECTED_RELEASE: ${{ env.RELEASE_SHA }}
+        run: node .github/scripts/verify-live-release.mjs
+
   retain-staging-release-receipt:
     name: Retain Staging Release Receipt
     runs-on: ubuntu-latest
     needs: [validate-release-candidate, deploy-api-staging, deploy-web-staging]
     env:
       RELEASE_SHA: ${{ needs.validate-release-candidate.outputs.release_sha }}
-      WEB_URL: ${{ needs.deploy-web-staging.outputs.deployment_url }}
+      WEB_URL: ${{ needs.deploy-web-staging.outputs.web_origin }}
+      WEB_DEPLOYMENT_URL: ${{ needs.deploy-web-staging.outputs.deployment_url }}
       API_URL: https://woof-api-staging.fly.dev/api/v1
     steps:
       - uses: actions/checkout@v7
@@ -198,6 +227,8 @@ jobs:
         env:
           RELEASE_ENVIRONMENT: staging
           RELEASE_RECEIPT_PATH: .release-evidence/staging-release-receipt.json
+          CANONICAL_RELEASE_CHECKS_VERIFIED: 'true'
+          LIVE_BLACK_BOX_VERIFIED: 'true'
           STAGING_WORKFLOW_VERIFIED: 'false'
         run: node .github/scripts/write-release-receipt.mjs
 

--- a/.github/workflows/release-promotion-authority-ci.yml
+++ b/.github/workflows/release-promotion-authority-ci.yml
@@ -2,32 +2,17 @@ name: Release Promotion Authority CI
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/deploy-staging.yml'
-      - '.github/workflows/deploy-production.yml'
-      - '.github/workflows/release-promotion-authority-ci.yml'
-      - '.github/workflows/dogos-operational-privacy-ci.yml'
-      - '.github/scripts/assert-release-promotion-authority.py'
-      - '.github/scripts/assert-operational-privacy-release.py'
-      - '.github/scripts/write-release-receipt.mjs'
-      - '.github/scripts/verify-web-deployment-provenance.mjs'
-      - 'docs/operations/RELEASE_PROMOTION_AUTHORITY_V1.md'
+    branches: [main]
   push:
     branches: [main]
-    paths:
-      - '.github/workflows/deploy-staging.yml'
-      - '.github/workflows/deploy-production.yml'
-      - '.github/workflows/release-promotion-authority-ci.yml'
-      - '.github/workflows/dogos-operational-privacy-ci.yml'
-      - '.github/scripts/assert-release-promotion-authority.py'
-      - '.github/scripts/assert-operational-privacy-release.py'
-      - '.github/scripts/write-release-receipt.mjs'
-      - '.github/scripts/verify-web-deployment-provenance.mjs'
-      - 'docs/operations/RELEASE_PROMOTION_AUTHORITY_V1.md'
   workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: release-promotion-authority-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   release-promotion-authority:
@@ -39,11 +24,17 @@ jobs:
       - name: Qualify staging and production promotion contract
         run: python3 .github/scripts/assert-release-promotion-authority.py
 
+      - name: Exercise exact-SHA main release-check verifier
+        run: python3 .github/scripts/verify-main-release-checks.py --self-test
+
       - name: Exercise privacy-safe release receipt writer
         run: node .github/scripts/write-release-receipt.mjs --self-test
 
       - name: Exercise Web deployment provenance verifier
         run: node .github/scripts/verify-web-deployment-provenance.mjs --self-test
+
+      - name: Exercise live release smoke verifier
+        run: node .github/scripts/verify-live-release.mjs --self-test
 
       - name: Re-qualify operational privacy and release identity
         run: python3 .github/scripts/assert-operational-privacy-release.py

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -1,374 +1,333 @@
-# Woof App Deployment Guide
+# Woof Production Deployment Guide
 
-Complete guide for deploying the Woof app to production for user testing.
+## Status
 
----
+**Pre-public-beta deployment authority.** This guide describes the current release path. It is not evidence that Woof is already live.
 
-## 📋 Prerequisites
+Woof keeps four claims separate:
 
-- [ ] Vercel account
-- [ ] Fly.io or Railway account
-- [ ] Neon or Supabase account (PostgreSQL)
-- [ ] GitHub repository with latest code
-- [ ] Environment variables prepared
+> repository-qualified ≠ deployed ≠ device-qualified ≠ pilot-validated
 
----
+A successful pull request proves repository behavior. A successful staging workflow proves one exact commit was deployed and live-smoke-qualified in staging. A successful production workflow proves that same staging-qualified commit was promoted to the configured production providers. Physical iPhone/TestFlight evidence and real-user pilot evidence remain separate gates.
 
-## 🗄️ Step 1: Deploy Database
+## Canonical architecture
 
-### Option A: Neon (Recommended)
-
-1. Go to [neon.tech](https://neon.tech)
-2. Create new project: "woof-production"
-3. Copy connection string
-4. Run migrations:
-
-```bash
-# Set DATABASE_URL in packages/database/.env
-DATABASE_URL="postgresql://user:pass@host/woof?sslmode=require"
-
-# Run migrations
-pnpm --filter @woof/database db:migrate
-
-# Seed production data
-pnpm --filter @woof/database db:seed
+```text
+qualified PR
+    |
+    v
+protected main
+    |
+    v
+exact-SHA canonical main checks
+    |
+    v
+Deploy to Staging
+    |-- managed staging PostgreSQL
+    |-- Fly app: woof-api-staging
+    |-- separate Vercel staging project
+    |-- stable staging WEB_ORIGIN
+    |-- migration + live/ready + Web provenance + live smoke
+    `-- 30-day staging receipt
+    |
+    v
+backup / restore + staging black-box qualification
+    |
+    v
+manual Deploy to Production(release_sha)
+    |-- re-verifies exact-SHA main checks
+    |-- requires successful staging run for that SHA
+    |-- managed production PostgreSQL
+    |-- Fly app: woof-api-prod
+    |-- separate Vercel production project
+    |-- stable production WEB_ORIGIN
+    |-- migration + live/ready + Web provenance + live smoke
+    `-- 90-day production receipt
 ```
 
-### Option B: Supabase
+Do not deploy from a laptop or from an uncommitted checkout. Do not manually mutate release identity. Production is a promotion of an exact Git SHA.
 
-1. Go to [supabase.com](https://supabase.com)
-2. Create new project
-3. Enable pgvector extension in SQL editor:
-```sql
-CREATE EXTENSION IF NOT EXISTS vector;
-```
-4. Copy connection string from Settings > Database
-5. Run migrations as above
+## 1. Repository authority
 
----
+Before public beta, apply the `main` ruleset tracked in issue #80:
 
-## 🚀 Step 2: Deploy Backend API
+- pull requests required for ordinary changes;
+- force pushes and branch deletion disabled;
+- required conversations resolved;
+- branches current before merge or equivalent merge-queue semantics;
+- minimal explicit emergency bypass;
+- required unconditional checks: root CI, Security Baseline, CodeQL, and Release Promotion Authority.
 
-### Option A: Fly.io (Recommended)
+The connected ChatGPT GitHub App does not have repository-administration authority, so this is an owner/admin action.
 
-1. Install Fly CLI:
-```bash
-brew install flyctl
-# or
-curl -L https://fly.io/install.sh | sh
-```
+## 2. Provider isolation
 
-2. Login and create app:
-```bash
-flyctl auth login
-cd apps/api
-flyctl launch --name woof-api --region sjc
-```
+Create separate resources for staging and production. Sharing credentials, databases, or the same Vercel project makes the staging boundary cosmetic rather than protective.
 
-3. Set environment variables:
-```bash
-flyctl secrets set \
-  NODE_ENV=production \
-  PORT=8080 \
-  API_PREFIX=api/v1 \
-  DATABASE_URL="postgresql://..." \
-  JWT_SECRET="$(openssl rand -base64 32)" \
-  JWT_REFRESH_SECRET="$(openssl rand -base64 32)" \
-  CORS_ORIGIN="https://woof.vercel.app"
+### PostgreSQL
+
+Provision two managed PostgreSQL databases or isolated projects:
+
+- staging database for `woof-api-staging`;
+- production database for `woof-api-prod`.
+
+The provider must support an operator-visible backup/snapshot mechanism suitable for the backup and restore rehearsal in issue #100. Keep production and staging credentials distinct. `DATABASE_URL` is application runtime authority and belongs in Fly secrets, never GitHub source or Vercel.
+
+Do **not** run development migration commands or manually seed production. Fly uses the committed release command:
+
+```text
+pnpm --filter @woof/database db:migrate:deploy
 ```
 
-4. Create `fly.toml` in apps/api:
-```toml
-app = "woof-api"
-primary_region = "sjc"
+### Fly.io
 
-[build]
-  builder = "paketobuildpacks/builder:base"
+Create or verify these applications:
 
-[env]
-  PORT = "8080"
-
-[http_service]
-  internal_port = 8080
-  force_https = true
-  auto_stop_machines = true
-  auto_start_machines = true
-  min_machines_running = 0
+```text
+woof-api-staging
+woof-api-prod
 ```
 
-5. Deploy:
-```bash
-flyctl deploy
+The committed `apps/api/fly.toml` is authoritative for port 4000, HTTPS, rolling deploys, the migration release command, one warm Machine minimum, and `/api/v1/ops/health/ready` traffic readiness.
+
+Use separately scoped deploy tokens for staging and production. GitHub receives deploy authority through environment-scoped `FLY_API_TOKEN`; the Fly applications themselves receive runtime secrets directly through Fly secret management.
+
+### Vercel
+
+Create **separate Vercel projects** for the Web client, for example:
+
+```text
+woof-web-staging
+woof-web-production
 ```
 
-6. Verify:
-```bash
-curl https://woof-api.fly.dev/api/v1/health
+Both projects use `apps/web` from this repository. The staging workflow intentionally builds with production semantics and deploys with `--prod` **inside the isolated staging project**. This produces a stable staging project alias while keeping it independent from the real production project.
+
+Never point the GitHub `staging` environment at the production Vercel project merely to make a workflow green.
+
+## 3. Stable Web origins and CORS
+
+Each GitHub environment requires a non-secret environment variable named `WEB_ORIGIN` containing the exact stable HTTPS browser origin, with no path, query, or fragment.
+
+Examples only:
+
+```text
+staging   WEB_ORIGIN=https://woof-web-staging.vercel.app
+production WEB_ORIGIN=https://app.example.com
 ```
 
-### Option B: Railway
+Use the real aliases/domains assigned to the projects rather than copying these examples blindly.
 
-1. Go to [railway.app](https://railway.app)
-2. Create new project from GitHub repo
-3. Select `apps/api` as root directory
-4. Add environment variables in Settings
-5. Deploy automatically on git push
+The matching Fly app must receive `CORS_ORIGIN` with the same stable Web origin. Multiple explicit HTTPS origins may be comma-separated when genuinely required. Wildcard CORS is forbidden in production.
 
----
+The release workflow live-smoke-checks that the configured stable origin receives the expected credentialed CORS response.
 
-## 🌐 Step 3: Deploy Frontend
+## 4. API runtime configuration
 
-### Vercel (Recommended)
+At minimum, each Fly application needs production-shaped runtime configuration for:
 
-1. Go to [vercel.com](https://vercel.com)
-2. Import from GitHub
-3. Configure project:
-   - **Framework Preset**: Next.js
-   - **Root Directory**: apps/web
-   - **Build Command**: `cd ../.. && pnpm install && pnpm --filter @woof/web build`
-   - **Output Directory**: apps/web/.next
-
-4. Add environment variables:
-```
-NEXT_PUBLIC_API_URL=https://woof-api.fly.dev/api/v1
+```text
+DATABASE_URL
+JWT_SECRET
+CORS_ORIGIN
 ```
 
-5. Deploy and verify
+`JWT_SECRET` must be a non-development secret of at least 32 characters. `NODE_ENV=production`, `PORT=4000`, `API_PREFIX=api/v1`, and `API_DOCS_ENABLED=false` are committed in `apps/api/fly.toml`.
 
----
+Configure optional systems only when their complete authority exists:
 
-## ✅ Step 4: Post-Deployment Verification
+- `SENTRY_DSN` for live error monitoring;
+- `OPS_METRICS_TOKEN` for protected metric scraping;
+- `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, `S3_PUBLIC_URL` for private media storage;
+- `VAPID_PUBLIC_KEY` + `VAPID_PRIVATE_KEY` + valid `CONNECTOR_CREDENTIALS_KEY` for Web Push;
+- `OPENAI_API_KEY` for enabled model-backed Health Lens behavior;
+- complete Behavior Vision URL/token/release pin if that service is enabled;
+- connector encryption authority before enabling dogOS connectors.
 
-### 1. API Health Check
-```bash
-curl https://woof-api.fly.dev/api/v1/health
-# Should return 200 OK
+Unavailable optional providers must remain explicit unavailable/degraded states. Do not add placeholder credentials solely to pass startup.
+
+## 5. GitHub environment authority
+
+Create GitHub environments named exactly:
+
+```text
+staging
+production
 ```
 
-### 2. Swagger Documentation
-Visit: `https://woof-api.fly.dev/docs`
+Configure **staging** with:
 
-### 3. Frontend Access
-Visit: `https://woof.vercel.app`
-
-### 4. Test Authentication
-1. Open frontend
-2. Click "Create Account"
-3. Register new user
-4. Verify login works
-5. Check API logs for authentication
-
-### 5. Test API Integration
-1. View feed (should fetch from API)
-2. Create post (if implemented)
-3. View events
-4. Check browser DevTools for API calls
-
----
-
-## 🔧 Step 5: Configure Domain (Optional)
-
-### Backend Custom Domain
-```bash
-flyctl certs add api.woofapp.com
+```text
+secret FLY_API_TOKEN
+secret VERCEL_TOKEN
+secret VERCEL_ORG_ID
+secret VERCEL_PROJECT_ID
+variable WEB_ORIGIN
 ```
 
-Update CORS in backend:
-```env
-CORS_ORIGIN=https://app.woofapp.com,https://woofapp.com
+Configure **production** with the same five values, but bound to production resources. `SLACK_WEBHOOK` is optional.
+
+The current Vercel account must first contain the intended Woof projects. Do not reuse an unrelated project ID. Production should require explicit environment reviewer approval before jobs can consume production authority.
+
+## 6. Canonical exact-SHA release checks
+
+Before staging or production can touch provider credentials, `.github/scripts/verify-main-release-checks.py` requires successful `push` runs for the exact candidate SHA from:
+
+```text
+ci.yml
+security-baseline-ci.yml
+codeql.yml
+release-promotion-authority-ci.yml
 ```
 
-### Frontend Custom Domain
-1. Go to Vercel project settings
-2. Add custom domain: `woofapp.com` or `app.woofapp.com`
-3. Configure DNS records as instructed
+These workflows are intentionally unconditional on `main`. Path-scoped feature lanes remain valuable domain evidence but are not global release blockers because an unrelated PR must not deadlock on a workflow that never ran.
 
----
+## 7. Staging release
 
-## 📊 Step 6: Monitoring & Analytics
+A merge to `main` automatically starts `Deploy to Staging`. The workflow:
 
-### 1. Sentry (Error Tracking)
+1. resolves an exact 40-character SHA;
+2. proves the checkout matches and is reachable from `origin/main`;
+3. waits for the canonical exact-SHA main checks;
+4. validates staging deployment authority;
+5. deploys `woof-api-staging` with the exact release SHA;
+6. runs the committed Prisma migration release command;
+7. requires `/ops/health/live` and database-backed `/ops/health/ready` to report that SHA;
+8. builds and deploys production-shaped Web artifacts to the isolated staging Vercel project;
+9. verifies both the immutable Vercel URL and stable staging origin expose the expected Web release/API provenance;
+10. runs the non-destructive live release smoke;
+11. retains a privacy-safe staging receipt for 30 days.
 
-**Backend:**
-```bash
-pnpm add @sentry/node
+A failed staging deploy is not permission to bypass a gate. Diagnose the first failing boundary and repair that boundary.
+
+## 8. Automated live smoke semantics
+
+`.github/scripts/verify-live-release.mjs` verifies without creating user data:
+
+- API liveness is HTTP 200 and reports the selected SHA;
+- database-backed readiness is HTTP 200 and reports the selected SHA;
+- production security headers include `X-Content-Type-Options: nosniff`;
+- the real stable Web origin receives the configured credentialed CORS authority;
+- unauthenticated `/auth/me` fails closed with HTTP 401;
+- Swagger/API documentation is not publicly reachable in the production-shaped runtime.
+
+Repository tests own negative/hostile CORS behavior. The deploy smoke intentionally avoids manufacturing a production server error merely to prove a known-invalid origin is rejected.
+
+## 9. Staging black-box acceptance
+
+Before the first public-beta production promotion, exercise the following against staging with synthetic accounts and retain a bounded pass/fail record, not private payloads:
+
+```text
+register -> login -> persisted session -> logout -> revoked session denied
+Guardian -> create pet -> Today -> Daily Signals -> Adventure -> Story/Field Journal
+caregiver invite -> accept -> authorized read/write -> revoke -> immediate denial
+Community/Packs -> approved locality -> visibility -> reactions -> cohort privacy
+realtime -> connect -> authorized conversation -> block/revoke -> authority removed
+Health Lens -> normal path -> model unavailable -> conservative fallback
+connector unavailable -> explicit unavailable state, never fabricated connectivity
+Media Library -> upload/read/delete where storage is configured
+account deletion -> database + owned external-object deletion
 ```
 
-```typescript
-// apps/api/src/main.ts
-import * as Sentry from '@sentry/node';
+Also test expired session, duplicate mutation/retry, interrupted network, DB/provider degradation where safely reproducible, and production Web CORS from the actual stable origin.
 
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  environment: process.env.NODE_ENV,
-});
+## 10. Backup and restore rehearsal
+
+Production promotion for public beta is blocked until issue #100 Phase 4 has real evidence.
+
+For the selected database provider:
+
+1. identify the actual backup/snapshot authority and retention policy;
+2. define RPO/RTO as operator goals, not guarantees;
+3. restore a real or production-equivalent snapshot into an isolated non-production database;
+4. apply the full committed migration chain/checks;
+5. verify auth/session records, pet ownership, caregiver grants, Daily Signals/Story schemas, and deletion/privacy invariants;
+6. record date, snapshot identity, target environment, release SHA, duration, and pass/fail without row contents or identifiers.
+
+“Backups enabled” is not restore evidence.
+
+## 11. Production promotion
+
+Production is manual-only. Select the exact SHA whose staging receipt and staging black-box evidence you intend to promote, then dispatch `Deploy to Production` with that full SHA.
+
+Before credentials are consumed, production independently re-verifies:
+
+- exact SHA syntax and checkout identity;
+- `main` ancestry;
+- canonical exact-SHA main release checks;
+- at least one successful `Deploy to Staging` run for exactly that SHA.
+
+The production jobs then repeat API migration/release identity, stable Web provenance, CORS, fail-closed auth, docs-disabled, and live-smoke checks before a 90-day production receipt can exist.
+
+Do not reinterpret a partial Fly-only or Vercel-only deployment as a complete Woof release.
+
+## 12. Live operational qualification
+
+Immediately after the first successful production release, close issue #100 Phase 6 with real provider evidence:
+
+- send one deliberate benign test event through production error monitoring and verify the exact release SHA;
+- externally scrape/aggregate protected operational metrics;
+- perform one non-destructive alert drill that reaches the accountable operator;
+- continuously observe `/ops/health/live` and `/ops/health/ready`;
+- verify the operator can reach the committed incident runbooks;
+- prove monitoring/provider failure becomes an explicit degraded-observability state rather than silent green.
+
+Only then describe live observability as proven.
+
+## 13. Rollback
+
+Application rollback is an explicit new production promotion of a previously staging-qualified exact `main` SHA. Never redeploy an unknown local checkout and never rewrite release identity.
+
+Database rollback is separate. Migrations are forward-safe authority; do not delete Prisma migration history, manually mark failed migrations successful, or restore over live production without a reviewed recovery plan.
+
+Before each production promotion, identify the prior known-good staging-qualified application SHA as the application rollback target and confirm the new migration remains compatible with it when rollback may be needed.
+
+## 14. Native distribution is a separate gate
+
+Web/API production success does not make the iOS client device-qualified. Before public beta, separately prove:
+
+- signed Release build on a physical iPhone;
+- install/launch and upgrade behavior;
+- TestFlight or equivalent distribution;
+- auth persistence and logout/account deletion;
+- offline/poor-network recovery;
+- notification/photo/camera permission states where used;
+- safe areas and keyboard overlap;
+- Dynamic Type/large text;
+- VoiceOver on critical paths.
+
+The existing Xcode simulator qualification is repository evidence, not a substitute for this gate.
+
+## 15. Pilot and launch boundary
+
+After deployment, recovery, observability, and device gates, run a small owner/advisor pilot. Measure whether Woof reduces relationship-management burden and improves useful actions rather than optimizing raw engagement.
+
+Public beta is justified only when one explicitly identified release is:
+
+```text
+protected-source qualified
++ staging deployed and black-box qualified
++ backup/restore rehearsed
++ manually promoted to production
++ production observable and recoverable
++ physical-device distributed
++ privacy boundaries verified
++ small-pilot validated
 ```
 
-**Frontend:**
-```bash
-pnpm add @sentry/nextjs
-```
+Until all of those have evidence, use the narrower truthful status that applies.
 
-### 2. Vercel Analytics
-Already configured via `@vercel/analytics` package.
+## Explicitly retired instructions
 
-### 3. Database Monitoring
-- Neon: Built-in dashboard
-- Supabase: Built-in dashboard + logs
+The old 2025 guide contained instructions that are no longer authoritative. Do not:
 
----
+- run interactive/development Prisma migration commands against production;
+- manually seed production merely to create test users;
+- expose Swagger in production;
+- hand-deploy from a laptop as the canonical release path;
+- reuse an unrelated Vercel project;
+- rely on old `/api/v1/health` paths;
+- claim PWA installation/offline support unless it is deliberately rebuilt and requalified;
+- claim the app is production-ready because provider accounts exist.
 
-## 🧪 Step 7: Create Test Accounts
-
-Run this script to create beta test users:
-
-```sql
--- Connect to production database
-INSERT INTO "User" (id, handle, email, "passwordHash", bio, points)
-VALUES
-  (gen_random_uuid(), 'tester1', 'tester1@woofapp.com', '$2b$10$...', 'Beta Tester 1', 0),
-  (gen_random_uuid(), 'tester2', 'tester2@woofapp.com', '$2b$10$...', 'Beta Tester 2', 0),
-  (gen_random_uuid(), 'tester3', 'tester3@woofapp.com', '$2b$10$...', 'Beta Tester 3', 0);
-```
-
-Or use the registration endpoint.
-
----
-
-## 📱 Step 8: PWA Configuration
-
-### 1. Update manifest.json
-```json
-{
-  "name": "Woof - Pet Social Fitness",
-  "short_name": "Woof",
-  "start_url": "/",
-  "display": "standalone",
-  "background_color": "#0a0e27",
-  "theme_color": "#00d9ff",
-  "icons": [
-    {
-      "src": "/icon-192.jpg",
-      "sizes": "192x192",
-      "type": "image/jpeg"
-    },
-    {
-      "src": "/icon-512.jpg",
-      "sizes": "512x512",
-      "type": "image/jpeg"
-    }
-  ]
-}
-```
-
-### 2. Test PWA
-1. Open app on mobile device
-2. Look for "Add to Home Screen" prompt
-3. Install and test offline functionality
-
----
-
-## 🚨 Troubleshooting
-
-### API Returns 500 Error
-1. Check Fly.io logs: `flyctl logs`
-2. Verify DATABASE_URL is correct
-3. Check migrations ran successfully
-
-### CORS Error
-1. Verify CORS_ORIGIN includes frontend URL
-2. Check for trailing slashes
-3. Restart API after environment changes
-
-### Frontend Build Fails
-1. Check pnpm workspace is set up correctly
-2. Verify all dependencies are installed
-3. Check build logs in Vercel dashboard
-
-### Database Connection Fails
-1. Verify DATABASE_URL format
-2. Check SSL mode requirement
-3. Test connection locally first
-
----
-
-## 📈 Scaling Considerations
-
-### Database
-- **Connection Pooling**: Use Prisma connection pooling
-- **Indexes**: Add indexes for frequently queried fields
-- **Backups**: Enable automated backups on Neon/Supabase
-
-### API
-- **Horizontal Scaling**: Increase Fly.io machine count
-- **Caching**: Enable Redis caching
-- **Rate Limiting**: Already configured in backend
-
-### Frontend
-- **Image Optimization**: Use Next.js Image component
-- **Code Splitting**: Automatic with Next.js
-- **Edge Functions**: Use Vercel Edge for dynamic content
-
----
-
-## 🔐 Security Checklist
-
-- [ ] Change all default secrets
-- [ ] Use strong JWT_SECRET (32+ characters)
-- [ ] Enable HTTPS only
-- [ ] Configure rate limiting
-- [ ] Set up CORS properly
-- [ ] Enable database SSL
-- [ ] Use environment variables (never commit secrets)
-- [ ] Set up monitoring alerts
-
----
-
-## 🎯 Pre-Launch Checklist
-
-- [ ] Database deployed and migrated
-- [ ] Backend API deployed and healthy
-- [ ] Frontend deployed and accessible
-- [ ] Authentication flow working
-- [ ] Core features functional
-- [ ] PWA installable
-- [ ] Error tracking configured
-- [ ] Analytics set up
-- [ ] Test accounts created
-- [ ] Documentation updated
-
----
-
-## 📞 Support Resources
-
-- **Fly.io**: https://fly.io/docs
-- **Vercel**: https://vercel.com/docs
-- **Neon**: https://neon.tech/docs
-- **Supabase**: https://supabase.com/docs
-- **Prisma**: https://www.prisma.io/docs
-- **NestJS**: https://docs.nestjs.com
-
----
-
-## 🎉 Launch Day
-
-1. **Final Smoke Test**
-   - Test all critical user flows
-   - Verify all API endpoints respond
-   - Check mobile responsiveness
-
-2. **Send Invites**
-   - Share app URL with beta testers
-   - Provide test account credentials
-   - Share feedback form
-
-3. **Monitor**
-   - Watch error logs in Sentry
-   - Monitor API response times
-   - Track user signups
-   - Respond to feedback
-
----
-
-**Last Updated**: October 9, 2025
-**Status**: Ready for deployment ✅
+The GitHub workflows, committed runtime config, release receipts, runbooks, and this guide now define deployment authority.

--- a/docs/operations/RELEASE_PROMOTION_AUTHORITY_V1.md
+++ b/docs/operations/RELEASE_PROMOTION_AUTHORITY_V1.md
@@ -1,10 +1,12 @@
-# Release Promotion Authority v1
+# Release Promotion Authority v2
+
+> The filename remains stable for existing repository references. This document now describes the v2 production-closure contract.
 
 ## Purpose
 
-Woof treats repository qualification, staging qualification, and production promotion as different claims.
+Woof treats repository qualification, staging qualification, production promotion, device distribution, and pilot validation as different claims.
 
-A green pull request does not mean a release is deployed. A merge to `main` does not mean a release is production. Production is an explicit promotion of one exact commit that has already completed the staging deployment workflow successfully.
+A green pull request does not mean a release is deployed. A merge to `main` does not mean a release is production. Production is an explicit promotion of one exact commit that has passed canonical exact-SHA `main` checks, completed staging successfully, and survived non-destructive live release verification.
 
 ## Authority model
 
@@ -17,13 +19,20 @@ qualified pull request
     v
 main
     |
-    +--> Deploy to Staging
-    |      - exact SHA validation
-    |      - main ancestry validation
+    +--> exact-SHA canonical main checks
+    |      - root CI
+    |      - Security Baseline
+    |      - CodeQL
+    |      - Release Promotion Authority
+    |
+    +--> Deploy to Staging waits for those checks
+    |      - exact SHA + main ancestry
+    |      - isolated staging API/database/Web project
     |      - API migration/deploy
     |      - live + ready exact-SHA verification
-    |      - Web deploy
-    |      - Web release/API-origin provenance verification
+    |      - immutable + stable Web provenance
+    |      - real stable-origin CORS
+    |      - fail-closed auth + docs-disabled live smoke
     |      - privacy-safe staging release receipt
     |
     v
@@ -31,45 +40,91 @@ explicit workflow_dispatch(release_sha)
     |
     v
 Deploy to Production
-       - exact SHA validation
-       - main ancestry validation
+       - exact SHA + main ancestry
+       - canonical exact-SHA checks re-verified
        - successful exact-SHA staging workflow required
        - production environment authority
+       - isolated production API/database/Web project
        - API migration/deploy
        - live + ready exact-SHA verification
-       - Web deploy
-       - Web release/API-origin provenance verification
+       - immutable + stable Web provenance
+       - real stable-origin CORS
+       - fail-closed auth + docs-disabled live smoke
        - privacy-safe production release receipt
 ```
+
+## Canonical main checks
+
+`.github/scripts/verify-main-release-checks.py` owns the minimal unconditional release set:
+
+```text
+ci.yml
+security-baseline-ci.yml
+codeql.yml
+release-promotion-authority-ci.yml
+```
+
+For the selected exact SHA, each workflow must have a successful `push` run. Pull-request success for another SHA is not accepted as release evidence.
+
+The set is intentionally small and unconditional. Domain workflows that are path-scoped cannot be globally required without risking a deadlock on a commit where they correctly did not run. They remain important PR/domain evidence and may be required by repository rules where GitHub semantics make that safe.
+
+`Release Promotion Authority CI` itself now runs on every pull request to `main` and every push to `main`. It is no longer path-scoped, so staging and production can depend on its presence for every candidate.
 
 ## Staging
 
 `Deploy to Staging` runs automatically for pushes to `main`. A manual dispatch re-runs the workflow for the Git ref selected when dispatching; the workflow still rejects that candidate unless its exact SHA is reachable from `origin/main`.
 
-The staging workflow rejects:
+Before any provider credential is consumed, staging:
 
-- branch names, abbreviated SHAs, uppercase/non-hex release identifiers, and other ambiguous values as release identity;
-- commits that are not reachable from `origin/main`;
-- a checkout whose resolved `HEAD` differs from the workflow's exact candidate SHA;
-- missing deployment credentials;
-- API liveness/readiness responses that do not report the exact candidate SHA;
-- Web deployments whose embedded release identity or API origin does not match the expected release.
+1. resolves the exact lowercase 40-character candidate SHA;
+2. checks out exactly that SHA;
+3. proves it is reachable from `origin/main`;
+4. waits for every canonical exact-SHA main check above to succeed.
 
-The old `develop`-branch trigger was removed because no canonical `develop` branch exists. A dormant staging workflow is not staging authority.
+Only then can staging provider jobs begin.
+
+The staging Web workflow is production-shaped but provider-isolated. The GitHub `staging` environment must point to a **dedicated staging Vercel project**. The workflow uses production-mode Vercel build/deploy semantics inside that staging project so a stable staging alias exists for browser CORS and black-box qualification without touching the real production project.
 
 ## Production
 
 `Deploy to Production` is manual-only. It does not run on a push to `main`.
 
-The operator must provide the exact 40-character release SHA. Before any production deployment credentials are used, the workflow proves:
+The operator provides the exact 40-character release SHA. Before production credentials are used, the workflow proves:
 
 1. the requested SHA resolves exactly;
 2. it is reachable from `origin/main`;
-3. GitHub Actions has a successful `Deploy to Staging` workflow run for that exact SHA.
+3. all canonical exact-SHA main checks are successful;
+4. GitHub Actions has a successful `Deploy to Staging` workflow run for that exact SHA.
 
-Only after those checks pass can the production environment jobs start.
+This makes production independently fail closed even if repository branch protection is temporarily misconfigured. Branch protection remains required as source-governance authority; deployment checks are defense in depth, not a replacement.
 
-This allows repository environment protection and required reviewers to remain an additional external control without making a merge itself equivalent to a production release.
+## Provider isolation
+
+Staging and production must use separate application/data authority:
+
+```text
+staging:
+  PostgreSQL staging database/project
+  Fly app woof-api-staging
+  Vercel staging project
+  GitHub staging environment
+
+production:
+  PostgreSQL production database/project
+  Fly app woof-api-prod
+  Vercel production project
+  GitHub production environment
+```
+
+Do not bind the staging environment to the production Vercel project. Because staging uses `--prod` inside its isolated project to maintain a stable staging alias, a cross-bound project ID would collapse the isolation boundary.
+
+## Stable Web origins
+
+Each GitHub environment provides a non-secret `WEB_ORIGIN` variable containing the exact stable HTTPS browser origin. It must contain no path, query, or fragment.
+
+The corresponding Fly application configures `CORS_ORIGIN` with that stable origin. The live release smoke proves the actual deployed API returns the expected credentialed CORS authority for that origin.
+
+The workflow separately retains the immutable Vercel deployment URL and the stable browser origin. The stable origin is the user-facing browser/CORS authority; the immutable URL is useful deployment provenance.
 
 ## Release identity
 
@@ -89,42 +144,65 @@ NEXT_PUBLIC_WOOF_RELEASE_SHA=<exact selected SHA>
 
 After deployment:
 
-- API `/ops/health/live` and `/ops/health/ready` must report the same exact SHA;
-- the Web deployment must expose the expected `woof-release` identity;
-- the Web deployment must expose the expected `woof-api-origin` identity.
+- API `/ops/health/live` and `/ops/health/ready` must report the exact SHA;
+- the immutable Web deployment must expose the expected `woof-release` and `woof-api-origin` provenance;
+- the stable Web origin must expose the same provenance.
 
-A successful workflow therefore means the released artifacts were checked against the selected candidate, not merely against whatever commit happened to trigger the workflow.
+## Live release smoke
+
+`.github/scripts/verify-live-release.mjs` is deliberately non-destructive. It proves:
+
+- process liveness returns HTTP 200 and the exact selected SHA;
+- database-backed readiness returns HTTP 200 and the exact selected SHA;
+- production security headers retain `X-Content-Type-Options: nosniff`;
+- the configured stable Web origin receives credentialed CORS authority;
+- unauthenticated `/auth/me` fails closed with HTTP 401;
+- production-shaped Swagger/API documentation is not publicly reachable.
+
+Negative hostile-origin CORS behavior remains repository-qualified. The live smoke does not manufacture a production 5xx solely to exercise that rejection path.
+
+This smoke is a release-integrity check, not the complete product journey suite. The richer staging/live black-box journeys remain tracked by the public-beta gate.
 
 ## Privacy-safe release receipts
 
-Successful staging and production deployments retain small JSON receipts as GitHub Actions artifacts.
+Successful staging and production deployments retain schema-v2 JSON receipts.
 
 Receipts contain only operational metadata:
 
 - environment;
 - exact release SHA;
 - repository/workflow/run identity;
-- API and Web HTTPS origins;
-- booleans recording the release/provenance checks that had to pass before the receipt job could run.
+- API HTTPS origin;
+- stable Web HTTPS origin;
+- immutable Web deployment HTTPS URL;
+- booleans proving main ancestry, canonical exact-SHA checks, API/Web release identity, Web/API provenance, live black-box smoke, and staging qualification where applicable.
 
 They do not contain credentials, bearer tokens, request bodies, user/pet identifiers, database rows, free-form user content, or provider payloads.
 
 Staging receipts are retained for 30 days. Production receipts are retained for 90 days.
 
-A production receipt cannot be generated unless exact-SHA staging qualification was verified by the production workflow.
+A receipt cannot be created unless canonical main checks and live smoke have passed. A production receipt additionally requires successful exact-SHA staging qualification.
 
-## External configuration still required
+## External configuration required
 
-This repository code cannot manufacture provider authority. Before the first live release, operators must configure:
+Repository code cannot manufacture provider authority.
 
 ### GitHub `staging` environment
+
+Secrets:
 
 - `FLY_API_TOKEN`
 - `VERCEL_TOKEN`
 - `VERCEL_ORG_ID`
 - `VERCEL_PROJECT_ID`
 
+Variable:
+
+- `WEB_ORIGIN`
+
 ### GitHub `production` environment
+
+Secrets:
 
 - `FLY_API_TOKEN`
 - `VERCEL_TOKEN`
@@ -132,36 +210,45 @@ This repository code cannot manufacture provider authority. Before the first liv
 - `VERCEL_PROJECT_ID`
 - optional `SLACK_WEBHOOK`
 
+Variable:
+
+- `WEB_ORIGIN`
+
 The production environment should require explicit reviewer approval once repository/environment administration is configured.
 
 ### Vercel
 
-An intended Woof Web project must exist and the IDs above must refer to that project. Do not reuse an unrelated Vercel project merely to satisfy the credential gate.
+Two intended Woof Web projects must exist. The staging and production environment IDs must refer to the correct isolated projects. Do not reuse an unrelated project merely to satisfy the credential gate.
 
 ### Fly.io
 
-The staging and production tokens must be authorized for the intended `woof-api-staging` and `woof-api-prod` applications respectively.
+Staging and production deploy tokens must be authorized for the intended `woof-api-staging` and `woof-api-prod` applications respectively. Runtime application secrets such as database, JWT, CORS, metrics, storage, and optional provider credentials belong to the corresponding Fly application, not source control.
+
+### Database
+
+Staging and production use isolated managed PostgreSQL authority. The production provider must expose real backup/snapshot authority suitable for the restore rehearsal in issue #100.
 
 ## Repository governance boundary
 
 This release authority does not replace branch protection.
 
-`main` still requires a GitHub ruleset/branch-protection boundary that, at minimum:
+`main` still requires the GitHub ruleset tracked by issue #80. The minimum source boundary is pull-request-only ordinary changes, required unconditional release checks, no force pushes/deletion, current-branch/merge-queue semantics, resolved conversations, and minimal explicit bypass.
 
-- requires pull requests for ordinary changes;
-- requires the intentionally selected release-critical checks;
-- prevents force pushes and branch deletion;
-- keeps bypass authority minimal and explicit.
+Until that external admin control is enabled, Woof must not claim complete production source-governance authority.
 
-Until that external repository-admin control is enabled, Woof must not claim complete production source-governance authority.
+## Recovery boundary
+
+A deployable release is not yet a recoverable service.
+
+Before public beta production promotion, issue #100 Phase 4 requires a real backup/restore rehearsal against the selected database provider. After production deployment, Phase 6 requires live monitoring/error/metrics/alert evidence tied to the deployed SHA.
+
+Do not interpret “provider says backups are enabled” as restore proof and do not describe repository alert configuration as proof that a live operator receives alerts.
 
 ## Rollback
 
-Rollback is an explicit new production promotion of a previously staging-qualified exact `main` SHA. Do not mutate release identity or redeploy an unknown local checkout.
+Application rollback is an explicit new production promotion of a previously staging-qualified exact `main` SHA. The rollback candidate must satisfy the same production preflight, including canonical exact-SHA checks and successful staging qualification.
 
-The chosen rollback SHA must satisfy the same production preflight, including a successful `Deploy to Staging` workflow run for that exact SHA. Commits from before this promotion authority existed are not grandfathered into production eligibility merely because they once existed on `main`.
-
-Database rollback is not implied by application rollback. Migrations must remain forward-safe, and destructive schema rollback requires its own reviewed recovery procedure.
+Database rollback is not implied by application rollback. Migrations remain forward-safe authority. Destructive schema rollback or backup restoration requires its own reviewed recovery procedure.
 
 ## Qualification
 
@@ -169,15 +256,17 @@ Repository qualification is owned by:
 
 ```bash
 python3 .github/scripts/assert-release-promotion-authority.py
+python3 .github/scripts/verify-main-release-checks.py --self-test
 node .github/scripts/write-release-receipt.mjs --self-test
 node .github/scripts/verify-web-deployment-provenance.mjs --self-test
+node .github/scripts/verify-live-release.mjs --self-test
 python3 .github/scripts/assert-operational-privacy-release.py
 ```
 
-These checks run in `Release Promotion Authority CI`.
+These checks run in the always-on `Release Promotion Authority CI` lane.
 
 ## Evidence boundary
 
-Passing this CI proves the repository's promotion contract and receipt machinery. It does **not** prove that Fly, Vercel, GitHub environments, alert routing, backups, physical-device distribution, or real-user pilots have been configured or exercised.
+Passing repository CI proves the promotion contract and receipt machinery. It does **not** prove that Fly, Vercel, GitHub environments, database backups, alert routing, physical-device distribution, or real-user pilots have been configured or exercised.
 
 Those remain separate launch gates and must only be claimed after live evidence exists.


### PR DESCRIPTION
## Purpose

Close the repository-side production deployment gap without pretending provider setup or live operations already exist.

This tranche turns deployment from “successful staging workflow + exact SHA” into a stronger release authority:

- staging and production both wait for canonical exact-SHA `main` checks before provider credentials are consumed;
- `Release Promotion Authority CI` becomes an unconditional PR/`main` authority lane;
- staging uses production-shaped Vercel semantics inside a **separate staging project**, giving it a stable browser/CORS origin without touching the production project;
- both immutable Vercel URLs and stable Web origins must expose the selected release/API provenance;
- a non-destructive live smoke proves exact API identity, database readiness, security headers, real-origin credentialed CORS, unauthenticated auth failure, and docs-disabled behavior;
- schema-v2 release receipts require canonical check proof + live smoke proof and retain both stable and immutable Web URLs;
- the stale 2025 root deployment guide is replaced with the actual 2026 authority, provider isolation, restore, observability, native distribution, rollback, and pilot sequence.

## Canonical exact-SHA checks

Before staging or production can touch provider credentials, the selected SHA must have successful `push` runs for:

- `ci.yml`
- `security-baseline-ci.yml`
- `codeql.yml`
- `release-promotion-authority-ci.yml`

Path-scoped domain lanes remain valuable evidence but are intentionally not universal blockers.

## External authority still required

This PR does **not** claim a live release. The owner still needs to configure:

- the `main` ruleset from #80;
- isolated staging + production managed PostgreSQL authority;
- Fly apps `woof-api-staging` / `woof-api-prod` and runtime secrets;
- separate Vercel staging + production Woof projects;
- GitHub `staging` / `production` environment secrets;
- a stable HTTPS `WEB_ORIGIN` variable per environment;
- production backup/restore rehearsal and live observability under #100;
- physical iPhone/TestFlight/accessibility evidence;
- small owner/advisor pilot.

## Evidence boundary

Repository-qualified != deployed != device-qualified != pilot-validated.

Do not merge until a fresh exact-head matrix validates this release-authority change.