### PR TITLE
Serialize caregiver issuance before overlap trigger

### DIFF
--- a/.github/workflows/dogos-caregiver-authority-ci.yml
+++ b/.github/workflows/dogos-caregiver-authority-ci.yml
@@ -111,6 +111,10 @@ jobs:
           grep -F "authorityClass: 'CONTEXT_ONLY'" apps/api/src/caregiver/caregiver.service.ts
           grep -F "caregiver grant is not currently active" \
             packages/database/prisma/migrations/20260829034500_add_dogos_caregiver_authority_v1/migration.sql
+          grep -F 'const issuanceLockKey = `dogos-caregiver:${input.petId}:${input.recipientUserId}`;' \
+            apps/api/src/caregiver/caregiver-operational.store.ts
+          grep -F "hashtextextended('dogos-caregiver:' || NEW.pet_id || ':' || NEW.recipient_user_id, 0)" \
+            packages/database/prisma/migrations/20260829034500_add_dogos_caregiver_authority_v1/migration.sql
 
           if grep -REn "householdMember\.(create|upsert|update|updateMany)|HouseholdsService" apps/api/src/caregiver; then
             echo 'Caregiver authority must not be implemented as generic household membership.' >&2

--- a/apps/api/src/caregiver/caregiver-operational.store.integration.spec.ts
+++ b/apps/api/src/caregiver/caregiver-operational.store.integration.spec.ts
@@ -164,12 +164,12 @@ describe('CaregiverOperationalStore integration', () => {
     ).rejects.toThrow();
   });
 
