### PR TITLE
Native accessibility foundation: reduced motion, keyboard safety, scalable navigation

### DIFF
--- a/.github/scripts/assert-native-accessibility-reality.py
+++ b/.github/scripts/assert-native-accessibility-reality.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Fail closed when the first native accessibility reality boundary drifts."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+NAVIGATOR = ROOT / "apps/mobile/src/navigation/AppNavigator.tsx"
+REDUCED_MOTION = ROOT / "apps/mobile/src/accessibility/useReducedMotionPreference.ts"
+PRIMARY_SCREENS = [
+    ROOT / "apps/mobile/src/screens/TodayScreen.tsx",
+    ROOT / "apps/mobile/src/screens/FirstAdventureScreen.tsx",
+    ROOT / "apps/mobile/src/screens/DailySignalsScreen.tsx",
+]
+
+for path in [NAVIGATOR, REDUCED_MOTION, *PRIMARY_SCREENS]:
+    if not path.is_file():
+        raise SystemExit(f"native accessibility authority source missing: {path.relative_to(ROOT)}")
+
+navigator = NAVIGATOR.read_text()
+reduced_motion = REDUCED_MOTION.read_text()
+
+required_navigator_markers = [
+    "useReducedMotionPreference",
+    "animation: reduceMotionEnabled ? 'none' : 'default'",
+    "KeyboardAvoidingView",
+    "keyboardAvoidanceBehavior",
+    "DailySignalsKeyboardSafeScreen",
+    '<View style={styles.loadingContainer} accessibilityRole="progressbar">',
+]
+for marker in required_navigator_markers:
+    if marker not in navigator:
+        raise SystemExit(f"native navigation accessibility marker missing: {marker}")
+
+if "height: 66" in navigator:
+    raise SystemExit("native tab bar must remain content/safe-area driven, not fixed to 66px")
+
+required_motion_markers = [
+    "AccessibilityInfo.isReduceMotionEnabled()",
+    "AccessibilityInfo.addEventListener(",
+    "'reduceMotionChanged'",
+    "subscription.remove()",
+]
+for marker in required_motion_markers:
+    if marker not in reduced_motion:
+        raise SystemExit(f"reduced-motion authority marker missing: {marker}")
+
+for path in (ROOT / "apps/mobile/src").rglob("*.tsx"):
+    text = path.read_text()
+    for forbidden in ["allowFontScaling={false}", "maxFontSizeMultiplier={1}"]:
+        if forbidden in text:
+            raise SystemExit(
+                f"native source disables user text scaling in {path.relative_to(ROOT)}: {forbidden}"
+            )
+
+print(
+    "Native accessibility foundation is explicit: tab navigation is content-driven, stack motion follows "
+    "the OS reduced-motion preference, launch/capture loading is announced, keyboard-sensitive capture "
+    "surfaces are protected, and text scaling remains user-controlled. Physical-device VoiceOver and "
+    "Dynamic Type usability remain separate evidence gates."
+)

