### PR TITLE
Add disposable staging user journey authority

### DIFF
--- a/.github/scripts/assert-staging-journey-authority.py
+++ b/.github/scripts/assert-staging-journey-authority.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Fail closed if deployed staging journey authority drifts."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(path: str) -> str:
+    target = ROOT / path
+    if not target.is_file():
+        raise SystemExit(f"required staging journey source missing: {path}")
+    return target.read_text()
+
+
+def require(path: str, *markers: str) -> None:
+    text = read(path)
+    missing = [marker for marker in markers if marker not in text]
+    if missing:
+        raise SystemExit(f"{path}: missing required staging journey markers: {missing}")
+
+
+def reject(path: str, *markers: str) -> None:
+    text = read(path)
+    present = [marker for marker in markers if marker in text]
+    if present:
+        raise SystemExit(f"{path}: forbidden staging journey markers: {present}")
+
+
+runner = ".github/scripts/verify-staging-user-journey.mjs"
+workflow = ".github/workflows/deploy-staging.yml"
+
+require(
+    runner,
+    "runStagingUserJourney",
+    "createSyntheticIdentity",
+    "registrationKey",
+    "petCreationKey",
+    "'/auth/register'",
+    "'/auth/me'",
+    "'/pets'",
+    "'/users/me'",
+    "deleted-session-rejected",
+    "deleted-credentials-rejected",
+    "finally",
+    "cleanup attempted",
+    "--self-test",
+)
+reject(
+    runner,
+    "DATABASE_URL",
+    "PrismaClient",
+    "console.log(identity",
+    "console.log(token",
+    "console.log(body",
+    "response.text()",
+)
+
+require(
+    workflow,
+    "Run non-destructive live release smoke",
+    "Run disposable staging user journey",
+    "verify-staging-user-journey.mjs",
+    "Retain Staging Release Receipt",
+)
+
+text = read(workflow)
+smoke = text.index("Run non-destructive live release smoke")
+journey = text.index("Run disposable staging user journey")
+receipt = text.index("retain-staging-release-receipt:")
+if not smoke < journey < receipt:
+    raise SystemExit(
+        "staging journey must run after live smoke and before staging receipt authority"
+    )
+
+print(
+    "Staging journey authority is fail-closed: public HTTP lifecycle, owned-pet mutation, "
+    "canonical account deletion, dead-session proof, privacy-safe logging, and failure cleanup are required."
+)