-  it('serializes concurrent overlapping issuance so at most one authority window is created', async () => {
+  it('serializes concurrent overlapping issuance before the trigger boundary', async () => {
     const { issuerUserId, recipientUserId, petId } = await fixture('concurrent');
     const issuedAt = new Date();
     const expiresAt = new Date(issuedAt.getTime() + 60 * 60 * 1000);
 
-    const results = await Promise.allSettled(
+    const results = await Promise.all(
       [0, 1].map((index) =>
         store.issueGrant({
           id: randomUUID(),
@@ -184,8 +184,7 @@ describe('CaregiverOperationalStore integration', () => {
       )
     );
 
-    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
-    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+    expect(results.sort()).toEqual([false, true]);
 
     const rows = await prisma.$queryRaw<Array<{ count: number }>>(Prisma.sql`
       SELECT COUNT(*)::int AS count
@@ -196,6 +195,44 @@ describe('CaregiverOperationalStore integration', () => {
         AND expires_at > ${issuedAt}
     `);
     expect(rows[0]?.count).toBe(1);
+  });
+
+  it('turns concurrent exact issuance replay into one create and one clean noop', async () => {
+    const { issuerUserId, recipientUserId, petId } = await fixture('exact-replay');
+    const issuedAt = new Date();
+    const expiresAt = new Date(issuedAt.getTime() + 60 * 60 * 1000);
+    const requestKey = `exact-replay-${randomUUID()}`;
+
+    const results = await Promise.all(
+      [0, 1].map(() =>
+        store.issueGrant({
+          id: randomUUID(),
+          petId,
+          issuerUserId,
+          recipientUserId,
+          requestKey,
+          capabilities: ['VIEW_TODAY'],
+          issuedAt,
+          expiresAt,
+        })
+      )
+    );
+
+    expect(results.sort()).toEqual([false, true]);
+
+    const counts = await prisma.$queryRaw<Array<{ grants: number; receipts: number }>>(Prisma.sql`
+      SELECT
+        (SELECT COUNT(*)::int
+         FROM dogos_caregiver.grants
+         WHERE issuer_user_id = ${issuerUserId} AND request_key = ${requestKey}) AS grants,
+        (SELECT COUNT(*)::int
+         FROM dogos_caregiver.grant_receipts receipt
+         INNER JOIN dogos_caregiver.grants grant_row ON grant_row.id = receipt.grant_id
+         WHERE grant_row.issuer_user_id = ${issuerUserId}
+           AND grant_row.request_key = ${requestKey}
+           AND receipt.transition = 'ISSUED') AS receipts
+    `);
+    expect(counts[0]).toEqual({ grants: 1, receipts: 1 });
   });
 
   it('treats expiry as present-tense authority and allows a later non-overlapping grant', async () => {

--- a/apps/api/src/caregiver/caregiver-operational.store.ts
+++ b/apps/api/src/caregiver/caregiver-operational.store.ts
@@ -145,6 +145,46 @@ export class CaregiverOperationalStore {
     expiresAt: Date;
   }) {
     return this.prisma.$transaction(async (tx) => {
+      // Use the exact same transaction-scoped lock identity as the database
+      // issuance trigger. Maintained API traffic therefore serializes before it
+      // attempts an INSERT, while direct/out-of-band writes still fail closed at
+      // the trigger boundary.
+      const issuanceLockKey = `dogos-caregiver:${input.petId}:${input.recipientUserId}`;
+      await tx.$queryRaw<Array<{ locked: string | null }>>(Prisma.sql`
+        SELECT pg_advisory_xact_lock(hashtextextended(${issuanceLockKey}, 0))::text AS locked
+      `);
+
+      // A concurrent exact request-key replay may have committed while this
+      // transaction waited for the pet/recipient lock. Let the service resolve
+      // whether the persisted request is an exact replay or a divergent reuse
+      // without intentionally colliding with either the unique constraint or the
+      // overlap trigger.
+      const replayRows = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+        SELECT id
+        FROM dogos_caregiver.grants
+        WHERE issuer_user_id = ${input.issuerUserId}
+          AND request_key = ${input.requestKey}
+        LIMIT 1
+      `);
+      if (replayRows[0]) return false;
+
+      // Preserve the trigger's overlap definition exactly. Returning false lets
+      // CaregiverService map a concurrent live-window conflict to its existing
+      // semantic 409 path instead of recovering from an expected PostgreSQL
+      // exception. The unchanged trigger remains the final authority for callers
+      // that bypass this store.
+      const liveRows = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+        SELECT id
+        FROM dogos_caregiver.grants
+        WHERE pet_id = ${input.petId}
+          AND recipient_user_id = ${input.recipientUserId}
+          AND status IN ('PENDING_ACCEPTANCE', 'ACTIVE')
+          AND issued_at < ${input.expiresAt}
+          AND expires_at > ${input.issuedAt}
+        LIMIT 1
+      `);
+      if (liveRows[0]) return false;
+
       const inserted = await tx.$queryRaw<Array<{ id: string }>>(Prisma.sql`
         INSERT INTO dogos_caregiver.grants (
           id, pet_id, issuer_user_id, recipient_user_id, request_key, policy_version,


### PR DESCRIPTION
## Purpose

Close #123 by removing exception-driven success from the maintained caregiver issuance path without weakening the database trigger that protects direct/out-of-band writes.

## Change

`CaregiverOperationalStore.issueGrant()` now acquires the **same transaction-scoped PostgreSQL advisory lock** already used by `dogos_caregiver.enforce_grant_issuance`, keyed by the exact `(pet_id, recipient_user_id)` authority identity.

While holding that lock, the store re-checks:

- issuer + request-key replay;
- overlapping `PENDING_ACCEPTANCE` / `ACTIVE` authority windows using the trigger's exact overlap predicate.

A replay or live overlap returns the existing `false` no-op signal, which lets the already-qualified service layer resolve exact replay vs semantic conflict without deliberately colliding with the trigger. Only a genuinely clear authority window attempts `INSERT`.

The database trigger is unchanged and remains fail-closed for direct SQL, stale callers, blocked relationships, and any path bypassing the maintained store.

## Concurrency evidence

The real PostgreSQL store integration now proves:

- two concurrent divergent overlapping issuance attempts both complete without an expected trigger exception, with exactly one `true` create and one `false` no-op;
- two concurrent exact request-key replays produce exactly one grant and one `ISSUED` receipt, again with one create and one clean no-op;
- later non-overlapping issuance after derived expiry remains allowed;
- existing lifecycle, receipt immutability, observation authority, block and privacy cascade contracts remain intact.

Caregiver Authority CI also binds the store lock key and trigger lock key as a source-level tripwire so they cannot silently diverge.

## Evidence boundary

This is concurrency/operational-resilience cleanup. It does not expand caregiver permissions, alter household authority, or claim live-production behavior. The database overlap trigger remains the final out-of-band authority boundary.