--- a/.github/workflows/native-accessibility-reality-ci.yml
+++ b/.github/workflows/native-accessibility-reality-ci.yml
@@ -1,0 +1,80 @@
+name: Native Accessibility Reality CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/mobile/src/accessibility/**'
+      - 'apps/mobile/src/navigation/AppNavigator.tsx'
+      - 'apps/mobile/src/screens/TodayScreen.tsx'
+      - 'apps/mobile/src/screens/FirstAdventureScreen.tsx'
+      - 'apps/mobile/src/screens/DailySignalsScreen.tsx'
+      - '.github/scripts/assert-native-accessibility-reality.py'
+      - '.github/workflows/native-accessibility-reality-ci.yml'
+      - 'docs/NATIVE_ACCESSIBILITY_REALITY_V1.md'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mobile/src/accessibility/**'
+      - 'apps/mobile/src/navigation/AppNavigator.tsx'
+      - 'apps/mobile/src/screens/TodayScreen.tsx'
+      - 'apps/mobile/src/screens/FirstAdventureScreen.tsx'
+      - 'apps/mobile/src/screens/DailySignalsScreen.tsx'
+      - '.github/scripts/assert-native-accessibility-reality.py'
+      - '.github/workflows/native-accessibility-reality-ci.yml'
+      - 'docs/NATIVE_ACCESSIBILITY_REALITY_V1.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-accessibility-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.20.2'
+  PNPM_VERSION: '8.15.1'
+
+jobs:
+  qualify:
+    name: Native semantics + text/motion/keyboard source authority
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install from committed lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Enforce native accessibility source boundary
+        run: python3 .github/scripts/assert-native-accessibility-reality.py
+
+      - name: Check native accessibility formatting
+        run: |
+          pnpm exec prettier --write \
+            apps/mobile/src/accessibility/useReducedMotionPreference.ts \
+            apps/mobile/src/navigation/AppNavigator.tsx \
+            .github/workflows/native-accessibility-reality-ci.yml \
+            docs/NATIVE_ACCESSIBILITY_REALITY_V1.md
+          if ! git diff --quiet; then
+            git diff -- \
+              apps/mobile/src/accessibility/useReducedMotionPreference.ts \
+              apps/mobile/src/navigation/AppNavigator.tsx \
+              .github/workflows/native-accessibility-reality-ci.yml \
+              docs/NATIVE_ACCESSIBILITY_REALITY_V1.md | head -c 60000
+            exit 1
+          fi
+
+      - name: Lint mobile
+        run: pnpm --filter @woof/mobile lint
+
+      - name: Type-check mobile
+        run: pnpm --filter @woof/mobile type-check

--- a/apps/mobile/src/accessibility/useReducedMotionPreference.ts
+++ b/apps/mobile/src/accessibility/useReducedMotionPreference.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+export function useReducedMotionPreference() {
+  const [reduceMotionEnabled, setReduceMotionEnabled] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    void AccessibilityInfo.isReduceMotionEnabled()
+      .then((enabled) => {
+        if (mounted) setReduceMotionEnabled(enabled);
+      })
+      .catch(() => {
+        // Keep normal navigation available if the platform cannot resolve the preference.
+      });
+
+    const subscription = AccessibilityInfo.addEventListener(
+      'reduceMotionChanged',
+      setReduceMotionEnabled
+    );
+
+    return () => {
+      mounted = false;
+      subscription.remove();
+    };
+  }, []);
+
+  return reduceMotionEnabled;
+}

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -126,12 +126,10 @@ const secondaryScreenOptions = {
 
 const keyboardAvoidanceBehavior = Platform.OS === 'ios' ? 'padding' : undefined;
 
-function DailySignalsKeyboardSafeScreen(
-  props: StackScreenProps<RootStackParamList, 'DailySignals'>
-) {
+function DailySignalsKeyboardSafeScreen() {
   return (
     <KeyboardAvoidingView style={styles.flex} behavior={keyboardAvoidanceBehavior}>
-      <DailySignalsScreen {...props} />
+      <DailySignalsScreen />
     </KeyboardAvoidingView>
   );
 }

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -1,9 +1,18 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createStackNavigator, type StackScreenProps } from '@react-navigation/stack';
+import { useReducedMotionPreference } from '../accessibility/useReducedMotionPreference';
 import { companionApi, type CompanionState } from '../api/companion';
 import { useAuth } from '../contexts/AuthContext';
 import { clearPetCreationRecovery } from '../onboarding/recovery';
@@ -97,7 +106,6 @@ const MainTabs = () => (
         borderTopColor: '#e5e7eb',
         paddingBottom: 6,
         paddingTop: 6,
-        height: 66,
       },
     })}
   >
@@ -116,10 +124,29 @@ const secondaryScreenOptions = {
   cardStyle: { backgroundColor: '#f9fafb' },
 };
 
+const keyboardAvoidanceBehavior = Platform.OS === 'ios' ? 'padding' : undefined;
+
+function DailySignalsKeyboardSafeScreen(
+  props: StackScreenProps<RootStackParamList, 'DailySignals'>
+) {
+  return (
+    <KeyboardAvoidingView style={styles.flex} behavior={keyboardAvoidanceBehavior}>
+      <DailySignalsScreen {...props} />
+    </KeyboardAvoidingView>
+  );
+}
+
 function AuthNavigator() {
+  const reduceMotionEnabled = useReducedMotionPreference();
+
   return (
     <NavigationContainer>
-      <Stack.Navigator screenOptions={{ cardStyle: { backgroundColor: '#ffffff' } }}>
+      <Stack.Navigator
+        screenOptions={{
+          cardStyle: { backgroundColor: '#ffffff' },
+          animation: reduceMotionEnabled ? 'none' : 'default',
+        }}
+      >
         <Stack.Screen name="Login" component={LoginScreen} options={{ headerShown: false }} />
         <Stack.Screen name="Register" component={RegisterScreen} options={{ headerShown: false }} />
       </Stack.Navigator>
@@ -128,13 +155,20 @@ function AuthNavigator() {
 }
 
 function GuardianNavigator() {
+  const reduceMotionEnabled = useReducedMotionPreference();
+
   return (
     <NavigationContainer>
-      <Stack.Navigator screenOptions={{ cardStyle: { backgroundColor: '#ffffff' } }}>
+      <Stack.Navigator
+        screenOptions={{
+          cardStyle: { backgroundColor: '#ffffff' },
+          animation: reduceMotionEnabled ? 'none' : 'default',
+        }}
+      >
         <Stack.Screen name="MainTabs" component={MainTabs} options={{ headerShown: false }} />
         <Stack.Screen
           name="DailySignals"
-          component={DailySignalsScreen}
+          component={DailySignalsKeyboardSafeScreen}
           options={{ ...secondaryScreenOptions, title: 'Daily Signals' }}
         />
         <Stack.Screen
@@ -188,9 +222,16 @@ function GuardianNavigator() {
 }
 
 function CompanionNavigator({ onResolved }: { onResolved: (state: CompanionState) => void }) {
+  const reduceMotionEnabled = useReducedMotionPreference();
+
   return (
     <NavigationContainer>
-      <Stack.Navigator screenOptions={{ cardStyle: { backgroundColor: '#ffffff' } }}>
+      <Stack.Navigator
+        screenOptions={{
+          cardStyle: { backgroundColor: '#ffffff' },
+          animation: reduceMotionEnabled ? 'none' : 'default',
+        }}
+      >
         <Stack.Screen name="CompanionHome" options={{ headerShown: false }}>
           {(props) => <CompanionHomeScreen {...props} onResolved={onResolved} />}
         </Stack.Screen>
@@ -311,11 +352,13 @@ function AuthenticatedEntry() {
 
   if (state.landing === 'NEEDS_PET_SETUP') {
     return (
-      <FirstAdventureScreen
-        onComplete={() => void load()}
-        onModeResolved={(next) => void applyResolved(next)}
-        onRecheck={() => void load()}
-      />
+      <KeyboardAvoidingView style={styles.flex} behavior={keyboardAvoidanceBehavior}>
+        <FirstAdventureScreen
+          onComplete={() => void load()}
+          onModeResolved={(next) => void applyResolved(next)}
+          onRecheck={() => void load()}
+        />
+      </KeyboardAvoidingView>
     );
   }
 
@@ -353,8 +396,9 @@ export const AppNavigator = () => {
 
   if (loading) {
     return (
-      <View style={styles.loadingContainer}>
+      <View style={styles.loadingContainer} accessibilityRole="progressbar">
         <ActivityIndicator size="large" color={colors.primary[600]} />
+        <Text style={styles.loadingText}>Opening Woof…</Text>
       </View>
     );
   }
@@ -363,6 +407,7 @@ export const AppNavigator = () => {
 };
 
 const styles = StyleSheet.create({
+  flex: { flex: 1 },
   loadingContainer: {
     flex: 1,
     justifyContent: 'center',

--- a/docs/NATIVE_ACCESSIBILITY_REALITY_V1.md
+++ b/docs/NATIVE_ACCESSIBILITY_REALITY_V1.md
@@ -1,0 +1,61 @@
+# Native Accessibility Reality v1
+
+Issue: #155
+
+## Purpose
+
+This tranche establishes a repository-qualified accessibility foundation for the maintained React Native client without pretending that source code or an unsigned simulator build proves physical-device usability.
+
+The first boundary focuses on platform behavior that can be made explicit without redesigning the product:
+
+- navigation must not force a fixed tab-bar height that can clip scaled labels or fight safe-area insets;
+- stack transitions must respect the operating system reduced-motion preference;
+- keyboard-sensitive First Adventure and Daily Signals capture surfaces must remain visible while text input is active;
+- launch and authority-loading states must expose progress semantics and readable status text;
+- user font scaling must remain enabled rather than being capped to preserve a default-size layout.
+
+## Reduced motion
+
+`useReducedMotionPreference` reads `AccessibilityInfo.isReduceMotionEnabled()` and subscribes to `reduceMotionChanged` for the lifetime of the mounted navigator.
+
+Auth, Guardian, and Companion stacks select React Navigation's `animation: 'none'` when reduced motion is enabled and `animation: 'default'` otherwise. The product therefore responds to preference changes while running instead of sampling the preference only once at install or startup.
+
+The hook fails open to normal navigation if the platform cannot resolve the preference. Accessibility preference lookup must not strand the user outside the app.
+
+## Dynamic Type and reflow boundary
+
+This release removes the explicit `height: 66` bottom-tab constraint. Tab content and platform safe-area behavior can determine the resulting height.
+
+The source contract also fails if maintained React Native TSX disables text scaling with `allowFontScaling={false}` or hard-caps text with `maxFontSizeMultiplier={1}`.
+
+This does **not** yet prove that every primary screen reflows correctly at the largest accessibility text sizes. Today relationship-tool card reflow and First Adventure alternative-action reflow remain explicit follow-up work in #155 and must be exercised with large Dynamic Type before stronger claims are made.
+
+## Keyboard boundary
+
+First Adventure pet setup and Daily Signals capture both contain meaningful text entry. They are wrapped in a `KeyboardAvoidingView` at the maintained navigation boundary. iOS uses `padding` behavior; other platforms keep their normal resize behavior.
+
+The screen-owned `ScrollView` remains responsible for scrolling and tap persistence. The navigator does not duplicate form state or validation.
+
+This is a structural keyboard-avoidance guarantee, not proof of every keyboard/device combination. Simulator and physical-device checks remain required.
+
+## Qualification
+
+`Native Accessibility Reality CI` proves:
+
+- required reduced-motion and keyboard-avoidance source markers remain present;
+- the tab bar does not return to the retired fixed 66-point height;
+- maintained mobile TSX does not disable user font scaling in the simple forbidden forms covered by the sentry;
+- the dedicated files are formatted;
+- the complete mobile package lints and type-checks.
+
+Any `apps/mobile/**` change also triggers the existing iOS CocoaPods + Xcode Qualification CI, which generates a production-shaped iOS project, resolves Pods, and compiles an unsigned Release simulator application with Xcode 26.
+
+## Evidence boundary
+
+Repository/source qualification can establish intentional semantics and compile-time compatibility. The Xcode lane can establish that a production-shaped simulator application builds. Neither proves VoiceOver reading/focus order, largest-Dynamic-Type usability, keyboard presentation on a particular device, or TestFlight behavior.
+
+Keep the evidence states separate:
+
+> source-qualified != simulator-qualified != physical-device-qualified != pilot-validated
+
+The next #155 tranche should target actual large-text reflow and explicit control labels/states in Today, First Adventure, and Daily Signals, followed by simulator and physical-iPhone execution evidence.


### PR DESCRIPTION
## Purpose

Advance #155 with a deliberately narrow first native-accessibility tranche that improves platform behavior without claiming physical-device or full Dynamic Type qualification.

## What changes

- removes the fixed 66-point bottom-tab height so tab content and safe-area behavior can determine layout;
- adds an OS-backed reduced-motion hook using `AccessibilityInfo.isReduceMotionEnabled()` plus the live `reduceMotionChanged` subscription;
- makes Auth, Guardian, and Companion stack transitions use `animation: 'none'` when the OS preference is enabled;
- wraps First Adventure pet setup and Daily Signals capture in platform-aware `KeyboardAvoidingView` containers without duplicating form state;
- gives the initial app-loading state explicit progress semantics and readable status copy;
- adds a fail-closed source contract that prevents the fixed tab height from returning and rejects simple attempts to disable/cap user font scaling;
- adds dedicated Native Accessibility Reality CI for source authority, formatting, full mobile lint, and full mobile type-check;
- documents what repository qualification does and does not prove.

Any `apps/mobile/**` change also triggers the existing iOS CocoaPods + Xcode Qualification workflow, so this tranche must still generate the production-shaped native project, resolve Pods, and compile an unsigned Release simulator app under Xcode 26.

## Deliberate non-claims

This does **not** yet claim that every primary screen reflows at the largest Dynamic Type sizes, that VoiceOver focus order is correct on a real device, or that TestFlight accessibility has been qualified.

The next #155 tranche should address Today relationship-tool reflow, First Adventure action reflow, explicit control labels/states, and then collect simulator plus physical-iPhone evidence.

Evidence remains:

> source-qualified != simulator-qualified != physical-device-qualified != pilot-validated