--- a/.github/scripts/verify-staging-user-journey.mjs
+++ b/.github/scripts/verify-staging-user-journey.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+
+import { randomBytes, randomUUID } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function normalizeApiUrl(value) {
+  const url = new URL(value);
+  if (url.protocol !== 'https:' && url.hostname !== 'localhost' && url.hostname !== '127.0.0.1') {
+    throw new Error('staging journey requires HTTPS outside local self-test');
+  }
+  return url.href.replace(/\/$/, '');
+}
+
+function createSyntheticIdentity(uuid = randomUUID()) {
+  const compact = uuid.replaceAll('-', '').slice(0, 16);
+  return {
+    email: `woof.blackbox+${compact}@example.com`,
+    handle: `bb_${compact}`.slice(0, 30),
+    password: `Wf!${randomBytes(18).toString('base64url')}`,
+    registrationKey: uuid,
+    petCreationKey: `staging-journey:${uuid}`,
+  };
+}
+
+async function requestJson(fetchImpl, apiUrl, path, options = {}) {
+  const response = await fetchImpl(`${apiUrl}${path}`, {
+    ...options,
+    headers: {
+      accept: 'application/json',
+      ...(options.body ? { 'content-type': 'application/json' } : {}),
+      ...(options.headers ?? {}),
+    },
+    signal: options.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+  });
+
+  let body = null;
+  const contentType = response.headers?.get?.('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    try {
+      body = await response.json();
+    } catch {
+      body = null;
+    }
+  }
+
+  return { status: response.status, body };
+}
+
+function bearer(token) {
+  return { authorization: `Bearer ${token}` };
+}
+
+export async function runStagingUserJourney({
+  apiUrl,
+  fetchImpl = globalThis.fetch,
+  identity = createSyntheticIdentity(),
+  log = console.log,
+}) {
+  assert(typeof fetchImpl === 'function', 'fetch implementation is required');
+  const baseUrl = normalizeApiUrl(apiUrl);
+  const startedAt = Date.now();
+  let token = null;
+  let accountCreated = false;
+  let accountDeleted = false;
+  let petId = null;
+
+  const step = async (name, fn) => {
+    const start = Date.now();
+    const result = await fn();
+    log(`staging-journey ${name} ok ${Date.now() - start}ms`);
+    return result;
+  };
+
+  try {
+    const registration = await step('register', () =>
+      requestJson(fetchImpl, baseUrl, '/auth/register', {
+        method: 'POST',
+        body: JSON.stringify({
+          email: identity.email,
+          handle: identity.handle,
+          password: identity.password,
+          bio: 'Automated staging release qualification account',
+          registrationKey: identity.registrationKey,
+        }),
+      })
+    );
+    assert(registration.status === 201, `register expected 201, received ${registration.status}`);
+    assert(typeof registration.body?.access_token === 'string', 'register response missing access token');
+    assert(registration.body?.user?.email === identity.email, 'register response email mismatch');
+    assert(registration.body?.user?.handle === identity.handle, 'register response handle mismatch');
+    token = registration.body.access_token;
+    accountCreated = true;
+
+    const profile = await step('authenticated-profile', () =>
+      requestJson(fetchImpl, baseUrl, '/auth/me', {
+        headers: bearer(token),
+      })
+    );
+    assert(profile.status === 200, `auth/me expected 200, received ${profile.status}`);
+    assert(profile.body?.email === identity.email, 'auth/me email mismatch');
+
+    const createdPet = await step('owned-pet-create', () =>
+      requestJson(fetchImpl, baseUrl, '/pets', {
+        method: 'POST',
+        headers: bearer(token),
+        body: JSON.stringify({
+          name: 'Journey Dog',
+          species: 'DOG',
+          creationKey: identity.petCreationKey,
+        }),
+      })
+    );
+    assert(createdPet.status === 201, `pet create expected 201, received ${createdPet.status}`);
+    assert(typeof createdPet.body?.id === 'string', 'pet create response missing id');
+    petId = createdPet.body.id;
+
+    const updatedPet = await step('owned-pet-update', () =>
+      requestJson(fetchImpl, baseUrl, `/pets/${encodeURIComponent(petId)}`, {
+        method: 'PUT',
+        headers: bearer(token),
+        body: JSON.stringify({ breed: 'Synthetic Qualification Dog' }),
+      })
+    );
+    assert(updatedPet.status === 200, `pet update expected 200, received ${updatedPet.status}`);
+    assert(updatedPet.body?.id === petId, 'pet update returned a different pet');
+
+    const deletion = await step('account-delete', () =>
+      requestJson(fetchImpl, baseUrl, '/users/me', {
+        method: 'DELETE',
+        headers: bearer(token),
+      })
+    );
+    assert(deletion.status === 200, `account deletion expected 200, received ${deletion.status}`);
+    assert(deletion.body?.deleted === true, 'account deletion did not confirm deletion');
+    accountDeleted = true;
+
+    const deadSession = await step('deleted-session-rejected', () =>
+      requestJson(fetchImpl, baseUrl, '/auth/me', {
+        headers: bearer(token),
+      })
+    );
+    assert(deadSession.status === 401, `deleted session expected 401, received ${deadSession.status}`);
+
+    const deadCredentials = await step('deleted-credentials-rejected', () =>
+      requestJson(fetchImpl, baseUrl, '/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ email: identity.email, password: identity.password }),
+      })
+    );
+    assert(
+      deadCredentials.status === 401,
+      `deleted credentials expected 401, received ${deadCredentials.status}`
+    );
+
+    log(`staging-journey complete ${Date.now() - startedAt}ms`);
+    return {
+      ok: true,
+      accountDeleted: true,
+      petAuthorityVerified: true,
+      deletedSessionRejected: true,
+      deletedCredentialsRejected: true,
+    };
+  } finally {
+    if (accountCreated && !accountDeleted && token) {
+      try {
+        const cleanup = await requestJson(fetchImpl, baseUrl, '/users/me', {
+          method: 'DELETE',
+          headers: bearer(token),
+        });
+        if (cleanup.status === 200 || cleanup.status === 401 || cleanup.status === 404) {
+          log('staging-journey cleanup attempted');
+        } else {
+          console.error(`staging-journey cleanup failed with status ${cleanup.status}`);
+        }
+      } catch {
+        console.error('staging-journey cleanup request failed');
+      }
+    }
+  }
+}
+
+function jsonResponse(status, body) {
+  return {
+    status,
+    headers: { get: () => 'application/json' },
+    async json() {
+      return body;
+    },
+  };
+}
+
+async function selfTest() {
+  const identity = {
+    email: 'woof.blackbox+selftest@example.com',
+    handle: 'bb_selftest',
+    password: 'SelfTest!Password123',
+    registrationKey: '123e4567-e89b-42d3-a456-426614174000',
+    petCreationKey: 'staging-journey:123e4567-e89b-42d3-a456-426614174000',
+  };
+  const calls = [];
+  const successFetch = async (url, options = {}) => {
+    const path = new URL(url).pathname;
+    calls.push({ path, method: options.method ?? 'GET' });
+    if (path.endsWith('/auth/register')) {
+      return jsonResponse(201, {
+        access_token: 'test-token',
+        user: { id: 'user-1', email: identity.email, handle: identity.handle },
+      });
+    }
+    if (path.endsWith('/auth/me') && calls.filter((call) => call.path.endsWith('/auth/me')).length === 1) {
+      return jsonResponse(200, { id: 'user-1', email: identity.email, handle: identity.handle });
+    }
+    if (path.endsWith('/pets') && options.method === 'POST') {
+      return jsonResponse(201, { id: 'pet-1', name: 'Journey Dog', species: 'DOG' });
+    }
+    if (path.endsWith('/pets/pet-1') && options.method === 'PUT') {
+      return jsonResponse(200, { id: 'pet-1', breed: 'Synthetic Qualification Dog' });
+    }
+    if (path.endsWith('/users/me') && options.method === 'DELETE') {
+      return jsonResponse(200, { deleted: true });
+    }
+    if (path.endsWith('/auth/me')) return jsonResponse(401, { statusCode: 401 });
+    if (path.endsWith('/auth/login')) return jsonResponse(401, { statusCode: 401 });
+    throw new Error(`unexpected self-test request ${options.method ?? 'GET'} ${path}`);
+  };
+
+  const result = await runStagingUserJourney({
+    apiUrl: 'http://localhost/api/v1',
+    fetchImpl: successFetch,
+    identity,
+    log: () => {},
+  });
+  assert(result.ok && result.accountDeleted, 'success self-test did not complete');
+  assert(calls.some((call) => call.path.endsWith('/users/me') && call.method === 'DELETE'), 'cleanup authority missing');
+
+  let cleanupAttempted = false;
+  const failureFetch = async (url, options = {}) => {
+    const path = new URL(url).pathname;
+    if (path.endsWith('/auth/register')) {
+      return jsonResponse(201, {
+        access_token: 'failure-token',
+        user: { id: 'user-2', email: identity.email, handle: identity.handle },
+      });
+    }
+    if (path.endsWith('/auth/me') && (options.method ?? 'GET') === 'GET') {
+      return jsonResponse(500, { statusCode: 500 });
+    }
+    if (path.endsWith('/users/me') && options.method === 'DELETE') {
+      cleanupAttempted = true;
+      return jsonResponse(200, { deleted: true });
+    }
+    throw new Error(`unexpected failure self-test request ${options.method ?? 'GET'} ${path}`);
+  };
+
+  let failedAsExpected = false;
+  try {
+    await runStagingUserJourney({
+      apiUrl: 'http://localhost/api/v1',
+      fetchImpl: failureFetch,
+      identity,
+      log: () => {},
+    });
+  } catch {
+    failedAsExpected = true;
+  }
+  assert(failedAsExpected, 'failure self-test should reject');
+  assert(cleanupAttempted, 'failure self-test did not attempt account cleanup');
+
+  console.log('staging user journey verifier self-test passed');
+}
+
+async function main() {
+  if (process.argv.includes('--self-test')) {
+    await selfTest();
+    return;
+  }
+  const apiUrl = process.env.API_URL;
+  assert(apiUrl, 'API_URL is required');
+  await runStagingUserJourney({ apiUrl });
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  main().catch((error) => {
+    console.error(`staging user journey failed: ${error instanceof Error ? error.message : 'unknown error'}`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -209,6 +209,11 @@ jobs:
           EXPECTED_RELEASE: ${{ env.RELEASE_SHA }}
         run: node .github/scripts/verify-live-release.mjs
 
+      - name: Run disposable staging user journey
+        env:
+          API_URL: ${{ env.EXPECTED_API_URL }}
+        run: node .github/scripts/verify-staging-user-journey.mjs
+
   retain-staging-release-receipt:
     name: Retain Staging Release Receipt
     runs-on: ubuntu-latest

--- a/.github/workflows/staging-journey-authority-ci.yml
+++ b/.github/workflows/staging-journey-authority-ci.yml
@@ -1,0 +1,41 @@
+name: Staging Journey Authority CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/scripts/verify-staging-user-journey.mjs'
+      - '.github/scripts/assert-staging-journey-authority.py'
+      - '.github/workflows/deploy-staging.yml'
+      - '.github/workflows/staging-journey-authority-ci.yml'
+      - 'docs/STAGING_JOURNEY_AUTHORITY_V1.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: staging-journey-authority-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  qualify:
+    name: Public-API disposable staging lifecycle authority
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20.20.2'
+
+      - name: Parse staging journey verifier
+        run: node --check .github/scripts/verify-staging-user-journey.mjs
+
+      - name: Exercise success and failure-cleanup self-tests
+        run: node .github/scripts/verify-staging-user-journey.mjs --self-test
+
+      - name: Parse staging journey source contract
+        run: python3 -m py_compile .github/scripts/assert-staging-journey-authority.py
+
+      - name: Enforce staging journey source contract
+        run: python3 .github/scripts/assert-staging-journey-authority.py

--- a/docs/STAGING_JOURNEY_AUTHORITY_V1.md
+++ b/docs/STAGING_JOURNEY_AUTHORITY_V1.md
@@ -1,0 +1,50 @@
+# Staging Journey Authority v1
+
+## Purpose
+
+A successful staging release must prove more than liveness, database readiness, and release provenance. It must prove that the deployed public API can execute a minimal real user lifecycle through the same authorization boundaries a normal client uses.
+
+This contract is intentionally small. It is a release qualification, not a synthetic product benchmark.
+
+## Qualified lifecycle
+
+After Web/API provenance and the non-destructive live smoke pass, staging runs a disposable synthetic journey against the public API:
+
+1. register a unique email account with a replay-safe `registrationKey`;
+2. use the returned access token to load `/auth/me`;
+3. create a minimal owned dog with a replay-safe `creationKey`;
+4. mutate that dog through the normal owner-authorized update route;
+5. delete the account through `DELETE /users/me`;
+6. prove the deleted access token is rejected;
+7. prove the deleted email/password credentials are rejected.
+
+The staging release receipt is retained only after this job succeeds because receipt creation depends on the entire staging Web job.
+
+## Privacy and cleanup
+
+The verifier must not print the synthetic email, password, bearer token, response bodies, database URLs, or database records.
+
+The account is disposable and the canonical account-deletion API is the cleanup authority. If any step fails after registration, a `finally` path attempts `DELETE /users/me` using the synthetic session. There is no direct database cleanup and no test-only API.
+
+Synthetic identifiers are unique per run and exist only long enough to exercise the journey.
+
+## Evidence boundary
+
+Repository CI proves the runner is parseable, its success path works under a fake HTTP transport, failure after registration triggers cleanup, and the staging workflow orders the journey after live smoke and before release receipt authority.
+
+Repository CI does **not** prove the deployed staging environment works. That evidence exists only when the real staging workflow executes the journey successfully against the deployed API.
+
+A green staging receipt therefore means, transitively:
+
+- exact-SHA canonical main release checks passed;
+- API migration/deployment and release identity passed;
+- immutable and stable Web provenance passed;
+- non-destructive live release smoke passed;
+- the disposable public-API lifecycle passed;
+- the receipt was emitted only after those authorities succeeded.
+
+## Non-goals
+
+v1 does not create caregiver relationships, community posts, Packs, media, push subscriptions, or realtime conversations. Those surfaces have their own repository authorities and should only be added to deployed synthetic qualification when their cleanup semantics and operational value justify the extra mutable staging state.
+
+Production promotion does not rerun this mutation directly against production. Instead, production requires a successful staging workflow for the exact same SHA and independently re-verifies canonical release authority before promotion.


### PR DESCRIPTION
## Purpose

Add a deployed staging qualification that proves a minimal real user lifecycle through Woof's public API before a staging release receipt can exist.

## Journey

After immutable/stable Web provenance and the non-destructive live release smoke pass, staging now:

1. registers a unique replay-safe synthetic account;
2. proves the returned session through `/auth/me`;
3. creates a minimal owned dog with a replay-safe creation key;
4. mutates that dog through the owner-authorized update route;
5. deletes the account through the canonical `DELETE /users/me` authority;
6. proves the deleted bearer session is rejected;
7. proves the deleted credentials are rejected.

The runner logs only step names/timings/status-derived failures. It does not print synthetic identity, password, token, response bodies, `DATABASE_URL`, or direct DB state.

If a step fails after registration, a `finally` path attempts canonical account deletion. There is no direct database cleanup and no test-only endpoint.

## Authority placement

The journey runs inside `Deploy Web to Staging` after the existing live smoke. `Retain Staging Release Receipt` already depends on the entire Web job, so receipt existence transitively requires the journey without adding another drift-prone receipt boolean.

Production continues to require a successful staging workflow for the exact same SHA. The mutation is not redundantly replayed against production.

## Qualification

Adds `Staging Journey Authority CI`, which:

- parses the Node runner;
- self-tests the successful lifecycle under a fake HTTP transport;
- self-tests failure-after-registration and requires cleanup to fire;
- parses/enforces a source contract that forbids DB authority and obvious secret/payload logging;
- enforces staging ordering: live smoke -> disposable journey -> receipt authority.

## Evidence boundary

Repository green proves the runner and authority wiring. It does **not** prove deployed staging behavior. Deployed evidence exists only when the real staging workflow runs the journey successfully against a configured environment.

This PR intentionally does not add caregiver, Community, Packs, media, push, or realtime mutation to the release gate. Those surfaces stay under their existing domain authorities until their deployed cleanup/value justify the extra mutable staging state.